### PR TITLE
fix: reap expired leases mid-poll (#38)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import {
   type MuninClientConfig,
   type MuninReadResult,
 } from "./munin-client.js";
-import { getFoundBatchEntry, extractTaskId, pickEarliestTask, selectNextTask, checkoutTaskBranch, finalizeTaskBranch } from "./task-helpers.js";
+import { getFoundBatchEntry, extractTaskId, pickEarliestTask, selectNextTask, checkoutTaskBranch, finalizeTaskBranch, shouldReapExpiredLease } from "./task-helpers.js";
 import { executeSdkTask } from "./sdk-executor.js";
 import { executeOllamaTask } from "./ollama-executor.js";
 import { configureHosts, resolveOllamaHost, getHostStatus, probeAllHosts, warmModel, getLoadedModels } from "./ollama-hosts.js";
@@ -1380,6 +1380,111 @@ async function recoverStaleTasks(): Promise<void> {
     }
   } catch (err) {
     console.error("Failed to recover stale tasks:", err);
+  }
+}
+
+// --- Lease reaping (runs mid-poll) ---
+// `recoverStaleTasks` only runs at startup. While the dispatcher is alive,
+// a crashed runtime or OOM kill can leave a task stuck with the `running` tag
+// past its lease. This reaper scans for such tasks on each poll and fails
+// them with a `lease-expired` reason. Fail-fast: no auto-retry to pending.
+
+async function reapExpiredLeases(): Promise<void> {
+  try {
+    const { results } = await munin.query({
+      query: "task",
+      tags: ["running"],
+      namespace: "tasks/",
+      entry_type: "state",
+      limit: 20,
+    });
+
+    const now = Date.now();
+
+    for (const result of results) {
+      if (!result.key || result.key !== "status") continue;
+
+      // Use query-result tags for the cheap filter to avoid a read per task.
+      const preDecision = shouldReapExpiredLease({
+        tags: result.tags,
+        namespace: result.namespace,
+        currentTask,
+        now,
+      });
+      if (!preDecision.reap) continue;
+
+      const entry = await munin.read(result.namespace, "status");
+      if (!entry) continue;
+
+      // Re-check with authoritative tags (lease may have just been renewed).
+      const decision = shouldReapExpiredLease({
+        tags: entry.tags,
+        namespace: result.namespace,
+        currentTask,
+        now: Date.now(),
+      });
+      if (!decision.reap) continue;
+
+      const expiredForS = Math.round(decision.expiredByMs / 1000);
+      const errorMessage = `Lease expired ${expiredForS}s ago (worker: ${decision.claimedBy || "unknown"})`;
+
+      console.log(`Reaping ${result.namespace} — ${errorMessage}`);
+
+      const task = parseTask(entry.content);
+      if (task && !task.sensitivityAssessment) {
+        task.sensitivityAssessment = getTaskSensitivityAssessment(task);
+        task.effectiveSensitivity = task.sensitivityAssessment.effective;
+      }
+      const classification = getTaskArtifactClassification(task || undefined, entry.content);
+      const runtime = getRuntimeFromTags(entry.tags);
+
+      try {
+        await munin.write(
+          result.namespace,
+          "status",
+          entry.content,
+          buildTerminalStatusTags("failed", entry.tags),
+          entry.updated_at,
+          classification,
+        );
+      } catch (err) {
+        // Compare-and-swap may fail if the task was just renewed/finished.
+        console.log(
+          `Reap of ${result.namespace} aborted (lost CAS race): ${(err as Error).message}`,
+        );
+        continue;
+      }
+
+      await munin.write(
+        result.namespace,
+        "result",
+        `## Result\n\n- **Exit code:** -1\n- **Error:** ${errorMessage}\n`,
+        undefined,
+        undefined,
+        classification,
+      );
+      if (runtime !== "pipeline") {
+        await writeStructuredTaskResult(
+          result.namespace,
+          createFailureStructuredResult(result.namespace, runtime, errorMessage, {
+            executor: "dispatcher",
+            resultSource: "lease-reaper",
+            replyTo: task?.replyTo,
+            replyFormat: task?.replyFormat,
+            group: task?.group,
+            sequence: task?.sequence,
+            pipeline: task?.pipeline,
+            sensitivity: buildTaskSensitivitySnapshot(task?.sensitivityAssessment),
+          }),
+          classification,
+        );
+      }
+      await munin.log(result.namespace, `Lease reaped: ${errorMessage}`);
+      await promoteDependents(extractTaskId(result.namespace));
+      await refreshPipelineSummaryFromContent(entry.content);
+    }
+  } catch (err) {
+    console.error("Failed to reap expired leases:", err);
   }
 }
 
@@ -3064,6 +3169,13 @@ async function pollLoop(): Promise<void> {
     try {
       pollCount++;
       await reconcileTrackedPipelineSummaries();
+      // Reap tasks whose lease expired mid-run (e.g. worker crashed after
+      // claiming). Runs every 5 polls (~2.5 min at default 30s interval) —
+      // cheap but not free, and lease window is 2 minutes so faster cadence
+      // buys little.
+      if (pollCount % 5 === 0) {
+        await reapExpiredLeases();
+      }
       const processedCancellation = await processCancellationRequests();
       const processedResume = await processResumeRequests();
       const processedApproval = await processApprovalDecisions();

--- a/src/task-helpers.ts
+++ b/src/task-helpers.ts
@@ -106,6 +106,98 @@ export function selectNextTask(
   return undefined;
 }
 
+// --- Lease reaping (#38) ---
+
+export interface ReapDecisionInput {
+  /** Tags on the running task entry. */
+  tags: string[];
+  /** Namespace of the task entry (e.g. "tasks/20260416-100000-a3f1"). */
+  namespace: string;
+  /** Namespace of the task this worker is currently executing, or null when idle. */
+  currentTask: string | null;
+  /** Epoch-millis "now" used to compare against the lease expiry. */
+  now: number;
+}
+
+export interface ReapDecision {
+  reap: boolean;
+  /** Value of the `claimed_by:` tag, or null if absent. */
+  claimedBy: string | null;
+  /** Parsed `lease_expires:` timestamp, or null if the tag is missing/malformed. */
+  leaseExpires: number | null;
+  /** Milliseconds past expiry (0 when reap=false). */
+  expiredByMs: number;
+  /** Why we declined to reap; empty string when reap=true. */
+  skipReason: "" | "currently-executing" | "lease-valid" | "no-lease-metadata";
+}
+
+function parseClaimedByTag(tags: string[]): string | null {
+  const tag = tags.find((t) => t.startsWith("claimed_by:"));
+  return tag ? tag.slice("claimed_by:".length) : null;
+}
+
+function parseLeaseExpiresTag(tags: string[]): number | null {
+  const tag = tags.find((t) => t.startsWith("lease_expires:"));
+  if (!tag) return null;
+  const raw = tag.slice("lease_expires:".length);
+  const ts = /^\d+$/.test(raw) ? Number(raw) : new Date(raw).getTime();
+  return Number.isNaN(ts) ? null : ts;
+}
+
+/**
+ * Decide whether a `running`-tagged task should be reaped because its lease
+ * has actually expired. Conservative on purpose:
+ *
+ * - The currently-executing task on this worker is never reaped (its next
+ *   lease renewal is about to land).
+ * - Tasks missing lease metadata entirely are left alone; startup recovery
+ *   (`recoverStaleTasks`) covers the legacy case, and mid-poll reaping should
+ *   only kill tasks we can prove are stuck.
+ * - Tasks whose lease expiry is still in the future are left alone.
+ */
+export function shouldReapExpiredLease(input: ReapDecisionInput): ReapDecision {
+  const claimedBy = parseClaimedByTag(input.tags);
+  const leaseExpires = parseLeaseExpiresTag(input.tags);
+
+  if (input.namespace === input.currentTask) {
+    return {
+      reap: false,
+      claimedBy,
+      leaseExpires,
+      expiredByMs: 0,
+      skipReason: "currently-executing",
+    };
+  }
+
+  if (leaseExpires === null) {
+    return {
+      reap: false,
+      claimedBy,
+      leaseExpires,
+      expiredByMs: 0,
+      skipReason: "no-lease-metadata",
+    };
+  }
+
+  if (input.now <= leaseExpires) {
+    return {
+      reap: false,
+      claimedBy,
+      leaseExpires,
+      expiredByMs: 0,
+      skipReason: "lease-valid",
+    };
+  }
+
+  return {
+    reap: true,
+    claimedBy,
+    leaseExpires,
+    expiredByMs: input.now - leaseExpires,
+    skipReason: "",
+  };
+}
+
 // --- Branch-per-task git flow (#47) ---
 
 export interface TaskBranchOptions {

--- a/tests/reap-expired-leases.test.ts
+++ b/tests/reap-expired-leases.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import { shouldReapExpiredLease } from "../src/task-helpers.js";
+
+const NS = "tasks/20260416-100000-a3f1";
+const OTHER_WORKER = "hugin-other-pid-42";
+const NOW = 1_700_000_000_000;
+
+function tagsWithLease(expiresAtMs: number, claimedBy = OTHER_WORKER): string[] {
+  return [
+    "running",
+    "runtime:claude",
+    `claimed_by:${claimedBy}`,
+    `lease_expires:${expiresAtMs}`,
+  ];
+}
+
+describe("shouldReapExpiredLease", () => {
+  it("reaps when lease expired by more than a second", () => {
+    const decision = shouldReapExpiredLease({
+      tags: tagsWithLease(NOW - 5_000),
+      namespace: NS,
+      currentTask: null,
+      now: NOW,
+    });
+    expect(decision.reap).toBe(true);
+    expect(decision.claimedBy).toBe(OTHER_WORKER);
+    expect(decision.leaseExpires).toBe(NOW - 5_000);
+    expect(decision.expiredByMs).toBe(5_000);
+    expect(decision.skipReason).toBe("");
+  });
+
+  it("does not reap when lease is still valid", () => {
+    const decision = shouldReapExpiredLease({
+      tags: tagsWithLease(NOW + 30_000),
+      namespace: NS,
+      currentTask: null,
+      now: NOW,
+    });
+    expect(decision.reap).toBe(false);
+    expect(decision.skipReason).toBe("lease-valid");
+  });
+
+  it("does not reap when lease expires exactly now", () => {
+    const decision = shouldReapExpiredLease({
+      tags: tagsWithLease(NOW),
+      namespace: NS,
+      currentTask: null,
+      now: NOW,
+    });
+    expect(decision.reap).toBe(false);
+    expect(decision.skipReason).toBe("lease-valid");
+  });
+
+  it("skips the currently-executing task on this worker", () => {
+    const decision = shouldReapExpiredLease({
+      tags: tagsWithLease(NOW - 60_000, "hugin-self-pid-1"),
+      namespace: NS,
+      currentTask: NS,
+      now: NOW,
+    });
+    expect(decision.reap).toBe(false);
+    expect(decision.skipReason).toBe("currently-executing");
+  });
+
+  it("skips tasks missing lease metadata (legacy)", () => {
+    const decision = shouldReapExpiredLease({
+      tags: ["running", "runtime:claude"],
+      namespace: NS,
+      currentTask: null,
+      now: NOW,
+    });
+    expect(decision.reap).toBe(false);
+    expect(decision.leaseExpires).toBeNull();
+    expect(decision.claimedBy).toBeNull();
+    expect(decision.skipReason).toBe("no-lease-metadata");
+  });
+
+  it("skips tasks with a malformed lease_expires tag", () => {
+    const decision = shouldReapExpiredLease({
+      tags: [
+        "running",
+        "runtime:claude",
+        "claimed_by:hugin-x",
+        "lease_expires:not-a-timestamp",
+      ],
+      namespace: NS,
+      currentTask: null,
+      now: NOW,
+    });
+    expect(decision.reap).toBe(false);
+    expect(decision.leaseExpires).toBeNull();
+    expect(decision.skipReason).toBe("no-lease-metadata");
+  });
+
+  it("accepts ISO 8601 lease_expires values (legacy tag format)", () => {
+    const expires = new Date(NOW - 10_000).toISOString();
+    const decision = shouldReapExpiredLease({
+      tags: [
+        "running",
+        "runtime:claude",
+        `claimed_by:${OTHER_WORKER}`,
+        `lease_expires:${expires}`,
+      ],
+      namespace: NS,
+      currentTask: null,
+      now: NOW,
+    });
+    expect(decision.reap).toBe(true);
+    expect(decision.leaseExpires).toBe(NOW - 10_000);
+    expect(decision.expiredByMs).toBe(10_000);
+  });
+
+  it("reaps foreign-worker tasks with expired leases", () => {
+    const decision = shouldReapExpiredLease({
+      tags: tagsWithLease(NOW - 120_000, "hugin-dead-worker"),
+      namespace: NS,
+      currentTask: "tasks/other-task-running-here",
+      now: NOW,
+    });
+    expect(decision.reap).toBe(true);
+    expect(decision.claimedBy).toBe("hugin-dead-worker");
+  });
+
+  it("reaps our own expired tasks if we're no longer running them", () => {
+    // Self-owned namespace but we've moved on to a different task: means this
+    // one crashed without cleaning up. Should be reaped.
+    const decision = shouldReapExpiredLease({
+      tags: tagsWithLease(NOW - 1_000, "hugin-self"),
+      namespace: NS,
+      currentTask: "tasks/different-task",
+      now: NOW,
+    });
+    expect(decision.reap).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #38.

`recoverStaleTasks()` only runs at startup, so a runtime crash or OOM kill
leaves tasks stuck with the `running` tag until the dispatcher next
restarts. This PR adds `reapExpiredLeases()` running every 5 polls
(~2.5 min at the default 30s interval). It transitions tasks whose lease
is genuinely in the past to `failed` with reason `lease-expired` — fail-fast
per the issue author's recommendation (no auto-retry to `pending`).

## Safety properties

The decision logic lives in `shouldReapExpiredLease` (pure, unit-tested):

- **Never** reap the currently-executing task on this worker.
- **Never** reap tasks missing `lease_expires:` metadata — those are legacy
  entries that startup recovery handles with an elapsed-time heuristic;
  mid-poll reaping can't prove they're stuck.
- **Re-read** authoritative tags with `munin.read` before writing, so a
  lease renewal that lands between the bulk query and the write is
  respected. The cheap filter runs off query-result tags to avoid N reads
  on the happy path.
- **Swallow CAS failures** — if `expected_updated_at` mismatches, the
  owning worker finished/renewed first. Skip silently.

## Test plan

- [x] `npm run build` — clean (strict TS)
- [x] `npm test` — 283 tests pass, including 9 new cases in
      `tests/reap-expired-leases.test.ts` covering expired/valid leases,
      the currentTask guard, legacy tasks, malformed timestamps, ISO 8601
      backcompat, and both foreign-worker + self-owned-other-task cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)