### PR TITLE
fix(tasks): guarantee terminal status tag when structured-result write throws

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3286,6 +3286,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         undefined,
         taskClassification,
       );
+      let postProcessingError: string | null = null;
       try {
         await writeStructuredTaskResult(
           taskNs,
@@ -3310,18 +3311,10 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
           taskClassification,
         );
       } catch (err) {
-        const errMsg = err instanceof Error ? err.message : String(err);
+        postProcessingError = err instanceof Error ? err.message : String(err);
         console.warn(
-          `Failed to write structured result for ${taskNs}: ${errMsg}. Proceeding to terminal status write so the task does not stay 'running'.`
+          `Failed to write structured result for ${taskNs}: ${postProcessingError}. Proceeding to terminal status write so the task does not stay 'running'.`
         );
-        try {
-          await munin.log(
-            taskNs,
-            `Post-processing error: structured result write failed (${errMsg}). Terminal status still recorded.`
-          );
-        } catch {
-          // Don't let a log failure block the status write.
-        }
       }
       await munin.write(
         taskNs,
@@ -3331,11 +3324,22 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         undefined,
         taskClassification,
       );
+      if (postProcessingError) {
+        try {
+          await munin.log(
+            taskNs,
+            `Post-processing error: structured result write failed (${postProcessingError}). Terminal status still recorded.`
+          );
+        } catch {
+          // Don't let a diagnostic log failure surface as a new error.
+        }
+      }
       await munin.log(
         taskNs,
         `Task cancelled in ${Math.round(durationMs / 1000)}s (reason: ${cancellation.reason}, executor: ${executorLabel})`
       );
     } else {
+      let postProcessingError: string | null = null;
       try {
         await writeStructuredTaskResult(
           taskNs,
@@ -3370,18 +3374,10 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
           taskClassification,
         );
       } catch (err) {
-        const errMsg = err instanceof Error ? err.message : String(err);
+        postProcessingError = err instanceof Error ? err.message : String(err);
         console.warn(
-          `Failed to write structured result for ${taskNs}: ${errMsg}. Proceeding to terminal status write so the task does not stay 'running'.`
+          `Failed to write structured result for ${taskNs}: ${postProcessingError}. Proceeding to terminal status write so the task does not stay 'running'.`
         );
-        try {
-          await munin.log(
-            taskNs,
-            `Post-processing error: structured result write failed (${errMsg}). Terminal status still recorded.`
-          );
-        } catch {
-          // Don't let a log failure block the status write.
-        }
       }
 
       await munin.write(
@@ -3393,6 +3389,16 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         undefined,
         taskClassification
       );
+      if (postProcessingError) {
+        try {
+          await munin.log(
+            taskNs,
+            `Post-processing error: structured result write failed (${postProcessingError}). Terminal status still recorded.`
+          );
+        } catch {
+          // Don't let a diagnostic log failure surface as a new error.
+        }
+      }
 
       await munin.log(
         taskNs,

--- a/src/index.ts
+++ b/src/index.ts
@@ -3286,28 +3286,43 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         undefined,
         taskClassification,
       );
-      await writeStructuredTaskResult(
-        taskNs,
-        createCancelledStructuredResult(taskNs, task.runtime, cancellation.reason, {
-          executor: effectiveExecutor,
-          resultSource,
-          startedAt,
-          completedAt,
-          durationSeconds: Math.round(durationMs / 1000),
-          logFile: `~/.hugin/logs/${taskId}.log`,
-          replyTo: task.replyTo,
-          replyFormat: task.replyFormat,
-          group: task.group,
-          sequence: task.sequence,
-          pipeline: task.pipeline,
-          runtimeMetadata,
-          approval: approvalMetadata,
-          bodyKind: structuredBodyKind,
-          bodyText: structuredBodyText,
-          sensitivity: taskSensitivitySnapshot,
-        }),
-        taskClassification,
-      );
+      try {
+        await writeStructuredTaskResult(
+          taskNs,
+          createCancelledStructuredResult(taskNs, task.runtime, cancellation.reason, {
+            executor: effectiveExecutor,
+            resultSource,
+            startedAt,
+            completedAt,
+            durationSeconds: Math.round(durationMs / 1000),
+            logFile: `~/.hugin/logs/${taskId}.log`,
+            replyTo: task.replyTo,
+            replyFormat: task.replyFormat,
+            group: task.group,
+            sequence: task.sequence,
+            pipeline: task.pipeline,
+            runtimeMetadata,
+            approval: approvalMetadata,
+            bodyKind: structuredBodyKind,
+            bodyText: structuredBodyText,
+            sensitivity: taskSensitivitySnapshot,
+          }),
+          taskClassification,
+        );
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        console.warn(
+          `Failed to write structured result for ${taskNs}: ${errMsg}. Proceeding to terminal status write so the task does not stay 'running'.`
+        );
+        try {
+          await munin.log(
+            taskNs,
+            `Post-processing error: structured result write failed (${errMsg}). Terminal status still recorded.`
+          );
+        } catch {
+          // Don't let a log failure block the status write.
+        }
+      }
       await munin.write(
         taskNs,
         "status",
@@ -3321,38 +3336,53 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         `Task cancelled in ${Math.round(durationMs / 1000)}s (reason: ${cancellation.reason}, executor: ${executorLabel})`
       );
     } else {
-      await writeStructuredTaskResult(
-        taskNs,
-        buildStructuredTaskResult({
-          schemaVersion: 1,
-          taskId,
-          taskNamespace: taskNs,
-          lifecycle: ok ? "completed" : "failed",
-          outcome: ok ? "completed" : isTimeout ? "timed_out" : "failed",
-          runtime: task.runtime,
-          executor: effectiveExecutor,
-          resultSource,
-          exitCode,
-          startedAt,
-          completedAt,
-          durationSeconds: Math.round(durationMs / 1000),
-          logFile: `~/.hugin/logs/${taskId}.log`,
-          replyTo: task.replyTo,
-          replyFormat: task.replyFormat,
-          group: task.group,
-          sequence: task.sequence,
-          costUsd: costUsd ?? undefined,
-          prUrl,
-          bodyKind: structuredBodyKind,
-          bodyText: structuredBodyText,
-          errorMessage: ok ? undefined : structuredBodyText,
-          runtimeMetadata,
-          pipeline: task.pipeline,
-          approval: approvalMetadata,
-          sensitivity: taskSensitivitySnapshot,
-        }),
-        taskClassification,
-      );
+      try {
+        await writeStructuredTaskResult(
+          taskNs,
+          buildStructuredTaskResult({
+            schemaVersion: 1,
+            taskId,
+            taskNamespace: taskNs,
+            lifecycle: ok ? "completed" : "failed",
+            outcome: ok ? "completed" : isTimeout ? "timed_out" : "failed",
+            runtime: task.runtime,
+            executor: effectiveExecutor,
+            resultSource,
+            exitCode,
+            startedAt,
+            completedAt,
+            durationSeconds: Math.round(durationMs / 1000),
+            logFile: `~/.hugin/logs/${taskId}.log`,
+            replyTo: task.replyTo,
+            replyFormat: task.replyFormat,
+            group: task.group,
+            sequence: task.sequence,
+            costUsd: costUsd ?? undefined,
+            prUrl,
+            bodyKind: structuredBodyKind,
+            bodyText: structuredBodyText,
+            errorMessage: ok ? undefined : structuredBodyText,
+            runtimeMetadata,
+            pipeline: task.pipeline,
+            approval: approvalMetadata,
+            sensitivity: taskSensitivitySnapshot,
+          }),
+          taskClassification,
+        );
+      } catch (err) {
+        const errMsg = err instanceof Error ? err.message : String(err);
+        console.warn(
+          `Failed to write structured result for ${taskNs}: ${errMsg}. Proceeding to terminal status write so the task does not stay 'running'.`
+        );
+        try {
+          await munin.log(
+            taskNs,
+            `Post-processing error: structured result write failed (${errMsg}). Terminal status still recorded.`
+          );
+        } catch {
+          // Don't let a log failure block the status write.
+        }
+      }
 
       await munin.write(
         taskNs,


### PR DESCRIPTION
## Summary

Wraps `writeStructuredTaskResult` in try/catch in both completion paths of `src/index.ts` so a throw (Zod validation, classification check) no longer prevents the terminal status write. The lifecycle-critical `"status"` flip from `running` to `completed`/`failed`/`cancelled` always lands.

Fixes #57.

## Why this matters

The issue (self-filed) traces a stuck-running task back to `src/index.ts`: `writeStructuredTaskResult` runs before `munin.write(..., "status", buildTerminalStatusTags(...))`, both inside a `try` at 2767 whose enclosing scope has a `finally` at 3436 but **no** `catch`. A throw from the structured-result path propagates up to the `pollLoop` generic handler at 3496 and the task's `running` tag never flips. As the maintainer puts it: "Losing the structured result is recoverable; a stuck `running` tag is not."

## Changes

`src/index.ts`, both the cancelled branch (~line 3289) and the non-cancelled completion branch (~line 3338):

- Introduce `let postProcessingError: string | null = null;` at the top of each branch.
- Wrap `writeStructuredTaskResult(...)` in try/catch. On catch, record the error message, `console.warn` it, but do **not** await anything else in the catch — the next `await` is the terminal-status `munin.write`.
- After the terminal-status `munin.write`, if `postProcessingError` is set, best-effort `munin.log` the post-processing error inside its own try/catch so a degraded log call cannot surface as a new error.

The existing happy-path `munin.log` calls (`Task completed in ...s`, `Task cancelled in ...s`) stay where they were.

`munin.write(..., "status", ...)` itself is NOT wrapped — if it throws, the pollLoop's existing generic handler should still see it; we do not want to silently swallow lifecycle-critical failures.

### Ordering

The first revision of this patch awaited the diagnostic `munin.log` inside the catch, BEFORE the terminal status write. An internal review (`codex review`) pointed out that a degraded Munin would then re-introduce the exact stuck-running failure mode the patch is trying to prevent. The commit log reflects that second pass: status write first, diagnostic log best-effort after.

## Testing

```
npm run build   # tsc, passes
npm test        # 28 files, 400 tests, all pass
```

## Scope

Not included: the issue's "unit test that injects a throw in the structured-result path" acceptance bullet. The completion flow is currently in the ~3700-line `pollOnce` function inside `src/index.ts`; a testable unit would require extracting it. Happy to follow up with that refactor in a separate PR if helpful.

## AI disclosure

This contribution was developed with AI assistance (Codex).
