### PR TITLE
fix: surface Munin write rejections; clamp task artifacts to namespace floor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,8 @@ import {
   compareSensitivity,
   detectPromptSensitivity,
   getDispatcherRuntimeMaxSensitivity,
+  maxSensitivity,
+  namespaceFallbackSensitivity,
   parseSensitivity,
   sensitivitySchema,
   sensitivityToMuninClassification,
@@ -490,7 +492,14 @@ function getTaskArtifactClassification(
     task?.pipeline?.sensitivity ||
     task?.declaredSensitivity ||
     (content ? getDeclaredSensitivityFromContent(content) : undefined);
-  return sensitivity ? sensitivityToMuninClassification(sensitivity) : undefined;
+  if (!sensitivity) return undefined;
+  // Clamp up to the tasks/* namespace floor. Owner-overridden tasks can
+  // legitimately carry effective sensitivity `public`, but Munin rejects
+  // writes below a namespace's floor — and task artifacts always land in
+  // `tasks/*`, whose floor is `internal`. Without clamping, the write is
+  // rejected and (prior to the write-ok check) silently dropped.
+  const clamped = maxSensitivity(sensitivity, namespaceFallbackSensitivity("tasks/"));
+  return sensitivityToMuninClassification(clamped);
 }
 
 function isOwnerSubmitter(submittedBy: string | undefined): boolean {
@@ -1287,12 +1296,8 @@ function startLeaseRenewal(taskNs: string, entryContent: string, baseTags: strin
     }
     try {
       const renewedTags = buildClaimTags(baseTags, "running");
-      const renewResult = await leaseMunin.write(taskNs, "status", entryContent, renewedTags) as Record<string, unknown>;
-      if (renewResult && !renewResult.ok) {
-        console.error(`Lease renewal write returned error for ${taskNs}:`, JSON.stringify(renewResult));
-      } else {
-        console.log(`Lease renewed for ${taskNs} (expires: ${leaseExpiry()})`);
-      }
+      await leaseMunin.write(taskNs, "status", entryContent, renewedTags);
+      console.log(`Lease renewed for ${taskNs} (expires: ${leaseExpiry()})`);
     } catch (err) {
       console.error(`Lease renewal failed for ${taskNs}:`, err);
     }
@@ -2488,13 +2493,9 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
       entry.content,
       claimTags,
       entry.updated_at
-    ) as Record<string, unknown>;
-    if (claimResult && !claimResult.ok) {
-      console.error(`Claim write returned error for ${taskNs}:`, JSON.stringify(claimResult));
-      return { hadTask: false, queueDepth };
-    }
+    );
     // Update entry.updated_at so subsequent CAS writes (failTaskWithMessage, etc.) use the fresh timestamp
-    if (claimResult && typeof claimResult.updated_at === "string") {
+    if (typeof claimResult.updated_at === "string") {
       entry.updated_at = claimResult.updated_at;
     }
   } catch (err) {

--- a/src/munin-client.ts
+++ b/src/munin-client.ts
@@ -256,12 +256,24 @@ export class MuninClient {
     tags?: string[],
     expectedUpdatedAt?: string,
     classification?: string,
-  ): Promise<unknown> {
+  ): Promise<Record<string, unknown>> {
     const args: Record<string, unknown> = { namespace, key, content };
     if (tags) args.tags = tags;
     if (expectedUpdatedAt) args.expected_updated_at = expectedUpdatedAt;
     if (classification) args.classification = classification;
-    return this.callTool("memory_write", args);
+    const result = (await this.callTool("memory_write", args)) as
+      | Record<string, unknown>
+      | undefined
+      | null;
+    if (result && result.ok === false) {
+      const error = typeof result.error === "string" ? result.error : "unknown";
+      const message =
+        typeof result.message === "string" ? result.message : JSON.stringify(result);
+      throw new Error(
+        `Munin write rejected for ${namespace}/${key}: ${error} — ${message}`,
+      );
+    }
+    return (result ?? {}) as Record<string, unknown>;
   }
 
   async readBatch(reads: MuninReadRequest[]): Promise<MuninReadResult[]> {

--- a/tests/munin-client.test.ts
+++ b/tests/munin-client.test.ts
@@ -147,6 +147,27 @@ describe("MuninClient", () => {
     expect(body.params.arguments.classification).toBe("private");
   });
 
+  it("throws when memory_write responds with ok:false", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      rpcResponse({
+        ok: false,
+        error: "validation_error",
+        message:
+          'Classification "public" is below namespace floor "internal" for "tasks/demo".',
+      }),
+    );
+
+    const client = new MuninClient({
+      baseUrl: "http://munin.test",
+      apiKey: "test-key",
+      minRequestSpacingMs: 0,
+    });
+
+    await expect(
+      client.write("tasks/demo", "result", "hello", undefined, undefined, "public"),
+    ).rejects.toThrow(/validation_error.*namespace floor/);
+  });
+
   it("supports bare-array batch-read responses", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       rpcResponseNoSpace([

--- a/tests/sensitivity.test.ts
+++ b/tests/sensitivity.test.ts
@@ -5,7 +5,9 @@ import {
   classifyPromptSensitivity,
   detectPromptSensitivity,
   getDispatcherRuntimeMaxSensitivity,
+  maxSensitivity,
   muninClassificationToSensitivity,
+  namespaceFallbackSensitivity,
   sensitivityToMuninClassification,
 } from "../src/sensitivity.js";
 
@@ -459,6 +461,30 @@ describe("sensitivity helpers", () => {
       });
       expect(a.effective).toBe("private");
       expect(a.override).toBeUndefined();
+    });
+  });
+
+  describe("tasks/* namespace floor clamping", () => {
+    // Regression: an owner-override task with effective sensitivity "public"
+    // used to produce a Munin write at classification "public", which Munin
+    // rejects below the `tasks/*` floor of `internal`. Hugin silently
+    // swallowed the rejection, leaving the task stuck as `running` forever.
+    // The fix clamps artifact classification up to the namespace floor.
+    it("clamps public effective sensitivity up to the tasks/* floor", () => {
+      const floor = namespaceFallbackSensitivity("tasks/");
+      expect(floor).toBe("internal");
+      expect(maxSensitivity("public", floor)).toBe("internal");
+      expect(sensitivityToMuninClassification(maxSensitivity("public", floor))).toBe(
+        "internal",
+      );
+    });
+
+    it("preserves private effective sensitivity through the clamp", () => {
+      const floor = namespaceFallbackSensitivity("tasks/");
+      expect(maxSensitivity("private", floor)).toBe("private");
+      expect(sensitivityToMuninClassification(maxSensitivity("private", floor))).toBe(
+        "client-confidential",
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary

- `munin.write()` now throws on `{ok: false}` responses, surfacing server-side rejections to `pollLoop`'s existing `catch (err) { console.error(\"Poll error:\", err) }`. Previously, every post-task write site in `src/index.ts` ignored the response envelope, silently swallowing validation errors.
- `getTaskArtifactClassification()` clamps artifact classification up to the `tasks/*` namespace floor (`internal`) so owner-override tasks don't attempt `classification: public` writes that Munin rejects below floor. Runtime trust (effective sensitivity) is unchanged; only artifact storage classification is clamped.

## Background

A research-spike task (`tasks/20260410-181800-locomo-baseline`) was submitted with `Sensitivity: public`. The detector inferred `internal` from the prompt and the owner-override escape hatch from #36 lowered effective sensitivity back to `public`. At completion, every post-task write hit Munin with `classification: public` against `tasks/*` (floor `internal`) and was rejected with `{ok: false, error: \"validation_error\", message: \"Classification \\\"public\\\" is below namespace floor \\\"internal\\\"...\"}`. Hugin ignored each rejection, the terminal `munin.log(\"Task completed in 404s\")` call (no classification) still landed, and the task sat as `running` for 18+ hours while systemd journal and Munin's log stream both claimed success.

Fixes #39 (silent-swallow bug) and #40 (classification-below-floor trigger).

## Changes

- `src/munin-client.ts` — `write()` now throws `Munin write rejected for {ns}/{key}: {error} — {message}` on `{ok: false}`. Return type narrows to `Record<string, unknown>`.
- `src/index.ts` — `getTaskArtifactClassification()` clamps up to `namespaceFallbackSensitivity(\"tasks/\")`. Claim site and lease-renewal site simplified (the manual `!ok` checks are now redundant — the thrown error goes to their existing try/catches).
- `tests/munin-client.test.ts` — asserts `write()` rejects with a classification-floor error on `{ok: false}` responses.
- `tests/sensitivity.test.ts` — two regression tests for the clamp invariant (`public → internal`, `private → private`) on the `tasks/*` floor.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 22 files, 265 tests pass (includes 1 new munin-client test, 2 new sensitivity tests)
- [ ] Deploy to huginmunin.local and verify a follow-up owner-override task completes with `result` + `result-structured` written and status flipped to `completed`
- [ ] Confirm previously stuck `tasks/20260410-181800-locomo-baseline` can be manually recovered (separate operation)

## Blast radius

Turning silent failures loud means any Munin write rejection now propagates. Existing call sites that should tolerate CAS conflicts (claim, lease renewal, stale task recovery, heartbeat) are already inside try/catches, so their behavior is unchanged. Write sites that are inside `pollOnce` but lacking their own catch will now route errors to `pollLoop`'s top-level catch — which is the desired loud-failure path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)