### PR TITLE
fix: auto-stash dirty worktree before pre-task git pull

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,9 +1,29 @@
 # Hugin — Status
 
-**Last session:** 2026-04-12 (evening — git-fetch retry/bypass, CI pipeline, branch protection)
-**Branch:** main
+**Last session:** 2026-04-13 (night — dirty-worktree auto-stash #45, PR #46)
+**Branch:** `fix/dirty-worktree-autostash` (PR #46 open against main)
 
-## Completed This Session (2026-04-12 — evening)
+## Completed This Session (2026-04-12/13 — night)
+
+### Fix: auto-stash dirty worktree before pre-task git sync (#45, PR #46)
+
+A Heimdall "mobile reading mode" task failed with "18 commits behind origin/main and cannot fast-forward. Manual intervention required." Not the same class as last session's fetch-retry bug (#42) — fetch succeeded, the *ff-only pull* refused because the Pi's heimdall worktree was dirty (732 lines across 8 tracked files + untracked `.claude/`, `.playwright-mcp/`). Likely debris from an earlier task that produced changes but didn't commit/push. Every subsequent task on that repo kept failing the same way until a human SSHed in.
+
+**Root cause:** `syncRepoBeforeTask` (`src/task-helpers.ts`) assumed a clean worktree and had no recovery path when prior task debris was present.
+
+**Fix (two commits on PR #46):**
+1. **Initial patch (`71ea945`):** On ff-pull failure, run `git status --porcelain`; if dirty, `git stash push -u -m "hugin-autosave <ts> task=<id>"` (includes untracked) and retry. If still failing, bail with clear error citing the stash label. Stashes are recoverable, nothing is ever lost.
+2. **Codex review fixes (`f8bd8e9`):**
+   - Switched from `git pull --ff-only` to `git merge --ff-only origin/main`. Pull does an implicit refetch — a post-fetch network/SSH blip could have been misread as "dirty worktree" and incorrectly triggered a stash on a clean repo. Merge uses the already-fetched ref, no network.
+   - Added `stashLabel` to `RepoSyncResult`. On success, dispatcher emits a grep-able per-task log line (`git -C <dir> stash list | grep <label>`) so operators with only Munin/Mímir visibility can find the stash without SSH.
+
+**Tests:** 3 new cases (dirty→retry-ok, dirty→retry-fail, stash-fails) + regression assertion that `git pull` is never spawned. `tests/repo-sync.test.ts` 13/13, full suite 269/269.
+
+**Pi recovery (2026-04-12 23:46 CEST):** heimdall stashed (`hugin-autosave 2026-04-12 before mobile-reading-spike retry`) + fast-forwarded. Two stashes preserved on Pi (the new one + a pre-existing `WIP on main: 6d0e872`). The failed Heimdall task can be re-dispatched once PR #46 merges and deploys.
+
+**Still open:** PR #46 awaiting merge + deploy. Once live, the whole class of "prior-task debris blocks next task" is gone.
+
+## Completed Previous Session (2026-04-12 — evening)
 
 ### Fix: pre-task git fetch retry + bypass system SSH config (#42, PR #43, `a59c8e3`, deployed)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2540,8 +2540,11 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
       throw new Error(`Internal dispatcher error: parsed task missing for ${taskNs}`);
     }
 
-    // Pre-task repo sync (#21): ensure local repo is up-to-date before execution
-    const syncResult = await syncRepoBeforeTask(task.workingDir);
+    // Pre-task repo sync (#21, #45): ensure local repo is up-to-date before execution.
+    // On dirty worktree left by a prior task, auto-stash and retry the fast-forward.
+    const syncResult = await syncRepoBeforeTask(task.workingDir, {
+      taskId: extractTaskId(taskNs),
+    });
     if (syncResult.action === "fetch-failed") {
       console.warn(`Pre-task repo fetch failed for ${taskNs} (non-fatal): ${syncResult.error}`);
     } else if (syncResult.action === "failed") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2547,6 +2547,12 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     });
     if (syncResult.action === "fetch-failed") {
       console.warn(`Pre-task repo fetch failed for ${taskNs} (non-fatal): ${syncResult.error}`);
+    } else if (syncResult.action === "synced" && syncResult.autoStashed) {
+      // Loud, grep-able marker so operators can find the stash via per-task logs
+      // even when they only have Munin/Mímir visibility (no SSH to the Pi).
+      console.warn(
+        `Pre-task repo sync: auto-stashed dirty state for ${taskNs} as "${syncResult.stashLabel}" in ${task.workingDir}. Recover on the Pi with: git -C ${task.workingDir} stash list | grep "${syncResult.stashLabel}"`,
+      );
     } else if (syncResult.action === "failed") {
       console.error(`Pre-task repo sync failed for ${taskNs}: ${syncResult.error}`);
       stopLeaseRenewal();

--- a/src/task-helpers.ts
+++ b/src/task-helpers.ts
@@ -114,6 +114,8 @@ export interface RepoSyncResult {
   error?: string;
   /** Set when dirty worktree state was auto-stashed to unblock the pull (#45). */
   autoStashed?: boolean;
+  /** Label of the auto-stash entry, when one was created. Surfaced so operators can recover. */
+  stashLabel?: string;
 }
 
 export interface SyncRepoOptions {
@@ -245,14 +247,18 @@ export async function syncRepoBeforeTask(
     return { action: "up-to-date", commitsBehind: 0 };
   }
 
-  // Attempt fast-forward pull
-  const firstPull = await runGitPullFfOnly(workingDir);
-  if (firstPull.ok) {
+  // Attempt fast-forward against the already-fetched ref. We use `git merge
+  // --ff-only origin/main` rather than `git pull` so we don't accidentally
+  // trigger another network fetch — that would make the failure signal
+  // ambiguous (network/SSH blip vs. real ff conflict) and could route a
+  // perfectly-clean repo through the auto-stash path unnecessarily.
+  const firstMerge = await runGitMergeFfOnly(workingDir);
+  if (firstMerge.ok) {
     console.log(`Pre-task repo sync: ${workingDir} synced ${commitsBehind} commits from origin`);
     return { action: "synced", commitsBehind };
   }
 
-  // Pull failed. Most common cause on the task dispatcher is a dirty worktree
+  // Merge failed. Most common cause on the task dispatcher is a dirty worktree
   // left by a prior task (crash, timeout, un-committed tool edits, tool
   // artifacts like .claude/ or .playwright-mcp/). Auto-stash and retry (#45).
   // Actual divergence — local commits on main not in origin — still falls
@@ -280,12 +286,13 @@ export async function syncRepoBeforeTask(
     `Pre-task repo sync: auto-stashed dirty state in ${workingDir} (${label}) to unblock fast-forward`,
   );
 
-  const secondPull = await runGitPullFfOnly(workingDir);
-  if (!secondPull.ok) {
+  const secondMerge = await runGitMergeFfOnly(workingDir);
+  if (!secondMerge.ok) {
     return {
       action: "failed",
       commitsBehind,
       autoStashed: true,
+      stashLabel: label,
       error: `Working directory ${workingDir} is ${commitsBehind} commits behind origin/main and cannot fast-forward even after auto-stashing dirty state (stash: ${label}). Manual intervention required.`,
     };
   }
@@ -293,12 +300,12 @@ export async function syncRepoBeforeTask(
   console.log(
     `Pre-task repo sync: ${workingDir} synced ${commitsBehind} commits from origin (auto-stashed prior dirty state as ${label})`,
   );
-  return { action: "synced", commitsBehind, autoStashed: true };
+  return { action: "synced", commitsBehind, autoStashed: true, stashLabel: label };
 }
 
-function runGitPullFfOnly(workingDir: string): Promise<{ ok: boolean; output: string }> {
+function runGitMergeFfOnly(workingDir: string): Promise<{ ok: boolean; output: string }> {
   return new Promise((resolve) => {
-    const child = spawn("git", ["pull", "--ff-only"], {
+    const child = spawn("git", ["merge", "--ff-only", "origin/main"], {
       cwd: workingDir,
       stdio: ["ignore", "pipe", "pipe"],
       env: { ...process.env, HOME: "/home/magnus" },
@@ -308,7 +315,7 @@ function runGitPullFfOnly(workingDir: string): Promise<{ ok: boolean; output: st
     child.stderr?.on("data", (d: Buffer) => (output += d.toString()));
     child.on("close", (code) => {
       if (code !== 0) {
-        console.warn(`Pre-task git pull --ff-only failed (exit ${code}) in ${workingDir}: ${output.trim()}`);
+        console.warn(`Pre-task git merge --ff-only failed (exit ${code}) in ${workingDir}: ${output.trim()}`);
       }
       resolve({ ok: code === 0, output });
     });

--- a/src/task-helpers.ts
+++ b/src/task-helpers.ts
@@ -112,11 +112,17 @@ export interface RepoSyncResult {
   action: "skipped" | "up-to-date" | "synced" | "fetch-failed" | "failed";
   commitsBehind?: number;
   error?: string;
+  /** Set when dirty worktree state was auto-stashed to unblock the pull (#45). */
+  autoStashed?: boolean;
 }
 
 export interface SyncRepoOptions {
   /** Backoff in ms before each retry attempt after the first. Defaults to [500, 2000]. */
   fetchRetryDelaysMs?: number[];
+  /** Task ID included in the auto-stash label for forensics. */
+  taskId?: string;
+  /** Clock override for deterministic stash labels in tests. */
+  now?: () => Date;
 }
 
 const DEFAULT_FETCH_RETRY_DELAYS_MS = [500, 2000];
@@ -240,7 +246,58 @@ export async function syncRepoBeforeTask(
   }
 
   // Attempt fast-forward pull
-  const pullOk = await new Promise<boolean>((resolve) => {
+  const firstPull = await runGitPullFfOnly(workingDir);
+  if (firstPull.ok) {
+    console.log(`Pre-task repo sync: ${workingDir} synced ${commitsBehind} commits from origin`);
+    return { action: "synced", commitsBehind };
+  }
+
+  // Pull failed. Most common cause on the task dispatcher is a dirty worktree
+  // left by a prior task (crash, timeout, un-committed tool edits, tool
+  // artifacts like .claude/ or .playwright-mcp/). Auto-stash and retry (#45).
+  // Actual divergence — local commits on main not in origin — still falls
+  // through to manual intervention.
+  const dirty = await isWorktreeDirty(workingDir);
+  if (!dirty) {
+    return {
+      action: "failed",
+      commitsBehind,
+      error: `Working directory ${workingDir} is ${commitsBehind} commits behind origin/main and cannot fast-forward (worktree clean — likely local commits on main). Manual intervention required.`,
+    };
+  }
+
+  const now = options.now ?? (() => new Date());
+  const label = buildAutoStashLabel(now(), options.taskId);
+  const stashOk = await runGitStashPush(workingDir, label);
+  if (!stashOk) {
+    return {
+      action: "failed",
+      commitsBehind,
+      error: `Working directory ${workingDir} is ${commitsBehind} commits behind origin/main; dirty worktree detected but auto-stash failed. Manual intervention required.`,
+    };
+  }
+  console.warn(
+    `Pre-task repo sync: auto-stashed dirty state in ${workingDir} (${label}) to unblock fast-forward`,
+  );
+
+  const secondPull = await runGitPullFfOnly(workingDir);
+  if (!secondPull.ok) {
+    return {
+      action: "failed",
+      commitsBehind,
+      autoStashed: true,
+      error: `Working directory ${workingDir} is ${commitsBehind} commits behind origin/main and cannot fast-forward even after auto-stashing dirty state (stash: ${label}). Manual intervention required.`,
+    };
+  }
+
+  console.log(
+    `Pre-task repo sync: ${workingDir} synced ${commitsBehind} commits from origin (auto-stashed prior dirty state as ${label})`,
+  );
+  return { action: "synced", commitsBehind, autoStashed: true };
+}
+
+function runGitPullFfOnly(workingDir: string): Promise<{ ok: boolean; output: string }> {
+  return new Promise((resolve) => {
     const child = spawn("git", ["pull", "--ff-only"], {
       cwd: workingDir,
       stdio: ["ignore", "pipe", "pipe"],
@@ -253,19 +310,48 @@ export async function syncRepoBeforeTask(
       if (code !== 0) {
         console.warn(`Pre-task git pull --ff-only failed (exit ${code}) in ${workingDir}: ${output.trim()}`);
       }
+      resolve({ ok: code === 0, output });
+    });
+    child.on("error", () => resolve({ ok: false, output }));
+  });
+}
+
+function isWorktreeDirty(workingDir: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const child = spawn("git", ["status", "--porcelain"], {
+      cwd: workingDir,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, HOME: "/home/magnus" },
+    });
+    let out = "";
+    child.stdout?.on("data", (d: Buffer) => (out += d.toString()));
+    child.on("close", (code) => resolve(code === 0 && out.trim().length > 0));
+    child.on("error", () => resolve(false));
+  });
+}
+
+function runGitStashPush(workingDir: string, label: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const child = spawn("git", ["stash", "push", "-u", "-m", label], {
+      cwd: workingDir,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, HOME: "/home/magnus" },
+    });
+    let output = "";
+    child.stdout?.on("data", (d: Buffer) => (output += d.toString()));
+    child.stderr?.on("data", (d: Buffer) => (output += d.toString()));
+    child.on("close", (code) => {
+      if (code !== 0) {
+        console.warn(`Auto-stash failed (exit ${code}) in ${workingDir}: ${output.trim()}`);
+      }
       resolve(code === 0);
     });
     child.on("error", () => resolve(false));
   });
+}
 
-  if (!pullOk) {
-    return {
-      action: "failed",
-      commitsBehind,
-      error: `Working directory ${workingDir} is ${commitsBehind} commits behind origin/main and cannot fast-forward. Manual intervention required.`,
-    };
-  }
-
-  console.log(`Pre-task repo sync: ${workingDir} synced ${commitsBehind} commits from origin`);
-  return { action: "synced", commitsBehind };
+function buildAutoStashLabel(now: Date, taskId: string | undefined): string {
+  const ts = now.toISOString().replace(/\.\d{3}Z$/, "Z");
+  const taskPart = taskId ? ` task=${taskId}` : "";
+  return `hugin-autosave ${ts}${taskPart}`;
 }

--- a/tests/repo-sync.test.ts
+++ b/tests/repo-sync.test.ts
@@ -153,7 +153,7 @@ describe("syncRepoBeforeTask", () => {
       { exitCode: 0 },                 // git remote get-url origin
       { exitCode: 0 },                 // git fetch origin
       { exitCode: 0, stdout: "3\n" },  // git rev-list --count: 3 behind
-      { exitCode: 0 },                 // git pull --ff-only
+      { exitCode: 0 },                 // git merge --ff-only origin/main
     ];
 
     const result = await syncRepoBeforeTask("/home/magnus/repos/hugin", {
@@ -161,18 +161,21 @@ describe("syncRepoBeforeTask", () => {
     });
     expect(result.action).toBe("synced");
     expect(result.commitsBehind).toBe(3);
+    expect(result.autoStashed).toBeUndefined();
+    expect(result.stashLabel).toBeUndefined();
     expect(spawnCalls).toHaveLength(5);
-    // Verify the pull used --ff-only
-    expect(spawnCalls[4].args).toContain("--ff-only");
+    // Verify the fast-forward uses merge against the already-fetched ref
+    // (no implicit refetch) per #45 review feedback.
+    expect(spawnCalls[4].args).toEqual(["merge", "--ff-only", "origin/main"]);
   });
 
-  it("fails when ff-pull fails and worktree is clean (real divergence)", async () => {
+  it("fails when ff-merge fails and worktree is clean (real divergence)", async () => {
     spawnBehaviors = [
       { exitCode: 0 },                 // git rev-parse --git-dir
       { exitCode: 0 },                 // git remote get-url origin
       { exitCode: 0 },                 // git fetch origin
       { exitCode: 0, stdout: "5\n" },  // git rev-list --count: 5 behind
-      { exitCode: 1, stderr: "fatal: Not possible to fast-forward" }, // git pull --ff-only fails
+      { exitCode: 1, stderr: "fatal: Not possible to fast-forward" }, // git merge --ff-only fails
       { exitCode: 0, stdout: "" },     // git status --porcelain: clean
     ];
 
@@ -197,13 +200,14 @@ describe("syncRepoBeforeTask", () => {
       { exitCode: 0 },                          // git remote get-url origin
       { exitCode: 0 },                          // git fetch origin
       { exitCode: 0, stdout: "6\n" },           // rev-list --count: 6 behind
-      { exitCode: 1, stderr: "error: Your local changes would be overwritten" }, // first pull fails
+      { exitCode: 1, stderr: "error: Your local changes would be overwritten" }, // first merge fails
       { exitCode: 0, stdout: " M STATUS.md\n?? .claude/\n" },                    // porcelain: dirty
       { exitCode: 0, stdout: "Saved working directory\n" },                       // stash push
-      { exitCode: 0 },                                                           // second pull succeeds
+      { exitCode: 0 },                                                           // second merge succeeds
     ];
 
     const fixedNow = new Date("2026-04-12T22:30:00.000Z");
+    const expectedLabel = "hugin-autosave 2026-04-12T22:30:00Z task=20260412-223000-abcd";
     const result = await syncRepoBeforeTask("/home/magnus/repos/heimdall", {
       fetchRetryDelaysMs: [0, 0],
       taskId: "20260412-223000-abcd",
@@ -213,35 +217,32 @@ describe("syncRepoBeforeTask", () => {
     expect(result.action).toBe("synced");
     expect(result.commitsBehind).toBe(6);
     expect(result.autoStashed).toBe(true);
+    expect(result.stashLabel).toBe(expectedLabel);
 
     // Validate stash invocation
     const stashCall = spawnCalls.find((c) => c.args[0] === "stash");
     expect(stashCall).toBeDefined();
-    expect(stashCall!.args).toEqual([
-      "stash",
-      "push",
-      "-u",
-      "-m",
-      "hugin-autosave 2026-04-12T22:30:00Z task=20260412-223000-abcd",
-    ]);
+    expect(stashCall!.args).toEqual(["stash", "push", "-u", "-m", expectedLabel]);
 
-    // Two ff-only pulls attempted
-    const pullCalls = spawnCalls.filter((c) => c.args[0] === "pull");
-    expect(pullCalls).toHaveLength(2);
-    expect(pullCalls[0].args).toContain("--ff-only");
-    expect(pullCalls[1].args).toContain("--ff-only");
+    // Two ff-only merges attempted against already-fetched ref (no implicit refetch).
+    const mergeCalls = spawnCalls.filter((c) => c.args[0] === "merge");
+    expect(mergeCalls).toHaveLength(2);
+    expect(mergeCalls[0].args).toEqual(["merge", "--ff-only", "origin/main"]);
+    expect(mergeCalls[1].args).toEqual(["merge", "--ff-only", "origin/main"]);
+    // And we did NOT use `git pull` (would trigger an implicit refetch).
+    expect(spawnCalls.find((c) => c.args[0] === "pull")).toBeUndefined();
   });
 
-  it("fails when dirty worktree + stash succeeds but second pull still fails", async () => {
+  it("fails when dirty worktree + stash succeeds but second merge still fails", async () => {
     spawnBehaviors = [
       { exitCode: 0 },                          // rev-parse
       { exitCode: 0 },                          // remote get-url
       { exitCode: 0 },                          // fetch
       { exitCode: 0, stdout: "2\n" },           // rev-list
-      { exitCode: 1, stderr: "ff fail" },       // first pull
+      { exitCode: 1, stderr: "ff fail" },       // first merge --ff-only
       { exitCode: 0, stdout: "?? untracked\n" }, // porcelain: dirty
       { exitCode: 0 },                          // stash push ok
-      { exitCode: 1, stderr: "still fails" },   // second pull fails (real divergence + debris)
+      { exitCode: 1, stderr: "still fails" },   // second merge --ff-only fails (real divergence + debris)
     ];
 
     const result = await syncRepoBeforeTask("/home/magnus/repos/hugin", {
@@ -252,6 +253,7 @@ describe("syncRepoBeforeTask", () => {
 
     expect(result.action).toBe("failed");
     expect(result.autoStashed).toBe(true);
+    expect(result.stashLabel).toBe("hugin-autosave 2026-04-12T22:30:00Z task=t1");
     expect(result.error).toContain("even after auto-stashing");
     expect(result.error).toContain("hugin-autosave 2026-04-12T22:30:00Z task=t1");
   });
@@ -262,7 +264,7 @@ describe("syncRepoBeforeTask", () => {
       { exitCode: 0 },                          // remote get-url
       { exitCode: 0 },                          // fetch
       { exitCode: 0, stdout: "1\n" },           // rev-list
-      { exitCode: 1, stderr: "ff fail" },       // first pull
+      { exitCode: 1, stderr: "ff fail" },       // first merge --ff-only
       { exitCode: 0, stdout: " M foo\n" },       // porcelain: dirty
       { exitCode: 1, stderr: "stash failed" },  // stash push fails
     ];
@@ -273,10 +275,11 @@ describe("syncRepoBeforeTask", () => {
 
     expect(result.action).toBe("failed");
     expect(result.autoStashed).toBeUndefined();
+    expect(result.stashLabel).toBeUndefined();
     expect(result.error).toContain("dirty worktree detected but auto-stash failed");
-    // Only one pull attempt (no retry after stash failure)
-    const pullCalls = spawnCalls.filter((c) => c.args[0] === "pull");
-    expect(pullCalls).toHaveLength(1);
+    // Only one merge attempt (no retry after stash failure)
+    const mergeCalls = spawnCalls.filter((c) => c.args[0] === "merge");
+    expect(mergeCalls).toHaveLength(1);
   });
 
   it("uses correct working directory for all spawn calls", async () => {

--- a/tests/repo-sync.test.ts
+++ b/tests/repo-sync.test.ts
@@ -166,13 +166,14 @@ describe("syncRepoBeforeTask", () => {
     expect(spawnCalls[4].args).toContain("--ff-only");
   });
 
-  it("fails when behind and fast-forward fails (conflicts/dirty worktree)", async () => {
+  it("fails when ff-pull fails and worktree is clean (real divergence)", async () => {
     spawnBehaviors = [
       { exitCode: 0 },                 // git rev-parse --git-dir
       { exitCode: 0 },                 // git remote get-url origin
       { exitCode: 0 },                 // git fetch origin
       { exitCode: 0, stdout: "5\n" },  // git rev-list --count: 5 behind
       { exitCode: 1, stderr: "fatal: Not possible to fast-forward" }, // git pull --ff-only fails
+      { exitCode: 0, stdout: "" },     // git status --porcelain: clean
     ];
 
     const result = await syncRepoBeforeTask("/home/magnus/repos/hugin", {
@@ -182,7 +183,100 @@ describe("syncRepoBeforeTask", () => {
     expect(result.commitsBehind).toBe(5);
     expect(result.error).toContain("5 commits behind origin/main");
     expect(result.error).toContain("cannot fast-forward");
+    expect(result.error).toContain("worktree clean");
     expect(result.error).toContain("Manual intervention required");
+    expect(result.autoStashed).toBeUndefined();
+    // Should NOT have attempted a stash (worktree was clean)
+    const stashCalls = spawnCalls.filter((c) => c.args[0] === "stash");
+    expect(stashCalls).toHaveLength(0);
+  });
+
+  it("auto-stashes dirty worktree and retries fast-forward (#45)", async () => {
+    spawnBehaviors = [
+      { exitCode: 0 },                          // git rev-parse --git-dir
+      { exitCode: 0 },                          // git remote get-url origin
+      { exitCode: 0 },                          // git fetch origin
+      { exitCode: 0, stdout: "6\n" },           // rev-list --count: 6 behind
+      { exitCode: 1, stderr: "error: Your local changes would be overwritten" }, // first pull fails
+      { exitCode: 0, stdout: " M STATUS.md\n?? .claude/\n" },                    // porcelain: dirty
+      { exitCode: 0, stdout: "Saved working directory\n" },                       // stash push
+      { exitCode: 0 },                                                           // second pull succeeds
+    ];
+
+    const fixedNow = new Date("2026-04-12T22:30:00.000Z");
+    const result = await syncRepoBeforeTask("/home/magnus/repos/heimdall", {
+      fetchRetryDelaysMs: [0, 0],
+      taskId: "20260412-223000-abcd",
+      now: () => fixedNow,
+    });
+
+    expect(result.action).toBe("synced");
+    expect(result.commitsBehind).toBe(6);
+    expect(result.autoStashed).toBe(true);
+
+    // Validate stash invocation
+    const stashCall = spawnCalls.find((c) => c.args[0] === "stash");
+    expect(stashCall).toBeDefined();
+    expect(stashCall!.args).toEqual([
+      "stash",
+      "push",
+      "-u",
+      "-m",
+      "hugin-autosave 2026-04-12T22:30:00Z task=20260412-223000-abcd",
+    ]);
+
+    // Two ff-only pulls attempted
+    const pullCalls = spawnCalls.filter((c) => c.args[0] === "pull");
+    expect(pullCalls).toHaveLength(2);
+    expect(pullCalls[0].args).toContain("--ff-only");
+    expect(pullCalls[1].args).toContain("--ff-only");
+  });
+
+  it("fails when dirty worktree + stash succeeds but second pull still fails", async () => {
+    spawnBehaviors = [
+      { exitCode: 0 },                          // rev-parse
+      { exitCode: 0 },                          // remote get-url
+      { exitCode: 0 },                          // fetch
+      { exitCode: 0, stdout: "2\n" },           // rev-list
+      { exitCode: 1, stderr: "ff fail" },       // first pull
+      { exitCode: 0, stdout: "?? untracked\n" }, // porcelain: dirty
+      { exitCode: 0 },                          // stash push ok
+      { exitCode: 1, stderr: "still fails" },   // second pull fails (real divergence + debris)
+    ];
+
+    const result = await syncRepoBeforeTask("/home/magnus/repos/hugin", {
+      fetchRetryDelaysMs: [0, 0],
+      taskId: "t1",
+      now: () => new Date("2026-04-12T22:30:00.000Z"),
+    });
+
+    expect(result.action).toBe("failed");
+    expect(result.autoStashed).toBe(true);
+    expect(result.error).toContain("even after auto-stashing");
+    expect(result.error).toContain("hugin-autosave 2026-04-12T22:30:00Z task=t1");
+  });
+
+  it("fails when dirty worktree but stash itself fails", async () => {
+    spawnBehaviors = [
+      { exitCode: 0 },                          // rev-parse
+      { exitCode: 0 },                          // remote get-url
+      { exitCode: 0 },                          // fetch
+      { exitCode: 0, stdout: "1\n" },           // rev-list
+      { exitCode: 1, stderr: "ff fail" },       // first pull
+      { exitCode: 0, stdout: " M foo\n" },       // porcelain: dirty
+      { exitCode: 1, stderr: "stash failed" },  // stash push fails
+    ];
+
+    const result = await syncRepoBeforeTask("/home/magnus/repos/hugin", {
+      fetchRetryDelaysMs: [0, 0],
+    });
+
+    expect(result.action).toBe("failed");
+    expect(result.autoStashed).toBeUndefined();
+    expect(result.error).toContain("dirty worktree detected but auto-stash failed");
+    // Only one pull attempt (no retry after stash failure)
+    const pullCalls = spawnCalls.filter((c) => c.args[0] === "pull");
+    expect(pullCalls).toHaveLength(1);
   });
 
   it("uses correct working directory for all spawn calls", async () => {


### PR DESCRIPTION
Closes #45.

## Summary
- Auto-stash dirty worktree state when `git pull --ff-only` fails, then retry the fast-forward.
- Stash label is `hugin-autosave <iso-ts> task=<id>` for forensics; nothing is ever destroyed.
- Real divergence (clean worktree + local commits on main) still fails loudly — we don't mask genuine problems.

## Why
Pre-task repo sync assumed a clean worktree. Any prior task that crashed, timed out, or left tool artifacts behind (e.g. `.claude/`, `.playwright-mcp/`) poisoned every subsequent task on that repo until a human SSHed in. Observed 2026-04-12 on Pi heimdall — 732 lines across 8 files dirty; the same changes already existed upstream, so auto-stash-and-pull would have fixed it cleanly.

## Test plan
- [x] `npm run build` clean
- [x] Unit tests: added 3 new cases covering dirty+retry success, dirty+retry fail, stash fail; updated clean-divergence case (269/269 passing)
- [ ] Verify on Pi by submitting a task to a repo after inducing dirty state