### PR TITLE
feat: HMAC-SHA256 task submission signing (#11)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,5 +159,5 @@ MUNIN_API_KEY=<same key Munin uses>
 | `OLLAMA_DEFAULT_MODEL` | `qwen2.5:3b` | Default model for ollama tasks without explicit Model field |
 | `HUGIN_INJECTION_POLICY` | `warn` | Prompt-injection policy for context-refs: `off` (no scan), `warn` (prepend warning banner), `block` (quarantine high-severity refs, task continues), `fail` (reject task). See `docs/security/prompt-injection-scanner.md`. |
 | `HUGIN_SIGNING_POLICY` | `off` | Task signature verification: `off` (skip), `warn` (log missing/invalid, never reject), `require` (reject unsigned/invalid). See `docs/security/task-signing.md`. |
-| `HUGIN_SUBMITTER_KEYS` | — | Inline JSON keystore for task signing: `{"<keyId>": "<hex-secret>"}`. |
+| `HUGIN_SUBMITTER_KEYS` | — | Inline JSON keystore for task signing: `{"<keyId>": "<hex-secret>"}` (64-char hex preferred; base64 accepted). |
 | `HUGIN_SUBMITTER_KEYS_FILE` | — | Path to a JSON keystore file. Takes precedence over `HUGIN_SUBMITTER_KEYS`. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ hugin/
 │   ├── ollama-hosts.ts    # Lazy host resolution with negative caching
 │   ├── context-loader.ts  # Context-refs resolver (fetch Munin entries for prompt injection)
 │   ├── prompt-injection-scanner.ts # Regex scanner for adversarial patterns in context-ref content
+│   ├── task-signing.ts             # HMAC-SHA256 task submission signing/verification
 │   └── munin-client.ts    # HTTP client for Munin JSON-RPC API
 ├── tests/
 │   ├── dispatcher.test.ts
@@ -157,3 +158,6 @@ MUNIN_API_KEY=<same key Munin uses>
 | `OLLAMA_LAPTOP_URL` | — | Ollama endpoint on laptop (via Tailscale, empty = disabled) |
 | `OLLAMA_DEFAULT_MODEL` | `qwen2.5:3b` | Default model for ollama tasks without explicit Model field |
 | `HUGIN_INJECTION_POLICY` | `warn` | Prompt-injection policy for context-refs: `off` (no scan), `warn` (prepend warning banner), `block` (quarantine high-severity refs, task continues), `fail` (reject task). See `docs/security/prompt-injection-scanner.md`. |
+| `HUGIN_SIGNING_POLICY` | `off` | Task signature verification: `off` (skip), `warn` (log missing/invalid, never reject), `require` (reject unsigned/invalid). See `docs/security/task-signing.md`. |
+| `HUGIN_SUBMITTER_KEYS` | — | Inline JSON keystore for task signing: `{"<keyId>": "<hex-secret>"}`. |
+| `HUGIN_SUBMITTER_KEYS_FILE` | — | Path to a JSON keystore file. Takes precedence over `HUGIN_SUBMITTER_KEYS`. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -200,5 +200,5 @@ Security assessments, threat models, and audit reports live in `docs/security/`.
 | `HUGIN_ALLOWED_EGRESS_HOSTS` | — | Comma-separated extra hosts to allow for outbound fetch (added to built-in allowlist) |
 | `HUGIN_INJECTION_POLICY` | `warn` | Prompt-injection policy for context-refs: `off` (no scan), `warn` (prepend warning banner), `block` (quarantine high-severity refs, task continues), `fail` (reject task). See `docs/security/prompt-injection-scanner.md`. |
 | `HUGIN_SIGNING_POLICY` | `off` | Task signature verification policy: `off` (skip), `warn` (log missing/invalid, never reject), `require` (reject tasks without a valid signature). See `docs/security/task-signing.md`. |
-| `HUGIN_SUBMITTER_KEYS` | — | Inline JSON keystore: `{"<keyId>": "<hex-or-base64-secret>"}`. |
+| `HUGIN_SUBMITTER_KEYS` | — | Inline JSON keystore: `{"<keyId>": "<hex-secret>"}` (64-char hex preferred; base64 accepted). |
 | `HUGIN_SUBMITTER_KEYS_FILE` | — | Path to a JSON keystore file. Takes precedence over `HUGIN_SUBMITTER_KEYS`. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,7 @@ hugin/
 │   ├── ollama-hosts.ts           # Lazy host resolution with negative caching
 │   ├── context-loader.ts         # Context-refs resolver with classification metadata
 │   ├── prompt-injection-scanner.ts # Regex scanner for adversarial patterns in context-ref content
+│   ├── task-signing.ts           # HMAC-SHA256 task submission signing/verification
 │   ├── munin-client.ts           # HTTP client for Munin JSON-RPC API
 │   ├── router.ts                 # Runtime auto-routing (pure function, filter/rank chain)
 │   ├── runtime-registry.ts       # Canonical runtime definitions (trust, cost, capabilities)
@@ -198,3 +199,6 @@ Security assessments, threat models, and audit reports live in `docs/security/`.
 | `OLLAMA_DEFAULT_MODEL` | `qwen2.5:3b` | Default model for ollama tasks without explicit Model field |
 | `HUGIN_ALLOWED_EGRESS_HOSTS` | — | Comma-separated extra hosts to allow for outbound fetch (added to built-in allowlist) |
 | `HUGIN_INJECTION_POLICY` | `warn` | Prompt-injection policy for context-refs: `off` (no scan), `warn` (prepend warning banner), `block` (quarantine high-severity refs, task continues), `fail` (reject task). See `docs/security/prompt-injection-scanner.md`. |
+| `HUGIN_SIGNING_POLICY` | `off` | Task signature verification policy: `off` (skip), `warn` (log missing/invalid, never reject), `require` (reject tasks without a valid signature). See `docs/security/task-signing.md`. |
+| `HUGIN_SUBMITTER_KEYS` | — | Inline JSON keystore: `{"<keyId>": "<hex-or-base64-secret>"}`. |
+| `HUGIN_SUBMITTER_KEYS_FILE` | — | Path to a JSON keystore file. Takes precedence over `HUGIN_SUBMITTER_KEYS`. |

--- a/docs/security/task-signing.md
+++ b/docs/security/task-signing.md
@@ -1,0 +1,160 @@
+# Cryptographic Task Signing
+
+**Status:** Hugin-side verification shipped; submitter rollout pending
+**Issue:** [#11](https://github.com/Magnus-Gille/hugin/issues/11)
+**Relates to:** `lethal-trifecta-assessment.md` §7.5 (Priority 2)
+
+## Why
+
+`Submitted by:` is a plain text field in the task body. Any agent with
+Munin write access to `tasks/*` can impersonate a trusted submitter by
+setting `Submitted by: claude-desktop` and pass the existing allowlist
+check. Signing binds the security-critical fields of a submission to a
+shared secret that only the claimed submitter knows.
+
+## Scheme (v1)
+
+**Algorithm:** HMAC-SHA256 with per-submitter shared secrets.
+
+**Why HMAC instead of Ed25519?** Grimnir is a closed personal system
+with all submitters under one operator. Symmetric keys are simpler to
+deploy and rotate. Upgrade to Ed25519 later if/when submitters leave
+operator control.
+
+**Signature format embedded in task body:**
+
+```markdown
+- **Signature:** v1:<keyId>:<hex-hmac>
+```
+
+- `v1` — scheme version
+- `keyId` — identifies which key was used; typically the same as the
+  submitter name (`Codex-desktop`, `ratatoskr`, etc.) but allows rotation
+  (`Codex-desktop-2026q2`)
+- `hex-hmac` — 64-char lowercase hex of the HMAC-SHA256 digest
+
+**Canonical payload** (what actually gets hashed):
+
+```
+context-refs-sha256=<hex or empty>
+prompt-sha256=<hex>
+runtime=<runtime>
+submitted-at=<iso-8601>
+submitter=<submittedBy>
+task-id=<taskId>
+version=v1
+```
+
+- Fields sorted by key, newline-delimited, trailing newline
+- Values are `\r\n`-stripped before signing — prevents
+  canonicalisation attacks where an attacker smuggles a second field
+  via an embedded newline
+- `prompt-sha256` binds the exact prompt; `context-refs-sha256` binds
+  the sorted ref list (prevents an attacker from adding a new
+  client-confidential ref to a pre-signed task)
+
+The canonical-payload rules are mirrored between
+`src/task-signing.ts` and `scripts/sign-task.mjs` — there is a test
+(`tests/task-signing.test.ts` "cross-language drift guard") that
+spawns the helper and asserts byte-for-byte equality with the Node
+module.
+
+## Policy modes
+
+Set `HUGIN_SIGNING_POLICY` on the Pi:
+
+| Policy | Effect |
+|--------|--------|
+| `off` (default) | Signatures ignored entirely. No verification, no logging. Zero-breakage default for the rollout period. |
+| `warn` | Verify when a signature is present; log missing / invalid / unknown-signer / malformed. Never rejects. |
+| `require` | Reject any task that is missing a valid signature from a known signer. |
+
+Rollout plan:
+1. Ship `off` (this PR)
+2. Roll out signing helpers to every submitter
+3. Flip Pi to `warn`, watch logs for stragglers
+4. Flip to `require` once the log is clean for ≥72h
+
+## Keys
+
+Keys are loaded at Hugin startup from either:
+
+- **`HUGIN_SUBMITTER_KEYS`** — inline JSON, e.g.
+  `{"Codex-desktop":"<hex>", "ratatoskr":"<hex>"}`
+- **`HUGIN_SUBMITTER_KEYS_FILE`** — path to a JSON file with the same
+  shape. Takes precedence over the inline var when both are set.
+
+**Secret format:** 64-char hex (32 bytes) strongly preferred. Base64
+and raw-UTF-8 strings are accepted for convenience but are weaker.
+
+**Key generation** (do once per submitter):
+
+```bash
+openssl rand -hex 32
+# or: node -e 'console.log(require("crypto").randomBytes(32).toString("hex"))'
+```
+
+Distribute the secret to the submitter by any secure channel (1Password
+items, Bitwarden, sealed envelope, etc.). The submitter stores it as
+the environment variable `HUGIN_SIGNING_SECRET`. **Never** commit secrets
+to the repo or log them.
+
+## Signing a task (submitter side)
+
+```bash
+HUGIN_SIGNING_SECRET=<hex> node scripts/sign-task.mjs \
+  --task-id 20260420-180000-a1b2 \
+  --submitter Codex-desktop \
+  --submitted-at 2026-04-20T18:00:00Z \
+  --runtime claude \
+  --prompt-file /tmp/prompt.md \
+  --context-refs "projects/hugin/status,meta/conventions/status"
+# → v1:Codex-desktop:abcdef1234...
+```
+
+Embed the output in the task body:
+
+```markdown
+## Task: Example
+
+- **Runtime:** claude
+- **Submitted by:** Codex-desktop
+- **Submitted at:** 2026-04-20T18:00:00Z
+- **Context-refs:** projects/hugin/status, meta/conventions/status
+- **Signature:** v1:Codex-desktop:abcdef1234...
+
+### Prompt
+Do the thing.
+```
+
+## Threat model
+
+**What this defends against:**
+- A compromised agent with Munin write access spoofing `Submitted by:`
+  to impersonate a trusted submitter
+- Replay of a captured signature against a different task (the
+  `task-id` binding prevents this within one Munin namespace)
+- Prompt/context-ref swaps on an already-signed task
+
+**What this does NOT defend against:**
+- **Key compromise.** If the submitter's host is fully compromised,
+  the attacker can sign arbitrary tasks. Use short-lived keys and
+  rotate on suspicion.
+- **Replay across time.** A signature with the same `task-id` +
+  metadata is still valid forever. Munin's UUID-per-task-id is the
+  de-facto nonce; if task-ids ever collide, this breaks.
+- **Pipeline tasks.** The pipeline dispatch path does not yet
+  participate in signing verification — noted as a known follow-up in
+  `verifyTaskEntrySignature` in `src/index.ts`.
+- **Submitter allowlist bypass.** Signing is checked *after* the
+  submitter allowlist; both layers must pass. An invalid submitter
+  with a valid signature still fails.
+
+## Known follow-ups
+
+- Per-submitter rollout (Codex CLI, Ratatoskr, /submit-task skill,
+  claude-code sessions) — tracked separately.
+- Pipeline task signing — the `Runtime: pipeline` branch skips HMAC
+  verification because its parsed fields differ; add a pipeline-aware
+  canonical payload when pipeline submitters adopt signing.
+- Optional Ed25519 upgrade path once signing is stable.

--- a/docs/security/task-signing.md
+++ b/docs/security/task-signing.md
@@ -49,9 +49,24 @@ version=v1
 - Values are `\r\n`-stripped before signing — prevents
   canonicalisation attacks where an attacker smuggles a second field
   via an embedded newline
-- `prompt-sha256` binds the exact prompt; `context-refs-sha256` binds
-  the sorted ref list (prevents an attacker from adding a new
-  client-confidential ref to a pre-signed task)
+- `prompt-sha256` binds the exact prompt. The prompt is first
+  canonicalised with `.trim()` on both sides (see `canonicalizePrompt`);
+  otherwise trailing newlines in `--prompt-file` input break
+  verification for every multi-line prompt
+- `context-refs-sha256` binds the sorted ref list (prevents an
+  attacker from adding a new client-confidential ref to a pre-signed
+  task)
+
+**`Runtime: auto` tasks** are signed with `runtime=auto`. The dispatcher
+reads the literal declared runtime from the task body at verify time,
+not the runtime the router later picks — otherwise auto-routed
+submissions would never verify.
+
+**Key-to-submitter binding.** `verifyTaskSignature` rejects with
+`submitter-mismatch` unless the `keyId` equals the claimed submitter or
+is a rotation alias of the form `<submitter>-<rotation>` (e.g.
+`Codex-desktop-2026q2`). Without this, any signer holding a configured
+key could mint signatures impersonating a different submitter.
 
 The canonical-payload rules are mirrored between
 `src/task-signing.ts` and `scripts/sign-task.mjs` — there is a test
@@ -66,8 +81,12 @@ Set `HUGIN_SIGNING_POLICY` on the Pi:
 | Policy | Effect |
 |--------|--------|
 | `off` (default) | Signatures ignored entirely. No verification, no logging. Zero-breakage default for the rollout period. |
-| `warn` | Verify when a signature is present; log missing / invalid / unknown-signer / malformed. Never rejects. |
-| `require` | Reject any task that is missing a valid signature from a known signer. |
+| `warn` | Verify when a signature is present; log missing / invalid / unknown-signer / submitter-mismatch / malformed. Never rejects. |
+| `require` | Reject any task that is missing a valid signature from a known signer. Pipeline parent tasks are rejected (v1 cannot bind ### Pipeline bodies yet); internally-generated children (`Submitted by: hugin`) are exempted. |
+
+An unrecognised value (typo such as `requrie`) fails startup rather
+than silently falling back to `off`: a security control must never
+degrade itself because of a misconfiguration.
 
 Rollout plan:
 1. Ship `off` (this PR)
@@ -84,8 +103,10 @@ Keys are loaded at Hugin startup from either:
 - **`HUGIN_SUBMITTER_KEYS_FILE`** — path to a JSON file with the same
   shape. Takes precedence over the inline var when both are set.
 
-**Secret format:** 64-char hex (32 bytes) strongly preferred. Base64
-and raw-UTF-8 strings are accepted for convenience but are weaker.
+**Secret format:** 64-char hex (32 bytes) is the production contract.
+Base64 (≥16 decoded bytes) is accepted for convenience (e.g. copy-paste
+from password managers). Raw UTF-8 is a last-resort fallback for local
+testing only — do not deploy non-hex secrets.
 
 **Key generation** (do once per submitter):
 
@@ -143,9 +164,11 @@ Do the thing.
 - **Replay across time.** A signature with the same `task-id` +
   metadata is still valid forever. Munin's UUID-per-task-id is the
   de-facto nonce; if task-ids ever collide, this breaks.
-- **Pipeline tasks.** The pipeline dispatch path does not yet
-  participate in signing verification — noted as a known follow-up in
-  `verifyTaskEntrySignature` in `src/index.ts`.
+- **Pipeline parent tasks.** The v1 canonical payload binds
+  `prompt-sha256`; pipelines declare a `### Pipeline` body instead.
+  `require` mode rejects pipeline parents until a pipeline-aware
+  scheme ships. Internally-generated child phase tasks are
+  dispatcher-trusted (exempt via `Submitted by: hugin`).
 - **Submitter allowlist bypass.** Signing is checked *after* the
   submitter allowlist; both layers must pass. An invalid submitter
   with a valid signature still fails.

--- a/scripts/sign-task.mjs
+++ b/scripts/sign-task.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+// Sign a task submission for Hugin.
+//
+// Usage:
+//   HUGIN_SIGNING_SECRET=<hex> node scripts/sign-task.mjs \
+//     --task-id 20260420-180000-a1b2 \
+//     --submitter Codex-desktop \
+//     --submitted-at 2026-04-20T18:00:00Z \
+//     --runtime claude \
+//     --prompt-file /tmp/prompt.md \
+//     [--context-refs "projects/hugin/status,meta/conventions/status"] \
+//     [--key-id Codex-desktop]
+//
+// Prints `v1:<keyId>:<hex>` on stdout. Submitters embed that as the
+// `**Signature:**` field in the task body:
+//
+//   - **Signature:** v1:Codex-desktop:abcdef...
+//
+// Canonical payload and HMAC-SHA256 are kept in lockstep with
+// src/task-signing.ts — do not drift these without updating both.
+
+import { createHmac, createHash } from "node:crypto";
+import * as fs from "node:fs";
+
+const SIGNATURE_VERSION = "v1";
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i++) {
+    const flag = argv[i];
+    if (!flag.startsWith("--")) continue;
+    const key = flag.slice(2);
+    const value = argv[i + 1];
+    args[key] = value;
+    i++;
+  }
+  return args;
+}
+
+function sanitize(v) {
+  return String(v).replace(/[\r\n]+/g, " ").trim();
+}
+
+function sha256Hex(s) {
+  return createHash("sha256").update(s).digest("hex");
+}
+
+function canonicalizeContextRefs(refs) {
+  return refs
+    .map((r) => r.trim())
+    .filter(Boolean)
+    .sort()
+    .join("\n");
+}
+
+function buildCanonicalPayload(params) {
+  const promptSha = sha256Hex(params.prompt);
+  const refs = params.contextRefs ?? [];
+  const contextRefsSha = refs.length ? sha256Hex(canonicalizeContextRefs(refs)) : "";
+  const fields = {
+    "context-refs-sha256": contextRefsSha,
+    "prompt-sha256": promptSha,
+    runtime: sanitize(params.runtime),
+    "submitted-at": sanitize(params.submittedAt),
+    submitter: sanitize(params.submitter),
+    "task-id": sanitize(params.taskId),
+    version: SIGNATURE_VERSION,
+  };
+  return (
+    Object.keys(fields)
+      .sort()
+      .map((k) => `${k}=${fields[k]}`)
+      .join("\n") + "\n"
+  );
+}
+
+function decodeSecret(raw) {
+  const trimmed = raw.trim();
+  if (/^[0-9a-f]+$/i.test(trimmed) && trimmed.length % 2 === 0 && trimmed.length >= 32) {
+    return Buffer.from(trimmed, "hex");
+  }
+  if (/^[A-Za-z0-9+/=]+$/.test(trimmed) && trimmed.length >= 24) {
+    const decoded = Buffer.from(trimmed, "base64");
+    if (decoded.length >= 16) return decoded;
+  }
+  return Buffer.from(trimmed, "utf8");
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const required = ["task-id", "submitter", "submitted-at", "runtime"];
+  for (const r of required) {
+    if (!args[r]) {
+      console.error(`missing --${r}`);
+      process.exit(2);
+    }
+  }
+  if (!args.prompt && !args["prompt-file"]) {
+    console.error("provide --prompt or --prompt-file");
+    process.exit(2);
+  }
+
+  const secret = process.env.HUGIN_SIGNING_SECRET;
+  if (!secret) {
+    console.error("HUGIN_SIGNING_SECRET not set");
+    process.exit(2);
+  }
+
+  const prompt = args["prompt-file"]
+    ? fs.readFileSync(args["prompt-file"], "utf8")
+    : args.prompt;
+  const contextRefs = args["context-refs"]
+    ? args["context-refs"].split(",").map((s) => s.trim()).filter(Boolean)
+    : [];
+  const keyId = args["key-id"] || args.submitter;
+
+  const payload = buildCanonicalPayload({
+    taskId: args["task-id"],
+    submitter: args.submitter,
+    submittedAt: args["submitted-at"],
+    runtime: args.runtime,
+    prompt,
+    contextRefs,
+  });
+  const hex = createHmac("sha256", decodeSecret(secret)).update(payload).digest("hex");
+  process.stdout.write(`${SIGNATURE_VERSION}:${keyId}:${hex}\n`);
+}
+
+main();

--- a/scripts/sign-task.mjs
+++ b/scripts/sign-task.mjs
@@ -53,8 +53,12 @@ function canonicalizeContextRefs(refs) {
     .join("\n");
 }
 
+function canonicalizePrompt(raw) {
+  return raw.trim();
+}
+
 function buildCanonicalPayload(params) {
-  const promptSha = sha256Hex(params.prompt);
+  const promptSha = sha256Hex(canonicalizePrompt(params.prompt));
   const refs = params.contextRefs ?? [];
   const contextRefsSha = refs.length ? sha256Hex(canonicalizeContextRefs(refs)) : "";
   const fields = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,15 @@ import {
   buildRuntimeCandidates,
   type RuntimeCapability,
 } from "./runtime-registry.js";
+import {
+  extractSignatureField,
+  loadKeyStoreFromEnv,
+  parseSigningPolicy,
+  verifyTaskSignature,
+  type KeyStore,
+  type SigningPolicy,
+  type VerificationResult,
+} from "./task-signing.js";
 
 const HUGIN_HOME = path.join(process.env.HOME || "/home/magnus", ".hugin");
 const LOG_DIR = path.join(HUGIN_HOME, "logs");
@@ -135,7 +144,21 @@ const config = {
     .split(",")
     .map((value) => value.trim())
     .filter(Boolean),
+  signingPolicy: parseSigningPolicy(process.env.HUGIN_SIGNING_POLICY) as SigningPolicy,
+  submitterKeys: loadKeyStoreFromEnv() as KeyStore,
 };
+
+if (config.signingPolicy !== "off") {
+  const keyIds = Object.keys(config.submitterKeys);
+  console.log(
+    `[signing] policy=${config.signingPolicy} keys=${keyIds.length ? keyIds.join(",") : "(none configured)"}`,
+  );
+  if (config.signingPolicy === "require" && keyIds.length === 0) {
+    console.error(
+      "HUGIN_SIGNING_POLICY=require but no keys configured (set HUGIN_SUBMITTER_KEYS or HUGIN_SUBMITTER_KEYS_FILE). All tasks will be rejected.",
+    );
+  }
+}
 
 const legacyClaudeExecutor = process.env.HUGIN_CLAUDE_EXECUTOR?.trim().toLowerCase();
 if (legacyClaudeExecutor && legacyClaudeExecutor !== "sdk") {
@@ -577,6 +600,79 @@ function getSecurityViolationForTask(
     });
   }
   return null;
+}
+
+interface SigningVerdict {
+  result: VerificationResult;
+  reject: boolean;
+  message: string;
+}
+
+function verifyTaskEntrySignature(
+  taskNs: string,
+  content: string,
+  parsedTask: TaskConfig | null,
+  submittedBy: string,
+): SigningVerdict {
+  const policy = config.signingPolicy;
+  const signatureRaw = extractSignatureField(content);
+
+  if (policy === "off") {
+    return {
+      result: signatureRaw ? { status: "valid" } : { status: "missing" },
+      reject: false,
+      message: "",
+    };
+  }
+
+  const params = parsedTask
+    ? {
+        taskId: extractTaskId(taskNs),
+        submitter: submittedBy,
+        submittedAt: parsedTask.submittedAt,
+        runtime: parsedTask.runtime,
+        prompt: parsedTask.prompt,
+        contextRefs: parsedTask.contextRefs,
+      }
+    : null;
+
+  // Pipeline tasks don't produce a TaskConfig here — we can still check
+  // signature presence but not verify HMAC. Treat that as an operational
+  // limitation and pass through for now; pipeline signing is a follow-up.
+  if (!params) {
+    if (policy === "require" && !signatureRaw) {
+      return {
+        result: { status: "missing" },
+        reject: true,
+        message: "Task rejected by HUGIN_SIGNING_POLICY=require: missing Signature field",
+      };
+    }
+    return { result: { status: "missing" }, reject: false, message: "" };
+  }
+
+  const result = verifyTaskSignature(params, signatureRaw, config.submitterKeys);
+
+  if (result.status === "valid") {
+    console.log(`[signing] task ${taskNs} signature valid (keyId=${result.keyId})`);
+    return { result, reject: false, message: "" };
+  }
+
+  const descriptor =
+    result.status === "missing"
+      ? "missing Signature field"
+      : `${result.status}${result.reason ? ` (${result.reason})` : ""}`;
+
+  if (policy === "warn") {
+    console.warn(`[signing] task ${taskNs} ${descriptor} — policy=warn, proceeding`);
+    return { result, reject: false, message: "" };
+  }
+
+  // policy === "require"
+  return {
+    result,
+    reject: true,
+    message: `Task rejected by HUGIN_SIGNING_POLICY=require: ${descriptor}`,
+  };
 }
 
 function getInjectionViolationForTask(task: TaskConfig): string | null {
@@ -2352,6 +2448,30 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
       taskNs,
       `Task rejected: submitter "${submittedBy}" not authorized`
     );
+    await promoteDependents(extractTaskId(taskNs));
+    await refreshPipelineSummaryFromContent(entry.content);
+    return { hadTask: true, queueDepth };
+  }
+
+  // Verify task signature per HUGIN_SIGNING_POLICY
+  const signingVerdict = verifyTaskEntrySignature(
+    taskNs,
+    entry.content,
+    parsedTask,
+    submittedBy,
+  );
+  if (signingVerdict.reject) {
+    console.warn(
+      `Rejecting task ${taskNs}: signature ${signingVerdict.result.status}` +
+        (signingVerdict.result.reason ? ` (${signingVerdict.result.reason})` : ""),
+    );
+    await failTaskWithMessage(
+      taskNs,
+      entry,
+      signingVerdict.message,
+      declaredRuntime === "pipeline" ? "runtime:pipeline" : undefined,
+    );
+    await munin.log(taskNs, `Task rejected by signing policy: ${signingVerdict.message}`);
     await promoteDependents(extractTaskId(taskNs));
     await refreshPipelineSummaryFromContent(entry.content);
     return { hadTask: true, queueDepth };

--- a/src/index.ts
+++ b/src/index.ts
@@ -625,30 +625,46 @@ function verifyTaskEntrySignature(
     };
   }
 
-  const params = parsedTask
-    ? {
-        taskId: extractTaskId(taskNs),
-        submitter: submittedBy,
-        submittedAt: parsedTask.submittedAt,
-        runtime: parsedTask.runtime,
-        prompt: parsedTask.prompt,
-        contextRefs: parsedTask.contextRefs,
-      }
-    : null;
+  // Internally-generated tasks (pipeline phase children, summary tasks,
+  // etc.) are submitted by Hugin itself. They never carry a signature
+  // because there is no external signer — the dispatcher trusts its own
+  // writes. Exempt them so `require` doesn't brick pipeline execution.
+  // When pipeline-aware signing ships (see docs/security/task-signing.md),
+  // this exemption becomes a proper internal signing path.
+  if (submittedBy === "hugin") {
+    return { result: { status: "valid" }, reject: false, message: "" };
+  }
 
-  // Pipeline tasks don't produce a TaskConfig here — we can still check
-  // signature presence but not verify HMAC. Treat that as an operational
-  // limitation and pass through for now; pipeline signing is a follow-up.
-  if (!params) {
-    if (policy === "require" && !signatureRaw) {
+  // Pipeline parent tasks don't produce a TaskConfig here — the HMAC
+  // scheme binds prompt/context-refs, which pipelines express differently
+  // (### Pipeline instead of ### Prompt). Until pipeline signing lands we
+  // cannot accept these under `require`; `warn` passes through.
+  if (!parsedTask) {
+    if (policy === "require") {
       return {
         result: { status: "missing" },
         reject: true,
-        message: "Task rejected by HUGIN_SIGNING_POLICY=require: missing Signature field",
+        message:
+          "Task rejected by HUGIN_SIGNING_POLICY=require: pipeline tasks cannot be verified by the v1 scheme",
       };
     }
     return { result: { status: "missing" }, reject: false, message: "" };
   }
+
+  // Use the runtime *as declared in the task body*, not the resolved
+  // execution runtime. Auto-routed tasks sign with `runtime=auto`; the
+  // dispatcher later overwrites parsedTask.runtime with the router's
+  // pick, so reading it here would break verification.
+  const declaredRuntime = parseDeclaredRuntime(content) ?? parsedTask.runtime;
+
+  const params = {
+    taskId: extractTaskId(taskNs),
+    submitter: submittedBy,
+    submittedAt: parsedTask.submittedAt,
+    runtime: declaredRuntime,
+    prompt: parsedTask.prompt,
+    contextRefs: parsedTask.contextRefs,
+  };
 
   const result = verifyTaskSignature(params, signatureRaw, config.submitterKeys);
 

--- a/src/task-signing.ts
+++ b/src/task-signing.ts
@@ -45,6 +45,7 @@ export type VerificationStatus =
   | "invalid"
   | "missing"
   | "unknown-signer"
+  | "submitter-mismatch"
   | "malformed"
   | "unsupported-version";
 
@@ -68,7 +69,7 @@ export type KeyStore = Record<string, string>;
  *     is unambiguous when inspected as text).
  */
 export function buildCanonicalPayload(params: SigningParams): string {
-  const promptSha = sha256Hex(params.prompt);
+  const promptSha = sha256Hex(canonicalizePrompt(params.prompt));
   const contextRefsSha = params.contextRefs?.length
     ? sha256Hex(canonicalizeContextRefs(params.contextRefs))
     : "";
@@ -151,6 +152,20 @@ export function verifyTaskSignature(
     };
   }
 
+  // Bind keyId to the claimed submitter. A signer with any configured key
+  // must not be able to mint signatures impersonating a different
+  // submitter. The keyId must either equal the submitter name or be a
+  // rotation alias of the form `<submitter>-<rotation>` (e.g.
+  // `Codex-desktop-2026q2`). This is enforced *before* HMAC comparison
+  // so unknown rotation shapes surface clearly in logs.
+  if (!keyIdMatchesSubmitter(parsed.keyId, params.submitter)) {
+    return {
+      status: "submitter-mismatch",
+      keyId: parsed.keyId,
+      reason: `keyId "${parsed.keyId}" is not authorized to sign for submitter "${params.submitter}"`,
+    };
+  }
+
   const expectedHex = signTask(params, parsed.keyId, secretHex).split(":")[2];
   const actual = Buffer.from(parsed.hex, "hex");
   const expected = Buffer.from(expectedHex, "hex");
@@ -229,6 +244,22 @@ function sanitizeValue(v: string): string {
   return v.replace(/[\r\n]+/g, " ").trim();
 }
 
+function keyIdMatchesSubmitter(keyId: string, submitter: string): boolean {
+  if (!keyId || !submitter) return false;
+  if (keyId === submitter) return true;
+  return keyId.startsWith(`${submitter}-`);
+}
+
+/**
+ * Normalize a prompt the same way on both sides of the signature. The task
+ * body in Munin may carry trailing whitespace from editors or CRLF line
+ * endings; the submitter helper reads the prompt from a file. Collapsing to
+ * `.trim()` matches what parseTask() uses when extracting the prompt.
+ */
+export function canonicalizePrompt(raw: string): string {
+  return raw.trim();
+}
+
 /**
  * Accepts hex (64 chars) or base64 secrets. Falls back to UTF-8 bytes for
  * arbitrary strings — useful for tests and non-production config. HMAC
@@ -253,8 +284,17 @@ function decodeSecret(raw: string): Buffer {
 
 export type SigningPolicy = "off" | "warn" | "require";
 
+/**
+ * Parse HUGIN_SIGNING_POLICY. Unset or blank → "off". Any other value that
+ * isn't one of the three canonical modes throws — a security control must
+ * never silently degrade to off because of a typo.
+ */
 export function parseSigningPolicy(value: string | undefined | null): SigningPolicy {
-  const raw = value?.trim().toLowerCase();
+  if (value === undefined || value === null) return "off";
+  const raw = value.trim().toLowerCase();
+  if (raw === "") return "off";
   if (raw === "off" || raw === "warn" || raw === "require") return raw;
-  return "off";
+  throw new Error(
+    `invalid HUGIN_SIGNING_POLICY "${value}" — expected one of: off, warn, require`,
+  );
 }

--- a/src/task-signing.ts
+++ b/src/task-signing.ts
@@ -1,0 +1,260 @@
+/**
+ * Task submission signing and verification.
+ *
+ * Protects against submitter spoofing: the `Submitted by:` field is
+ * plain text, so any agent with Munin write access to `tasks/*` can
+ * impersonate a trusted submitter. Signing binds the critical task
+ * metadata (submitter, runtime, prompt, context-refs) to a shared
+ * secret that only the claimed submitter knows.
+ *
+ * v1 design — HMAC-SHA256 with per-submitter shared secrets:
+ *   - Signature field embedded in task body: `**Signature:** v1:<keyId>:<hex>`
+ *   - Canonical payload: newline-delimited, sorted `key=value` pairs
+ *     over the security-critical fields (see CANONICAL_FIELDS below)
+ *   - Comparison is constant-time via crypto.timingSafeEqual
+ *
+ * Policy enforcement lives in the dispatcher. This module is pure:
+ * given a SigningParams + Signature + KeyStore, it returns a
+ * VerificationResult. The caller decides whether to warn or reject.
+ *
+ * See docs/security/task-signing.md.
+ */
+
+import { createHmac, createHash, timingSafeEqual } from "node:crypto";
+import * as fs from "node:fs";
+
+export const SIGNATURE_VERSION = "v1" as const;
+
+export interface SigningParams {
+  taskId: string;
+  submitter: string;
+  submittedAt: string;
+  runtime: string;
+  prompt: string;
+  contextRefs?: string[];
+}
+
+export interface ParsedSignature {
+  version: string;
+  keyId: string;
+  hex: string;
+}
+
+export type VerificationStatus =
+  | "valid"
+  | "invalid"
+  | "missing"
+  | "unknown-signer"
+  | "malformed"
+  | "unsupported-version";
+
+export interface VerificationResult {
+  status: VerificationStatus;
+  keyId?: string;
+  reason?: string;
+}
+
+export type KeyStore = Record<string, string>;
+
+/**
+ * Canonical payload construction. Ordering and formatting must be stable
+ * across submitters and Hugin or signatures will not match.
+ *
+ * Rules:
+ *   - Each value is trimmed and stripped of embedded \n and \r.
+ *   - Missing values serialize as an empty string for their field.
+ *   - Fields are sorted by key and joined with `\n`.
+ *   - Payload ends with a trailing newline (so empty vs. missing-last-field
+ *     is unambiguous when inspected as text).
+ */
+export function buildCanonicalPayload(params: SigningParams): string {
+  const promptSha = sha256Hex(params.prompt);
+  const contextRefsSha = params.contextRefs?.length
+    ? sha256Hex(canonicalizeContextRefs(params.contextRefs))
+    : "";
+
+  const fields: Record<string, string> = {
+    "context-refs-sha256": contextRefsSha,
+    "prompt-sha256": promptSha,
+    runtime: sanitizeValue(params.runtime),
+    "submitted-at": sanitizeValue(params.submittedAt),
+    submitter: sanitizeValue(params.submitter),
+    "task-id": sanitizeValue(params.taskId),
+    version: SIGNATURE_VERSION,
+  };
+
+  return (
+    Object.keys(fields)
+      .sort()
+      .map((k) => `${k}=${fields[k]}`)
+      .join("\n") + "\n"
+  );
+}
+
+export function signTask(
+  params: SigningParams,
+  keyId: string,
+  secretHex: string,
+): string {
+  const secret = decodeSecret(secretHex);
+  const payload = buildCanonicalPayload(params);
+  const hex = createHmac("sha256", secret).update(payload).digest("hex");
+  return `${SIGNATURE_VERSION}:${keyId}:${hex}`;
+}
+
+export function parseSignature(raw: string | undefined | null): ParsedSignature | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const parts = trimmed.split(":");
+  if (parts.length !== 3) return null;
+  const [version, keyId, hex] = parts;
+  if (!version || !keyId || !hex) return null;
+  if (!/^[0-9a-f]+$/i.test(hex)) return null;
+  return { version, keyId, hex: hex.toLowerCase() };
+}
+
+/**
+ * Extract a signature line from a task body. Matches:
+ *   `- **Signature:** v1:<keyId>:<hex>` or `**Signature:** v1:<keyId>:<hex>`.
+ * Returns null when no signature line is present.
+ */
+export function extractSignatureField(content: string): string | null {
+  const match = content.match(/\*\*Signature:\*\*\s*(\S+)/i);
+  return match?.[1]?.trim() || null;
+}
+
+export function verifyTaskSignature(
+  params: SigningParams,
+  signatureRaw: string | null | undefined,
+  keys: KeyStore,
+): VerificationResult {
+  if (!signatureRaw) return { status: "missing" };
+
+  const parsed = parseSignature(signatureRaw);
+  if (!parsed) return { status: "malformed", reason: "unparseable signature field" };
+
+  if (parsed.version !== SIGNATURE_VERSION) {
+    return {
+      status: "unsupported-version",
+      keyId: parsed.keyId,
+      reason: `unsupported signature version "${parsed.version}" (expected ${SIGNATURE_VERSION})`,
+    };
+  }
+
+  const secretHex = keys[parsed.keyId];
+  if (!secretHex) {
+    return {
+      status: "unknown-signer",
+      keyId: parsed.keyId,
+      reason: `no signing key configured for "${parsed.keyId}"`,
+    };
+  }
+
+  const expectedHex = signTask(params, parsed.keyId, secretHex).split(":")[2];
+  const actual = Buffer.from(parsed.hex, "hex");
+  const expected = Buffer.from(expectedHex, "hex");
+
+  if (actual.length !== expected.length) {
+    return { status: "invalid", keyId: parsed.keyId, reason: "signature length mismatch" };
+  }
+  if (!timingSafeEqual(actual, expected)) {
+    return { status: "invalid", keyId: parsed.keyId, reason: "signature does not match" };
+  }
+
+  return { status: "valid", keyId: parsed.keyId };
+}
+
+/**
+ * Load the keystore from HUGIN_SUBMITTER_KEYS (JSON string) or
+ * HUGIN_SUBMITTER_KEYS_FILE (path to JSON). File takes precedence if set.
+ *
+ * Expected shape: `{"<keyId>": "<hex-or-base64-secret>"}`.
+ * Invalid JSON or missing files log a warning and return an empty store.
+ */
+export function loadKeyStoreFromEnv(env: NodeJS.ProcessEnv = process.env): KeyStore {
+  const filePath = env.HUGIN_SUBMITTER_KEYS_FILE?.trim();
+  if (filePath) {
+    try {
+      const raw = fs.readFileSync(filePath, "utf8");
+      return parseKeyStoreJson(raw, `file ${filePath}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[signing] failed to load HUGIN_SUBMITTER_KEYS_FILE (${filePath}): ${msg}`);
+      return {};
+    }
+  }
+
+  const inline = env.HUGIN_SUBMITTER_KEYS?.trim();
+  if (inline) {
+    return parseKeyStoreJson(inline, "HUGIN_SUBMITTER_KEYS");
+  }
+
+  return {};
+}
+
+function parseKeyStoreJson(raw: string, source: string): KeyStore {
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      console.warn(`[signing] ${source}: expected JSON object of {keyId: secret}, ignoring`);
+      return {};
+    }
+    const out: KeyStore = {};
+    for (const [keyId, value] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof value !== "string" || !value.trim()) continue;
+      out[keyId.trim()] = value.trim();
+    }
+    return out;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[signing] ${source} is not valid JSON: ${msg}`);
+    return {};
+  }
+}
+
+function sha256Hex(s: string): string {
+  return createHash("sha256").update(s).digest("hex");
+}
+
+function canonicalizeContextRefs(refs: string[]): string {
+  return refs
+    .map((r) => r.trim())
+    .filter(Boolean)
+    .sort()
+    .join("\n");
+}
+
+function sanitizeValue(v: string): string {
+  return v.replace(/[\r\n]+/g, " ").trim();
+}
+
+/**
+ * Accepts hex (64 chars) or base64 secrets. Falls back to UTF-8 bytes for
+ * arbitrary strings — useful for tests and non-production config. HMAC
+ * accepts any byte length, but short secrets weaken the guarantee.
+ */
+function decodeSecret(raw: string): Buffer {
+  const trimmed = raw.trim();
+  if (/^[0-9a-f]+$/i.test(trimmed) && trimmed.length % 2 === 0 && trimmed.length >= 32) {
+    return Buffer.from(trimmed, "hex");
+  }
+  // Accept base64 only when it clearly looks like base64 and decodes cleanly.
+  if (/^[A-Za-z0-9+/=]+$/.test(trimmed) && trimmed.length >= 24) {
+    try {
+      const decoded = Buffer.from(trimmed, "base64");
+      if (decoded.length >= 16) return decoded;
+    } catch {
+      // fall through
+    }
+  }
+  return Buffer.from(trimmed, "utf8");
+}
+
+export type SigningPolicy = "off" | "warn" | "require";
+
+export function parseSigningPolicy(value: string | undefined | null): SigningPolicy {
+  const raw = value?.trim().toLowerCase();
+  if (raw === "off" || raw === "warn" || raw === "require") return raw;
+  return "off";
+}

--- a/tests/task-signing.test.ts
+++ b/tests/task-signing.test.ts
@@ -1,0 +1,267 @@
+import { describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  buildCanonicalPayload,
+  extractSignatureField,
+  loadKeyStoreFromEnv,
+  parseSignature,
+  parseSigningPolicy,
+  signTask,
+  verifyTaskSignature,
+  type SigningParams,
+} from "../src/task-signing.js";
+
+const SECRET_HEX = "a".repeat(64); // 32 bytes of 0xaa
+const KEY_ID = "Codex-desktop";
+const KEYS = { [KEY_ID]: SECRET_HEX };
+
+function makeParams(overrides: Partial<SigningParams> = {}): SigningParams {
+  return {
+    taskId: "20260420-120000-a1b2",
+    submitter: KEY_ID,
+    submittedAt: "2026-04-20T12:00:00Z",
+    runtime: "claude",
+    prompt: "Do the thing.",
+    ...overrides,
+  };
+}
+
+describe("buildCanonicalPayload", () => {
+  it("produces a stable, sorted, newline-terminated representation", () => {
+    const payload = buildCanonicalPayload(makeParams());
+    expect(payload.endsWith("\n")).toBe(true);
+    const lines = payload.trimEnd().split("\n");
+    const sorted = [...lines].sort();
+    expect(lines).toEqual(sorted);
+  });
+
+  it("hashes the prompt rather than including it verbatim", () => {
+    const payload = buildCanonicalPayload(makeParams({ prompt: "secret" }));
+    expect(payload).not.toContain("secret");
+    expect(payload).toMatch(/prompt-sha256=[0-9a-f]{64}/);
+  });
+
+  it("hashes context-refs when present and omits otherwise", () => {
+    const without = buildCanonicalPayload(makeParams());
+    expect(without).toContain("context-refs-sha256=\n");
+
+    const withRefs = buildCanonicalPayload(
+      makeParams({ contextRefs: ["meta/a", "meta/b"] }),
+    );
+    expect(withRefs).toMatch(/context-refs-sha256=[0-9a-f]{64}/);
+  });
+
+  it("is order-independent for context-refs", () => {
+    const a = buildCanonicalPayload(makeParams({ contextRefs: ["meta/a", "meta/b"] }));
+    const b = buildCanonicalPayload(makeParams({ contextRefs: ["meta/b", "meta/a"] }));
+    expect(a).toEqual(b);
+  });
+
+  it("differs when any signed field changes", () => {
+    const base = buildCanonicalPayload(makeParams());
+    expect(buildCanonicalPayload(makeParams({ submitter: "hugin" }))).not.toEqual(base);
+    expect(buildCanonicalPayload(makeParams({ runtime: "codex" }))).not.toEqual(base);
+    expect(buildCanonicalPayload(makeParams({ prompt: "Different" }))).not.toEqual(base);
+    expect(buildCanonicalPayload(makeParams({ taskId: "other" }))).not.toEqual(base);
+    expect(
+      buildCanonicalPayload(makeParams({ submittedAt: "2026-04-20T12:00:01Z" })),
+    ).not.toEqual(base);
+  });
+
+  it("strips embedded newlines in values (defense against canonicalisation attacks)", () => {
+    const payload = buildCanonicalPayload(
+      makeParams({ submitter: "Codex-desktop\nsubmitter=hugin" }),
+    );
+    // Must not produce two submitter lines.
+    const submitterLines = payload.split("\n").filter((l) => l.startsWith("submitter="));
+    expect(submitterLines).toHaveLength(1);
+  });
+});
+
+describe("signTask + verifyTaskSignature round-trip", () => {
+  it("verifies a valid signature", () => {
+    const sig = signTask(makeParams(), KEY_ID, SECRET_HEX);
+    const result = verifyTaskSignature(makeParams(), sig, KEYS);
+    expect(result.status).toBe("valid");
+    expect(result.keyId).toBe(KEY_ID);
+  });
+
+  it("rejects a tampered prompt", () => {
+    const sig = signTask(makeParams(), KEY_ID, SECRET_HEX);
+    const result = verifyTaskSignature(
+      makeParams({ prompt: "Do a different thing." }),
+      sig,
+      KEYS,
+    );
+    expect(result.status).toBe("invalid");
+  });
+
+  it("rejects a swapped submitter", () => {
+    const sig = signTask(makeParams(), KEY_ID, SECRET_HEX);
+    const result = verifyTaskSignature(
+      makeParams({ submitter: "hugin" }),
+      sig,
+      KEYS,
+    );
+    expect(result.status).toBe("invalid");
+  });
+
+  it("rejects a swapped runtime (cloud → ollama escalation)", () => {
+    const sig = signTask(makeParams({ runtime: "ollama" }), KEY_ID, SECRET_HEX);
+    const result = verifyTaskSignature(
+      makeParams({ runtime: "claude" }),
+      sig,
+      KEYS,
+    );
+    expect(result.status).toBe("invalid");
+  });
+
+  it("returns missing when no signature is provided", () => {
+    const result = verifyTaskSignature(makeParams(), null, KEYS);
+    expect(result.status).toBe("missing");
+  });
+
+  it("returns unknown-signer when the keyId has no key", () => {
+    const sig = signTask(makeParams(), "rogue", SECRET_HEX);
+    const result = verifyTaskSignature(makeParams(), sig, KEYS);
+    expect(result.status).toBe("unknown-signer");
+    expect(result.keyId).toBe("rogue");
+  });
+
+  it("returns malformed for garbage input", () => {
+    expect(verifyTaskSignature(makeParams(), "not-a-signature", KEYS).status).toBe(
+      "malformed",
+    );
+    expect(verifyTaskSignature(makeParams(), "v1:missing-hex", KEYS).status).toBe(
+      "malformed",
+    );
+  });
+
+  it("returns unsupported-version for future versions", () => {
+    const result = verifyTaskSignature(makeParams(), `v9:${KEY_ID}:${"0".repeat(64)}`, KEYS);
+    expect(result.status).toBe("unsupported-version");
+  });
+
+  it("accepts either hex case for the signature portion", () => {
+    const sig = signTask(makeParams(), KEY_ID, SECRET_HEX);
+    const [version, keyId, hex] = sig.split(":");
+    const upperHex = `${version}:${keyId}:${hex.toUpperCase()}`;
+    expect(verifyTaskSignature(makeParams(), upperHex, KEYS).status).toBe("valid");
+  });
+});
+
+describe("extractSignatureField", () => {
+  it("parses a bullet-style signature line", () => {
+    const content = `## Task: x\n\n- **Signature:** v1:Codex-desktop:${"a".repeat(64)}\n\n### Prompt\nhi`;
+    expect(extractSignatureField(content)).toBe(`v1:Codex-desktop:${"a".repeat(64)}`);
+  });
+
+  it("parses a bare signature line", () => {
+    const content = `**Signature:** v1:k:${"b".repeat(64)}`;
+    expect(extractSignatureField(content)).toBe(`v1:k:${"b".repeat(64)}`);
+  });
+
+  it("returns null when absent", () => {
+    expect(extractSignatureField("no signature here")).toBeNull();
+  });
+});
+
+describe("parseSignature", () => {
+  it("rejects non-hex trailing segments", () => {
+    expect(parseSignature("v1:k:zzzz")).toBeNull();
+  });
+
+  it("requires exactly three colon-separated parts", () => {
+    expect(parseSignature("v1:k:abcd:extra")).toBeNull();
+    expect(parseSignature("v1k:abcd")).toBeNull();
+  });
+});
+
+describe("parseSigningPolicy", () => {
+  it("accepts off|warn|require and defaults to off", () => {
+    expect(parseSigningPolicy("off")).toBe("off");
+    expect(parseSigningPolicy("WARN")).toBe("warn");
+    expect(parseSigningPolicy("require")).toBe("require");
+    expect(parseSigningPolicy("   ")).toBe("off");
+    expect(parseSigningPolicy("")).toBe("off");
+    expect(parseSigningPolicy("yolo")).toBe("off");
+    expect(parseSigningPolicy(undefined)).toBe("off");
+  });
+});
+
+describe("scripts/sign-task.mjs (cross-language drift guard)", () => {
+  it("produces the same signature as the in-process signTask", async () => {
+    const { execFileSync } = await import("node:child_process");
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "hugin-sign-"));
+    try {
+      const promptFile = path.join(tmp, "prompt.md");
+      fs.writeFileSync(promptFile, "Do the thing.");
+      const stdout = execFileSync(
+        "node",
+        [
+          "scripts/sign-task.mjs",
+          "--task-id",
+          "20260420-120000-a1b2",
+          "--submitter",
+          KEY_ID,
+          "--submitted-at",
+          "2026-04-20T12:00:00Z",
+          "--runtime",
+          "claude",
+          "--prompt-file",
+          promptFile,
+          "--key-id",
+          KEY_ID,
+        ],
+        {
+          env: { ...process.env, HUGIN_SIGNING_SECRET: SECRET_HEX },
+          encoding: "utf8",
+        },
+      ).trim();
+      const expected = signTask(makeParams(), KEY_ID, SECRET_HEX);
+      expect(stdout).toBe(expected);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("loadKeyStoreFromEnv", () => {
+  it("loads an inline JSON keystore from HUGIN_SUBMITTER_KEYS", () => {
+    const store = loadKeyStoreFromEnv({
+      HUGIN_SUBMITTER_KEYS: JSON.stringify({ Codex: SECRET_HEX, ratatoskr: "x".repeat(64) }),
+    } as NodeJS.ProcessEnv);
+    expect(store.Codex).toBe(SECRET_HEX);
+    expect(store.ratatoskr).toBe("x".repeat(64));
+  });
+
+  it("loads from HUGIN_SUBMITTER_KEYS_FILE taking precedence over inline", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "hugin-keys-"));
+    try {
+      const filePath = path.join(tmp, "keys.json");
+      fs.writeFileSync(filePath, JSON.stringify({ "from-file": SECRET_HEX }));
+      const store = loadKeyStoreFromEnv({
+        HUGIN_SUBMITTER_KEYS_FILE: filePath,
+        HUGIN_SUBMITTER_KEYS: JSON.stringify({ "from-inline": "ignored" }),
+      } as NodeJS.ProcessEnv);
+      expect(store["from-file"]).toBe(SECRET_HEX);
+      expect(store["from-inline"]).toBeUndefined();
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("returns an empty store for invalid JSON", () => {
+    const store = loadKeyStoreFromEnv({
+      HUGIN_SUBMITTER_KEYS: "{not json",
+    } as NodeJS.ProcessEnv);
+    expect(store).toEqual({});
+  });
+
+  it("returns an empty store when neither env var is set", () => {
+    const store = loadKeyStoreFromEnv({} as NodeJS.ProcessEnv);
+    expect(store).toEqual({});
+  });
+});

--- a/tests/task-signing.test.ts
+++ b/tests/task-signing.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import {
   buildCanonicalPayload,
+  canonicalizePrompt,
   extractSignatureField,
   loadKeyStoreFromEnv,
   parseSignature,
@@ -98,14 +99,38 @@ describe("signTask + verifyTaskSignature round-trip", () => {
     expect(result.status).toBe("invalid");
   });
 
-  it("rejects a swapped submitter", () => {
+  it("rejects a swapped submitter via submitter-mismatch binding", () => {
     const sig = signTask(makeParams(), KEY_ID, SECRET_HEX);
     const result = verifyTaskSignature(
       makeParams({ submitter: "hugin" }),
       sig,
       KEYS,
     );
-    expect(result.status).toBe("invalid");
+    // keyId=Codex-desktop cannot sign for submitter=hugin regardless of
+    // whether the HMAC happens to match.
+    expect(result.status).toBe("submitter-mismatch");
+  });
+
+  it("blocks cross-submitter spoofing even with a valid HMAC", () => {
+    // A signer holding the ratatoskr key tries to pass itself off as
+    // Codex-desktop by claiming Submitted by: Codex-desktop but signing
+    // with Signature: v1:ratatoskr:...
+    const ratatoskrSecret = "b".repeat(64);
+    const keys = { ratatoskr: ratatoskrSecret, [KEY_ID]: SECRET_HEX };
+    const spoofed = makeParams({ submitter: KEY_ID }); // body claims Codex-desktop
+    const sig = signTask(spoofed, "ratatoskr", ratatoskrSecret); // signed by ratatoskr
+    const result = verifyTaskSignature(spoofed, sig, keys);
+    expect(result.status).toBe("submitter-mismatch");
+    expect(result.keyId).toBe("ratatoskr");
+  });
+
+  it("accepts rotation aliases of the form <submitter>-<rotation>", () => {
+    const rotationKeyId = "Codex-desktop-2026q2";
+    const keys = { [rotationKeyId]: SECRET_HEX };
+    const sig = signTask(makeParams(), rotationKeyId, SECRET_HEX);
+    const result = verifyTaskSignature(makeParams(), sig, keys);
+    expect(result.status).toBe("valid");
+    expect(result.keyId).toBe(rotationKeyId);
   });
 
   it("rejects a swapped runtime (cloud → ollama escalation)", () => {
@@ -180,14 +205,35 @@ describe("parseSignature", () => {
 });
 
 describe("parseSigningPolicy", () => {
-  it("accepts off|warn|require and defaults to off", () => {
+  it("accepts off|warn|require and defaults to off when unset", () => {
     expect(parseSigningPolicy("off")).toBe("off");
     expect(parseSigningPolicy("WARN")).toBe("warn");
     expect(parseSigningPolicy("require")).toBe("require");
     expect(parseSigningPolicy("   ")).toBe("off");
     expect(parseSigningPolicy("")).toBe("off");
-    expect(parseSigningPolicy("yolo")).toBe("off");
     expect(parseSigningPolicy(undefined)).toBe("off");
+    expect(parseSigningPolicy(null)).toBe("off");
+  });
+
+  it("throws on typos so the control never silently disables", () => {
+    // A typo like `requrie` must fail loud, not fall back to off.
+    expect(() => parseSigningPolicy("requrie")).toThrow(/invalid HUGIN_SIGNING_POLICY/);
+    expect(() => parseSigningPolicy("yolo")).toThrow(/invalid HUGIN_SIGNING_POLICY/);
+  });
+});
+
+describe("canonicalizePrompt", () => {
+  it("is applied on both sides of the signature", () => {
+    // Prompts that differ only in leading/trailing whitespace hash to the
+    // same canonical payload — the submitter helper trims, so the
+    // verifier must trim too.
+    const a = buildCanonicalPayload(makeParams({ prompt: "Do the thing." }));
+    const b = buildCanonicalPayload(makeParams({ prompt: "  Do the thing.\n\n" }));
+    expect(a).toEqual(b);
+  });
+
+  it("exposes the canonicalization rule so submitters can match it", () => {
+    expect(canonicalizePrompt("  hi\n")).toBe("hi");
   });
 });
 
@@ -221,6 +267,46 @@ describe("scripts/sign-task.mjs (cross-language drift guard)", () => {
         },
       ).trim();
       const expected = signTask(makeParams(), KEY_ID, SECRET_HEX);
+      expect(stdout).toBe(expected);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("agrees on prompts with trailing whitespace / EOF newlines", async () => {
+    // Real markdown prompt files routinely end with a newline. Both sides
+    // must canonicalize away that noise — otherwise --prompt-file signing
+    // silently breaks verification for every multi-line prompt.
+    const { execFileSync } = await import("node:child_process");
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "hugin-sign-"));
+    try {
+      const promptFile = path.join(tmp, "prompt.md");
+      fs.writeFileSync(promptFile, "  Do the thing.\n\n");
+      const stdout = execFileSync(
+        "node",
+        [
+          "scripts/sign-task.mjs",
+          "--task-id",
+          "20260420-120000-a1b2",
+          "--submitter",
+          KEY_ID,
+          "--submitted-at",
+          "2026-04-20T12:00:00Z",
+          "--runtime",
+          "claude",
+          "--prompt-file",
+          promptFile,
+          "--key-id",
+          KEY_ID,
+        ],
+        {
+          env: { ...process.env, HUGIN_SIGNING_SECRET: SECRET_HEX },
+          encoding: "utf8",
+        },
+      ).trim();
+      // Hugin's parseTask trims the prompt extracted from Munin; the
+      // expected signature must correspond to the trimmed form.
+      const expected = signTask(makeParams({ prompt: "Do the thing." }), KEY_ID, SECRET_HEX);
       expect(stdout).toBe(expected);
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- `src/task-signing.ts`: HMAC-SHA256 sign/verify, canonical-payload builder, keystore loader (env + file), constant-time comparison.
- `src/index.ts`: signature verification wired between submitter-allowlist and sensitivity checks. Three policy modes via `HUGIN_SIGNING_POLICY`: `off` (default), `warn`, `require`.
- `scripts/sign-task.mjs`: submitter-side helper. A drift-guard test spawns the helper and asserts byte equality with the Node module.
- `docs/security/task-signing.md` covers threat model, scheme, key management, and rollout plan.

Defaults to `off` so nothing breaks. Rollout plan: ship this → add signing to submitters one at a time → flip Pi to `warn` → then `require`.

## Signed fields

Canonical payload (sorted, `\n`-delimited, trailing `\n`):

```
context-refs-sha256=<hex or empty>
prompt-sha256=<hex>
runtime=<runtime>
submitted-at=<iso>
submitter=<submittedBy>
task-id=<taskId>
version=v1
```

`prompt-sha256` binds the exact prompt; `context-refs-sha256` binds the sorted ref list (prevents an attacker from swapping in a new client-confidential ref on a pre-signed task). Values are `\r\n`-stripped before signing to block canonicalization smuggling.

## Not in this PR (tracked as follow-ups)

- Per-submitter rollout (Codex CLI, Ratatoskr, /submit-task skill, claude-code sessions)
- Pipeline-task signing (the `Runtime: pipeline` path doesn't produce the TaskConfig shape this verifier expects — noted in `verifyTaskEntrySignature`)
- Optional Ed25519 upgrade path

## Test plan

- [x] 26 new unit tests covering canonical form, HMAC round-trip, every tamper vector (prompt / submitter / runtime / context-refs / task-id / submitted-at), malformed / missing / unknown-signer / unsupported-version, keystore loading
- [x] Cross-language drift guard: spawns `scripts/sign-task.mjs` and asserts byte-equal signatures with `signTask()`
- [x] 340/340 passing, build clean
- [ ] Post-merge: leave `off` on the Pi. Flip to `warn` only after the first submitter is signing.