### PR TITLE
feat: owner-override escape hatch for declared sensitivity (#36)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,58 @@
 # Hugin — Status
 
-**Last session:** 2026-04-09 (Cleanup batch + #33 session-id rotation)
-**Branch:** main
+**Last session:** 2026-04-10 (PR #35 merged, PR #37 owner-override opened)
+**Branch:** feat/owner-override (PR #37 open against main)
+
+## Completed This Session (2026-04-10)
+
+### PR #35 — sensitivity classifier robustness (MERGED, `f98278d`)
+Three rounds of codex adversarial review. Each round's findings fixed or formally deferred:
+- **Round 1 fix (`e5ebcdd`):** Credential assignment detection with `hasCredentialAssignment()` helper, 60-char window, placeholder rejection, `-ed` form additions to `TECHNICAL_CONTEXT`.
+- **Round 2 fix (`f57d01b`):** `matchAll` scan across multiple credential keywords per line, newline normalization, `isSecretShapedValue()` entropy fallback, `CREDENTIAL_PLACEHOLDER_ASSIGNMENT` guard in per-line loop.
+- **Round 3 narrow fix (`38c1005`):** `normalizeForClassification()` — NFKC + zero-width/bidi stripping + Cyrillic/Greek homoglyph map + whitespace collapse. Defeats tab/NBSP/ZWSP/fullwidth/Cyrillic-`а` bypasses.
+- **Round 3 Findings 1 & 3 deferred to #36** — alphabetic-only secret detection and RFC-example JWT false positives are in fundamental tension that regex cannot resolve. Owner-override is the architectural fix.
+
+### PR #37 — owner-override escape hatch (OPEN)
+Closes #36. Two commits on `feat/owner-override`:
+- **`67997c3` feat:** `detectPromptSensitivity()` returning `{ sensitivity, hardPrivate }`. Only `SECRET_SHAPED_PATTERNS` is hard. `buildSensitivityAssessment` gains `allowOwnerOverride` + `hardPrivate` inputs; when set, `effective` clamps DOWN to `declared` unless hard. `mismatch` still fires on detector disagreement even when override is honored (audit trail). Pipeline compiler + dispatch threaded through. `assessTaskSecurity` warns on every applied override.
+- **`0b307e8` security:** `HUGIN_OWNER_SUBMITTERS` default narrowed — `hugin` and `ratatoskr` removed. Only human-driven clients (claude-code/desktop/web/mobile, Codex*) trusted to declare sensitivity by default. Agent principals must be explicitly added via env var if they need override access.
+
+### Security model (documented in PR body)
+- This is a policy knob, not a tamper-proof gate. Check is string match on self-reported `Submitted by` front-matter.
+- Protects against: accidental misclassification, out-of-allowlist submitters, secret-shaped strings (hardPrivate), agent self-escalation (via default exclusion).
+- Does NOT protect against: prompt-injected Claude Code holding the Bearer token, compromised tools with `MUNIN_API_KEY`. In those cases the attacker had Munin write access and could `memory_read` private data directly — the override doesn't meaningfully expand blast radius.
+- Future hardening (not in #37): bind owner identity to Munin OAuth principal, out-of-band consent, rate limiting, dedicated audit log.
+
+### Tests
+- 259/259 passing (248 before #37 + 11 new in `tests/sensitivity.test.ts`)
+- New coverage: detectPromptSensitivity hard/soft split, override happy path, hard-private block, missing-declared guard, detector<=declared, legacy behavior, real-world #36 case (research prompt with auth vocabulary), counter-case (real `sk-ant-…` still blocked)
+
+## Active PRs
+- **#37 feat/owner-override** — open, ready to merge. No CI gates configured. Self-review on the diff is the last step before merging + deploying.
+
+## Pending Follow-ups
+- **Merge #37** after review on GitHub.
+- **Deploy to Pi** after merge. Restart will invalidate any active MCP sessions (known issue).
+- **Resubmit `tasks/20260409-133844-managed-agents-fit`** with `**Sensitivity:** internal` front-matter once the override is live. The existing failed entry stays as history — no cleanup needed.
+- **Monitor override usage** — every applied override emits `[sensitivity] owner override` warning. If no overrides fire in a week, the detector is precise enough. If many fire, mine them for classifier tuning targets.
+
+## Plan Status
+- **Phase 1: Dependency-aware task joins** — done and live-validated.
+- **Phase 2: Pipeline compiler and decomposition** — done and live-validated.
+- **Phase 3: Structured results and pipeline operations** — done and live-validated.
+- **Phase 4: Human gates for side effects** — done and live-validated.
+- **Critical pre-Phase-5 security hardening** — done and live-validated.
+- **Phase 5: Sensitivity classification** — done and corpus-evaluated (19/19). Hardening in flight via #35 (merged) + #37 (open).
+- **Phase 6: Router (`Runtime: auto`)** — **DONE.** Fully live-evaluated. All 7/7 eval scenarios pass. Safety gate: zero sensitivity violations.
+- **Phase 7: Methodology templates** — not started.
+- **Bet 1 status** — closed.
+- **Bet 2 status** — **CLOSED. All 7/7 eval tasks pass.** Safety gate confirmed. Root cause of Pi parse failures was orphan dispatcher processes (fixed).
+
+---
+
+## Previous Sessions (kept for history)
+
+### 2026-04-09 (afternoon, Cleanup batch + #33 session-id rotation)
 
 ## Plan Status
 - **Phase 1: Dependency-aware task joins** — done and live-validated.

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,7 @@ import {
   classifyContextSensitivity,
   classifyPromptSensitivity,
   compareSensitivity,
+  detectPromptSensitivity,
   getDispatcherRuntimeMaxSensitivity,
   parseSensitivity,
   sensitivitySchema,
@@ -105,6 +106,18 @@ const config = {
   workspace: process.env.HUGIN_WORKSPACE || "/home/magnus/workspace",
   maxOutputChars: parseInt(process.env.HUGIN_MAX_OUTPUT_CHARS || "50000"),
   allowedSubmitters: (process.env.HUGIN_ALLOWED_SUBMITTERS || "Codex,Codex-desktop,ratatoskr,Codex-web,Codex-mobile,claude-code,claude-desktop,claude-web,claude-mobile,hugin")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean),
+  // Submitters allowed to override a detector-raised sensitivity with an
+  // explicit `declared` value on the task front-matter. Defaults to the same
+  // list as `allowedSubmitters` since Hugin today is single-user; narrow
+  // this once family/agent principals can submit tasks.
+  ownerSubmitters: (
+    process.env.HUGIN_OWNER_SUBMITTERS ??
+    process.env.HUGIN_ALLOWED_SUBMITTERS ??
+    "Codex,Codex-desktop,ratatoskr,Codex-web,Codex-mobile,claude-code,claude-desktop,claude-web,claude-mobile,hugin"
+  )
     .split(",")
     .map((s) => s.trim())
     .filter(Boolean),
@@ -453,18 +466,25 @@ function getTaskArtifactClassification(
   return sensitivity ? sensitivityToMuninClassification(sensitivity) : undefined;
 }
 
+function isOwnerSubmitter(submittedBy: string | undefined): boolean {
+  if (!submittedBy) return false;
+  return config.ownerSubmitters.includes(submittedBy);
+}
+
 function getTaskSensitivityAssessment(task: TaskConfig): SensitivityAssessment {
   const declared = task.declaredSensitivity;
   const baseline = task.pipeline?.sensitivity || "internal";
   const contextSensitivity = classifyContextSensitivity(task.context, task.workingDir);
-  const promptSensitivity = classifyPromptSensitivity(task.prompt);
+  const promptDetection = detectPromptSensitivity(task.prompt);
   const refsSensitivity = task.contextResolution?.maxSensitivity;
   return buildSensitivityAssessment({
     declared,
     baseline,
     context: contextSensitivity,
-    prompt: promptSensitivity,
+    prompt: promptDetection.sensitivity,
     refs: refsSensitivity,
+    hardPrivate: promptDetection.hardPrivate,
+    allowOwnerOverride: isOwnerSubmitter(task.submittedBy),
   });
 }
 
@@ -485,6 +505,15 @@ async function assessTaskSecurity(task: TaskConfig): Promise<SensitivityAssessme
   const assessment = getTaskSensitivityAssessment(task);
   task.effectiveSensitivity = assessment.effective;
   task.sensitivityAssessment = assessment;
+
+  if (assessment.override?.applied) {
+    // Owner override is visible in logs so we can mine false positives and
+    // tune the classifier. Never silent.
+    console.warn(
+      `[sensitivity] owner override: submitter="${task.submittedBy}" declared=${assessment.declared} detector=${assessment.override.detectorMax} -> effective=${assessment.effective} reasons=[${assessment.reasons.join(", ")}]`,
+    );
+  }
+
   return assessment;
 }
 
@@ -2472,6 +2501,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         entry,
         queueDepth,
         await probeAllHosts(),
+        { allowOwnerOverride: isOwnerSubmitter(submittedBy) },
       );
       stopLeaseRenewal();
       stopCancellationWatch();

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,13 +110,19 @@ const config = {
     .map((s) => s.trim())
     .filter(Boolean),
   // Submitters allowed to override a detector-raised sensitivity with an
-  // explicit `declared` value on the task front-matter. Defaults to the same
-  // list as `allowedSubmitters` since Hugin today is single-user; narrow
-  // this once family/agent principals can submit tasks.
+  // explicit `declared` value on the task front-matter. Narrower than
+  // `allowedSubmitters` on purpose: agent principals (hugin, ratatoskr) are
+  // excluded so that a prompt-injected or misbehaving agent cannot self-
+  // escalate its own classifier by submitting a task with `Sensitivity:
+  // internal`. Only human-driven clients — Claude Code/Desktop/Web/Mobile
+  // and the various Codex CLIs — are trusted to set declared sensitivity,
+  // on the assumption that the owner is operating them directly.
+  //
+  // If ratatoskr or hugin start failing often enough that auto-override is
+  // worth the risk, add them to HUGIN_OWNER_SUBMITTERS explicitly.
   ownerSubmitters: (
     process.env.HUGIN_OWNER_SUBMITTERS ??
-    process.env.HUGIN_ALLOWED_SUBMITTERS ??
-    "Codex,Codex-desktop,ratatoskr,Codex-web,Codex-mobile,claude-code,claude-desktop,claude-web,claude-mobile,hugin"
+    "Codex,Codex-desktop,Codex-web,Codex-mobile,claude-code,claude-desktop,claude-web,claude-mobile"
   )
     .split(",")
     .map((s) => s.trim())

--- a/src/pipeline-compiler.ts
+++ b/src/pipeline-compiler.ts
@@ -23,6 +23,7 @@ import {
   buildSensitivityPolicyError,
   classifyContextSensitivity,
   classifyPromptSensitivity,
+  detectPromptSensitivity,
   getPipelineRuntimeMaxSensitivity,
   maxSensitivity,
   parseSensitivity,
@@ -370,6 +371,7 @@ function validateAuthority(
 function computePhaseEffectiveSensitivities(
   phases: ParsedPipelinePhase[],
   pipelineSensitivity: PipelineSensitivity,
+  options?: { allowOwnerOverride?: boolean },
 ): Map<string, PipelineSensitivity> {
   const byName = new Map(phases.map((phase) => [phase.name, phase]));
   const computed = new Map<string, PipelineSensitivity>();
@@ -385,7 +387,7 @@ function computePhaseEffectiveSensitivities(
 
     const declared = parseSensitivity(phase.sensitivity);
     const contextSensitivity = classifyContextSensitivity(phase.context, undefined);
-    const promptSensitivity = classifyPromptSensitivity(phase.prompt);
+    const promptDetection = detectPromptSensitivity(phase.prompt);
     const inheritedSensitivity = phase.dependsOn.reduce<PipelineSensitivity | undefined>(
       (current, dependencyName) =>
         maxSensitivity(current, visit(dependencyName)),
@@ -396,9 +398,17 @@ function computePhaseEffectiveSensitivities(
       declared,
       baseline: pipelineSensitivity,
       context: contextSensitivity,
-      prompt: promptSensitivity,
+      prompt: promptDetection.sensitivity,
       inherited: inheritedSensitivity,
+      hardPrivate: promptDetection.hardPrivate,
+      allowOwnerOverride: options?.allowOwnerOverride,
     });
+
+    if (assessment.override?.applied) {
+      console.warn(
+        `[sensitivity] owner override on phase "${phase.name}": declared=${assessment.declared} detector=${assessment.override.detectorMax} -> effective=${assessment.effective}`,
+      );
+    }
 
     computed.set(phaseName, assessment.effective);
     return assessment.effective;
@@ -411,11 +421,22 @@ function computePhaseEffectiveSensitivities(
   return computed;
 }
 
+export interface CompilePipelineOptions {
+  /**
+   * When true, the phase sensitivity assessor honors owner-override — a
+   * phase's `declared` sensitivity can cap the detector's soft signals.
+   * Hard-private (secret-shaped) matches are still unoverridable. Caller
+   * must gate this on the submitter principal.
+   */
+  allowOwnerOverride?: boolean;
+}
+
 export function compilePipelineTask(
   pipelineId: string,
   sourceTaskNamespace: string,
   content: string,
   ollamaHosts?: OllamaHost[],
+  options?: CompilePipelineOptions,
 ): PipelineIR {
   const parsed = parsePipelineDocument(content);
   if (parsed.phases.length === 0) {
@@ -433,6 +454,7 @@ export function compilePipelineTask(
   const phaseSensitivities = computePhaseEffectiveSensitivities(
     parsed.phases,
     parsed.sensitivity,
+    { allowOwnerOverride: options?.allowOwnerOverride },
   );
 
   const phases: PipelinePhaseIR[] = parsed.phases.map((phase) => {

--- a/src/pipeline-dispatch.ts
+++ b/src/pipeline-dispatch.ts
@@ -82,12 +82,15 @@ export async function handlePipelineTask(
   entry: MuninEntry & { found: true },
   queueDepth: number,
   ollamaHosts?: OllamaHost[],
+  options?: { allowOwnerOverride?: boolean },
 ): Promise<{ hadTask: boolean; queueDepth: number }> {
   const pipelineId = extractTaskId(taskNs);
   let pipeline: PipelineIR;
 
   try {
-    pipeline = compilePipelineTask(pipelineId, taskNs, entry.content, ollamaHosts);
+    pipeline = compilePipelineTask(pipelineId, taskNs, entry.content, ollamaHosts, {
+      allowOwnerOverride: options?.allowOwnerOverride,
+    });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     await hooks.failTaskWithMessage(

--- a/src/sensitivity.ts
+++ b/src/sensitivity.ts
@@ -177,8 +177,26 @@ const INTERNAL_PATH_PREFIXES = [
 export interface SensitivityAssessment {
   declared?: Sensitivity;
   effective: Sensitivity;
+  /**
+   * True when the detector signals were strictly higher than the declared
+   * sensitivity. This is audit-facing: owner overrides still set `mismatch`
+   * so that false-positives can be mined and the classifier tuned. See
+   * {@link override} to check whether the effective value was actually
+   * lowered by an owner override.
+   */
   mismatch: boolean;
   reasons: string[];
+  /**
+   * Present only when an owner override was applied — the effective value
+   * was clamped DOWN to `declared` because the detector's signals were
+   * soft-private and the caller opted in via `allowOwnerOverride`. The
+   * `detectorMax` field records what the detector would have returned
+   * without the override, so audit logs can surface the false positive.
+   */
+  override?: {
+    applied: true;
+    detectorMax: Sensitivity;
+  };
 }
 
 export function compareSensitivity(a: Sensitivity, b: Sensitivity): number {
@@ -281,10 +299,23 @@ function normalizeForClassification(text: string): string {
     .replace(/[^\S\n]+/g, " ");
 }
 
-export function classifyPromptSensitivity(
+/**
+ * Detection result for a prompt. `hardPrivate` is true only when a
+ * high-confidence secret-shape pattern matched (real-looking API keys,
+ * PEM headers, etc). Those matches are NEVER overridable by an owner,
+ * even with `allowOwnerOverride`. Everything else — keyword matches,
+ * credential-assignment heuristics, always-private vocabulary — is
+ * soft-private and can be lowered by an explicit owner declaration.
+ */
+export interface PromptSensitivityDetection {
+  sensitivity: Sensitivity | undefined;
+  hardPrivate: boolean;
+}
+
+export function detectPromptSensitivity(
   prompt: string | undefined,
-): Sensitivity | undefined {
-  if (!prompt) return undefined;
+): PromptSensitivityDetection {
+  if (!prompt) return { sensitivity: undefined, hardPrivate: false };
 
   // Normalize Unicode, strip zero-width characters, and collapse non-newline
   // whitespace so homoglyph/ZWSP/NBSP/tab-based bypasses can't evade the
@@ -295,25 +326,27 @@ export function classifyPromptSensitivity(
 
   // Secret-shaped strings are scanned against the normalized text before
   // stripping code blocks — a real key pasted into a code fence is still a
-  // real key.
+  // real key. These are hard-private: not overridable.
   if (SECRET_SHAPED_PATTERNS.some((p) => p.test(normalized))) {
-    return "private";
+    return { sensitivity: "private", hardPrivate: true };
   }
 
   // Credential assignments (`password: hunter2`, `api key = xyz`,
   // `the API key for prod is sk-...`) are also scanned against the
   // normalized text — a secret assigned inside a code fence is still a
   // secret. They run before technical-context suppression so a line like
-  // `rotate auth module password: hunter2` cannot sneak past.
+  // `rotate auth module password: hunter2` cannot sneak past. Soft-private:
+  // a shape-based heuristic, so the owner can override (e.g. an RFC example
+  // or a task that legitimately documents credential handling).
   if (hasCredentialAssignment(normalized)) {
-    return "private";
+    return { sensitivity: "private", hardPrivate: false };
   }
 
   const stripped = stripCodeAndPaths(normalized);
 
   // Unambiguous vocabulary — any match across the full text is private
   if (ALWAYS_PRIVATE_PATTERNS.some((p) => p.test(stripped))) {
-    return "private";
+    return { sensitivity: "private", hardPrivate: false };
   }
 
   // Credential-adjacent and context-sensitive keywords — check per line,
@@ -329,14 +362,24 @@ export function classifyPromptSensitivity(
     if (CREDENTIAL_PLACEHOLDER_ASSIGNMENT.test(line)) continue;
 
     if (TECHNICAL_PRIVATE_PATTERNS.some((p) => p.test(line))) {
-      return "private";
+      return { sensitivity: "private", hardPrivate: false };
     }
     if (CONTEXT_SENSITIVE_PATTERNS.some((p) => p.test(line))) {
-      return "private";
+      return { sensitivity: "private", hardPrivate: false };
     }
   }
 
-  return undefined;
+  return { sensitivity: undefined, hardPrivate: false };
+}
+
+/**
+ * Backwards-compatible wrapper around {@link detectPromptSensitivity}
+ * for callers that only need the sensitivity level.
+ */
+export function classifyPromptSensitivity(
+  prompt: string | undefined,
+): Sensitivity | undefined {
+  return detectPromptSensitivity(prompt).sensitivity;
 }
 
 export function classifyContextSensitivity(
@@ -435,11 +478,24 @@ export function buildSensitivityAssessment(input: {
   prompt?: Sensitivity;
   refs?: Sensitivity;
   inherited?: Sensitivity;
+  /**
+   * True when the `prompt` signal came from a high-confidence secret-shape
+   * pattern (real-looking API keys, PEM headers, etc). Hard-private signals
+   * cannot be overridden by the owner even when `allowOwnerOverride` is set.
+   */
+  hardPrivate?: boolean;
+  /**
+   * Allow the owner to cap the effective sensitivity at `declared` when the
+   * detector's soft signals would otherwise raise it higher. Requires an
+   * explicit `declared` value and is ignored when `hardPrivate` is true.
+   * Callers must gate this on principal identity — only the owner (or an
+   * allowlisted equivalent) should pass `true`.
+   */
+  allowOwnerOverride?: boolean;
 }): SensitivityAssessment {
   const baseline = input.baseline || "internal";
-  const effective = maxSensitivity(
+  const detectorMax = maxSensitivity(
     baseline,
-    input.declared,
     input.context,
     input.prompt,
     input.refs,
@@ -454,13 +510,43 @@ export function buildSensitivityAssessment(input: {
     input.inherited ? `inherited:${input.inherited}` : undefined,
   ].filter((value): value is string => Boolean(value));
 
-  return {
+  const detectorExceedsDeclared =
+    Boolean(input.declared) && compareSensitivity(detectorMax, input.declared!) > 0;
+
+  // Owner override: cap the effective level at `declared` when the
+  // detector would have raised it, but ONLY if the signal is soft.
+  // Hard-private (secret-shaped) matches are never overridable.
+  const overrideApplied =
+    Boolean(input.allowOwnerOverride) &&
+    Boolean(input.declared) &&
+    !input.hardPrivate &&
+    detectorExceedsDeclared;
+
+  const effective: Sensitivity = overrideApplied
+    ? input.declared!
+    : maxSensitivity(detectorMax, input.declared);
+
+  if (overrideApplied) {
+    reasons.push(`owner-override:${input.declared}<${detectorMax}`);
+  } else if (input.allowOwnerOverride && input.hardPrivate && detectorExceedsDeclared) {
+    reasons.push(`owner-override-blocked:hard-private`);
+  }
+
+  const assessment: SensitivityAssessment = {
     declared: input.declared,
     effective,
-    mismatch:
-      Boolean(input.declared) && compareSensitivity(effective, input.declared!) > 0,
+    // Mismatch reflects the *detector's* disagreement with `declared`,
+    // regardless of whether the override was honored. This keeps the
+    // audit trail surfacing every false-positive we tune against.
+    mismatch: detectorExceedsDeclared,
     reasons,
   };
+
+  if (overrideApplied) {
+    assessment.override = { applied: true, detectorMax };
+  }
+
+  return assessment;
 }
 
 export function buildSensitivityPolicyError(input: {

--- a/tests/sensitivity.test.ts
+++ b/tests/sensitivity.test.ts
@@ -3,6 +3,7 @@ import {
   buildSensitivityAssessment,
   classifyContextSensitivity,
   classifyPromptSensitivity,
+  detectPromptSensitivity,
   getDispatcherRuntimeMaxSensitivity,
   muninClassificationToSensitivity,
   sensitivityToMuninClassification,
@@ -317,5 +318,147 @@ describe("sensitivity helpers", () => {
     expect(getDispatcherRuntimeMaxSensitivity("claude")).toBe("internal");
     expect(getDispatcherRuntimeMaxSensitivity("codex")).toBe("internal");
     expect(getDispatcherRuntimeMaxSensitivity("ollama")).toBe("private");
+  });
+
+  describe("detectPromptSensitivity (#36)", () => {
+    it("flags secret-shaped matches as hardPrivate", () => {
+      expect(
+        detectPromptSensitivity("sk-ant-api03-1234567890abcdefghij"),
+      ).toEqual({ sensitivity: "private", hardPrivate: true });
+      expect(
+        detectPromptSensitivity("AWS key AKIA1234567890ABCDEF"),
+      ).toEqual({ sensitivity: "private", hardPrivate: true });
+      expect(
+        detectPromptSensitivity(
+          "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA...",
+        ),
+      ).toEqual({ sensitivity: "private", hardPrivate: true });
+    });
+
+    it("flags credential assignments as soft private (overridable)", () => {
+      // Shape-based heuristic, not entropy — the owner should be able to
+      // override these (e.g. RFC examples, documentation).
+      const r = detectPromptSensitivity("API key: abc123");
+      expect(r.sensitivity).toBe("private");
+      expect(r.hardPrivate).toBe(false);
+    });
+
+    it("flags always-private vocabulary as soft private", () => {
+      const r = detectPromptSensitivity("summarize my medical history");
+      expect(r.sensitivity).toBe("private");
+      expect(r.hardPrivate).toBe(false);
+    });
+
+    it("returns hardPrivate=false when nothing matches", () => {
+      expect(detectPromptSensitivity("build a weather dashboard")).toEqual({
+        sensitivity: undefined,
+        hardPrivate: false,
+      });
+    });
+  });
+
+  describe("owner override (#36)", () => {
+    it("caps effective at declared when override allowed and detector is soft", () => {
+      const a = buildSensitivityAssessment({
+        declared: "internal",
+        baseline: "internal",
+        prompt: "private",
+        allowOwnerOverride: true,
+      });
+      expect(a.effective).toBe("internal");
+      expect(a.mismatch).toBe(true);
+      expect(a.override?.applied).toBe(true);
+      expect(a.override?.detectorMax).toBe("private");
+      expect(a.reasons.some((r) => r.startsWith("owner-override:"))).toBe(
+        true,
+      );
+    });
+
+    it("refuses to override hard-private (secret-shaped) matches", () => {
+      const a = buildSensitivityAssessment({
+        declared: "internal",
+        baseline: "internal",
+        prompt: "private",
+        hardPrivate: true,
+        allowOwnerOverride: true,
+      });
+      expect(a.effective).toBe("private");
+      expect(a.mismatch).toBe(true);
+      expect(a.override).toBeUndefined();
+      expect(a.reasons).toContain("owner-override-blocked:hard-private");
+    });
+
+    it("ignores allowOwnerOverride without a declared value", () => {
+      const a = buildSensitivityAssessment({
+        baseline: "internal",
+        prompt: "private",
+        allowOwnerOverride: true,
+      });
+      expect(a.effective).toBe("private");
+      expect(a.override).toBeUndefined();
+    });
+
+    it("does not apply override when detector <= declared", () => {
+      const a = buildSensitivityAssessment({
+        declared: "private",
+        baseline: "internal",
+        prompt: "internal",
+        allowOwnerOverride: true,
+      });
+      expect(a.effective).toBe("private");
+      expect(a.mismatch).toBe(false);
+      expect(a.override).toBeUndefined();
+    });
+
+    it("preserves legacy monotonic behavior when override not requested", () => {
+      const a = buildSensitivityAssessment({
+        declared: "internal",
+        baseline: "internal",
+        prompt: "private",
+      });
+      expect(a.effective).toBe("private");
+      expect(a.mismatch).toBe(true);
+      expect(a.override).toBeUndefined();
+    });
+
+    it("allows owner to route a false-positive research task as internal", () => {
+      // Real-world case from #36: a research spike that mentions "API key"
+      // vocabulary gets flagged as private by the classifier. Owner knows
+      // better and declares internal — override should kick in.
+      const detection = detectPromptSensitivity(
+        "Evaluate the OAuth 2.1 and API key story for the managed-agents API. The bearer token value for this example is mF_9.B5f-4.1JqM.",
+      );
+      const a = buildSensitivityAssessment({
+        declared: "internal",
+        baseline: "internal",
+        prompt: detection.sensitivity,
+        hardPrivate: detection.hardPrivate,
+        allowOwnerOverride: true,
+      });
+      // Detector still tripped (credential assignment heuristic), but the
+      // match is soft so owner-override lowers it to internal.
+      expect(detection.sensitivity).toBe("private");
+      expect(detection.hardPrivate).toBe(false);
+      expect(a.effective).toBe("internal");
+      expect(a.override?.applied).toBe(true);
+    });
+
+    it("blocks owner override when a real-looking secret is in the prompt", () => {
+      // Counter-case: the prompt contains an actual-looking API key, so
+      // detection is hard. Owner's declared=internal should be rejected.
+      const detection = detectPromptSensitivity(
+        "rotate this token: sk-ant-api03-1234567890abcdefghij",
+      );
+      expect(detection.hardPrivate).toBe(true);
+      const a = buildSensitivityAssessment({
+        declared: "internal",
+        baseline: "internal",
+        prompt: detection.sensitivity,
+        hardPrivate: detection.hardPrivate,
+        allowOwnerOverride: true,
+      });
+      expect(a.effective).toBe("private");
+      expect(a.override).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Adds an opt-in owner-override to `buildSensitivityAssessment`: when the caller sets `allowOwnerOverride` + an explicit `declared` value, the effective sensitivity is clamped DOWN to `declared` — instead of being raised to the detector's max.
- Only `SECRET_SHAPED_PATTERNS` matches (real-looking API keys, `AKIA…`, PEM headers) are `hardPrivate: true` and stay unoverridable. Everything softer (keyword match, credential-assignment heuristic, `ALWAYS_PRIVATE` vocabulary) is overridable.
- `mismatch` still reflects the detector's disagreement even when the override is honored, so false positives keep landing in the audit trail for later classifier tuning.
- Warning log on every applied override — never silent.
- **Agent principals (`hugin`, `ratatoskr`) are explicitly excluded from the default owner-submitter list** so a prompt-injected or misbehaving agent cannot self-escalate its own classifier. Only human-driven clients (Claude Code/Desktop/Web/Mobile, Codex CLIs) are trusted by default.

## Why

After #35, the classifier is much better but false positives are inevitable in any keyword-based classifier. Today a false positive leaves the owner with no escape hatch: a research spike that mentions "API key" vocabulary gets routed as `client-confidential` with no way to say *"I know what this is, route it as internal."*

This unblocks that case without weakening the detector:
- The detector still fires and logs the mismatch.
- Soft heuristics (shape-based, vocabulary-based) can be overridden.
- Hard-entropy secret shapes cannot — a real-looking `sk-ant-…` is never routable as internal.

## Security model

**This is not a tamper-proof gate** — it is a policy knob expressing "trusted human-driven tools can declare sensitivity." The check is a string match on the self-reported `Submitted by` front-matter field against `HUGIN_OWNER_SUBMITTERS`.

**What it protects against:**
- Accidental misclassification by a trusted submitter (the override is opt-in — soft-private remains the default when no declared value is set).
- Submitters outside the allowlist (legacy monotonic behavior).
- Real secrets (`SECRET_SHAPED_PATTERNS` → `hardPrivate`, never overridable).
- **Agents self-escalating** — `hugin` and `ratatoskr` are excluded from the default list.

**What it does NOT protect against:**
- A prompt-injected Claude Code session on the laptop — that session has the Bearer token and can submit override-enabled tasks by claiming `Submitted by: claude-code`.
- A compromised tool holding `MUNIN_API_KEY`.
- Anyone who obtains the Bearer/OAuth token.

In those cases, the attacker already had Munin write access and could `memory_read` private data directly — the override doesn't meaningfully expand their blast radius. The classifier was never the last line of defense.

**Future hardening (not in this PR):**
- Bind owner identity to the Munin OAuth principal that wrote the entry, not the self-reported front-matter field.
- Out-of-band consent for overrides.
- Rate limiting + alerting on override bursts.
- Dedicated audit log separated from Munin.

## Scope

- `detectPromptSensitivity(prompt)` — new; returns `{ sensitivity, hardPrivate }`. `classifyPromptSensitivity` kept as thin wrapper.
- `buildSensitivityAssessment` — new `allowOwnerOverride` + `hardPrivate` inputs. New `override: { applied, detectorMax }` on `SensitivityAssessment`.
- `src/index.ts` — new `HUGIN_OWNER_SUBMITTERS` config (defaults to human-driven clients only, excluding agent principals). `getTaskSensitivityAssessment` gates the override on `isOwnerSubmitter(task.submittedBy)` and warns on every applied override.
- `src/pipeline-compiler.ts` + `src/pipeline-dispatch.ts` — threads `allowOwnerOverride` through pipeline compilation so phases of owner-submitted pipelines also get the override.

## Design note

The issue's guardrail said: *"Never allows overriding `SECRET_SHAPED_PATTERNS` matches — those are always private."* I honored this literally: only `SECRET_SHAPED_PATTERNS` is `hardPrivate`. Credential-assignment heuristics (`password: hunter2`, `API key: abc123`) are kept soft-private because that's exactly the class of false positive #36 was filed to fix — RFC 7519 / cloud-provider doc examples, auth-documentation tasks, research spikes. If the owner opted into override AND declared `internal`, that's double-explicit consent and they get through.

## Test plan

- [x] `npm test` — 259 tests passing (248 before + 11 new)
- [x] `detectPromptSensitivity` unit tests for hard/soft classification
- [x] `buildSensitivityAssessment` unit tests: happy path, hard-private block, missing declared, detector ≤ declared, legacy (no override) behavior
- [x] Real-world #36 case: research-spike style prompt with auth vocabulary → routed internal when declared
- [x] Counter-case: real-looking `sk-ant-…` → still private even with override

## Closes

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)