### PR TITLE
fix: suppress credential vocabulary in technical contexts

### DIFF
--- a/src/sensitivity.ts
+++ b/src/sensitivity.ts
@@ -44,9 +44,12 @@ const TECHNICAL_PRIVATE_PATTERNS = [
 /**
  * Actual secret-shaped strings. These match real credentials and have near-zero
  * false-positive rate — any match is always private regardless of context.
+ *
+ * `sk-` is restricted to known provider prefixes so that all-lowercase slug
+ * identifiers like `sk-telemetry-auth-pipeline-id` do not false-positive.
  */
 const SECRET_SHAPED_PATTERNS = [
-  /\bsk-[A-Za-z0-9_-]{20,}\b/,             // OpenAI / Anthropic API keys
+  /\bsk-(?:ant|proj|svcacct|live|test|or)-[A-Za-z0-9_-]{16,}\b/, // Anthropic / OpenAI / OpenRouter API keys
   /\bghp_[A-Za-z0-9]{20,}\b/,              // GitHub personal access tokens
   /\bgho_[A-Za-z0-9]{20,}\b/,              // GitHub OAuth tokens
   /\bgithub_pat_[A-Za-z0-9_]{22,}\b/,      // GitHub fine-grained PATs
@@ -54,6 +57,39 @@ const SECRET_SHAPED_PATTERNS = [
   /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/,      // Slack tokens
   /-----BEGIN [A-Z ]*PRIVATE KEY-----/,    // PEM private keys
 ];
+
+/**
+ * A credential keyword followed by an apparent value — e.g. `password: hunter2`,
+ * `api key = xyz`, `bearer token is eyJ...`, `the API key for prod is sk-...`.
+ * These must always classify as private, even on lines that also contain
+ * technical-context words, because the presence of an assignment means the
+ * prompt contains the secret itself, not just a discussion of one.
+ *
+ * Up to 40 characters of filler are allowed between the credential keyword and
+ * the value indicator (`:`, `=`, or `is`) so that natural-language assignments
+ * like `API key for prod is sk-xxx` are caught, while staying bounded enough
+ * to avoid matching unrelated mentions in long prose.
+ */
+const CREDENTIAL_KEYWORD = /\b(?:password|api[- ]?key|bearer\s+token|private\s+key)\b/i;
+const CREDENTIAL_VALUE_INDICATOR = /(?:[:=]|\bis\b)\s*\S/i;
+const AUTHORIZATION_HEADER_PATTERN = /\bAuthorization\s*:\s*Bearer\s+\S/i;
+
+function hasCredentialAssignment(text: string): boolean {
+  if (AUTHORIZATION_HEADER_PATTERN.test(text)) return true;
+  // Reset lastIndex on the global-less regexes is unnecessary, but we scan
+  // each line so keyword matches don't span lines.
+  for (const line of text.split("\n")) {
+    const keywordMatch = line.match(CREDENTIAL_KEYWORD);
+    if (!keywordMatch) continue;
+    const afterKeyword = line.slice(
+      (keywordMatch.index ?? 0) + keywordMatch[0].length,
+    );
+    // Allow up to 40 chars of filler before the value indicator.
+    const window = afterKeyword.slice(0, 40 + 10);
+    if (CREDENTIAL_VALUE_INDICATOR.test(window)) return true;
+  }
+  return false;
+}
 
 /**
  * Keywords that appear in both private-data and technical-discussion contexts.
@@ -67,7 +103,13 @@ const CONTEXT_SENSITIVE_PATTERNS = [
   /\bjournal\b/i,
 ];
 
-/** Words that signal a keyword is being discussed, not contained. */
+/**
+ * Words that signal a keyword is being discussed, not contained. `API` stays
+ * in the list — value-bearing credential lines like `my API key is abc123` are
+ * caught earlier by `CREDENTIAL_ASSIGNMENT_PATTERNS` before this suppression
+ * runs, so technical discussion that happens to say `API key` (e.g.
+ * `Auth model (API key? OAuth?)`) remains correctly classified as non-private.
+ */
 const TECHNICAL_CONTEXT = /\b(?:handling|scanning|management|rotation|module|system|API|integration|processing|calculation|architecture|endpoint|schema|service|engine|middleware|template|pipeline|detection|verification|authentication|authorization|signing|encryption|hashing|registry|configuration|systemd|SDK|CLI|framework|protocol)\b/i;
 
 const PRIVATE_PATH_PREFIXES = [
@@ -138,6 +180,15 @@ export function classifyPromptSensitivity(
   // Secret-shaped strings are scanned against the RAW text, before stripping
   // code blocks — a real key pasted into a code fence is still a real key.
   if (SECRET_SHAPED_PATTERNS.some((p) => p.test(prompt))) {
+    return "private";
+  }
+
+  // Credential assignments (`password: hunter2`, `api key = xyz`,
+  // `the API key for prod is sk-...`) are also scanned against the RAW text —
+  // a secret assigned inside a code fence is still a secret. They run before
+  // technical-context suppression so a line like
+  // `rotate auth module password: hunter2` cannot sneak past.
+  if (hasCredentialAssignment(prompt)) {
     return "private";
   }
 

--- a/src/sensitivity.ts
+++ b/src/sensitivity.ts
@@ -45,11 +45,15 @@ const TECHNICAL_PRIVATE_PATTERNS = [
  * Actual secret-shaped strings. These match real credentials and have near-zero
  * false-positive rate — any match is always private regardless of context.
  *
- * `sk-` is restricted to known provider prefixes so that all-lowercase slug
- * identifiers like `sk-telemetry-auth-pipeline-id` do not false-positive.
+ * Two layers for `sk-`: a prefix allowlist (Anthropic / OpenAI / OpenRouter)
+ * and a generic entropy fallback that requires ≥32 chars plus at least one
+ * uppercase letter or digit. Slugs like `sk-telemetry-auth-pipeline-id` are
+ * all-lowercase and short, so they never trigger; legacy `sk-...` secrets
+ * that don't match the allowlist still get caught by the entropy fallback.
  */
 const SECRET_SHAPED_PATTERNS = [
-  /\bsk-(?:ant|proj|svcacct|live|test|or)-[A-Za-z0-9_-]{16,}\b/, // Anthropic / OpenAI / OpenRouter API keys
+  /\bsk-(?:ant|proj|svcacct|live|test|or)-[A-Za-z0-9_-]{16,}\b/, // Prefixed provider keys
+  /\bsk-(?=[A-Za-z0-9_-]*[A-Z\d])[A-Za-z0-9_-]{32,}\b/,          // Generic sk- with entropy
   /\bghp_[A-Za-z0-9]{20,}\b/,              // GitHub personal access tokens
   /\bgho_[A-Za-z0-9]{20,}\b/,              // GitHub OAuth tokens
   /\bgithub_pat_[A-Za-z0-9_]{22,}\b/,      // GitHub fine-grained PATs
@@ -59,34 +63,74 @@ const SECRET_SHAPED_PATTERNS = [
 ];
 
 /**
- * A credential keyword followed by an apparent value — e.g. `password: hunter2`,
- * `api key = xyz`, `bearer token is eyJ...`, `the API key for prod is sk-...`.
- * These must always classify as private, even on lines that also contain
- * technical-context words, because the presence of an assignment means the
- * prompt contains the secret itself, not just a discussion of one.
+ * A credential keyword followed by an apparent secret value — e.g.
+ * `password: hunter2`, `api key = abc123`, `bearer token is eyJ...`,
+ * `the API key for prod is sk-...`. These must always classify as private,
+ * even on lines that also contain technical-context words, because the
+ * presence of an assignment means the prompt contains the secret itself,
+ * not just a discussion of one.
  *
- * Up to 40 characters of filler are allowed between the credential keyword and
- * the value indicator (`:`, `=`, or `is`) so that natural-language assignments
- * like `API key for prod is sk-xxx` are caught, while staying bounded enough
- * to avoid matching unrelated mentions in long prose.
+ * Three guardrails against round-2 Codex review findings:
+ *   1. Global keyword regex + `matchAll` so every credential occurrence on
+ *      the line is scanned, not just the first. Catches patterns like
+ *      `API key auth design notes ... password: hunter2`.
+ *   2. Newlines normalized to spaces so `API key rotation\n: abc123` and
+ *      `API key for prod\nis abc123` are still caught.
+ *   3. The value after the indicator must contain a digit to count as a
+ *      secret. Rejects descriptive prose like `is required`, `is hashed`,
+ *      `is encrypted` that would otherwise false-positive. Accepts the
+ *      limitation that pure-alphabetic passwords (e.g. `swordfish`) are
+ *      missed — real secrets almost always contain digits.
  */
-const CREDENTIAL_KEYWORD = /\b(?:password|api[- ]?key|bearer\s+token|private\s+key)\b/i;
-const CREDENTIAL_VALUE_INDICATOR = /(?:[:=]|\bis\b)\s*\S/i;
-const AUTHORIZATION_HEADER_PATTERN = /\bAuthorization\s*:\s*Bearer\s+\S/i;
+const CREDENTIAL_KEYWORD = /\b(?:password|api[- ]?key|bearer\s+token|private\s+key)\b/gi;
+const CREDENTIAL_VALUE_INDICATOR = /(?:[:=]|\bis\b)\s*(\S+)/i;
+const AUTHORIZATION_HEADER_PATTERN = /\bAuthorization\s*:\s*Bearer\s+(\S+)/i;
+
+/**
+ * Detects a credential keyword followed by a placeholder value like
+ * `password: $SECRET_VAR`, `api key: ${API_KEY}`, or `password: <YOUR_PASSWORD>`.
+ * Lines matching this pattern are documentation/templates, not credential
+ * leaks, and should be exempted from the per-line credential-keyword check.
+ */
+const CREDENTIAL_PLACEHOLDER_ASSIGNMENT =
+  /\b(?:password|api[- ]?key|bearer\s+token|private\s+key)\b[^:=\n]{0,20}[:=]\s*(?:\$\{?[A-Za-z_]|<[A-Za-z_])/i;
+
+/**
+ * Heuristic: does `value` look like an actual secret, or is it descriptive
+ * prose? Real secrets almost always contain at least one digit. Placeholder
+ * syntax (`$VAR`, `${VAR}`, `<TOKEN>`) is explicitly excluded.
+ */
+function isSecretShapedValue(value: string | undefined): boolean {
+  if (!value) return false;
+  // Trim leading/trailing quotes/backticks to look at the actual token
+  const stripped = value.replace(/^["'`]+|["'`]+$/g, "");
+  if (!stripped) return false;
+  // Common placeholder patterns — not secrets
+  if (/^<[^>]*>$/.test(stripped)) return false;
+  if (/^\$\{?[A-Za-z_][A-Za-z0-9_]*\}?$/.test(stripped)) return false;
+  // Must contain at least one digit to look like a secret value
+  return /\d/.test(stripped);
+}
 
 function hasCredentialAssignment(text: string): boolean {
-  if (AUTHORIZATION_HEADER_PATTERN.test(text)) return true;
-  // Reset lastIndex on the global-less regexes is unnecessary, but we scan
-  // each line so keyword matches don't span lines.
-  for (const line of text.split("\n")) {
-    const keywordMatch = line.match(CREDENTIAL_KEYWORD);
-    if (!keywordMatch) continue;
-    const afterKeyword = line.slice(
-      (keywordMatch.index ?? 0) + keywordMatch[0].length,
+  // Handle `Authorization: Bearer <token>` specifically — the header form
+  // doesn't go through the credential-keyword loop.
+  const authMatch = text.match(AUTHORIZATION_HEADER_PATTERN);
+  if (authMatch && isSecretShapedValue(authMatch[1])) return true;
+
+  // Collapse newlines so a keyword on one line and its value on the next
+  // are still caught by the 60-char window.
+  const normalized = text.replace(/\r?\n/g, " ");
+
+  // Scan every credential keyword occurrence, not just the first per line.
+  for (const match of normalized.matchAll(CREDENTIAL_KEYWORD)) {
+    const afterKeyword = normalized.slice(
+      (match.index ?? 0) + match[0].length,
     );
-    // Allow up to 40 chars of filler before the value indicator.
-    const window = afterKeyword.slice(0, 40 + 10);
-    if (CREDENTIAL_VALUE_INDICATOR.test(window)) return true;
+    const window = afterKeyword.slice(0, 60);
+    const indicatorMatch = window.match(CREDENTIAL_VALUE_INDICATOR);
+    if (!indicatorMatch) continue;
+    if (isSecretShapedValue(indicatorMatch[1])) return true;
   }
   return false;
 }
@@ -104,13 +148,17 @@ const CONTEXT_SENSITIVE_PATTERNS = [
 ];
 
 /**
- * Words that signal a keyword is being discussed, not contained. `API` stays
- * in the list — value-bearing credential lines like `my API key is abc123` are
- * caught earlier by `CREDENTIAL_ASSIGNMENT_PATTERNS` before this suppression
- * runs, so technical discussion that happens to say `API key` (e.g.
- * `Auth model (API key? OAuth?)`) remains correctly classified as non-private.
+ * Words that signal a keyword is being discussed, not contained. Includes
+ * both -ing and -ed forms of the common security verbs so that descriptive
+ * sentences like `the password is hashed` or `the private key is encrypted`
+ * don't fall through to the per-line credential check.
+ *
+ * `API` stays in the list — value-bearing credential lines like
+ * `my API key is abc123` are caught earlier by `hasCredentialAssignment`
+ * before this suppression runs, so pure technical discussion that says
+ * `API key` (e.g. `Auth model (API key? OAuth?)`) remains non-private.
  */
-const TECHNICAL_CONTEXT = /\b(?:handling|scanning|management|rotation|module|system|API|integration|processing|calculation|architecture|endpoint|schema|service|engine|middleware|template|pipeline|detection|verification|authentication|authorization|signing|encryption|hashing|registry|configuration|systemd|SDK|CLI|framework|protocol)\b/i;
+const TECHNICAL_CONTEXT = /\b(?:handling|handled|scanning|scanned|management|managed|rotation|rotated|module|system|API|integration|integrated|processing|processed|calculation|calculated|architecture|endpoint|schema|service|engine|middleware|template|pipeline|detection|detected|verification|verified|authentication|authenticated|authorization|authorized|signing|signed|encryption|encrypted|hashing|hashed|registry|registered|configuration|configured|systemd|SDK|CLI|framework|protocol|required|optional|generated|stored|provided|available)\b/i;
 
 const PRIVATE_PATH_PREFIXES = [
   "/home/magnus/mimir",
@@ -200,11 +248,16 @@ export function classifyPromptSensitivity(
   }
 
   // Credential-adjacent and context-sensitive keywords — check per line,
-  // suppress when the same line contains a technical modifier.
+  // suppress when the same line contains a technical modifier or is a
+  // placeholder-style template assignment.
   const lines = stripped.split("\n");
   for (const line of lines) {
     const hasTechnicalContext = TECHNICAL_CONTEXT.test(line);
     if (hasTechnicalContext) continue;
+
+    // Lines like `password: $SECRET_VAR` or `api key: <YOUR_KEY>` are
+    // templates/docs, not credential leaks — skip them.
+    if (CREDENTIAL_PLACEHOLDER_ASSIGNMENT.test(line)) continue;
 
     if (TECHNICAL_PRIVATE_PATTERNS.some((p) => p.test(line))) {
       return "private";

--- a/src/sensitivity.ts
+++ b/src/sensitivity.ts
@@ -220,27 +220,96 @@ function stripCodeAndPaths(text: string): string {
     .replace(/\b[\w-]+\/[\w/*-]+/g, ""); // namespace/path patterns like clients/invoices
 }
 
+/**
+ * Cyrillic and Greek letters that are visually indistinguishable from Latin
+ * letters commonly used in credential vocabulary (password, api, key, bearer,
+ * token, private, secret, etc.). Covers the common homoglyph-bypass vector
+ * without pulling in the full Unicode confusables database.
+ */
+const HOMOGLYPH_MAP: Record<string, string> = {
+  // Cyrillic lowercase
+  "\u0430": "a", "\u0435": "e", "\u043E": "o", "\u0440": "p",
+  "\u0441": "c", "\u0443": "y", "\u0445": "x", "\u0456": "i",
+  "\u0458": "j", "\u0455": "s", "\u04BB": "h",
+  // Cyrillic uppercase
+  "\u0410": "A", "\u0412": "B", "\u0415": "E", "\u041A": "K",
+  "\u041C": "M", "\u041D": "H", "\u041E": "O", "\u0420": "P",
+  "\u0421": "C", "\u0422": "T", "\u0425": "X", "\u0406": "I",
+  "\u0408": "J", "\u0405": "S",
+  // Greek lowercase
+  "\u03B1": "a", "\u03BF": "o", "\u03C1": "p", "\u03B5": "e",
+  "\u03C4": "t", "\u03BD": "v", "\u03BA": "k",
+  // Greek uppercase (that look Latin)
+  "\u0391": "A", "\u0392": "B", "\u0395": "E", "\u0396": "Z",
+  "\u0397": "H", "\u0399": "I", "\u039A": "K", "\u039C": "M",
+  "\u039D": "N", "\u039F": "O", "\u03A1": "P", "\u03A4": "T",
+  "\u03A5": "Y", "\u03A7": "X",
+};
+
+const HOMOGLYPH_RE = new RegExp(
+  `[${Object.keys(HOMOGLYPH_MAP).join("")}]`,
+  "g",
+);
+
+/**
+ * Normalize a prompt before classification so zero-width characters,
+ * non-breaking spaces, tabs, and Unicode homoglyphs don't provide a bypass
+ * path around the ASCII-only regexes below. Without this, attacks like
+ * `api\u200Bkey: hunter2` or `pаssword: hunter2` (Cyrillic `а`) evade the
+ * credential-keyword detector.
+ *
+ *   1. NFKC folds compatibility characters (e.g. Unicode `ＡＰＩ` → `API`).
+ *   2. Zero-width and bidi control characters are stripped entirely.
+ *   3. Common Cyrillic/Greek homoglyphs are folded to their Latin look-alike.
+ *   4. All Unicode whitespace (tabs, NBSP, em-space, etc.) is collapsed
+ *      to a single ASCII space, except for newlines which are preserved
+ *      because the per-line loop depends on them.
+ */
+function normalizeForClassification(text: string): string {
+  return text
+    .normalize("NFKC")
+    // Strip zero-width, bidi marks, and other format/control characters.
+    // \u200B–\u200F: zero-width + LRM/RLM
+    // \u202A–\u202E: bidi embedding/override
+    // \u2060–\u206F: word joiner + invisible format
+    // \uFEFF: BOM / ZWNBSP
+    .replace(/[\u200B-\u200F\u202A-\u202E\u2060-\u206F\uFEFF]/g, "")
+    // Fold Cyrillic/Greek homoglyphs to their Latin look-alikes.
+    .replace(HOMOGLYPH_RE, (c) => HOMOGLYPH_MAP[c] ?? c)
+    // Collapse non-newline Unicode whitespace (tabs, NBSP, em-space, etc.)
+    // to ASCII space. Newlines are preserved so per-line scanning still works.
+    .replace(/[^\S\n]+/g, " ");
+}
+
 export function classifyPromptSensitivity(
   prompt: string | undefined,
 ): Sensitivity | undefined {
   if (!prompt) return undefined;
 
-  // Secret-shaped strings are scanned against the RAW text, before stripping
-  // code blocks — a real key pasted into a code fence is still a real key.
-  if (SECRET_SHAPED_PATTERNS.some((p) => p.test(prompt))) {
+  // Normalize Unicode, strip zero-width characters, and collapse non-newline
+  // whitespace so homoglyph/ZWSP/NBSP/tab-based bypasses can't evade the
+  // ASCII-only regexes below. All subsequent checks run on the normalized
+  // string — there is no "raw" fallback because the pre-normalization text
+  // would reopen the bypass.
+  const normalized = normalizeForClassification(prompt);
+
+  // Secret-shaped strings are scanned against the normalized text before
+  // stripping code blocks — a real key pasted into a code fence is still a
+  // real key.
+  if (SECRET_SHAPED_PATTERNS.some((p) => p.test(normalized))) {
     return "private";
   }
 
   // Credential assignments (`password: hunter2`, `api key = xyz`,
-  // `the API key for prod is sk-...`) are also scanned against the RAW text —
-  // a secret assigned inside a code fence is still a secret. They run before
-  // technical-context suppression so a line like
+  // `the API key for prod is sk-...`) are also scanned against the
+  // normalized text — a secret assigned inside a code fence is still a
+  // secret. They run before technical-context suppression so a line like
   // `rotate auth module password: hunter2` cannot sneak past.
-  if (hasCredentialAssignment(prompt)) {
+  if (hasCredentialAssignment(normalized)) {
     return "private";
   }
 
-  const stripped = stripCodeAndPaths(prompt);
+  const stripped = stripCodeAndPaths(normalized);
 
   // Unambiguous vocabulary — any match across the full text is private
   if (ALWAYS_PRIVATE_PATTERNS.some((p) => p.test(stripped))) {

--- a/src/sensitivity.ts
+++ b/src/sensitivity.ts
@@ -15,17 +15,44 @@ const SENSITIVITY_ORDER: Record<Sensitivity, number> = {
   private: 2,
 };
 
-/** Unambiguous private-data keywords — any match triggers private classification. */
+/**
+ * Unambiguous private-data keywords — any match triggers private classification.
+ * These are words that do not come up in legitimate technical discussion.
+ */
 const ALWAYS_PRIVATE_PATTERNS = [
-  /\bpassword\b/i,
-  /\bapi[- ]?key\b/i,
-  /\bbearer token\b/i,
-  /\bprivate key\b/i,
   /\bmedical\b/i,
   /\bsalary\b/i,
   /\bpassport\b/i,
   /\bdiary\b/i,
   /\bpersonal notes?\b/i,
+];
+
+/**
+ * Credential-adjacent vocabulary. Matches actual secrets if the line is a raw
+ * dump, but must be suppressed in technical discussion (research on auth
+ * systems, code work on secret-handling modules, debates about API auth).
+ * Matched per-line with the same technical-context suppression as
+ * CONTEXT_SENSITIVE_PATTERNS.
+ */
+const TECHNICAL_PRIVATE_PATTERNS = [
+  /\bpassword\b/i,
+  /\bapi[- ]?key\b/i,
+  /\bbearer token\b/i,
+  /\bprivate key\b/i,
+];
+
+/**
+ * Actual secret-shaped strings. These match real credentials and have near-zero
+ * false-positive rate — any match is always private regardless of context.
+ */
+const SECRET_SHAPED_PATTERNS = [
+  /\bsk-[A-Za-z0-9_-]{20,}\b/,             // OpenAI / Anthropic API keys
+  /\bghp_[A-Za-z0-9]{20,}\b/,              // GitHub personal access tokens
+  /\bgho_[A-Za-z0-9]{20,}\b/,              // GitHub OAuth tokens
+  /\bgithub_pat_[A-Za-z0-9_]{22,}\b/,      // GitHub fine-grained PATs
+  /\bAKIA[0-9A-Z]{16}\b/,                  // AWS access keys
+  /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/,      // Slack tokens
+  /-----BEGIN [A-Z ]*PRIVATE KEY-----/,    // PEM private keys
 ];
 
 /**
@@ -107,20 +134,31 @@ export function classifyPromptSensitivity(
   prompt: string | undefined,
 ): Sensitivity | undefined {
   if (!prompt) return undefined;
+
+  // Secret-shaped strings are scanned against the RAW text, before stripping
+  // code blocks — a real key pasted into a code fence is still a real key.
+  if (SECRET_SHAPED_PATTERNS.some((p) => p.test(prompt))) {
+    return "private";
+  }
+
   const stripped = stripCodeAndPaths(prompt);
 
-  // Unambiguous patterns — any match across the full text is private
+  // Unambiguous vocabulary — any match across the full text is private
   if (ALWAYS_PRIVATE_PATTERNS.some((p) => p.test(stripped))) {
     return "private";
   }
 
-  // Context-sensitive patterns — check per line, suppress when technical context is present
+  // Credential-adjacent and context-sensitive keywords — check per line,
+  // suppress when the same line contains a technical modifier.
   const lines = stripped.split("\n");
   for (const line of lines) {
-    if (
-      CONTEXT_SENSITIVE_PATTERNS.some((p) => p.test(line)) &&
-      !TECHNICAL_CONTEXT.test(line)
-    ) {
+    const hasTechnicalContext = TECHNICAL_CONTEXT.test(line);
+    if (hasTechnicalContext) continue;
+
+    if (TECHNICAL_PRIVATE_PATTERNS.some((p) => p.test(line))) {
+      return "private";
+    }
+    if (CONTEXT_SENSITIVE_PATTERNS.some((p) => p.test(line))) {
       return "private";
     }
   }

--- a/tests/sensitivity.test.ts
+++ b/tests/sensitivity.test.ts
@@ -130,12 +130,12 @@ describe("sensitivity helpers", () => {
   });
 
   it("flags credential assignments even next to technical nouns (#35 codex review)", () => {
-    // Bare "API key" mentions must trip — "API" is no longer a technical-context word
+    // Bare "API key" mentions with a digit-containing value must trip
     expect(
       classifyPromptSensitivity("my API key is abc123"),
     ).toBe("private");
     expect(
-      classifyPromptSensitivity("API key: xyz"),
+      classifyPromptSensitivity("API key: abc123"),
     ).toBe("private");
     // Value-bearing credential lines must trip even with technical modifiers
     expect(
@@ -175,6 +175,70 @@ describe("sensitivity helpers", () => {
     expect(
       classifyPromptSensitivity("sk-proj-1234567890abcdefghij"),
     ).toBe("private");
+  });
+
+  it("catches bare sk- secrets without provider prefix (#35 codex round 2)", () => {
+    // Legacy/generic sk- keys with entropy (uppercase or digits) must trip
+    // via the SECRET_SHAPED_PATTERNS entropy fallback
+    expect(
+      classifyPromptSensitivity(
+        "legacy key sk-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN",
+      ),
+    ).toBe("private");
+    expect(
+      classifyPromptSensitivity(
+        "OPENAI_API_KEY=sk-abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN",
+      ),
+    ).toBe("private");
+    // But long all-lowercase slugs without entropy stay non-private
+    expect(
+      classifyPromptSensitivity(
+        "sk-some-very-long-namespace-slug-without-caps-or-digits",
+      ),
+    ).toBeUndefined();
+  });
+
+  it("scans all credential keywords and spans line breaks (#35 codex round 2)", () => {
+    // Finding 2a: value-bearing credential later in long line (first keyword
+    // has no value in its window, but second keyword does)
+    expect(
+      classifyPromptSensitivity(
+        "API key auth design and implementation notes before the prod password: hunter2",
+      ),
+    ).toBe("private");
+    // Finding 2b: newlines between keyword and value must be normalized
+    expect(
+      classifyPromptSensitivity("API key rotation settings\n: abc123"),
+    ).toBe("private");
+    expect(
+      classifyPromptSensitivity("API key for prod\nis abc123"),
+    ).toBe("private");
+  });
+
+  it("rejects descriptive prose as credential assignment (#35 codex round 2)", () => {
+    // Finding 3: value indicator followed by a plain English word must not trip
+    expect(
+      classifyPromptSensitivity("The API key is required for this endpoint."),
+    ).toBeUndefined();
+    expect(
+      classifyPromptSensitivity("The password is hashed using argon2."),
+    ).toBeUndefined();
+    expect(
+      classifyPromptSensitivity("The private key is encrypted at rest."),
+    ).toBeUndefined();
+    expect(
+      classifyPromptSensitivity("The bearer token is managed by the SDK."),
+    ).toBeUndefined();
+    // Placeholder syntax is also not a secret
+    expect(
+      classifyPromptSensitivity("password: $SECRET_VAR"),
+    ).toBeUndefined();
+    expect(
+      classifyPromptSensitivity("api key: ${API_KEY}"),
+    ).toBeUndefined();
+    expect(
+      classifyPromptSensitivity("password: <YOUR_PASSWORD>"),
+    ).toBeUndefined();
   });
 
   it("always flags secret-shaped credential strings regardless of context", () => {

--- a/tests/sensitivity.test.ts
+++ b/tests/sensitivity.test.ts
@@ -84,13 +84,68 @@ describe("sensitivity helpers", () => {
     ).toBe("private");
   });
 
-  it("still catches unambiguous private-data patterns regardless of context", () => {
-    // "password" is always private even in technical context
+  it("still catches truly unambiguous private-data patterns", () => {
+    // Vocabulary that does not appear in technical discussion
     expect(
-      classifyPromptSensitivity("password handling module"),
+      classifyPromptSensitivity("summarize my medical history"),
     ).toBe("private");
     expect(
+      classifyPromptSensitivity("draft a salary negotiation email"),
+    ).toBe("private");
+    expect(
+      classifyPromptSensitivity("copy the number from my passport"),
+    ).toBe("private");
+    expect(
+      classifyPromptSensitivity("what's in my diary this week"),
+    ).toBe("private");
+  });
+
+  it("suppresses credential vocabulary in technical discussion", () => {
+    // Research and code work about auth systems must not trip sensitivity
+    expect(
+      classifyPromptSensitivity("password handling module"),
+    ).toBeUndefined();
+    expect(
       classifyPromptSensitivity("api key rotation system"),
+    ).toBeUndefined();
+    expect(
+      classifyPromptSensitivity("compare bearer token management frameworks"),
+    ).toBeUndefined();
+    expect(
+      classifyPromptSensitivity("private key signing service architecture"),
+    ).toBeUndefined();
+    // Real research-spike content from Grimnir workflows
+    expect(
+      classifyPromptSensitivity("Auth model (API key? OAuth? scopes?)"),
+    ).toBeUndefined();
+    expect(
+      classifyPromptSensitivity(
+        "Evaluate the OAuth 2.1 and API key auth story for the managed-agents API",
+      ),
+    ).toBeUndefined();
+    // But a bare credential reference with no technical framing still trips
+    expect(
+      classifyPromptSensitivity("my password is in the notes app"),
+    ).toBe("private");
+  });
+
+  it("always flags secret-shaped credential strings regardless of context", () => {
+    // Real credentials must trip even inside code fences or technical framing
+    expect(
+      classifyPromptSensitivity("rotate this token: sk-ant-1234567890abcdefghij"),
+    ).toBe("private");
+    expect(
+      classifyPromptSensitivity(
+        "example in the docs:\n```\nghp_1234567890abcdefghijklmnopqrstuvwxyz12\n```",
+      ),
+    ).toBe("private");
+    expect(
+      classifyPromptSensitivity("AWS key AKIA1234567890ABCDEF for the CI role"),
+    ).toBe("private");
+    expect(
+      classifyPromptSensitivity(
+        "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA...",
+      ),
     ).toBe("private");
   });
 

--- a/tests/sensitivity.test.ts
+++ b/tests/sensitivity.test.ts
@@ -129,6 +129,54 @@ describe("sensitivity helpers", () => {
     ).toBe("private");
   });
 
+  it("flags credential assignments even next to technical nouns (#35 codex review)", () => {
+    // Bare "API key" mentions must trip — "API" is no longer a technical-context word
+    expect(
+      classifyPromptSensitivity("my API key is abc123"),
+    ).toBe("private");
+    expect(
+      classifyPromptSensitivity("API key: xyz"),
+    ).toBe("private");
+    // Value-bearing credential lines must trip even with technical modifiers
+    expect(
+      classifyPromptSensitivity("rotate auth module password: hunter2"),
+    ).toBe("private");
+    expect(
+      classifyPromptSensitivity("auth service bearer token: eyJhbGciOiJIUzI1NiJ9"),
+    ).toBe("private");
+    expect(
+      classifyPromptSensitivity("Authorization: Bearer eyJhbGciOiJIUzI1NiJ9"),
+    ).toBe("private");
+    // Natural-language assignment with filler between keyword and value
+    expect(
+      classifyPromptSensitivity("the API key for prod is sk-1234"),
+    ).toBe("private");
+    // Credential discussion without a value still passes
+    expect(
+      classifyPromptSensitivity("compare bearer token management frameworks"),
+    ).toBeUndefined();
+    expect(
+      classifyPromptSensitivity("password handling module design"),
+    ).toBeUndefined();
+  });
+
+  it("does not false-positive on slug-like sk- identifiers (#35 codex review)", () => {
+    // All-lowercase sk- slugs without known provider prefix must not trip
+    expect(
+      classifyPromptSensitivity("sk-telemetry-auth-pipeline-id"),
+    ).toBeUndefined();
+    expect(
+      classifyPromptSensitivity("slug: sk-user-onboarding-flow-prod"),
+    ).toBeUndefined();
+    // Real provider-prefixed keys still trip
+    expect(
+      classifyPromptSensitivity("sk-ant-api03-1234567890abcdefghij"),
+    ).toBe("private");
+    expect(
+      classifyPromptSensitivity("sk-proj-1234567890abcdefghij"),
+    ).toBe("private");
+  });
+
   it("always flags secret-shaped credential strings regardless of context", () => {
     // Real credentials must trip even inside code fences or technical framing
     expect(

--- a/tests/sensitivity.test.ts
+++ b/tests/sensitivity.test.ts
@@ -215,6 +215,33 @@ describe("sensitivity helpers", () => {
     ).toBe("private");
   });
 
+  it("resists Unicode/whitespace bypasses (#35 codex round 3)", () => {
+    // Tab instead of space between keyword parts
+    expect(
+      classifyPromptSensitivity("api\tkey: abc123"),
+    ).toBe("private");
+    // Non-breaking space (NBSP, U+00A0)
+    expect(
+      classifyPromptSensitivity("api\u00A0key: abc123"),
+    ).toBe("private");
+    // Zero-width space (U+200B) inside the keyword
+    expect(
+      classifyPromptSensitivity("api\u200Bkey: abc123"),
+    ).toBe("private");
+    // Zero-width space inside a known provider-prefix secret
+    expect(
+      classifyPromptSensitivity("sk-\u200Bproj-1234567890abcdefghij"),
+    ).toBe("private");
+    // Cyrillic 'а' homoglyph replacing Latin 'a' in password
+    expect(
+      classifyPromptSensitivity("p\u0430ssword: hunter2"),
+    ).toBe("private");
+    // Fullwidth ASCII should NFKC-fold to plain ASCII
+    expect(
+      classifyPromptSensitivity("ＡＰＩ key: abc123"),
+    ).toBe("private");
+  });
+
   it("rejects descriptive prose as credential assignment (#35 codex round 2)", () => {
     // Finding 3: value indicator followed by a plain English word must not trip
     expect(


### PR DESCRIPTION
## Summary

Fixes a false-positive in `classifyPromptSensitivity` that flagged any task mentioning technical auth vocabulary (e.g. "API key rotation", "bearer token management") as `private`, blocking legitimate research and code work from `claude`/`codex` runtimes.

Real trigger: a research spike about the Anthropic Managed Agents platform containing the bullet `Auth model (API key? OAuth? scopes?)` was escalated to `client-confidential` and rejected at dispatch.

## Approach — three-tier pattern split

1. **`ALWAYS_PRIVATE_PATTERNS`** — unambiguous private-data vocabulary (`medical`, `salary`, `passport`, `diary`, `personal notes`). Any match is always private. These words don't appear in legitimate technical discussion.

2. **`TECHNICAL_PRIVATE_PATTERNS`** (new) — credential-adjacent vocabulary (`password`, `api key`, `bearer token`, `private key`). Matched per-line and suppressed when the line contains a technical modifier (same mechanism already used for `CONTEXT_SENSITIVE_PATTERNS`).

3. **`SECRET_SHAPED_PATTERNS`** (new) — real credential-shaped strings (`sk-…`, `ghp_…`, `gho_…`, `github_pat_…`, `AKIA…`, `xox[baprs]-…`, PEM private key headers). Scanned against the **raw** prompt before code-block stripping — a key pasted into a fenced block is still a key.

## Net effect

- `"api key rotation system"` → `undefined` ✅ (was `private`)
- `"Auth model (API key? OAuth? scopes?)"` → `undefined` ✅ (was `private`)
- `"compare bearer token management frameworks"` → `undefined` ✅ (was `private`)
- `"my password is in the notes app"` → still `private` ✅ (negative anchor)
- `"rotate this token: sk-ant-1234567890abcdefghij"` → `private` ✅ (stronger — now caught even in code fences)
- `"example:\n\`\`\`\nghp_1234567890abcdefghijklmnopqrstuvwxyz12\n\`\`\`"` → `private` ✅ (stronger)

## Test plan

- [x] Removed wrong-behavior lock-in (`"api key rotation system" → private`)
- [x] Added positive tests for technical framings that must not trip
- [x] Added negative anchor (`"my password is in the notes app"`) that must still trip
- [x] Added secret-shaped pattern coverage (sk-, ghp_, AKIA, PEM)
- [x] All 242 tests pass (net +2)
- [x] Deployed to huginmunin Pi, service restarted, health check green
- [x] Re-submitted the blocked research spike — now dispatches at `internal` as expected

## Follow-up

There's still no owner-override escape hatch in `buildSensitivityAssessment` — declared sensitivity can only *raise* the effective level, never lower it. Worth a separate issue for the medium-term fix (owner attestation to override detection when the human knows better than the classifier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)