### PR TITLE
feat: orchestrator v1 Steps 1-3 + impl-review fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,8 @@ node_modules/
 dist/
 .env
 .DS_Store
-debate/
+debate/*
+!debate/INDEX.md
+!debate/*-summary.md
+!debate/*-critique-log.json
 .claude/

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,9 +1,50 @@
 # Hugin — Status
 
-**Last session:** 2026-04-25
+**Last session:** 2026-04-26
 **Branch:** main
 
-## Completed This Session (2026-04-25)
+## Completed This Session (2026-04-26)
+
+### Step 2 done — runtime registry extended (uncommitted)
+
+`src/runtime-registry.ts` gains orthogonal policy fields (`provider`, `egress`, `zdrRequired`, `autoEligible`, `family`, `reasoningLevel`, `harnessCmd`, `harnessFlags`) per spec §6. Two new runtime rows: `openrouter` (one-shot, third-party, ZDR, explicit-only) and `pi-harness` (harness, third-party, ZDR, explicit-only, `pi --no-session --provider openrouter`). All four legacy rows backfilled with sensible defaults.
+
+Stable alias map (`ALIAS_MAP_V1`) added with `tiny` / `medium` / `large-reasoning` / `pi-large-coder`. `resolveAlias()` and `getAliasMap()` helpers exposed.
+
+`src/router.ts` gains an `autoEligible: false` filter so the auto-router never picks orchestrator runtimes (they remain selectable explicitly via the alias map).
+
+Type plumbing: `DispatcherRuntime` widened to include `openrouter | pi-harness` in both `runtime-registry.ts` and `task-result-schema.ts`. Two narrow casts at `src/index.ts:2698` and `src/pipeline-compiler.ts:527` keep the dispatcher-side types honest (auto-router and pipeline runtime IDs are restricted to legacy three).
+
+Tests: `tests/runtime-registry.test.ts` extended with 9 new tests (alias map + policy fields). `tests/router.test.ts` extended with 4 new autoEligible tests. 431/431 passing.
+
+### Step 3 done — `finalizeDelegatedOutput()` shared helper (uncommitted)
+
+New `src/finalize-delegated-output.ts`. Single helper used by every output-return surface (broker, executors, MCP) per spec §4/§5/§7. Wraps the existing exfiltration scanner, returns a typed `DelegationResult` with `result_kind: "text" | "diff"`, structured diff metadata, and `provenance: { source: "delegated", scanner_pass, policy_version, harness_version? }`. Scanner policy `warn` (default) keeps content but flags; `redact` substitutes matched spans. `tests/finalize-delegated-output.test.ts`: 13 tests covering text path, diff path, clean/warn/redact transitions, metadata propagation.
+
+### Step 1 done — orchestrator v1 data-model spec (`docs/orchestrator-v1-data-model.md`, uncommitted)
+
+Locks request envelope, harness `WorktreeSpec`, 5-state await machine with `result_kind: text | diff`, append-only journal events + projection, runtime registry extension, end-to-end provenance chain. §11 records the Option B decision and the eval data backing it.
+
+### Decision: orchestrator v1 builds; pi-harness on Pi enters v1 (Option B)
+
+Magnus overrode the prior debate's "priority not earned" verdict and chose to build the orchestrator stack and learn from real usage. Adversarial debate (`debate/orch-v1-build-*`) re-framed as HOW not IF, ran 2 rounds with Codex (gpt-5.4 xhigh), surfaced 17 critique points (6/17 caught by self-review = 35%). All 17 valid; 5 critical. Net: ~2,000 LOC / ~5 days revised estimate (up from original ~1,000 LOC / 2 days).
+
+Key contract changes from the debate:
+- Drop `hugin_run` (sync) from v1 — submit+await over 30s poll cannot deliver real sync.
+- Hugin is sole journal writer (laptop MCP cannot own a Pi-side journal).
+- Add orthogonal `provider`/`egress`/`zdrRequired`/`autoEligible` fields instead of stretching the trust tier.
+- Hugin owns ZDR enforcement (pinned allowlist + cached catalog metadata).
+- Append-only event log + read-time projection (no JSONL mutation) for journal.
+- Pi-side broker (Tailscale-only, bearer auth) replaces laptop-side signing keys.
+- Stable aliases (`tiny`, `medium`, `large-reasoning`, `pi-large-coder`) over literal model names.
+
+Then a parallel-session result flipped the harness scope: `pi` (the pi-coding-agent) scored 5/6 strict, 6/6 lenient on the aider-eval task set against `openrouter/qwen/qwen3-coder-next`, headless one-shot via `pi --no-session -p`, fresh `git worktree add` per task. **Decision: Option B** — `pi` enters v1 as a harness runtime running on the Pi, calling cloud models via OR; working trees are per-task git worktrees on the Pi; Hugin never auto-pushes; diffs return to Claude for review.
+
+Spec finalized: `docs/orchestrator-v1-data-model.md` (Step 1 deliverable). Covers request envelope, harness `WorktreeSpec`, 5-state await machine with `result_kind: text | diff`, append-only journal events, runtime registry extension (incl. new `pi-harness` provider row), provenance chain end-to-end. Step 2 (runtime registry extension) is unblocked.
+
+Debate artifacts (committed): `debate/INDEX.md`, `debate/orch-v1-build-summary.md`, `debate/orch-v1-build-critique-log.json`. Drafts/critiques/rebuttals stay local per skill defaults.
+
+
 
 ### Fix: status-first ordering in task completion (#57, `3501c7a`, merged + deployed)
 
@@ -24,6 +65,37 @@ Plan: telemetry schema v2 → OpenRouter executor → `hugin-mcp` package → or
 Key concessions: latency premise stale (`think:false` cut Pi Ollama from 90s → 2s), OpenRouter routing semantics undefined (would systematically lose to free+trusted Ollama), `infer_direct` was a security regression (now requires structural controls: 500-char cap, local-only, forced public, audit log), Hugin is serial (delegation = token/model/async offload, not parallel speedup), no success gate.
 
 Revised build order: **#57 fix ✅ → journal analysis → 10–20 task benchmark → decision gate → (if green) design `cloud-third-party` trust tier → OpenRouter → MCP → skill**.
+
+### Review: v1 build-plan critique written (`debate/orch-v1-build-codex-critique.md`)
+
+Second-pass HOW critique against the new "build it now" framing. Main findings:
+
+- `hugin_run` is not a credible sync surface on top of the current 30s poll + single-task dispatcher; either async-only v1 or a real direct path is needed.
+- The proposed orchestrator journal cannot be laptop-MCP-owned if the authoritative `~/.hugin` files live on the Pi; Hugin should stay the sole journal writer.
+- OpenRouter needs provider-aware metadata and server-side model-policy enforcement; overloading `semi-trusted` is too blunt.
+- MCP-originated submission needs an explicit auth/signing/secret story before `HUGIN_SIGNING_POLICY=require`.
+
+Munin context load was attempted first per instructions but unavailable from this session: `memory_orient` safety-blocked, subsequent `memory_read`/`memory_query` calls returned `user cancelled MCP tool call`. The critique is therefore grounded in local repo state + code, not live Munin status.
+
+### Debate: Round 2 rebuttal to Claude response written (`debate/orch-v1-build-codex-rebuttal-1.md`)
+
+Reviewed Claude's revised plan against the live code seams it now depends on. Judgement:
+
+- **Resolved adequately:** F1 (`hugin_run` removed), F2 (Hugin-only journal ownership), F3 (provider/egress/zdr/explicit-only policy shape), F4 (Hugin-side allowlist enforcement), F5 (shared result finalization path).
+- **Still incomplete:** F6 (broker endpoint auth/scope/idempotency/provenance still underspecified), F7 (`await` resumability does not solve Pi reboot + lease-orphan ambiguity), F8 (alias versioning / corpus regime shifts), F9 (append-only journal cannot support post-hoc `rate` updates without an event/projection design).
+- **New issues introduced by the revision:** broker requires turning Hugin from localhost-only health server into a remote authenticated control surface; overlaying full prompt/output into the main invocation journal changes retention/blast radius; `orchestrator_session_id` must stay distinct from Munin's task-scoped `mcp-session-id`.
+
+Most important pre-code requirement: define the Pi-side delegation contract first — request envelope, append-only journal event model, await/result state machine, and provenance chain. If that authority boundary is wrong, the broker, aliases, and telemetry all become migration pain.
+
+### Review: Round 2 rebuttal to Step 1-3 implementation review written (`debate/orch-v1-impl-review-codex-rebuttal-1.md`)
+
+Reviewed Claude's Step 1-3 response against the live spec and source. Munin partially improved this round: `memory_orient` succeeded, but the requested `memory_read("projects/hugin","synthesis")`, fallback `status`, `memory_query(...)`, and `memory_narrative(...)` calls still cancelled / safety-blocked, so the rebuttal remains grounded in local state plus live code.
+
+Judgement:
+
+- **Adequate concessions:** Finding 2 is genuinely conceded (redacted diff cannot stay on the success branch), Finding 4's default flip to `copy_node_modules: false` is directionally right, and Finding 5's `envelope_version` / `result_schema_version` additions are valid as far as the request/result wire goes.
+- **Still incomplete:** `runtime_row_id?: string` fixes observability after the fact but not control-plane identity, union widening, or row-scoped policy lookup; the proposed §12 write-ordering invariants still do not choose a single source of truth for submit/complete/await and over-apply the #57 status-first lesson; journal/event versioning remains missing even after the result/request version concession.
+- **Most important pre-Step-4 requirement:** write the delegated-task durability contract as a source-of-truth spec, not just an ordering list — what makes a submission durable, what makes a completion durable, what `await` reads after crash/restart, and where stable runtime-row identity lives end to end.
 
 ### Research: orchestrator sweep for multi-host placement layer (`4374037`, committed by Hugin task `20260424-210931-orchestrator-sweep`)
 

--- a/debate/INDEX.md
+++ b/debate/INDEX.md
@@ -1,0 +1,11 @@
+# Debate Index
+
+| Date | Topic | Rounds | Key decision | Critique points | Self-review catch rate |
+|------|-------|--------|--------------|----------------|-----------------------|
+| 2026-03-15 | [Architecture Guide](arch-guide-summary.md) | 2 | Guide needs trustworthiness pass before it qualifies as internal reference; 3 factual inaccuracies found in Hugin sections | 15 | 2/15 (13%) |
+| 2026-04-01 | [Multi-agent orchestration](multi-agent-orch-summary.md) | 2 | Worker/lease model before DAG, not after | 12 | 2/12 (17%) |
+| 2026-04-01 | [debate-codex skill improvements](skill-improvements-summary.md) | 2 | Adopt type-specific prompts + severity calibration only; defer tiers and structural changes | 14 | 3/14 (21%) |
+| 2026-04-09 | [Zombie process root cause](zombie-procs-summary.md) | 2 | Dual systemd service confirmed; repo hugin.service + deploy-pi.sh need user-level rewrite; shutdown() needs child-await before exit | 9 | 3/9 (33%) |
+| 2026-04-25 | [Orchestrator stack plan](orch-stack-summary.md) | 2 | Run falsifiable go/no-go with existing telemetry before writing any new code; multi-host sprint is still the approved priority | 11 | 3/11 (27%) |
+| 2026-04-25 | [Orchestrator v1 build (HOW)](orch-v1-build-summary.md) | 2 | Build it, but contracts-first: define delegation data model + state machine + journal event model + broker auth boundary BEFORE any executor/MCP code; drop `hugin_run` from v1; use overlay journal not shadow; new provider/egress/zdr fields orthogonal to trust tier | 17 | 6/17 (35%) |
+| 2026-04-26 | [Orchestrator v1 Steps 1-3 review](orch-v1-impl-review-summary.md) | 2 | Step 1-3 contracts NOT locked enough for Step 4: scanner-redact-on-diff is a contract bug (must escalate to scanner_blocked); durability/runtime-row-identity model must be spec'd before broker; copy_node_modules default flips to false; add envelope_version + result_schema_version | 12 | 3/12 (25%) |

--- a/debate/arch-guide-critique-log.json
+++ b/debate/arch-guide-critique-log.json
@@ -1,0 +1,137 @@
+[
+  {
+    "id": "arch-guide-C01",
+    "source": "codex-round-1",
+    "text": "Topology diagram shows task submission going to Hugin, but clients submit to Munin; Hugin only exposes /health",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "arch-guide-C02",
+    "source": "codex-round-1",
+    "text": "Stale-task recovery description says 'time in running state' but code measures time since submission",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "critical",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "arch-guide-C03",
+    "source": "codex-round-1",
+    "text": "Deployment section says .env is deployed and only built artifacts synced; actual script syncs repo tree and preserves .env on target",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "arch-guide-C04",
+    "source": "codex-round-1",
+    "text": "Internal inconsistency: 'all three services' vs 'two-service system'",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "minor",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "arch-guide-C05",
+    "source": "codex-round-1",
+    "text": "'Three src/index.ts files' claim is rhetoric; important behavior lives in munin-client.ts, systemd units, deploy scripts",
+    "classification": "partially_valid",
+    "impact": "acknowledged",
+    "severity": "minor",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "arch-guide-C06",
+    "source": "codex-round-1",
+    "text": "Missing rationale for markdown task format over JSON/typed schema",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "arch-guide-C07",
+    "source": "codex-round-1",
+    "text": "Missing rationale for polling+search as queue primitive vs dedicated queue",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "arch-guide-C08",
+    "source": "codex-round-1",
+    "text": "Missing rationale for tags as state machine vs structured fields",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "arch-guide-C09",
+    "source": "codex-round-1",
+    "text": "'One task at a time' justified only with slogan, not actual rationale (CPU? isolation? cost?)",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "minor",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "arch-guide-C10",
+    "source": "codex-round-1",
+    "text": "4000-char output truncation has no stated rationale or discussion of what's lost",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "minor",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "arch-guide-C11",
+    "source": "codex-round-1",
+    "text": "No rationale for full CLI spawning vs narrower execution sandbox, inconsistent with security posture",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "arch-guide-C12",
+    "source": "codex-round-1",
+    "text": "Document lacks source-of-truth pointers; Munin/Mimir sections presented as authoritative but code lives elsewhere",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "arch-guide-C13",
+    "source": "codex-round-1",
+    "text": "Guide evaluated as 'well-written' but trustworthiness is the key criterion for a reference document",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "critical",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "arch-guide-C14",
+    "source": "codex-round-2",
+    "text": "Stale-recovery fix should resolve code-vs-design mismatch, not just update prose",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "arch-guide-C15",
+    "source": "codex-round-2",
+    "text": "Action items are document-centric; should prioritize trustworthiness pass over polish pass",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": false
+  }
+]

--- a/debate/arch-guide-summary.md
+++ b/debate/arch-guide-summary.md
@@ -1,0 +1,78 @@
+# Debate Summary: Jarvis Architecture Guide
+
+**Date:** 2026-03-15
+**Participants:** Claude (Opus 4.6) vs Codex (GPT-5.4)
+**Rounds:** 2
+**Artifact:** `docs/architecture.md` (commit 18791cf, 513 lines)
+
+## Key Outcome
+
+The architecture guide is a strong **overview/onboarding document** but does not yet meet the bar of a trustworthy **internal reference**. The most important finding is that verifiable claims in the Hugin section contain factual inaccuracies, which undermines confidence in sections that can't be checked from this repo.
+
+## Concessions Accepted by Both Sides
+
+1. **Topology diagram is wrong** — task-submission arrow points at Hugin, but clients submit to Munin
+2. **Stale-recovery description doesn't match code** — guide says "time in running state," code measures time since submission
+3. **Deployment description is inaccurate** — guide says .env is deployed and only built artifacts synced; script does the opposite
+4. **"Two-service" vs "three services" inconsistency**
+5. **Missing source-of-truth pointers** — Munin/Mimir sections need to state they're summaries, not authoritative
+6. **Claude's 8/10 rating was too generous** for the "internal reference" rubric
+
+## Defenses Accepted by Codex
+
+1. **The guide has real onboarding value** — topology, lifecycle, and workflow sections are useful (just not sufficient as reference)
+2. **Operational procedures could live in a separate runbook** — but architecture guide still needs to be factually correct and explain rationale
+
+## Unresolved Disagreements
+
+1. **Branding language** — Claude sees mnemonic value; Codex sees it as spending trust budget before earning it. Minor disagreement.
+2. **Scope of "simplest thing that works" as rationale** — Codex wants explicit limitation/trigger statements; Claude thinks stating it explicitly is sufficient. Codex's position is stronger.
+
+## New Issues from Round 2
+
+1. Stale-recovery fix should resolve code vs design intent, not just update prose
+2. Action items should prioritize a trustworthiness pass over a polish pass
+
+## Final Verdict
+
+**Codex's position:** The single most important next step is a **trustworthiness pass** — verify every implementation-backed claim against code, and label Munin/Mimir material as summary-level with source-of-truth pointers.
+
+**Claude's position (revised):** Agrees. The guide needs factual corrections first, rationale additions second, and operational detail third.
+
+## Action Items
+
+| Priority | Action | Owner |
+|----------|--------|-------|
+| P0 | Fix topology diagram task-submission arrow | Magnus |
+| P0 | Fix stale-recovery description AND decide if code or design is correct | Magnus |
+| P0 | Fix deployment section to match deploy-pi.sh | Magnus |
+| P1 | Add source-of-truth pointers for Munin/Mimir sections | Magnus |
+| P1 | Add rationale for: markdown task format, polling-as-queue, tags-as-state-machine, CLI spawning | Magnus |
+| P1 | Fix "two-service" → "three services" | Magnus |
+| P2 | Soften "three src/index.ts" claim | Magnus |
+| P2 | Add rationale for: one-at-a-time, 4000-char limit | Magnus |
+| P3 | Consider separate runbook for operational procedures | Magnus |
+
+## Critique Statistics
+
+- **Total critique points:** 15
+- **Valid:** 13 | **Partially valid:** 1 | **Invalid:** 0
+- **Caught by self-review:** 2/15 (13%)
+- **Critical severity:** 2 | **Major:** 9 | **Minor:** 4
+
+## Debate Files
+
+- `arch-guide-claude-draft.md` — Claude's initial assessment
+- `arch-guide-claude-self-review.md` — Claude's self-critique
+- `arch-guide-codex-critique.md` — Codex Round 1 critique
+- `arch-guide-claude-response-1.md` — Claude's response
+- `arch-guide-codex-rebuttal-1.md` — Codex Round 2 rebuttal
+- `arch-guide-critique-log.json` — Structured critique log
+- `arch-guide-summary.md` — This file
+
+## Costs
+
+| Invocation | Wall-clock time | Model version |
+|------------|-----------------|---------------|
+| Codex R1   | ~3m             | gpt-5.4       |
+| Codex R2   | ~2m             | gpt-5.4       |

--- a/debate/multi-agent-orch-critique-log.json
+++ b/debate/multi-agent-orch-critique-log.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "orch-C01",
+    "source": "codex-round-1",
+    "text": "DAG-first doesn't enable multi-agent behavior without parallel execution — just a fancier sequential queue",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "critical",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-C02",
+    "source": "codex-round-1",
+    "text": "Worker identity/leases must come before DAG — stale recovery assumes single-instance",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "critical",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "orch-C03",
+    "source": "codex-round-1",
+    "text": "Security model is routing labels, not enforcement — self-declared submitter, env inheritance, exfiltration via sub-task prompts",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "critical",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-C04",
+    "source": "codex-round-1",
+    "text": "Missing dependency failure policy — what happens when a DAG node fails?",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "orch-C05",
+    "source": "codex-round-1",
+    "text": "Munin coordination uses tag scans and whole-entry rereads — not efficient for dense graphs",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "minor",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-C06",
+    "source": "codex-round-1",
+    "text": "General DAG invites cycles/debugging problems — parent/child joins are simpler and sufficient",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-C07",
+    "source": "codex-round-1",
+    "text": "One scheduler, many workers should be an explicit design invariant",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-C08",
+    "source": "codex-round-2",
+    "text": "Event-driven promotion needs a reconciliation loop — crash between completion and promotion leaves children blocked",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-C09",
+    "source": "codex-round-2",
+    "text": "HMAC submitter auth is weak if signing secret is in task's env — doesn't create real privilege boundary",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-C10",
+    "source": "codex-round-2",
+    "text": "failure_policy at task level is too coarse — should be per-dependency-edge for mixed critical/optional inputs",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "minor",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-C11",
+    "source": "codex-round-2",
+    "text": "max_children is only meaningful if enforced by scheduler, not just declared in task metadata",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "minor",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-C12",
+    "source": "codex-round-2",
+    "text": "Worker boundary underspecified — is a worker a host daemon, execution slot, or endpoint label?",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": false
+  }
+]

--- a/debate/multi-agent-orch-summary.md
+++ b/debate/multi-agent-orch-summary.md
@@ -1,0 +1,72 @@
+# Debate Summary: Multi-Agent Orchestration for Grimnir/Hugin
+
+**Date:** 2026-04-01
+**Participants:** Claude Opus 4.6, Codex (gpt-5.4)
+**Rounds:** 2
+**Debate type:** Architecture
+
+## Concessions Accepted By Both Sides
+
+1. **DAG-first was the wrong sequencing.** Adding `blocked`/`depends-on` to a single-worker system produces dependency-aware queueing, not multi-agent orchestration. Both sides agree on this.
+2. **Worker identity and leases are the real first step.** Without explicit task ownership, stale recovery, parallel execution, and remote workers are all built on ambiguity.
+3. **The security model needs enforcement, not just labels.** `security:local` vs `security:cloud` as routing hints is necessary but not sufficient. Real boundaries require authenticated submitters, env scrubbing, and privilege escalation rules.
+4. **One scheduler, many workers** is the correct architectural invariant. Workers never run their own Hugin. The Pi is the coordinator; compute nodes are workers.
+5. **Parent/child joins before general DAG.** Narrow the scope to one level of fan-out with capped children before enabling arbitrary dependency graphs.
+
+## Defenses Accepted By Codex
+
+- Learning from Temporal/Celery/K8s patterns without adopting the infrastructure is appropriate for a Pi-based system
+- Munin doesn't need to be split into separate stores immediately — coordination semantics matter more than raw throughput
+- "One scheduler, many workers" is a valid and explicit design constraint
+
+## Unresolved Disagreements
+
+- **Munin coordination efficiency**: Claude deferred the tag-scan/reread cost issue; Codex maintains it matters even at small scale for operational clarity
+- **HMAC auth strength**: Codex correctly notes that if the signing secret is in the task's env, it doesn't create a real privilege boundary. No resolution proposed yet.
+- **Failure policy granularity**: Per-task vs per-dependency-edge. Acknowledged but deferred.
+
+## New Issues From Round 2
+
+- Event-driven promotion needs a reconciliation loop (crash recovery)
+- Worker boundary needs clear definition (host daemon vs execution slot vs endpoint label)
+- `max_children` must be scheduler-enforced, not just declared metadata
+
+## Final Verdict
+
+**Both sides converged on the same next step:**
+
+### Step 0: Worker/Lease State Machine
+1. Introduce `worker_id` attached to task claims (`claimed_by`, `lease_expires`)
+2. Lease renewal during execution (heartbeat extends lease)
+3. Stale recovery becomes lease-based, not "all running = mine"
+4. Define what a "worker" is: execution slot on a host, with explicit capabilities
+
+### Then:
+- Step 1: Parent/child joins with failure policy
+- Step 2: Capability registry + security-aware routing
+- Step 3: Remote worker protocol (assign, monitor lease, collect)
+- Later: General DAG, agent messaging, dynamic graph construction
+
+## Action Items
+
+- [ ] Design the worker/lease state machine (schema + state transitions)
+- [ ] Define worker boundary: is ollama-laptop a worker? Is Claude SDK a worker? Are they the same kind of thing?
+- [ ] Write a concrete worked example: a multi-agent workflow (e.g., code review pipeline) showing how parent/child joins + workers would flow
+- [ ] Decide on authenticated submitter mechanism that actually works given env inheritance
+
+## All Debate Files
+
+- [draft](multi-agent-orch-claude-draft.md)
+- [self-review](multi-agent-orch-claude-self-review.md)
+- [codex-critique](multi-agent-orch-codex-critique.md)
+- [claude-response-1](multi-agent-orch-claude-response-1.md)
+- [codex-rebuttal-1](multi-agent-orch-codex-rebuttal-1.md)
+- [critique-log](multi-agent-orch-critique-log.json)
+- [summary](multi-agent-orch-summary.md)
+
+## Costs
+
+| Invocation | Wall-clock time | Model version |
+|------------|-----------------|---------------|
+| Codex R1   | ~3m             | gpt-5.4       |
+| Codex R2   | ~3m             | gpt-5.4       |

--- a/debate/orch-stack-critique-log.json
+++ b/debate/orch-stack-critique-log.json
@@ -1,0 +1,101 @@
+[
+  {
+    "id": "orch-stack-C01",
+    "source": "codex-round-1",
+    "text": "Plan does not argue why it should jump queue ahead of #57, signing rollout, and multi-host sprint — just assumes priority without making the case",
+    "classification": "valid",
+    "impact": "partially_changed",
+    "severity": "major",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "orch-stack-C02",
+    "source": "codex-round-1",
+    "text": "Latency premise is stale: think:false change cut Pi Ollama from ~90s to ~2s; async-queue justification was built on outdated assumption",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-stack-C03",
+    "source": "codex-round-1",
+    "text": "OpenRouter will be systematically eliminated by the current router (per-token + semi-trusted loses to free + trusted Ollama); trust model for third-party cloud provider is undefined",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "critical",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-stack-C04",
+    "source": "codex-round-1",
+    "text": "Schema v2 first not justified: Hugin already records rich journal telemetry; orchestratorRating alone is not a learning loop without task-class labels and baselines",
+    "classification": "valid",
+    "impact": "partially_changed",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-stack-C05",
+    "source": "codex-round-1",
+    "text": "infer_direct with documentation-only guard is a security regression inconsistent with Hugin's existing scanning/provenance/signing posture",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "critical",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "orch-stack-C06",
+    "source": "codex-round-1",
+    "text": "Hugin is a single serial dispatcher, not a parallel worker pool — delegation does not provide fan-out; the value proposition was misstated",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-stack-C07",
+    "source": "codex-round-1",
+    "text": "No explicit success gates: the plan is a hypothesis, not a gated bet; project already uses explicit gates for equivalent-sized bets (MBA before Mac Studio)",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "orch-stack-C08",
+    "source": "codex-round-2",
+    "text": "#57 gate is accepted too narrowly — all new task submission paths (not just hugin_rate) increase completion-path churn before non-atomic completion is fixed",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-stack-C09",
+    "source": "codex-round-2",
+    "text": "Response proposes priority:high / Group: for queue starvation but Group: already has semantics in the codebase; Priority: field would be new scope with parser + scheduler changes",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-stack-C10",
+    "source": "codex-round-2",
+    "text": "New cloud-third-party trust tier increases coupling before reversibility is earned; removing OpenRouter later would be cross-cutting, not just deleting one executor",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-stack-C11",
+    "source": "codex-round-2",
+    "text": "Revised build order is still implementation-then-validation; approved next architectural move is DIY multi-host on Munin; orchestrator stack has not displaced that with evidence",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "critical",
+    "caught_by_self_review": false
+  }
+]

--- a/debate/orch-stack-summary.md
+++ b/debate/orch-stack-summary.md
@@ -1,0 +1,104 @@
+# Orch Stack Debate Summary
+
+**Date:** 2026-04-25
+**Topic:** Hugin Orchestrator Stack — design and build order for enabling Claude Code to delegate cheap subtasks to Ollama/OpenRouter via Hugin
+**Participants:** Claude (proposer), Codex gpt-5.4 xhigh (adversarial reviewer)
+**Rounds:** 2
+
+---
+
+## Starting Position
+
+A four-component plan: (1) telemetry schema v2, (2) OpenRouter executor, (3) `hugin-mcp` package, (4) orchestrator skill. Build order: schema → executor → MCP → skill. Estimated ~2,090 LOC over ~5–6 days. Core claim: Claude Code can orchestrate subtask delegation to save Anthropic token spend.
+
+---
+
+## Concessions Accepted by Claude
+
+| Finding | Substance |
+|---|---|
+| **Latency premise stale** | `think:false` cut Pi Ollama from ~90s to ~2s. Async-queue justification was built on outdated data. Split design (direct sync for fast; queue for slow) is correct. |
+| **OpenRouter routing semantics undefined** | `semi-trusted + per-token` loses to Ollama in every router decision. A new `cloud-third-party` trust tier is needed before writing the executor — but this raises a reversibility concern too. |
+| **Schema v2 premature** | Existing journal telemetry is richer than the draft acknowledged. Run journal analysis first; defer `orchestratorRating` schema; build `proxy-checks.ts` standalone. |
+| **`infer_direct` security regression** | Documentation-only control is inconsistent with Hugin's existing scanning posture. Structural controls required: 500-char cap, local Ollama only, no Context-refs, forced public sensitivity, audit log. |
+| **Hugin is serial, not a parallel worker pool** | Delegation's value is token offload + model offload + async offload — not parallel speedup. Value proposition restated. |
+| **No success gate** | Added explicit numeric thresholds: ≥20% token reduction, ≤2× latency, ≤30% escalation rate, zero new stuck-running states. |
+
+---
+
+## Defenses Accepted by Codex
+
+- **MCP abstraction is correct.** Thin MCP hiding submission mechanics is better than teaching the orchestrator skill to hand-roll task IDs, front-matter, signing, and await logic.
+- **Semantic decomposition belongs in the skill, not the router.** The static policy engine in `router.ts` is not a semantic planner. The distinction is valid.
+- **`infer_direct` structural controls (Round 2).** The revised controls — 500-char cap, local-only, forced public, audit log — are adequate as a design correction.
+- **Serial-dispatcher reframe (Round 2).** Conceding that delegation is token/model/async offload (not parallelism) is a real improvement.
+
+---
+
+## Unresolved Disagreements
+
+### 1. Scope of the #57 gate
+**Claude:** #57 must precede `hugin_rate`; the rest of the stack can proceed in parallel.
+**Codex:** All new task submission paths increase completion-path churn before non-atomic completion is fixed. The gate should be broader.
+**Status:** Acknowledged, not resolved. A conservative reading (Codex's) would delay MCP submission tools until #57 is fixed.
+
+### 2. Priority vs. multi-host sprint
+**Claude:** Schema + OpenRouter executor are additive and don't conflict with multi-host.
+**Codex:** The approved next architectural move is DIY multi-host. Orchestrator stack has not earned displacement of that with evidence — build order is still implementation-then-validation.
+**Status:** This is the core unresolved tension. Codex's final verdict (below) directly addresses it.
+
+### 3. New trust tier timing
+**Claude:** Define `cloud-third-party` before writing OpenRouter executor.
+**Codex:** Adding a new cross-cutting trust class before earning reversibility is a coupling cost the plan doesn't account for. OpenRouter may not belong in v1 at all — first prove local-only orchestration is worth anything.
+
+---
+
+## New Issues Raised in Round 2
+
+- **`Group:` / `Priority:` starvation concern** — proposing `priority: high` subtasks introduces new scheduler scope (parser changes, priority field, queue ordering) that was not in scope. `Group:` already has different semantics and cannot be repurposed.
+- **Reversibility cost of new trust tier** — `cloud-third-party` is cross-cutting; removing it later requires touching `runtime-registry`, routing rank, sensitivity ceilings. Local-only experiment stays reversible; new trust class does not.
+
+---
+
+## Final Verdict (Codex)
+
+> **Priority has not been earned.** The single most important next step before any code is written is: run a falsifiable go/no-go evaluation using existing telemetry plus a fixed benchmark of manual local-only delegations, and use that to decide whether orchestration deserves priority at all.
+>
+> 1. Use the existing journal and a fixed task set to measure token savings, wall-clock impact, escalation rate, and queue impact.
+> 2. Keep the experiment local-only first — no OpenRouter, no new trust tier, no new scheduler semantics.
+> 3. Compare against the opportunity cost of continuing the approved DIY multi-host sprint.
+>
+> If the experiment passes, argue about proxy-checks, MCP shape, and external runtimes. If not, the correct outcome is: do not prioritize this now.
+
+---
+
+## Action Items
+
+| # | Item | Owner | Blocks |
+|---|---|---|---|
+| 1 | Fix #57 (non-atomic task completion) | Magnus | `hugin_rate`, new submission paths |
+| 2 | Run journal analysis: extract token/cost/latency signal from existing Hugin logs | Magnus | Decision on schema v2 |
+| 3 | Define falsifiable go/no-go benchmark: 10–20 tasks, measure token savings and escalation rate using local-only manual delegation | Magnus | Any new code |
+| 4 | If go/no-go passes: design `cloud-third-party` trust tier **with explicit rollback plan** | Magnus | OpenRouter executor |
+| 5 | Multi-host sprint: continue DIY implementation per orchestrator-sweep decision | Magnus | Mac Studio purchase gate |
+
+---
+
+## Files
+
+- `debate/orch-stack-claude-draft.md`
+- `debate/orch-stack-claude-self-review.md`
+- `debate/orch-stack-codex-critique.md`
+- `debate/orch-stack-claude-response-1.md`
+- `debate/orch-stack-codex-rebuttal-1.md`
+- `debate/orch-stack-summary.md`
+- `debate/orch-stack-critique-log.json`
+
+---
+
+## Costs
+
+| Invocation | Wall-clock time | Model version |
+|---|---|---|
+| Codex R1 | ~4m | gpt-5.4 xhigh |
+| Codex R2 | ~3m | gpt-5.4 xhigh |

--- a/debate/orch-v1-build-critique-log.json
+++ b/debate/orch-v1-build-critique-log.json
@@ -1,0 +1,155 @@
+[
+  {
+    "id": "orch-v1-build-F01",
+    "source": "codex-round-1",
+    "text": "hugin_run has no credible v1 sync path: submit+await over 30s poll + single-task dispatcher cannot deliver real synchronous behavior",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "critical",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "orch-v1-build-F02",
+    "source": "codex-round-1",
+    "text": "Journal ownership and current-session semantics not designed: laptop MCP cannot own a Pi journal; parent_session_id and task_type have no carrier in current task schema",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "critical",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-v1-build-F03",
+    "source": "codex-round-1",
+    "text": "OpenRouter being squeezed into wrong policy primitive: reusing semi-trusted collapses Anthropic subscription and third-party relay into one bucket; need provider/egress/zdrRequired/autoEligible fields",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "orch-v1-build-F04",
+    "source": "codex-round-1",
+    "text": "ZDR enforcement on wrong host and wrong phase: MCP startup catalog fetch leaks if other submitters; live fetch is a boot dependency; Hugin should pin allowlist with cached metadata + fail closed",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-v1-build-F05",
+    "source": "codex-round-1",
+    "text": "Output return paths can bypass exfil scanner: existing scan runs in dispatcher completion; MCP returning raw provider bytes regresses this",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "critical",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "orch-v1-build-F06",
+    "source": "codex-round-1",
+    "text": "MCP-originated submission missing real auth/secret-management story: laptop needs MUNIN_API_KEY + signing key + allowlisted submitter identity; not designed",
+    "classification": "valid",
+    "impact": "partially_changed",
+    "severity": "major",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "orch-v1-build-F07",
+    "source": "codex-round-1",
+    "text": "Partial-failure and reconnect semantics underspecified: 'await blocks until done/timeout' conflates queue wait, provider delay, host sleep, laptop sleep, task failure",
+    "classification": "valid",
+    "impact": "partially_changed",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-v1-build-F08",
+    "source": "codex-round-1",
+    "text": "Model/skill contract already stale: scope locks qwen3:14b but registry defaults laptop to qwen3.5:35b-a3b; gpt-oss reasoning levels not handled",
+    "classification": "valid",
+    "impact": "partially_changed",
+    "severity": "major",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "orch-v1-build-F09",
+    "source": "codex-round-1",
+    "text": "Telemetry plan duplicates existing data but misses defensible fields: skill_version, provider_policy_version, retry/escalation chain, verification outcome, submitter identity, parent_session_id source",
+    "classification": "valid",
+    "impact": "partially_changed",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-v1-build-F10",
+    "source": "codex-round-2",
+    "text": "Append-only JSONL journal cannot support post-hoc rating updates by task_id without an event-log + projection model or a different store",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "critical",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-v1-build-F11",
+    "source": "codex-round-2",
+    "text": "Broker endpoint requires new remote exposure model: Hugin is 127.0.0.1 and /health-only today; broker means network surface + auth hardening + request handling, not 'one more helper'",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-v1-build-F12",
+    "source": "codex-round-2",
+    "text": "Lease reaper interaction with 'running' state: post-reboot tasks remain 'running' for up to ~3 minutes (60s reaper sweep + 120s lease); await needs explicit stale/orphan_suspected state",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-v1-build-F13",
+    "source": "codex-round-2",
+    "text": "Alias governance underspecified: silent alias retargeting causes corpus regime change; need alias_map_version, model_alias_requested + model_effective fields, manual promotion only",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "orch-v1-build-F14",
+    "source": "codex-round-2",
+    "text": "Session ID confusion risk: orchestrator_session_id must not conflate with Hugin's existing task-scoped Munin session IDs used for outcome-aware telemetry",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "minor",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-v1-build-F15",
+    "source": "codex-round-2",
+    "text": "Folding full prompt/output into main invocation journal changes blast radius: retention, growth, and existing consumer surface area all change vs separate file",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-v1-build-F16",
+    "source": "codex-round-2",
+    "text": "verification_outcome useful as taxonomy but not a cure for self-rating bias; pair with weekly external spot-audit + objective behavioral traces (retries, discards, escalations)",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "minor",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "orch-v1-build-F17",
+    "source": "codex-round-2",
+    "text": "Build order should start with delegation data model (envelope + state machine + journal event model + alias resolution) BEFORE broker skeleton, not after",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": false
+  }
+]

--- a/debate/orch-v1-build-summary.md
+++ b/debate/orch-v1-build-summary.md
@@ -1,0 +1,135 @@
+# Orchestrator Stack v1 — How To Build It (Debate Summary)
+
+**Date:** 2026-04-25
+**Topic:** HOW to build the Hugin orchestrator stack v1 (IF settled — Magnus is building this)
+**Participants:** Claude (proposer), Codex gpt-5.4 xhigh (adversarial reviewer)
+**Rounds:** 2
+
+---
+
+## Starting Position
+
+Six-step build, ~1,000 LOC, ~2 days: (1) MCP skeleton (`hugin-mcp` with 5 tools `submit/await/run/rate/list`), (2) OpenRouter executor in Hugin reusing `semi-trusted` tier, (3) separate orchestrator journal at `~/.hugin/orchestrator-journal.jsonl`, (4) wire MCP→Hugin, (5) `delegate` skill at `~/.claude/skills/delegate/`, (6) dogfood. ZDR enforcement at MCP startup. Hard fail on errors, no auto-Claude-fallback.
+
+---
+
+## Concessions Accepted by Claude
+
+| Finding | Substance |
+|---|---|
+| **F1 — `hugin_run` not credible** | Submit+await over a 30s poll + single-task dispatcher cannot deliver real sync. **Drop `run` from v1.** Defer until/unless a separate inline-execution path is built post-dogfood. |
+| **F2 — Journal ownership** | Laptop MCP cannot own a Pi-side journal; `parent_session_id` and `task_type` had no carrier. **Hugin is sole writer.** MCP carries `orchestrator_session_id` + `task_type` as task metadata; `rate` and `list` become Hugin endpoints. |
+| **F3 — OR trust primitive** | Reusing `semi-trusted` collapses Anthropic-subscription and third-party-relay into one bucket. **Add orthogonal fields:** `provider`, `egress`, `zdrRequired`, `autoEligible`. Keeps trust binary; OR is explicit-only. |
+| **F4 — ZDR enforcement host** | MCP-side enforcement leaks if other submitters bypass it. **Hugin owns enforcement** with a pinned dogfood allowlist + cached catalog metadata + per-task fail-closed rejection. |
+| **F5 — Output finalization bypass** | Existing exfil scanner runs in dispatcher completion; raw provider output via MCP would regress. **Single shared `finalizeDelegatedOutput()` helper** used by every output-return surface. MCP returns scanned structured results, never raw bytes. |
+| **F6 — MCP auth/secrets (partial)** | Conceded direction (Pi-side broker over laptop signing keys). Detailed design still owed. |
+| **F7 — `await` semantics (partial)** | Conceded resumability and idempotent state response. Stale/orphan distinction owed. |
+| **F8 — Model/skill drift (partial)** | Conceded stable aliases (`local-small`, `studio-proxy-coder`, etc.) over literal model names. Alias governance still owed. |
+| **F9 — Telemetry overlap (partial)** | Conceded overlay over shadow journal. Append-only-vs-mutation problem still owed. |
+
+---
+
+## Defenses Accepted by Codex
+
+- **MCP boundary shape (no `run`).** Codex agreed the thin-MCP approach centralizing Munin/signing/await mechanics is the right abstraction once `run` is dropped.
+- **Skill-not-router orchestration.** The static filter/rank router is correctly distinct from a semantic planner; orchestration logic belongs in a skill.
+- **Hard-fail over auto-fallback.** Preserves the failure signal that's load-bearing for the learning loop.
+- **Verification-required protocol.** Skill rule that Claude must verify delegated output before reuse stands.
+- **Finalization centralization (F5 fix).** Codex marked this "adequately fixed in principle" once routed through a single helper.
+
+---
+
+## Unresolved (deferred to implementation)
+
+### 1. Append-only journal vs post-hoc rating updates
+**Status:** Acknowledged, design owed. Need either an event-log + projection model or a different store. The current proposal mutates JSONL by `task_id`, which the existing `appendFileSync` primitive doesn't support. Decision before code: separate rating-event JSONL with projection at read time, or move journal to SQLite/Munin entries.
+
+### 2. Broker endpoint exposure
+**Status:** Acknowledged, design owed. Hugin currently binds `127.0.0.1` and serves `/health` only. Broker requires network reachability (Tailscale-only acceptable), bearer-token auth, idempotency keys, rate limiting, and explicit caller-identity preservation (`broker_principal` + `orchestrator_submitter` distinct).
+
+### 3. Lease reaper + reboot UX
+**Status:** Acknowledged. `workerId` is PID-based; reboot leaves tasks tagged `running` for up to ~3 minutes (60s reaper sweep + 120s lease). `await` must surface `lease_expires_at`, `claimed_by`, `last_status_at`, and `orphan_suspected` — not just `running`.
+
+### 4. Alias governance
+**Status:** Acknowledged. Manual promotion only; never silent retargeting. Journal must record `model_alias_requested`, `model_effective`, and `alias_map_version` so corpus regime changes are detectable.
+
+### 5. Self-rating bias mitigation
+**Status:** Pair `verification_outcome` with weekly Magnus spot-audit + objective behavioral traces (retries, discards, escalations). Self-report alone is not enough.
+
+---
+
+## Final Verdict (Codex)
+
+> The single most important thing to get right before any code is written is **the Pi-side delegation contract as an authority boundary**: the request envelope, the append-only journal event model, the result/await state machine, and the provenance chain from broker principal to task record to rating.
+>
+> If that contract is right, broker-vs-signing, OpenRouter, aliases, and the skill are all reversible implementation details. If that contract is wrong, you will hard-code the most expensive failures first: ambiguous identity, misleading `await` semantics, silent alias regime shifts, and a journal model that cannot represent rating updates cleanly.
+
+---
+
+## Revised Build Order (post-debate)
+
+Codex's reorder, accepted:
+
+1. **Delegation data model first (no code, just types/schema):**
+   - Request envelope: `orchestrator_session_id`, `task_type`, alias/model/runtime/host/sensitivity, idempotency key, provenance fields
+   - Result/state machine including `running / completed / failed / stale / unknown` with `orphan_suspected` flag
+   - Journal event model: submission event, completion event, rating event, alias-map version, policy version (decide: append-only events with read-time projection vs mutable store)
+2. **Runtime registry extension:** alias resolution + `provider/egress/zdrRequired/autoEligible` fields + reasoning-level pinning for gpt-oss.
+3. **Shared `finalizeDelegatedOutput()` helper** + provenance tags on structured results.
+4. **Broker endpoint** (`POST /orchestrator/submit`, `/await`, `/rate`, `/list`, `/models`) with bearer auth, idempotency, Tailscale-only exposure, audit fields.
+5. **OpenRouter executor** behind the contracts with pinned ZDR allowlist + cached catalog metadata.
+6. **MCP server** (`submit/await/rate/list/models`) talking only to broker.
+7. **Delegate skill** at `~/.claude/skills/delegate/` against stable aliases.
+8. **Dogfood + weekly spot-audit.**
+
+---
+
+## Action Items
+
+| # | Item | Owner | Blocks |
+|---|---|---|---|
+| 1 | Decide journal storage model (append-only events + projection, vs SQLite, vs Munin entries) | Magnus | All journal-write code |
+| 2 | Decide broker exposure model (Tailscale-only? localhost + SSH tunnel? mTLS?) | Magnus | Broker skeleton |
+| 3 | Write delegation data model spec (envelope, state machine, event types) as `docs/orchestrator-v1-data-model.md` | Claude | All other steps |
+| 4 | Curate initial alias map: `local-small=qwen2.5:3b`, `local-medium=qwen3.5:35b-a3b`, `studio-proxy-large=gpt-oss-120b@medium`, `studio-proxy-coder=qwen3-coder` | Magnus | Skill |
+| 5 | Update STATUS.md to reflect build decision (supersede "evaluation gate" framing) | Claude | None (paperwork) |
+| 6 | Multi-host sprint stays parallel priority (not blocked by orchestrator) | Magnus | — |
+
+---
+
+## Estimate (revised)
+
+| Piece | LOC | Wall-clock |
+|---|---|---|
+| Data-model spec doc | 0 | half-day |
+| Hugin contracts (envelope, state machine, event journal, registry extension, finalize helper, alias resolver) | ~700 | 1.5 days |
+| Broker endpoint + auth | ~250 | half-day |
+| OpenRouter executor + ZDR allowlist | ~300 | half-day |
+| MCP server (5 tools) | ~400 | half-day |
+| Delegate skill | ~300 markdown | half-day |
+| Tests | ~400 | 1 day |
+| **Total** | **~2,000 LOC + 300 markdown** | **~5 focused days** |
+
+Up from the original 1k LOC / 2 days. Codex's 1.8–2.6k / 4–6 day estimate was correct.
+
+---
+
+## Files
+
+- `debate/orch-v1-build-snapshot.md`
+- `debate/orch-v1-build-claude-draft.md`
+- `debate/orch-v1-build-claude-self-review.md`
+- `debate/orch-v1-build-codex-critique.md`
+- `debate/orch-v1-build-claude-response-1.md`
+- `debate/orch-v1-build-codex-rebuttal-1.md`
+- `debate/orch-v1-build-summary.md`
+- `debate/orch-v1-build-critique-log.json`
+
+---
+
+## Costs
+
+| Invocation | Wall-clock time | Model version |
+|---|---|---|
+| Codex R1 | ~7m | gpt-5.4 xhigh |
+| Codex R2 | ~6m | gpt-5.4 xhigh |

--- a/debate/orch-v1-impl-review-critique-log.json
+++ b/debate/orch-v1-impl-review-critique-log.json
@@ -1,0 +1,110 @@
+[
+  {
+    "id": "orch-v1-impl-review-C01",
+    "source": "codex-round-1",
+    "text": "Step 2 widens the shared DispatcherRuntime contract to include orchestrator-only runtimes (openrouter, pi-harness) before the dispatcher can parse or execute them, and discards row-level identity. Sensitivity policy keys off coarse DispatcherRuntime instead of registry row.",
+    "classification": "valid",
+    "impact": "partially_changed",
+    "severity": "major",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "orch-v1-impl-review-C02",
+    "source": "codex-round-1",
+    "text": "Scanner semantics are internally inconsistent: spec defines DelegationError.kind 'scanner_blocked' as 'redact mode triggered', but finalizeDelegatedOutput returns a successful DelegationResult with scanner_pass: 'redact'. Tests lock in redacted-diff-as-success, but a redacted unified diff is no longer a valid patch.",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "critical",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-v1-impl-review-C03",
+    "source": "codex-round-1",
+    "text": "Partial-failure ordering is unspecified across the six writes (journal submit, Munin task, finalize, structured result, journal complete, await visibility). The state machine does not model 'accepted but not indexed' or 'task complete but journal append failed'. Hugin shipped a real bug in this exact class last sprint (#57).",
+    "classification": "valid",
+    "impact": "partially_changed",
+    "severity": "critical",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-v1-impl-review-C04",
+    "source": "codex-round-1",
+    "text": "Worktree contract bakes in Pi disk model and Node-repo assumption with no baseline. copy_node_modules defaults to true; 7-day retention is unjustified by disk budget or task-volume estimate.",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "orch-v1-impl-review-C05",
+    "source": "codex-round-1",
+    "text": "Protocol versioning and retry semantics are too thin. No envelope_version on DelegationRequest, no result_schema_version on DelegationResult. Retry/idempotency-key reuse rules are unspecified.",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "orch-v1-impl-review-C06",
+    "source": "codex-round-2",
+    "text": "Finding 1 remedy (runtime_row_id?: string in DelegationResult) is a posterior-attribution fix, not a control-plane fix. The shared task-result schema still blesses orchestrator runtimes the dispatcher cannot run; sensitivity policy still keys by coarse DispatcherRuntime; BrokerAnnotations.alias_resolved records coarse runtime/host rather than stable runtime-row identity. The deeper rework: split LegacyDispatcherRuntime, carry stable runtime-row identity at submit/complete, move policy lookups to registry-row scope.",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-v1-impl-review-C07",
+    "source": "codex-round-2",
+    "text": "Finding 3 remedy imports the #57 lesson too literally. In existing Hugin, structured result write is secondary (non-fatal) so status-first ordering works. In orchestrator await, the structured DelegationResult IS the payload, so 'status first, result later' creates a 'completed task with no durable result' failure mode. The right fix is a source-of-truth contract: what makes a submission durable, what makes a completion durable, what await reads, and what can be backfilled.",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "critical",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-v1-impl-review-C08",
+    "source": "codex-round-2",
+    "text": "Versioning concession only half-closes the issue. Journal event schemas (DelegationSubmittedEvent, DelegationCompletedEvent, DelegationRatedEvent) and the 'envelope encoded' Munin task representation remain unversioned even though both are part of the public recovery/projection contract.",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "minor",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-v1-impl-review-C09",
+    "source": "codex-round-2",
+    "text": "submitted_not_indexed proposed in the response leaks an internal indexing gap into the client contract. Munin task entries should be the durable submit record OR the broker index should be canonical, but both being canonical is contradictory.",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-v1-impl-review-C10",
+    "source": "codex-round-2",
+    "text": "20GB worktree cap idea is concrete but lacks admission-control semantics. What happens when worktree creation would exceed budget, or disk fills mid-claim? Reject at submit, eager reap, or fail mid-run?",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "minor",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-v1-impl-review-C11",
+    "source": "codex-round-2",
+    "text": "runtime_row_id should be required, not optional. Broker already knows it at submit time (alias resolution); making it optional weakens the corpus boundary on day one.",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "minor",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "orch-v1-impl-review-C12",
+    "source": "codex-round-2",
+    "text": "Munin CAS is per-key. 'structured result + status flip in Munin (atomic CAS)' as proposed in the response is not a real operation — status and result are separate keys, so the proposed ordering invariant relies on a primitive the substrate does not have.",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": false
+  }
+]

--- a/debate/orch-v1-impl-review-summary.md
+++ b/debate/orch-v1-impl-review-summary.md
@@ -1,0 +1,74 @@
+# orch-v1-impl-review — Debate Summary
+
+**Date:** 2026-04-26
+**Participants:** Claude (Opus 4.7), Codex (gpt-5.4 @ xhigh)
+**Rounds:** 2
+**Topic type:** Architecture (primary) + Protocol (secondary)
+**Under review:** Step 1-3 of orchestrator v1 — `docs/orchestrator-v1-data-model.md`, `src/runtime-registry.ts`, `src/router.ts`, `src/task-result-schema.ts`, `src/finalize-delegated-output.ts`.
+
+## Bottom line
+
+The chosen seams (alias indirection, `autoEligible: false` as explicit-only firewall, single shared finalizer, append-only JSONL journal) are correct. **The contract surface is not yet locked enough for Step 4 (Pi-side broker) to start.** Two contract-level bugs and a missing durability model must close first.
+
+## Concessions accepted (Claude → Codex)
+
+- **C02 (critical, changed):** Scanner contract is internally inconsistent. `DelegationError.kind` includes `scanner_blocked` ("redact mode triggered"), but `finalizeDelegatedOutput` returns `scanner_pass: "redact"` as a successful result. For diffs this is worse than aesthetic — a redacted unified diff is no longer a valid patch. **Fix:** text-mode redact stays on the success branch; diff-mode (and future executable-artifact result kinds) escalates to `scanner_blocked` failure.
+- **C04 (major, changed):** Worktree defaults bake in Pi disk model and Node-repo assumption with no baseline. **Fix:** flip `copy_node_modules` default to `false`; replace "short enough to not fill the Pi disk" with a measured budget (cap + admission-control semantics).
+- **C05 (major, changed):** Protocol versioning is too thin. **Fix:** add `envelope_version: 1` on `DelegationRequest`, `result_schema_version: 1` on `DelegationResult`, and define idempotency-key reuse semantics (same key for the same logical task; new key = new task).
+- **C01 (major, partially_changed):** Step 2 widened `DispatcherRuntime` for orchestrator-only runtimes the dispatcher cannot yet parse or execute. **Partial fix:** add `runtime_row_id?: string` to `DelegationResult` for posterior attribution. **Acknowledged-but-deferred:** the deeper rework (split `LegacyDispatcherRuntime`, carry runtime-row identity through submit/execute/complete, move sensitivity lookup to registry-row scope) is a Step 4 prerequisite, not a Step 3 fix.
+- **C03 (critical, partially_changed):** Partial-failure ordering is unspecified. The proposed §12 invariants (Munin first, journal append after) are a sketch but rely on a Munin atomic-CAS primitive that does not exist (status and result are separate keys — see C12) and import the wrong lesson from #57 (see C07). **Acknowledged-but-deferred:** the right shape is a source-of-truth contract, not an ordering list.
+
+## Defenses Codex accepted
+
+- Centralizing finalization in a single `finalizeDelegatedOutput` is the right seam. The objection was "one finalizer with contradictory semantics," not "multiple finalizers."
+- `autoEligible: false` as the explicit-only firewall is a hard contract, not a soft preference. The router test suite locks this in.
+- Keeping `model_effective` + `runtime_effective` + `host_effective` alongside any new row identifier is correct; replacing them would make operator queries harder.
+- Option B (pi-harness in v1) was not contested. The eval data (5/6 strict, 6/6 lenient) supports it.
+
+## Unresolved disagreements
+
+None substantive. Codex's Round 2 evasion-flags (C06, C07, C12) all converged with Claude's "acknowledged-but-deferred" position: the underlying issues are real, the proposed remedies are necessary but insufficient, and the deeper rework belongs in Step 4 prep rather than retroactive Step 3 patches.
+
+## New issues from Round 2
+
+- **C06:** `runtime_row_id?: string` is necessary but not sufficient — the control-plane problems happen earlier (schema accepts runtimes the dispatcher rejects; sensitivity keys by coarse runtime).
+- **C07:** Status-first ordering fits #57's bug but does not fit orchestrator `await`, where the structured result *is* the payload.
+- **C09:** Proposed `submitted_not_indexed` await branch leaks an internal indexing gap into the public contract.
+- **C12:** Munin CAS is per-key; "atomic structured-result + status flip" is not a real operation on this substrate.
+
+## Final verdict
+
+**Codex (Round 2):** "Define the authoritative delegated-task durability model — which persisted record makes a delegated submission real, which persisted record makes a delegated completion real, how `await` resolves from that record after crash/restart, and how stable runtime-row identity is threaded through submit → execute → complete. Until that is locked, Step 4 will hard-code the most expensive class of bug first: a control plane that can say 'completed' without a durable result, or 'known task' without a durable identity."
+
+**Claude (post-Round-2):** Agreed. Step 4 (Pi-side broker) requires a Step 3.5 deliverable: a durability + runtime-row-identity addendum to `docs/orchestrator-v1-data-model.md`. Until that lands, broker code would hard-code the wrong shape.
+
+## Action items (in priority order)
+
+1. **Resolve C02 (scanner contract).** Update spec §4 to make redact-on-diff escalate to `scanner_blocked`; update test at `tests/finalize-delegated-output.test.ts:138-168` to expect failure rather than success on redacted diff. Owner: Claude (next session).
+2. **Write Step 3.5: durability + runtime-row-identity addendum.** Define source-of-truth records for submit and complete, what `await` reads, what can be backfilled, how idempotency-after-crash recovers. Carry stable `runtime_row_id` (required, not optional) through `BrokerAnnotations.alias_resolved`. Move sensitivity policy from `DispatcherRuntime` to registry-row scope. Owner: Claude (next session).
+3. **Apply C04 (worktree defaults).** Flip `copy_node_modules` to default `false`. Add admission-control semantics for the worktree disk cap. Owner: Claude (next session).
+4. **Apply C05 (versioning).** Add `envelope_version`, `result_schema_version`, journal event `event_schema_version`. Define idempotency-key reuse semantics. Owner: Claude (next session).
+5. **C01 deeper rework (LegacyDispatcherRuntime split).** Schedule for the start of Step 4 — broker code should be the first consumer of the corrected boundary. Owner: Claude (Step 4 entry).
+6. **Defer:** the journal projection benchmark, scanner runtime baseline on large diffs, and concurrent-broker single-writer enforcement remain open but do not block Step 4.
+
+## Files
+
+- `debate/orch-v1-impl-review-claude-draft.md` — Claude's position (pre-debate)
+- `debate/orch-v1-impl-review-claude-self-review.md` — self-review with debate type
+- `debate/orch-v1-impl-review-codex-critique.md` — Codex Round 1
+- `debate/orch-v1-impl-review-claude-response-1.md` — Claude Round 1 response
+- `debate/orch-v1-impl-review-codex-rebuttal-1.md` — Codex Round 2 rebuttal
+- `debate/orch-v1-impl-review-critique-log.json` — structured critique log
+- `debate/orch-v1-impl-review-snapshot/` — frozen artifacts under review
+- `debate/orch-v1-impl-review-summary.md` — this file
+
+## Costs
+
+| Invocation | Wall-clock time | Model version |
+|------------|-----------------|---------------|
+| Codex R1   | ~2m             | gpt-5.4 @ xhigh |
+| Codex R2   | ~2m             | gpt-5.4 @ xhigh |
+
+## Notes on Munin context loading
+
+In Round 1 all four Munin calls (`memory_read synthesis`, `memory_read status`, `memory_query decisions`, `memory_narrative`) returned `user cancelled MCP tool call`. In Round 2 `memory_orient` succeeded but the four item-level reads still failed the same way. Codex grounded both rounds in local state (STATUS.md, snapshot files, live src/) instead. This is a session-level Munin connectivity issue worth flagging for follow-up — not a debate finding.

--- a/debate/skill-improvements-critique-log.json
+++ b/debate/skill-improvements-critique-log.json
@@ -1,0 +1,128 @@
+[
+  {
+    "id": "skill-improvements-C01",
+    "source": "codex-round-1",
+    "text": "Tier system adds complexity to solve a problem (heaviness) that lacks evidence — only 2 debates on record, both completed quickly",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "critical",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "skill-improvements-C02",
+    "source": "codex-round-1",
+    "text": "Quick tier removes self-review and critique log, breaking Step 10 index tracking and Step 11 completeness verification",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "critical",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "skill-improvements-C03",
+    "source": "codex-round-1",
+    "text": "Quick tier fragments the dataset, making future historical learning (Idea #8) harder rather than easier",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "skill-improvements-C04",
+    "source": "codex-round-1",
+    "text": "Rejecting role inversion is conjecture, not evidence — self-review catch rates don't speak to role inversion quality",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "skill-improvements-C05",
+    "source": "codex-round-1",
+    "text": "Phasing order is backwards — front-loads the biggest, least-validated change instead of starting with narrow, evidence-producing fixes",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "critical",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "skill-improvements-C06",
+    "source": "codex-round-1",
+    "text": "Type-specific prompting risks anchoring Codex away from cross-cutting issues",
+    "classification": "partially_valid",
+    "impact": "partially_changed",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "skill-improvements-C07",
+    "source": "codex-round-1",
+    "text": "Dynamic round scoring is gameable — atomizing issues or restating in different language to justify continuation",
+    "classification": "partially_valid",
+    "impact": "partially_changed",
+    "severity": "minor",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "skill-improvements-C08",
+    "source": "codex-round-1",
+    "text": "Deep tier creates expectation gradient making Standard feel second-rate",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "minor",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "skill-improvements-C09",
+    "source": "codex-round-1",
+    "text": "SKILL.md size concern should focus on branching factor and conditional complexity, not raw line count",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "skill-improvements-C10",
+    "source": "codex-round-1",
+    "text": "Deep tier context dilution — later rounds become context-management exercises rather than better critique",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "minor",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "skill-improvements-C11",
+    "source": "codex-round-2",
+    "text": "Step 6 symmetry problem — if Round 1 becomes type-aware but Round 2 stays generic, domain-specific probing drops off",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "skill-improvements-C12",
+    "source": "codex-round-2",
+    "text": "Severity calibration still lacks a semantic target — does severity measure the flaw, the consequence of ignoring it, or the reversibility?",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "skill-improvements-C13",
+    "source": "codex-round-2",
+    "text": "Mixed-type debates need a composition rule for combined prompts, not just 'additive' handwaving",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "minor",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "skill-improvements-C14",
+    "source": "codex-round-2",
+    "text": "Prompt/checklist drift is now an immediate implementation problem since type-specific prompts are adopt-first",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": false
+  }
+]

--- a/debate/skill-improvements-summary.md
+++ b/debate/skill-improvements-summary.md
@@ -1,0 +1,70 @@
+# Debate Summary: /debate-codex Skill Improvements
+
+**Date:** 2026-04-01
+**Participants:** Claude (Opus 4.6) vs Codex (GPT-5.4)
+**Rounds:** 2
+**Debate type:** Docs/process
+
+## Key Outcome
+
+The debate dramatically narrowed the scope of proposed changes. Claude entered with 5 "adopt" proposals centered on a tier system; exited with 2 narrow "adopt" proposals and everything else deferred or dropped.
+
+## Concessions accepted by Claude
+
+1. **Tiers are not justified yet.** Only 2 debates on record, both completed quickly. The existing skill already has scope control (when to/not to debate) and variable depth (Step 7). Tiers solve a hypothetical problem.
+2. **Quick tier is self-defeating.** Removing self-review and critique logs breaks the artifact model (Step 10/11) and fragments the dataset needed for historical learning.
+3. **Phasing was backwards.** Starting with the most invasive, least validated change is wrong. Narrow, evidence-producing fixes first.
+4. **Rejecting role inversion was overconfident.** Should be "defer and test," not "reject."
+5. **SKILL.md size concern is about branching factor, not line count.** A linear 400-line skill is safer than a 320-line skill with three conditional modes.
+
+## Defenses accepted by Codex
+
+1. **Type-specific prompts address a real gap.** Step 3 has a literal placeholder for debate-specific questions. The type classification in Step 2 is already done but not used.
+2. **Severity calibration addresses a real inconsistency.** The critique log records severity with no definition. Periodic synthesis depends on it.
+3. **"Additive, not substitutive" resolves the type-anchoring risk.** Type-specific prompts should add domain attack vectors on top of universal framing, not replace it.
+4. **The circularity argument is valid for narrow fixes.** Improving data collection (severity definitions, better prompts) is a prerequisite for gathering useful data, not something that requires data first.
+
+## Unresolved issues from Round 2
+
+1. **Step 6 symmetry:** If Round 1 becomes type-aware, Round 2 should too — otherwise domain-specific probing drops off in rebuttals.
+2. **Severity semantic target:** Does severity measure the flaw itself, the consequence of ignoring it, or the reversibility? Needs definition before implementation.
+3. **Mixed-type composition rule:** How to combine prompts for architecture+security debates. "Additive" is direction, not a rule.
+4. **Prompt/checklist drift:** Type-specific prompts and checklists are two things to keep in sync. Need a source-of-truth strategy.
+
+## Final agreed position
+
+| Proposal | Status | Rationale |
+|----------|--------|-----------|
+| Type-specific Codex prompts (#2) | **Adopt first** | Real gap; additive to universal frame; apply to both Step 3 and Step 6 |
+| Calibrated severity (#5) | **Adopt first** | Real inconsistency; prerequisite for useful synthesis data |
+| Debate tiers (#7) | **Defer** | No evidence of heaviness problem; adds branching complexity |
+| Steelman (#3) | **Defer** | Potentially useful but test experimentally |
+| Dynamic rounds (#1) | **Defer** | Clarify Step 7 prose instead; no evidence current rule is failing |
+| Role inversion (#4) | **Defer and test** | Interesting but untested; experiment in select debates |
+| Pre-debate triage (#6) | **Defer** | Subsumed by better defaults |
+| Historical learning (#8) | **Defer** | Need 15-20 debates with improved format first |
+
+## Action items
+
+1. **Patch SKILL.md Step 3 and Step 6:** Make debate-type classification shape the Codex prompt in both rounds, additively. Resolve the composition question for mixed-type debates.
+2. **Define severity in Step 8:** Specify what severity measures (propose: consequence of ignoring the critique point, anchored to blast radius + reversibility of the underlying decision).
+3. **Run 5-10 more debates** on the tightened baseline before reconsidering structural changes.
+4. **Experiment with steelman and role inversion** in 2-3 select debates to gather evidence.
+
+## Debate files
+
+- `debate/skill-improvements-snapshot.md`
+- `debate/skill-improvements-claude-draft.md`
+- `debate/skill-improvements-claude-self-review.md`
+- `debate/skill-improvements-codex-critique.md`
+- `debate/skill-improvements-claude-response-1.md`
+- `debate/skill-improvements-codex-rebuttal-1.md`
+- `debate/skill-improvements-critique-log.json`
+- `debate/skill-improvements-summary.md`
+
+## Costs
+
+| Invocation | Wall-clock time | Model version |
+|------------|-----------------|---------------|
+| Codex R1   | ~3m             | gpt-5.4       |
+| Codex R2   | ~4m             | gpt-5.4       |

--- a/debate/zombie-procs-critique-log.json
+++ b/debate/zombie-procs-critique-log.json
@@ -1,0 +1,83 @@
+[
+  {
+    "id": "zombie-procs-C01",
+    "source": "codex-round-1",
+    "text": "Which service wins port race is not proven — could be system-level winning, making user-level the zombie producer",
+    "classification": "partially_valid",
+    "impact": "acknowledged",
+    "severity": "critical",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "zombie-procs-C02",
+    "source": "codex-round-1",
+    "text": "User-level service ReadWritePaths=/home/magnus/repos/hugin prevents log writes to /home/magnus/.hugin/logs/ — a real bug that would cause task failures",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "zombie-procs-C03",
+    "source": "codex-round-1",
+    "text": "Fix 3 calls process.exit(0) immediately after currentChild.kill(SIGTERM), orphaning the child before it can exit",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "zombie-procs-C04",
+    "source": "codex-round-1",
+    "text": "munin-memory.service After= dependency is silently ignored in user-level context if munin-memory is system-level",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "minor",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "zombie-procs-C05",
+    "source": "codex-round-1",
+    "text": "Migration plan doesn't remove legacy system-level service atomically — deploy-pi.sh needs idempotent removal block",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "zombie-procs-C06",
+    "source": "codex-round-1",
+    "text": "Linger not verified or enforced — user-level service won't start on boot if Linger=no",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "zombie-procs-C07",
+    "source": "codex-round-1",
+    "text": "StartLimitBurst claim about crash loop persistence needs verification",
+    "classification": "partially_valid",
+    "impact": "acknowledged",
+    "severity": "minor",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "zombie-procs-C08",
+    "source": "codex-round-2",
+    "text": "ReadWritePaths fix is underspecified — Option A (broad) vs Option B (surgical) not decided; needs write-path audit",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "zombie-procs-C09",
+    "source": "codex-round-2",
+    "text": "Repo hugin.service has User=magnus and WantedBy=multi-user.target — wrong for a user-level service template",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": false
+  }
+]

--- a/debate/zombie-procs-summary.md
+++ b/debate/zombie-procs-summary.md
@@ -1,0 +1,77 @@
+# Zombie Procs Debate Summary
+
+**Date:** 2026-04-09
+**Participants:** Claude (author + adversarial reviewer), Codex (rate-limited — Claude stood in)
+**Rounds:** 2
+**Topic:** Root cause and fix for accumulating zombie `node dist/index.js` processes on the Pi
+
+---
+
+## Diagnosis confirmed
+
+**Primary cause: Dual systemd service registration.**
+Both `/etc/systemd/system/hugin.service` (system-level, installed by `deploy-pi.sh`) and `~/.config/systemd/user/hugin.service` (user-level) are enabled with `Restart=always`. User-level service wins port 3032; system-level crash-loops indefinitely. Confirmed by: active PID cgroup is `/user.slice/...`, system-level `MainPID=0, NRestarts=60+, ActiveState=activating`.
+
+**Same issue on Ratatoskr** (port 3034).
+
+---
+
+## Concessions accepted
+
+| Issue | Original position | Revised |
+|-------|------------------|---------|
+| C02 ReadWritePaths | Assumption / may be problem | Confirmed real bug: user-level service can't write to `.hugin/logs/` — tasks will fail |
+| C03 Fix 3 shutdown | Add process.exit at end of shutdown() | Must await child exit first; hard timer is the only unconditional exit path |
+| C05 Migration atomicity | Manual one-time step | deploy-pi.sh needs idempotent system-service removal block |
+| C09 Repo service file | Not discussed | hugin.service (repo) has wrong directives for user-level (`User=magnus`, `WantedBy=multi-user.target`) |
+
+---
+
+## Defenses accepted by adversarial reviewer
+
+- Dual-service diagnosis is correct (C01 resolved by cgroup evidence)
+- Linger=yes confirmed (C06 moot)
+- Fix 1 + Fix 2 are sound as core fixes
+- Revised Fix 3 (await child exit, hard timer backstop) is correct
+
+---
+
+## Unresolved / open questions
+
+- **ReadWritePaths scope** (C08): Option A (`/home/magnus`) vs Option B (`/home/magnus/repos/hugin /home/magnus/.hugin`). Needs write-path audit. Use Option A as safe default until audited.
+- **munin-memory.service scope** (C04): Is it user-level or system-level? `After=` dependency may be silently ignored. Worth verifying but non-blocking.
+
+---
+
+## Action items
+
+| # | Action | Severity | Notes |
+|---|--------|----------|-------|
+| 1 | Remove system-level hugin + ratatoskr services from Pi (one-time) | Critical | `sudo systemctl stop/disable/rm` both |
+| 2 | Fix `scripts/deploy-pi.sh`: user-level install, idempotent legacy-removal block, `systemctl --user` for restart | Critical | Single commit |
+| 3 | Fix repo `hugin.service`: remove `User=magnus`, change `WantedBy=default.target`, fix `ReadWritePaths` (use `/home/magnus /tmp` for now) | Critical | Part of same commit |
+| 4 | Fix `src/index.ts` `shutdown()`: await child exit before process.exit; hard 30s timer as only unconditional exit | Major | Follow-up commit |
+| 5 | Audit Hugin write paths to determine correct `ReadWritePaths` | Major | `strace` or code grep; resolve C08 |
+| 6 | Verify munin-memory.service scope; clean up `After=` if needed | Minor | SSH check |
+
+---
+
+## Files
+
+- `debate/zombie-procs-snapshot.md`
+- `debate/zombie-procs-claude-draft.md`
+- `debate/zombie-procs-claude-self-review.md`
+- `debate/zombie-procs-codex-critique.md`
+- `debate/zombie-procs-claude-response-1.md`
+- `debate/zombie-procs-codex-rebuttal-1.md`
+- `debate/zombie-procs-critique-log.json`
+- `debate/zombie-procs-summary.md`
+
+---
+
+## Costs
+
+| Invocation | Notes |
+|------------|-------|
+| Codex R1 | Rate-limited; Claude substituted |
+| Codex R2 | Rate-limited; Claude substituted |

--- a/docs/orchestrator-v1-data-model.md
+++ b/docs/orchestrator-v1-data-model.md
@@ -1,0 +1,670 @@
+# Orchestrator v1 — Delegation Data Model
+
+**Status:** Draft contract spec, pending Magnus sign-off
+**Date:** 2026-04-25 (updated 2026-04-26 — Option B locked in: `pi` harness on Pi enters v1)
+**Scope:** v1 = one-shot inference **and** `pi` harness on Pi. Other harnesses (`aider`, `opencode`, `claude-code`) remain deferred.
+**Purpose:** Lock the contracts that every other implementation step builds against. If this is right, broker/executor/MCP/skill are reversible. If this is wrong, everything downstream gets re-cut.
+
+---
+
+## 1. Scope
+
+**Decision (2026-04-26):** Option B from §11 selected. `pi` harness on Pi enters v1, calling cloud models via OpenRouter. Driven by parallel-session eval data (5/6 strict, 6/6 lenient on the aider task set; see §11.1).
+
+What v1 delegates:
+
+**One-shot path** (single prompt → text output):
+- Summarize this transcript
+- Extract these fields as JSON
+- Classify these items
+- Draft this paragraph
+- Rewrite this sentence
+- Reason about this question
+
+**Harness path** (prompt + working tree → diff):
+- Refactor this file/symbol across the repo
+- Add a small feature with edits to N files
+- Apply a mechanical rename
+- Anything pi can do in headless one-shot mode (`pi -p ... --no-session`)
+
+What v1 does **not** cover:
+- Other harnesses (`aider`, `opencode`, `claude-code` on Pi) — deferred to v1.5
+- Multi-turn harness conversations — pi runs `--no-session` only
+- Working trees on the laptop — v1 working trees live on the Pi (git worktrees against `origin/<branch>` HEAD at submission time)
+- Auto-commit/push of harness output — Pi never pushes; diff is returned to Claude for review and laptop-side application
+
+---
+
+## 2. Aliases (v1 active set)
+
+Aliases split into two families: one-shot aliases (`tiny`, `medium`, `large-reasoning`) and harness aliases (`pi-large-coder`).
+
+| Alias | Family | Harness | Backing model | Host | Runtime | Notes |
+|---|---|---|---|---|---|---|
+| `tiny` | one-shot | — | `qwen2.5:3b` | Pi (huginmunin.local) | ollama | Only viable Pi model per ollama-performance-spike |
+| `medium` | one-shot | — | `qwen3:14b` | MBA via Tailscale | ollama | Validated in aider eval. **Registry currently defaults laptop to `qwen3.5:35b-a3b`, which the eval found unreliable — registry default needs follow-up fix; alias pins to working model.** |
+| `large-reasoning` | one-shot | — | `gpt-oss-120b` @ reasoning level `medium` | OpenRouter | openrouter | Studio proxy. Reasoning level pinned for v1; level routing deferred. |
+| `pi-large-coder` | harness | `pi` | `qwen/qwen3-coder-next` | Pi (harness) → OpenRouter (model) | pi-harness | Validated 2026-04-26: 5/6 strict, 6/6 lenient on aider eval. Headless one-shot via `pi -p ... --no-session`. Pi reads files via tool calls; output is a unified diff. |
+
+Alias governance rules:
+- Manual promotion only. No silent retargeting.
+- Each alias change bumps `alias_map_version` (monotonic integer).
+- Journal records `alias_requested` AND `model_effective` per delegation.
+- For harness aliases, journal also records `harness_version` (the `pi` CLI version at execution time).
+- Cross-version corpus comparisons require explicit segmentation by `alias_map_version` and (for harness rows) `harness_version`.
+
+**Out of v1, by name:**
+- `medium-coder` (pi × MBA × ollama): pi's OpenAI-compatible adapter cannot disable thinking on `qwen3:14b`, making local pi+ollama unusable in eval. Revisit when pi adds native `/api/chat` or thinking-control support.
+- `pi-tiny` (pi on Pi against local `qwen2.5:3b`): no eval signal yet; almost certainly under-powered for code edits.
+
+Alias governance rules:
+- Manual promotion only. No silent retargeting.
+- Each alias change bumps `alias_map_version` (monotonic integer).
+- Journal records `alias_requested` AND `model_effective` per delegation.
+- Cross-version corpus comparisons require explicit segmentation by `alias_map_version`.
+
+---
+
+## 3. Request envelope
+
+What the MCP submits via the broker. JSON over HTTP `POST /orchestrator/submit`.
+
+```typescript
+interface DelegationRequest {
+  // Wire format
+  envelope_version: 1;                  // Pinned at 1 for v1. Broker rejects unknown versions with `kind: "policy_rejected"`.
+
+  // Identity & idempotency
+  idempotency_key: string;              // UUID v4 from MCP. Broker dedupes within 24h window. See §3.1 for reuse rules.
+  orchestrator_session_id: string;      // UUID per Claude Code session. NOT the Munin session ID.
+  orchestrator_submitter: string;       // "claude-code-mcp" — the broker principal that authenticated.
+  parent_task_id?: string;              // Reserved for v1.5 multi-step orchestration. Always null in v1.
+
+  // What to do
+  task_type: TaskType;                  // Claude's tag — see §4
+  prompt: string;                       // Full prompt text. UTF-8. No length cap from envelope; runtime caps apply.
+
+  // How to do it
+  alias_requested: Alias;               // Required. See §2.
+  alias_map_version: number;            // Read by MCP from /orchestrator/models at session start.
+
+  // Harness-only fields (required iff alias_requested resolves to a harness family)
+  worktree?: WorktreeSpec;              // Required for harness aliases. Rejected for one-shot aliases.
+
+  // Constraints
+  sensitivity?: "public" | "internal";  // Defaults to "internal". "private" rejected — local-only models can do private but v1 does not auto-route there.
+  timeout_ms?: number;                  // Defaults to runtime default (currently 300_000 one-shot, 900_000 harness).
+  max_output_tokens?: number;           // Optional cap. Ignored for harness aliases (pi controls its own context).
+}
+
+interface WorktreeSpec {
+  repo: string;                         // Repo slug, e.g. "hugin". Resolves to /home/magnus/repos/<repo> on the Pi.
+  base_ref: string;                     // Git ref the harness branches from, e.g. "origin/main". Broker resolves to a SHA at submission time and pins it.
+  target_files?: string[];              // Optional advisory list; pi can read more via tool calls. Used only for the journal.
+  copy_node_modules?: boolean;          // Default false. Set true per-call for Node repos that need installed deps available at run time. See §11.3 for cap/admission.
+}
+
+type TaskType =
+  | "summarize"
+  | "extract"
+  | "classify"
+  | "draft"
+  | "reason"
+  | "rewrite"
+  | "code-edit"      // Harness only.
+  | "other";
+
+type Alias =
+  | "tiny"
+  | "medium"
+  | "large-reasoning"
+  | "pi-large-coder";
+```
+
+**Broker-added fields** (set by Hugin, not the MCP):
+
+```typescript
+interface BrokerAnnotations {
+  task_id: string;                      // Hugin-generated task ID (existing scheme).
+  broker_principal: string;             // Bearer-token identity; matches a key in HUGIN_BROKER_KEYS.
+  received_at: string;                  // ISO timestamp.
+  alias_resolved: {                     // Snapshot at submission time (immune to later registry edits).
+    alias: Alias;
+    family: "one-shot" | "harness";
+    harness?: "pi";                     // Set iff family === "harness".
+    harness_version?: string;           // pi CLI version, captured at submission.
+    model_requested: string;
+    runtime: "ollama" | "openrouter" | "pi-harness";
+    runtime_row_id: string;             // REQUIRED. Stable registry row id (e.g. "ollama-pi", "pi-harness"). Threads through submit → execute → complete; the journal segments corpora by this even when "runtime" is coarse.
+    host: "pi" | "mba" | "openrouter";
+    reasoning_level?: "low" | "medium" | "high";
+  };
+  worktree_resolved?: {                 // Set iff family === "harness".
+    repo: string;
+    base_ref: string;
+    base_sha: string;                   // Pinned SHA at submission time.
+    worktree_path: string;              // Absolute path on Pi, e.g. /home/magnus/.hugin/worktrees/<task_id>.
+  };
+  policy_version: string;               // ZDR allowlist version + reasoning-level pinning version, e.g. "zdr-v1+rlv-v1".
+}
+```
+
+The broker validates: `envelope_version === 1`, bearer token → known principal, idempotency key not seen (or seen with same prompt hash — see §3.1), alias is currently active, sensitivity ≤ runtime ceiling, prompt non-empty. Rejects with a typed error otherwise.
+
+### 3.1 Idempotency-key reuse semantics
+
+The `idempotency_key` is the client's commitment that two submissions are *the same logical task*. Rules:
+
+1. **Same key, same payload (within 24h):** broker treats the second submission as a retry. It returns the existing `task_id` instead of creating a new one. This is the recovery path when the MCP didn't get an HTTP response (network drop, broker restart between accept and ack) and resubmits.
+2. **Same key, different payload (within 24h):** broker rejects with `kind: "policy_rejected"`, message indicating idempotency-key collision. The client must rotate the key — generating a new key is treated as a new task.
+3. **Same key, after 24h:** the dedupe window has expired. The broker treats it as a new task and accepts. Old retries against this key resolve to the new task; this is acceptable because 24h is a generous upper bound on real retry windows.
+4. **New key, regardless of payload:** new logical task. Always accepted (subject to other policy gates).
+
+Payload equality is computed as `sha256(canonicalized_envelope)` where canonicalization sorts keys and excludes broker-added fields. The client must hold the key stable across retries; the broker holds the hash.
+
+---
+
+## 4. Result/await state machine
+
+`hugin_await(task_id, max_wait_s?)` returns one of these states. Idempotent — Claude can call repeatedly with the same `task_id`.
+
+```typescript
+type AwaitResponse =
+  | { status: "completed"; result: DelegationResult }
+  | { status: "failed"; error: DelegationError }
+  | { status: "running"; lease: LeaseInfo; orphan_suspected: false }
+  | { status: "stale"; lease: LeaseInfo; orphan_suspected: true }
+  | { status: "unknown"; reason: "task_id_not_found" | "broker_unavailable" };
+
+interface DelegationResult {
+  result_schema_version: 1;            // Pinned at 1 for v1. Bumped only on breaking changes to this shape.
+  task_id: string;
+  alias_requested: Alias;
+  model_effective: string;             // What actually ran (post-fallback if any).
+  runtime_effective: "ollama" | "openrouter" | "pi-harness";
+  runtime_row_id_effective: string;    // REQUIRED. Stable registry row id of the runtime that actually executed. Equals BrokerAnnotations.alias_resolved.runtime_row_id unless fallback fired.
+  host_effective: "pi" | "mba" | "openrouter";
+  result_kind: "text" | "diff";        // "diff" only for harness aliases.
+
+  // For result_kind === "text": one-shot output.
+  output?: string;                      // Scanned, post-finalization. Never raw provider bytes.
+
+  // For result_kind === "diff": harness output.
+  diff?: {
+    base_sha: string;                   // Pinned at submission. Caller applies onto this.
+    head_sha: string;                   // SHA of the harness's working-tree commit on Pi.
+    files_touched: string[];            // Relative paths.
+    unified_diff: string;               // Output of `git diff <base_sha> <head_sha>`. Scanned. Always intact in a `completed` result — see scanner contract below.
+    stats: { files: number; insertions: number; deletions: number };
+    worktree_path: string;              // Absolute Pi path; reaped after retention window.
+  };
+
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+  duration_s: number;
+  load_ms?: number;
+  cost_usd: number;
+  finalized_at: string;
+  provenance: {
+    source: "delegated";
+    scanner_pass: "clean" | "warn" | "redact";
+    policy_version: string;
+    harness_version?: string;          // For harness results.
+  };
+}
+
+interface DelegationError {
+  task_id: string;
+  kind:
+    | "alias_unknown"
+    | "alias_unavailable"        // Host down, MBA asleep, OR rate-limited
+    | "policy_rejected"          // ZDR / sensitivity / timeout
+    | "executor_failed"          // Model returned error or empty
+    | "scanner_blocked"          // Exfil scanner under `redact` policy matched an executable artifact (e.g. a unified diff). See scanner contract below.
+    | "timeout"
+    | "internal";
+  message: string;
+  retryable: boolean;            // Hint for the skill's retry decision.
+}
+
+interface LeaseInfo {
+  claimed_by: string | null;     // workerId or null if unclaimed.
+  claimed_at: string | null;
+  lease_expires_at: string | null;
+  last_heartbeat_at: string | null;
+  queue_depth_when_submitted: number;
+}
+```
+
+State transitions:
+- `pending` (in queue, not visible to await — counts as `running` to the caller with `claimed_by: null`)
+- `running` → `completed` | `failed` (normal lifecycle)
+- `running` → `stale` when `lease_expires_at < now()` and no heartbeat. **The reaper will eventually flip `stale` → `failed` (kind: `internal`, retryable: true) once it sweeps.** Until then, await reports `stale` so Claude knows the difference between "actually running" and "probably orphaned."
+
+Important: `stale` is a *view* over the raw task state, not a stored status. Munin still says `running`; the broker computes `stale` by comparing `lease_expires_at` to now. This avoids a state-write race with the reaper.
+
+### 4.1 Scanner contract (text vs diff asymmetry)
+
+`finalizeDelegatedOutput` is the single seam where raw provider bytes become a `DelegationResult` or a `DelegationError`. Its contract is **asymmetric** by `result_kind`:
+
+| Scanner outcome | Policy | `result_kind: "text"` | `result_kind: "diff"` |
+|---|---|---|---|
+| no match | any | `completed`, `scanner_pass: "clean"` | `completed`, `scanner_pass: "clean"` |
+| match | `warn` (default) | `completed`, `scanner_pass: "warn"`, raw output | `completed`, `scanner_pass: "warn"`, raw diff |
+| match | `redact` | `completed`, `scanner_pass: "redact"`, redacted output | **`failed`, `kind: "scanner_blocked"`, `retryable: false`** |
+
+Why the asymmetry: a redacted human-readable string is still useful — the reader sees `[redacted: private-key]` where the secret was and can decide what to do. A redacted unified diff is no longer a valid patch; replacing the matched span with `[redacted: private-key]` breaks `git apply`. The contract therefore guarantees: **a `completed` result whose `result_kind` is `"diff"` always carries an intact, applyable `unified_diff`.** If redaction would corrupt the diff, the caller sees `failed/scanner_blocked` instead.
+
+This rule generalises: any future executable-artifact result kind (e.g. `tool-call-trace`, `binary-patch`) must explicitly declare whether redaction preserves semantics. If not, it escalates to `scanner_blocked`.
+
+`scanner_blocked` is `retryable: false` because retrying the same prompt against the same model is unlikely to produce different scanner output. Escalation to a different alias (e.g. a smaller model, or a one-shot path that produces text instead of a diff) is the recovery path; that's a Step 7 (skill) decision, not a broker retry.
+
+---
+
+## 5. Journal event model
+
+**Decision:** append-only JSONL event log + read-time projection. No mutation. No new dependency.
+
+File: `~/.hugin/delegation-events.jsonl` on the Pi. Separate from the main `invocation-journal.jsonl` because:
+- Different cardinality (delegated calls likely 5–10× top-level Hugin tasks)
+- Different schema (full prompts/outputs)
+- Different retention story (full-text content has tighter blast radius)
+- Different consumers (corpus analysis tools, not the existing journal scripts)
+
+### Event types
+
+Three event kinds, all append-only. Every event carries `event_schema_version` so future projection code can branch on shape changes without a migration. v1 pins all events at version 1.
+
+```typescript
+interface DelegationSubmittedEvent {
+  event_schema_version: 1;
+  event_type: "delegation_submitted";
+  event_ts: string;                    // ISO
+  task_id: string;
+  // Full envelope at submission time:
+  envelope: DelegationRequest & BrokerAnnotations;
+  prompt_chars: number;
+  prompt_sha256: string;               // For dedup analysis without storing twice.
+}
+
+interface DelegationCompletedEvent {
+  event_schema_version: 1;
+  event_type: "delegation_completed";
+  event_ts: string;
+  task_id: string;
+  outcome: "completed" | "failed";
+  // For completed:
+  output?: string;                     // Full text. Post-scanner.
+  output_chars?: number;
+  output_sha256?: string;
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+  duration_s?: number;
+  load_ms?: number;
+  cost_usd?: number;
+  model_effective?: string;
+  runtime_effective?: string;
+  host_effective?: string;
+  scanner_pass?: "clean" | "warn" | "redact";
+  // For failed:
+  error_kind?: DelegationError["kind"];
+  error_message?: string;
+}
+
+interface DelegationRatedEvent {
+  event_schema_version: 1;
+  event_type: "delegation_rated";
+  event_ts: string;
+  task_id: string;
+  rating: "pass" | "partial" | "redo" | "wrong";
+  rating_reason: string;               // Required, non-empty.
+  verification_outcome:                // Structured detail beyond the rating.
+    | "accepted_unchanged"
+    | "minor_edit"
+    | "major_rewrite"
+    | "discarded"
+    | "escalated_to_claude";
+  rated_by: string;                    // Always "claude-code-mcp" in v1; reserved for human audit later.
+  retries_count?: number;              // How many times the parent session re-invoked the same task.
+}
+```
+
+**Forward-compat rule:** projection code MUST tolerate unknown `event_schema_version` values by skipping the event (with a logged warning) rather than crashing. Producers MUST bump the version on any breaking shape change; additive field changes do not require a bump.
+
+### Projection (read-time)
+
+Reading the journal:
+
+```typescript
+function projectDelegations(events: Event[]): Map<string, DelegationRow> {
+  const rows = new Map<string, DelegationRow>();
+  for (const e of events) {
+    const row = rows.get(e.task_id) ?? { task_id: e.task_id };
+    if (e.event_type === "delegation_submitted") {
+      row.envelope = e.envelope;
+      row.submitted_at = e.event_ts;
+      row.prompt_chars = e.prompt_chars;
+    } else if (e.event_type === "delegation_completed") {
+      row.outcome = e.outcome;
+      row.completed_at = e.event_ts;
+      // ...merge tokens/cost/model/etc.
+    } else if (e.event_type === "delegation_rated") {
+      row.rating = e.rating;
+      row.rating_reason = e.rating_reason;
+      row.verification_outcome = e.verification_outcome;
+      row.rated_at = e.event_ts;
+    }
+    rows.set(e.task_id, row);
+  }
+  return rows;
+}
+```
+
+Properties:
+- Single writer: Hugin's broker process. Append-only. No locks.
+- Multiple ratings allowed: only the latest `delegation_rated` event for a given `task_id` wins. Earlier ones become history.
+- Unrated tasks visible: a row without a `delegation_rated` event projects with `rating: null`. The skill or a periodic check can flag these.
+- Audit-friendly: the raw event log is the source of truth. Any projection is reproducible from the same events.
+
+### Audit fields populated downstream (not in v1)
+
+Reserved field names recorded but not written by v1, to avoid schema churn later:
+- `external_audit_rating` (Magnus weekly spot-audit, future)
+- `audit_disagrees_with_self_rating` (boolean, future)
+
+---
+
+## 6. Runtime registry extension
+
+`src/runtime-registry.ts` gains:
+
+```typescript
+interface RuntimeDefinition {
+  // ... existing fields ...
+  provider: "anthropic" | "openai-spawn" | "ollama-local" | "openrouter" | "pi-harness";
+  egress: "subscription" | "local" | "third-party";
+  zdrRequired: boolean;                // true for "openrouter" and "pi-harness" (since pi-harness uses OR).
+  autoEligible: boolean;               // false for "openrouter" and "pi-harness" — explicit-only routing.
+  reasoningLevel?: "low" | "medium" | "high";  // Pinned per runtime row for gpt-oss family.
+  family: "one-shot" | "harness";      // Selects executor path.
+  harnessCmd?: string;                 // For family === "harness": the CLI binary, e.g. "pi".
+  harnessFlags?: string[];             // Static flags, e.g. ["--no-session", "--provider", "openrouter"].
+}
+
+interface AliasMap {
+  version: number;                     // Monotonic. Bumped on any retargeting.
+  effective_at: string;                // ISO when this map became active.
+  aliases: Record<Alias, AliasResolution>;
+}
+
+interface AliasResolution {
+  model: string;
+  runtime: string;
+  host?: string;
+  reasoningLevel?: "low" | "medium" | "high";
+  family: "one-shot" | "harness";
+  harness?: "pi";
+  notes?: string;
+}
+```
+
+The router (`src/router.ts`) gains one rule: skip runtimes with `autoEligible: false` from auto-routing. They can still be selected explicitly by alias.
+
+### v1 runtime rows added
+
+| Runtime ID | provider | egress | zdrRequired | autoEligible | family | harnessCmd | harnessFlags |
+|---|---|---|---|---|---|---|---|
+| `openrouter` | openrouter | third-party | true | false | one-shot | — | — |
+| `pi-harness` | pi-harness | third-party | true | false | harness | `pi` | `["--no-session", "--provider", "openrouter"]` |
+
+The existing `ollama-local` runtime is unchanged; `tiny` and `medium` aliases continue to point at it.
+
+---
+
+## 7. Provenance chain (end-to-end)
+
+```
+Claude Code session
+  ↓ (intent: delegate sub-task)
+Delegate skill (heuristic chooses alias)
+  ↓
+hugin-mcp tool call (laptop)
+  ↓ (HTTPS over Tailscale, bearer token)
+Hugin broker endpoint (Pi)
+  ├─→ DelegationSubmittedEvent (journal)
+  ├─→ Munin task entry (under tasks/<id>) with envelope encoded
+  ↓
+Hugin dispatcher (existing poll loop)
+  ↓
+Executor (ollama-executor or openrouter-executor)
+  ↓
+Raw provider output
+  ↓
+finalizeDelegatedOutput()  ← exfil scanner, structured-result builder, provenance tags
+  ↓
+Munin result-structured + DelegationCompletedEvent (journal)
+  ↓
+hugin_await returns to MCP
+  ↓
+MCP returns scanned result to Claude session
+  ↓ (Claude verifies output, decides to use/redo)
+Claude calls hugin_rate
+  ↓
+DelegationRatedEvent (journal)
+```
+
+Every transition logs an event. Every output crossing the broker→MCP boundary has been through `finalizeDelegatedOutput()`. Every task ID is traceable end-to-end.
+
+---
+
+## 8. Open questions Magnus must close before Step 2
+
+These remain open. Each has a default the spec proceeds with absent a contrary answer.
+
+1. **MBA medium model:** Default `qwen3:14b` for the `medium` alias (eval-validated). Registry's current laptop default of `qwen3.5:35b-a3b` is a separate fix tracked outside this spec.
+2. **Tailscale ACL:** Default — broker accepts any tailnet device that presents a valid bearer token from `HUGIN_BROKER_KEYS`. Tag-pinning is an upgrade for later if the keystore alone proves insufficient.
+3. **Idempotency window:** Default 24h. Affects how aggressive MCP retries can be without creating phantom duplicates.
+4. **Reasoning-level pinning for `gpt-oss-120b`:** Default `medium`. Pinned per-alias for v1; per-call override is a v1.5 ask.
+5. **Harness retention:** Default 7 days for `~/.hugin/worktrees/<task_id>` before reaping. See §11.3 for the disk cap and admission-control rules that pair with retention.
+
+---
+
+## 11. `pi` harness in v1 — decision and eval data
+
+**Decision (2026-04-26): Option B selected.** `pi` enters v1 as a harness runtime running on the Pi, calling cloud models via OpenRouter. No multi-host dependency. Working trees are managed per-task on the Pi via `git worktree add`.
+
+### 11.1 Eval data (the basis for the decision)
+
+| Question | Answer |
+|---|---|
+| How many tasks "useful" (X/6) | 5✓ / 1~ / 0✗ — strict 5/6, lenient 6/6 |
+| Against which models | Cloud only: `openrouter/qwen/qwen3-coder-next` (the 30B-A3B coder MoE) |
+| Working tree / file scope | Fresh `git worktree add` from `aider-eval/base` (commit `929c6e8`). `cp -R node_modules` from main repo. No file pre-loading — pi reads files itself via tool calls (iterative loop, like opencode) |
+| Invocation mode | Headless one-shot: `pi --provider openrouter --model qwen/qwen3-coder-next --no-session -p "<prompt>"`. No multi-turn, no interactive — just `-p` and exit |
+| Wall time | 2 min 16 sec total (parallel cloud, longest task 129s) |
+| The "~" task | Task 05 (rename `ModelSpec` → `ModelConfig` across files): rename done correctly across all 5 files, no test regressions, but also renamed `topModelSpec` → `topModelConfig` against an explicit "leave variables alone" instruction. Strict scorer ✗, lenient scorer ✓ |
+| Local pi (Pi+ollama) | Tested ollama config — works but blocked: `qwen3:14b` takes 85s for "what is 2+2" because thinking can't be disabled via pi's OpenAI-compatible adapter. No local 6-task data yet |
+
+Source artifacts: `data/aider-eval/pi-task-{01..06}-transcript.txt`, dispatch script `/tmp/aider-eval/dispatch-pi.sh`, runner `/tmp/aider-eval/run-pi-task.sh`. Munin log entry `da0c410d-afa6-41da-b804-e2f494acc0ec` posted at 2026-04-26T10:28 UTC.
+
+### 11.2 Architectural rationale
+
+Pi is the always-on orchestration host; Studio (future) and OpenRouter (now) are stateless model servers. Putting the harness *on the Pi* — not the laptop, not the Studio — means:
+
+- Working trees live next to the orchestrator (no cross-machine sync).
+- Harness invocation does not depend on the laptop being awake.
+- Model choice is independent of harness placement (pi calls OR for the model; OR is just an HTTP endpoint).
+- No multi-host sprint dependency — Hugin on Pi is sufficient.
+
+The Pi RAM constraint that rules out local-Ollama for harness work does **not** apply here, because pi calls OR for the model; the Pi is only running the harness control loop (I/O bound, not compute bound).
+
+### 11.3 Working-tree contract
+
+Every `pi-large-coder` delegation creates and tears down a per-task worktree:
+
+```
+~/.hugin/worktrees/<task_id>/        # git worktree add <repo> <base_sha>
+  node_modules/                      # only if copy_node_modules: true
+  ...repo files at base_sha...
+```
+
+`copy_node_modules` defaults to `false`. The eval that validated `pi` used `cp -R node_modules` from a Node repo where the harness needed installed deps to run tests. That pattern doesn't generalise — Python venvs, Rust target dirs, Go module caches all behave differently — so v1 ships with no copy by default and the caller opts in per task. For non-Node repos, the harness must bootstrap its own deps (or the task must avoid commands that need them); per-toolchain dep-bootstrap support is deferred to v1.5.
+
+Lifecycle:
+1. **Submit:** broker resolves `worktree.base_ref` → `base_sha`, records both in `worktree_resolved`. Admission control runs here (see §11.3.1) — if the broker projects that the new worktree would exceed the disk cap, submission is rejected with `kind: "policy_rejected"` before any disk is touched.
+2. **Claim:** dispatcher calls worktree-manager: `git worktree add <path> <base_sha>` + `cp -R ../<repo>/node_modules <path>/` iff `copy_node_modules: true`.
+3. **Run:** `cd <path> && pi --no-session --provider openrouter --model <resolved> -p "<prompt>"`. pi makes file changes via its own tool calls.
+4. **Capture:** `git -C <path> add -A && git -C <path> commit -m "harness: <task_id>"` to get a `head_sha`. Then `git -C <path> diff <base_sha> <head_sha>` is the diff returned.
+5. **Finalize:** diff and stats run through `finalizeDelegatedOutput()` (exfil scanner). Worktree path is recorded in the result for retention/reaping.
+6. **Reap:** worktrees older than 7 days (configurable) are removed by a periodic sweep. The Pi never pushes; never modifies the main worktree.
+
+Hugin pushes nothing. Diffs cross the broker → MCP → Claude boundary; Claude applies on the laptop (or asks the user to).
+
+### 11.3.1 Worktree disk admission control
+
+The Pi has finite disk. Worktrees grow without bound if retention is the only mechanism, especially when `copy_node_modules: true` clones can be hundreds of megabytes each. v1 caps total worktree disk and admits new ones against the cap.
+
+**Configuration:**
+- `HUGIN_WORKTREE_BUDGET_BYTES` — cap on cumulative `~/.hugin/worktrees/` size. Default 20 GiB. Tunable per-host.
+- `HUGIN_WORKTREE_RETENTION_DAYS` — soft retention. Default 7. Time-based reap runs daily.
+
+**Admission rules (broker side, at submit):**
+1. Read current `~/.hugin/worktrees/` size from a small cached value the worktree-manager refreshes after every add/reap. (No `du` on every submit — too expensive.)
+2. Estimate the projected worktree size: repo size at `base_sha` (cheap to compute via `git -C <repo> rev-list --objects --count` or stat the existing worktree on disk) + `node_modules` size if `copy_node_modules: true`.
+3. If `current + projected > budget`:
+   a. **Eager reap:** delete worktrees older than `HUGIN_WORKTREE_RETENTION_DAYS / 2` (LRU among same-age ties). Recompute current. If still over budget, continue.
+   b. **LRU eviction (above-cap path):** while `current + projected > budget`, delete the oldest fully-completed worktree (status: `completed | failed`, never `running`). Recompute current.
+   c. If after a + b the projection still exceeds the budget, reject submission with `DelegationError { kind: "policy_rejected", message: "worktree_budget_exhausted", retryable: false }`. The skill's recovery path is to escalate the alias or wait.
+
+**Mid-run failure (disk fills between claim and finalize):**
+A claimed task that is `running` is never evicted by admission control. If the disk genuinely fills mid-run (e.g. the harness writes a huge file), the executor reports an OS error and the task fails with `kind: "executor_failed"`. The reaper then sweeps it like any other failed task. We do not pre-allocate or quota individual worktrees in v1; the budget is a coarse cap, not a per-task reservation.
+
+**Operational telemetry:**
+The broker emits `delegation_admission_evaluated` log lines (size projection, budget, decision) so disk pressure becomes observable before it becomes a rejection rate. Promotion to a journal event kind is deferred to v1.5.
+
+### 11.4 What is **not** locked yet
+
+These are deferred to implementation time and do not block Step 2:
+
+- Per-toolchain dep bootstrap beyond `copy_node_modules` (Python venvs, Rust target dirs, Go module caches). **Tentative:** v1 supports Node repos with explicit opt-in; non-Node repos run with no copied deps and the harness bootstraps as needed (or the task avoids commands that need them). Promotion to first-class spec is a v1.5 ask.
+- Concurrency limit on harness runs (eval ran 6 in parallel; v1 dispatcher serializes, so this is not a v1 issue).
+- Auto-application of diffs by the skill vs. always-review. **Tentative:** always-review for v1 — Claude shows the diff, the user (or Claude itself within session) applies it.
+
+---
+
+## 12. Durability and recovery contract
+
+The Step 1 spec (as originally drafted) named the writes that happen on submit and complete but did not lock which write is the durable record, which is the derived view, or how the system recovers when a write succeeds and the next one fails. The recent #57 fix (status-first ordering for legacy task results) does not transplant directly: in the orchestrator, the structured `DelegationResult` *is* the payload `hugin_await` returns, so a "completed status with no durable result" is not an acceptable state.
+
+This section locks the durability model.
+
+### 12.1 Sources of truth (per phase)
+
+| Phase | Durable record | Derived views |
+|---|---|---|
+| Submission | The Munin task entry under `tasks/<task_id>` (status + envelope) | `delegation_submitted` journal event; broker in-memory index |
+| Execution | The lease state on the Munin entry (`claimed_by`, `lease_expires_at`, `last_heartbeat_at`) | `running` / `stale` views computed by the broker |
+| Completion (success) | The Munin entry under `tasks/<task_id>/result-structured` (the full `DelegationResult` JSON) plus the terminal-status flip on `tasks/<task_id>` | `delegation_completed` journal event; `output` in the Munin human-readable result key |
+| Completion (failure) | The Munin terminal-status flip (`tasks/<task_id>` tags include the failure marker) plus a stored `DelegationError` JSON | `delegation_completed { outcome: "failed" }` journal event |
+| Rating | The latest `delegation_rated` journal event | (none — the journal is canonical for ratings) |
+
+**Rule:** Munin holds the durable records for submission, execution, and completion. The journal is the canonical record for rating, and a derived/auditable view of the other phases. The broker in-memory index is purely a cache and must be reconstructible from Munin alone.
+
+### 12.2 Submit ordering
+
+The broker's `POST /orchestrator/submit` performs writes in this order:
+
+1. **Acquire dedupe lock** on the `idempotency_key` (in-memory; non-durable). If another submission with the same key is in-flight, queue this one or reject.
+2. **Munin write:** create `tasks/<task_id>` with the full envelope (request + `BrokerAnnotations`) and tags `["pending", "runtime:<runtime>", "orch-v1"]`. This write must succeed before the broker returns `200 OK` to the MCP. *This is the durability boundary — once Munin acks, the submission is durable.*
+3. **Journal append:** write `delegation_submitted` to `~/.hugin/delegation-events.jsonl`. If this fails, log a warning but do not roll back the Munin write — the event is reconstructible from the Munin envelope. Periodic reconciliation (§12.5) will detect and backfill missing journal entries.
+4. **Acknowledge** to the MCP with `{ task_id }`.
+
+**Crash between (2) and (3):** Munin has the task; journal is missing the submitted event. Reconciliation backfills it on next broker startup (or on-demand). The MCP retry path (same `idempotency_key`) finds the existing Munin entry and returns the same `task_id`.
+
+**Crash between (1) and (2):** No durable state. The MCP retry creates the task fresh.
+
+**Crash between (2) and (4):** Munin has the task; the MCP did not receive an ack. The MCP retry with the same `idempotency_key` and same payload returns the existing `task_id` (per §3.1 rule 1).
+
+### 12.3 Complete ordering
+
+When the executor finishes a task, the broker performs:
+
+1. **Compute** the `DelegationResult` (or `DelegationError`) by running the executor output through `finalizeDelegatedOutput`. This is in-memory; nothing is durable yet.
+2. **Munin write:** atomic CAS on `tasks/<task_id>` flips the lifecycle tag to terminal (`completed` or `failed`) AND writes `tasks/<task_id>/result-structured` with the full result JSON in a single Munin operation. Munin's substrate does not support multi-key CAS, so this is implemented as: (a) write `result-structured` first; (b) CAS the status tag from `running` → terminal, gated on the lease still being valid. If (a) succeeds and (b) fails, the result is orphaned in `result-structured` but the task is still `running`. The reaper detects this on its next sweep and either re-completes (if the worker is gone) or escalates.
+3. **Journal append:** `delegation_completed`. Same recovery posture as submit (§12.2 step 3) — backfill on reconciliation if the append fails.
+
+**Why result-first inside Munin:** `hugin_await` reads `tasks/<task_id>` for status and `tasks/<task_id>/result-structured` for the payload. If status is terminal but the payload key is missing, `await` would have to invent a result — unacceptable. Writing the payload first guarantees that any caller who sees terminal status can read a durable result.
+
+**Crash between (1) and (2a):** No durable completion; the lease eventually expires; the reaper re-queues the task as `failed` with `kind: "internal"` (existing legacy behavior).
+
+**Crash between (2a) and (2b):** Result is durable but status is still `running`. The reaper sweep checks for an existing `result-structured` key and, if found and the lease has expired, completes the CAS itself. If the CAS fails (another worker claimed it), the recovery path is to delete the orphaned result and re-run.
+
+**Crash between (2b) and (3):** Task is terminal in Munin; journal is missing the completed event. Reconciliation backfills.
+
+### 12.4 `hugin_await` semantics
+
+`hugin_await(task_id)` is implemented as a pure read against Munin:
+
+1. Read `tasks/<task_id>` (status + tags + lease).
+2. If terminal status:
+   - `completed` → read `tasks/<task_id>/result-structured`. If missing, return `{ status: "failed", error: { kind: "internal", message: "result-structured key missing for terminal task; reconciliation pending", retryable: true } }` (recoverable by next reaper pass).
+   - `failed` → read the stored `DelegationError`. Return `{ status: "failed", error }`.
+3. If `running` and `lease_expires_at` is in the future → return `{ status: "running", lease, orphan_suspected: false }`.
+4. If `running` and `lease_expires_at` is past → return `{ status: "stale", lease, orphan_suspected: true }`.
+5. If task does not exist → return `{ status: "unknown", reason: "task_id_not_found" }`.
+
+The earlier proposal of a `submitted_not_indexed` await branch is dropped: Munin is the canonical submit record, so there is no separate index to lag behind. The broker's in-memory index is purely a performance optimisation; await reads Munin directly.
+
+### 12.5 Reconciliation sweep
+
+A periodic reconciliation pass (default every 60s, configurable via `HUGIN_RECONCILIATION_INTERVAL_MS`) does:
+
+1. Scan Munin for `tasks/*` entries with the `orch-v1` tag and a status that disagrees with the broker's in-memory cache.
+2. For each Munin task without a matching `delegation_submitted` event in the journal: append the event from the stored envelope (idempotent — the journal append checks if the event already exists before writing).
+3. For each terminal Munin task without a matching `delegation_completed` event: append the event from the stored result/error.
+4. For each Munin task in `running` with an expired lease and an existing `result-structured` key: complete the CAS (per §12.3 crash recovery).
+5. For each Munin task in `running` with an expired lease and no result: flip to `failed { kind: "internal", message: "lease expired without result" }`.
+
+Reconciliation is designed to be idempotent — running it twice produces the same state. It is the recovery path for every "crash between writes" scenario in §12.2 and §12.3.
+
+### 12.6 Runtime-row identity through the chain
+
+Every persisted record carries `runtime_row_id` (the registry row id, e.g. `"ollama-pi"`, `"pi-harness"`):
+
+- `BrokerAnnotations.alias_resolved.runtime_row_id` — captured at submit time.
+- `DelegationResult.runtime_row_id_effective` — the row that actually ran (post-fallback).
+- `DelegationSubmittedEvent.envelope.alias_resolved.runtime_row_id` — derived from the envelope.
+- `DelegationCompletedEvent.runtime_row_id_effective` — derived from the result.
+
+Sensitivity policy and routing decisions resolve through `runtime_row_id` (registry-row scope) rather than the coarse `dispatcherRuntime` field. This is what unblocks future cases like a second OpenRouter row with different cost/ZDR/reasoning profiles. The `runtime` and `host` fields remain in the envelope/result for human readability and for consumers that don't need row-level precision.
+
+The dispatcher's legacy in-process executor continues to key off `dispatcherRuntime` (`claude` / `codex` / `ollama`) — that's the `LegacyDispatcherRuntime` boundary in `runtime-registry.ts`. Orchestrator-only runtimes (`openrouter`, `pi-harness`) never flow through the legacy dispatcher; they go through the broker → executor path that uses `runtime_row_id` end-to-end.
+
+---
+
+## 9. What this spec deliberately does NOT cover
+
+- Other harness runtimes (`aider`, `opencode`, `claude-code-on-pi`) — out of scope for v1, deferred to v1.5. Only `pi` ships in v1.
+- Multi-turn harness sessions — `pi` is invoked `--no-session` only; multi-turn would require persistent state across `await` calls, deferred.
+- Multi-step orchestration (`parent_task_id` chaining) — reserved field, not used.
+- Auto-apply of harness diffs — Claude reviews and applies; Pi never pushes.
+- Cost caps per call — addressed in Step 5 (executor) via env config.
+- Skill heuristics (when to delegate code-edit vs. handle in session) — addressed in Step 7.
+- MCP server lifecycle (Claude Code restart, reconnect) — addressed in Step 6.
+- Multi-host orchestration (Hugin running on MBA too) — separate sprint.
+
+---
+
+## 10. Acceptance criteria for Step 1
+
+This spec is approved when:
+- [x] Pi-harness scope decision (Option B) recorded with eval data (§11).
+- [ ] Magnus signs off on the alias set including `pi-large-coder` (§2).
+- [ ] Magnus confirms the worktree contract: per-task `git worktree add` from pinned base SHA, no auto-push, 7-day retention (§11.3).
+- [ ] Magnus confirms the journal event model (append-only, projection at read time, no mutation, no new dependency).
+- [ ] Magnus confirms the broker is Tailscale-only with bearer-token auth.
+- [ ] Defaults for §8 questions accepted (or contrary answers given).
+
+After acceptance: Step 2 (runtime registry extension) is unblocked. Each subsequent step has its own acceptance gate before code is written.

--- a/docs/research/journal-analysis-scoping.md
+++ b/docs/research/journal-analysis-scoping.md
@@ -1,0 +1,190 @@
+# Journal Analysis — Evaluation Track Scoping
+
+**Status:** Draft scope, awaiting approval
+**Date:** 2026-04-25
+**Purpose:** Produce evidence to make a falsifiable go/no-go decision on the orchestrator stack (per `debate/orch-stack-summary.md`). Does not prejudge the answer.
+
+---
+
+## Why this exists
+
+The Codex debate concluded the orchestrator stack has not earned priority over the multi-host sprint. The agreed gate before any orchestrator code is written:
+
+> Run a falsifiable go/no-go evaluation using existing telemetry plus a fixed benchmark of manual local-only delegations.
+
+The four numeric thresholds the orchestrator stack must clear to be worth building:
+
+| Gate | Threshold |
+|---|---|
+| Token-cost reduction (orchestrator vs. status-quo Claude) | ≥ 20 % |
+| p95 latency increase | ≤ 2× |
+| Escalation rate (Ollama → Claude redo) | ≤ 30 % |
+| New stuck-running states introduced | 0 |
+
+This document scopes the analysis that produces the evidence to evaluate the first three. Stuck-running is a runtime property and is checked separately during the manual benchmark.
+
+---
+
+## Inputs
+
+- **Journal:** `~/.hugin/invocation-journal.jsonl` on `huginmunin.local` (Pi). 261 entries as of 2026-04-25 (172 claude, 89 ollama).
+- **Append site:** `src/index.ts:3465-3484`.
+- **Per-runtime fields available:**
+  - **All:** `ts, task_id, repo, runtime, executor, model_requested, exit_code, duration_s, timeout_ms, cost_usd, group, quota_before, quota_after, cancellation_reason, cancellation_source`.
+  - **Ollama extras:** `runtime_requested/effective, host_requested/effective, model_effective, fallback_triggered, fallback_reason, prompt_tokens, completion_tokens, total_tokens, inference_ms, load_ms, prompt_chars, output_chars, free_mem_before/after_mb, context_refs_*, injection_policy, external_policy, max_provenance, external_blocked`.
+- **No tokens recorded for Claude runs.** This is the first known gap — see Limitations.
+
+---
+
+## Track A — Static analysis of the existing journal
+
+Two artifacts:
+
+1. **`scripts/analyze-journal.mjs`** — one-shot Node script, reads JSONL from `--input` (default `~/.hugin/invocation-journal.jsonl`), writes a markdown report to `--out` (default stdout). No deps beyond `node:fs`. Pure aggregation, no external calls.
+2. **`docs/research/journal-analysis-report.md`** — the report it produces, committed for traceability.
+
+### Questions the report must answer
+
+Each question maps to a section in the report. Numbers, not narrative.
+
+| # | Question | What it answers |
+|---|---|---|
+| 1 | Cost distribution by `runtime` × `model_requested` (sum, p50, p95 of `cost_usd`) | What share of spend is concentrated where? |
+| 2 | Duration distribution by `runtime` × `model_requested` (p50, p95 of `duration_s`) | Latency baseline for the ≤2× gate |
+| 3 | Cost per `repo` (top 10) | Which repos drive spend? Concentration test |
+| 4 | Failure rate (`exit_code != 0` ÷ total) by runtime, by model | Quality baseline for the ≤30 % escalation gate |
+| 5 | Cancellation rate and reason histogram | Does cancellation noise dominate any class? |
+| 6 | Ollama-only: fallback rate, escalation reasons, output-token distribution | What proportion of Ollama runs already fail back to Claude today? |
+| 7 | Group/Sequence presence: how many tasks ran as multi-step? | Is the existing pipeline path used at all? |
+| 8 | Prompt-token and prompt-char distribution (Ollama only — Claude has no token data) | What fraction of Claude runs have prompts small enough that local could plausibly handle them? Use `repo` + `task_id` heuristics as a proxy. |
+
+### Heuristic: which Claude tasks "look delegable"
+
+The journal has no prompt content, no labels, no runtime spend without tokens. The closest signal we have is:
+
+- `cost_usd` low + `duration_s` short → mechanical task
+- `repo` matches a known low-stakes context (`scratch`, daily journal, hygiene scripts)
+- `task_id` patterns from `submit-*.sh` scripts (deterministic prefix)
+- Heartbeat/status-poll-style names
+
+Report should produce a **candidate-delegable bucket** by intersecting these signals and report:
+- Count, total cost, p50/p95 duration of the bucket
+- What fraction of total Claude spend the bucket represents
+
+If the bucket is < 10 % of total Claude spend, the orchestrator stack cannot clear the 20 % gate without including riskier tasks. That is a no-go signal at the static-analysis stage.
+
+### Decision criteria from Track A alone
+
+| Outcome | Action |
+|---|---|
+| Candidate-delegable bucket ≥ 20 % of Claude spend | Proceed to Track B (manual benchmark) |
+| Bucket < 10 % | Stop. Recommend deferring orchestrator stack indefinitely, document in `decisions/`. |
+| Bucket 10–20 % | Marginal. Proceed to Track B but with a smaller benchmark (5 tasks instead of 15) and a higher quality bar. |
+
+---
+
+## Track B — Manual delegation benchmark
+
+Only run if Track A passes. Goal: take a fixed task set, run each through both Claude (status quo) and a chosen Ollama config (local-only, no OpenRouter, no new trust tier), compare token cost and quality.
+
+### Selection
+
+- 10–20 tasks pulled from the candidate-delegable bucket identified by Track A.
+- Stratified across `repo` and `model_requested` so no single source dominates.
+- Each task represented as a Hugin submission (already what we have — these are real journal entries).
+- Tasks are **replayed by hand**, not auto-rerun. The point is to evaluate quality with eyes on the output.
+
+### Method
+
+For each benchmark task:
+
+1. Submit to Hugin with `Runtime: claude` (or whatever it ran originally) — record output, cost, duration.
+2. Submit to Hugin with `Runtime: ollama, Model: <local model>, Fallback: none` — record output, prompt+completion tokens, duration, fallback reason if any.
+3. Manually grade Ollama output: `pass` (acceptable as-is), `escalate` (needs Claude redo), `fail` (wrong answer).
+4. Record per-task row in `docs/research/journal-benchmark-results.md`.
+
+### What "Ollama config" means
+
+To keep this experiment cheap, do **not** introduce anything new:
+
+- Local Pi Ollama only (`OLLAMA_PI_URL`).
+- Existing models already pulled (no new downloads).
+- No OpenRouter. No `cloud-third-party` trust tier. No `infer_direct`. No `priority` field.
+- Existing context-refs path. No prompt-engineering rounds — single-shot.
+
+If the local-only experiment fails the gates, adding cloud routing or smarter prompts would not save it.
+
+### Aggregate gates
+
+| Gate | Threshold | Computed as |
+|---|---|---|
+| Token-cost reduction | ≥ 20 % | `(sum_claude_cost − sum_ollama_inferred_cost) ÷ sum_claude_cost` where Ollama cost is imputed as the marginal infra cost (≈ 0 for self-hosted Pi) plus escalation cost |
+| p95 latency multiplier | ≤ 2× | `p95(ollama_duration) ÷ p95(claude_duration)` for benchmark tasks only |
+| Escalation rate | ≤ 30 % | `count(escalate) + count(fail) ÷ total_tasks` |
+| Stuck-running | 0 | Operational check during the run |
+
+The first gate has a subtlety: pure infra cost on the Pi is ~$0, so naively the reduction is 100 %. The real comparison is **Anthropic spend avoided** vs. **escalation cost when Ollama fails**. Concretely:
+
+```
+saved   = Σ claude_cost(task)            for tasks where ollama passed
+spent   = Σ claude_cost(task)            for tasks that escalated (paid twice)
+        + opportunity cost of latency    (qualitative)
+net     = saved − spent
+gate    = net ÷ Σ claude_cost(all)       ≥ 20 %
+```
+
+### Decision criteria from Track B
+
+| Outcome | Action |
+|---|---|
+| All four gates pass | Re-open orchestrator stack design with the concessions from `debate/orch-stack-summary.md` baked in. |
+| Token-cost gate fails | Stop. Local-only delegation is not economic; cloud delegation cannot rescue this without a new trust tier the debate flagged as cross-cutting. |
+| Latency gate fails | Stop or scope down to async-only tasks (no synchronous orchestrator). |
+| Escalation rate fails | Stop. Quality is the load-bearing assumption; if it fails on hand-picked candidates, it will fail on the unfiltered population. |
+
+---
+
+## Limitations to document up front
+
+These are gaps the analysis cannot close — list them in the report so future readers don't over-trust the numbers:
+
+1. **No prompt-token data for Claude runs.** All token-cost comparisons rely on `cost_usd` from the journal, which is inferred from billing not from prompt size. We cannot say "this task had a 200-token prompt and could run on a 3B model".
+2. **No quality grading on historical runs.** We're inferring "this could have been Ollama" from cost/duration heuristics, not from output content. Track B's manual grading is the only quality signal.
+3. **Population bias.** 261 entries skew toward what Magnus actually submitted in 2026-Q1. Future workload composition may differ.
+4. **No stuck-running comparison.** #57 was just fixed; the journal predates the fix. Stuck-running rate cannot be back-computed from the existing corpus.
+5. **Pi is single-host.** Multi-host sprint will change the cost/latency profile. This evaluation freezes that variable; it should be redone after multi-host lands if the answer is borderline.
+
+---
+
+## Cost estimate
+
+| Track | Wall-clock | LOC |
+|---|---|---|
+| A: static analysis script + report | 2–3 hours | ~250 LOC `analyze-journal.mjs` + ~400 LOC report (mostly tables) |
+| B: 15-task manual benchmark | 4–6 hours (mostly waiting on Ollama) | 0 (uses existing Hugin submission paths) + ~200 LOC results report |
+| **Total** | **6–9 hours** | **~250 LOC code, rest documentation** |
+
+Compared to the orchestrator stack's ~2,090 LOC estimate, this is < 15 % of the cost, and most of that is documentation that retains value regardless of outcome.
+
+---
+
+## What this scope deliberately excludes
+
+- Any change to the journal schema. If the analysis reveals a missing field, propose schema v2 in a separate doc.
+- Any new runtime, MCP tool, executor, or skill.
+- Any benchmark that requires non-local inference.
+- A "scoring" framework. Grading in Track B is `pass / escalate / fail` — three buckets, eyeball judgement, recorded with a one-line reason.
+- Anything that touches multi-host. The analysis runs on the existing single-Pi setup.
+
+---
+
+## Acceptance checklist
+
+This scope is approved to proceed when:
+
+- [ ] User confirms the four gate thresholds are still correct
+- [ ] User confirms Track A → Track B handoff criteria (≥ 20 %, 10–20 %, < 10 %)
+- [ ] User confirms the limitations list is acceptable (especially "no prompt-token data for Claude")
+- [ ] User confirms multi-host sprint stays the priority and this analysis runs in parallel, not blocking it
+
+After approval: Track A is implementable as a single afternoon task. Track B is gated on Track A's outcome.

--- a/docs/research/orchestrator-stack-v1-scope.md
+++ b/docs/research/orchestrator-stack-v1-scope.md
@@ -1,6 +1,17 @@
 # Orchestrator Stack v1 — Scope
 
-**Status:** Approved scope, ready to build
+> **⚠ Superseded by [`docs/orchestrator-v1-data-model.md`](../orchestrator-v1-data-model.md).**
+>
+> This scope doc is kept for historical context. The contract spec is the single source of truth. Notable contract changes since this doc was written:
+>
+> - **`hugin_run` (sync) is dropped.** A 30s poll + serial dispatcher cannot deliver real sync. v1 is async-only: `hugin_submit` + `hugin_await`.
+> - **Single `~/.hugin/orchestrator-journal.jsonl` is replaced** by an append-only `delegation-events.jsonl` event log + read-time projection. Hugin is the sole journal writer; the laptop MCP never writes to a Pi-side journal.
+> - **Pi-harness (Option B)** entered v1 scope after a parallel-session aider eval (`pi --no-session --provider openrouter` against `qwen/qwen3-coder-next` scored 5/6 strict, 6/6 lenient). Worktrees live on the Pi; Hugin never auto-pushes; diffs return to Claude for review.
+> - **Stable aliases** (`tiny`, `medium`, `large-reasoning`, `pi-large-coder`) replace literal model names at the MCP boundary.
+> - **Pi-side broker** with Tailscale-only bearer auth replaces laptop-side signing keys for orchestrator submissions.
+> - **Orthogonal policy fields** (`provider`, `egress`, `zdrRequired`, `autoEligible`) replace stretching the trust tier.
+
+**Status:** Superseded — see banner above.
 **Date:** 2026-04-25
 **Decision:** Build it. Run it. Learn from real usage. Defer the formal go/no-go evaluation until we have a corpus of real ratings.
 

--- a/docs/research/orchestrator-stack-v1-scope.md
+++ b/docs/research/orchestrator-stack-v1-scope.md
@@ -1,0 +1,168 @@
+# Orchestrator Stack v1 — Scope
+
+**Status:** Approved scope, ready to build
+**Date:** 2026-04-25
+**Decision:** Build it. Run it. Learn from real usage. Defer the formal go/no-go evaluation until we have a corpus of real ratings.
+
+## What we're building
+
+A way for Claude Code (in an interactive session) to delegate sub-tasks to cheaper inference — local Ollama on the Pi or MBA, or OpenRouter as a proxy for the future Mac Studio. Three pieces:
+
+1. **`hugin-mcp`** — MCP server exposing 5 tools to Claude Code
+2. **OpenRouter executor** in Hugin — new runtime alongside `ollama` and `claude`
+3. **`delegate` skill** — `~/.claude/skills/delegate/` — guidelines for *when* and *what* to delegate, not just *how*
+
+Plus a separate journal for delegation telemetry so we can analyze it without polluting the main Hugin journal.
+
+## Decisions locked
+
+| # | Decision | Value |
+|---|---|---|
+| 1 | Entry point | Skill (`delegate`), Claude consults it when orchestrating; tooling lives in MCP |
+| 2 | Sync vs async | Both — Claude picks per call (`hugin_run` for sync ≤ 30s tasks, `hugin_submit` + `hugin_await` for async) |
+| 3 | OpenRouter in v1 | Yes — needed to test "is the Studio good enough" before buying |
+| 4 | Transport | MCP server, not CLI or direct HTTP |
+| 5 | Orchestrator logic location | Skill (under Claude's control, not hardcoded in MCP) |
+| 6 | Heuristics | Both — skill gives guidelines + Claude has discretion. Always log enough data to refine guidelines later. |
+| 7 | Quality rating | **Always** — every delegated call rated `pass / partial / redo / wrong` + one-line reason via `hugin_rate` |
+| 8 | Telemetry storage | New file `~/.hugin/orchestrator-journal.jsonl`, full prompts + outputs (Pi disk is cheap, corpus value is high) |
+| 9 | Pi model | `qwen2.5:3b` (only viable Pi model per `ollama-performance-spike.md`) |
+| 10 | MBA model (M4, 32 GB) | `qwen3:14b` (validated via aider eval, runs cleanly) |
+| 11 | Studio proxy via OpenRouter | `gpt-oss-120b` (general/reasoning) + `qwen3-coder` (code) — same shortlist as the harness eval |
+| 12 | Model picker | Claude picks via the skill's guidelines. MCP rejects unknown models. |
+| 13 | OpenRouter trust | "Anything goes" for the trial — OpenRouter is a Studio proxy, treated as `internal` ceiling. **ZDR-only:** MCP fetches the OR model catalog at startup and rejects models without zero-data-retention policy. |
+| 14 | Fallback on failure | Hard fail. MCP returns the error to Claude; skill decides whether to retry on a different runtime or escalate to itself (Claude). No automatic Claude fallback — that hides the failure signal. |
+| 15 | Sensitivity guard | No content blocking. Trust Claude. ZDR enforcement on OpenRouter is the only hard floor. |
+| 16 | Skill path | `~/.claude/skills/delegate/` |
+| 17 | "v1 done" criterion | Magnus decides — eat your own dogfood, iterate, evaluate when there's enough signal |
+
+## MCP tools
+
+```
+hugin_submit(prompt, runtime?, model?, host?, sensitivity?, capabilities?, timeout?, task_type)
+  → { task_id, expected_duration_estimate }
+  Submits an async task. Returns immediately.
+
+hugin_await(task_id, timeout?)
+  → { status, output, tokens, cost, duration, model_effective, host_effective, fallback_triggered }
+  Blocks until the task completes or timeout. Polls Munin under the hood.
+
+hugin_run(prompt, runtime?, model?, host?, sensitivity?, capabilities?, timeout?, task_type)
+  → { output, tokens, cost, duration, model_effective, host_effective }
+  Synchronous wrapper. Submit + await in one call. For tasks under ~30s.
+
+hugin_rate(task_id, rating, reason)
+  → { ok }
+  rating: "pass" | "partial" | "redo" | "wrong"
+  reason: one-line string
+  Records Claude's quality grade in the orchestrator journal. Required after every delegation.
+
+hugin_list(filter?)
+  → [{ task_id, runtime, model, status, cost, duration }, ...]
+  Lists Claude's recent delegations in the current session for inspection.
+```
+
+`task_type` is a Claude-supplied tag from a small enum: `summarize | extract | draft | code-edit | reason | classify | other`. Used for retrospective analysis — what task types have which quality profile on which models.
+
+## Orchestrator journal schema
+
+`~/.hugin/orchestrator-journal.jsonl`, one record per delegated call. Append-only. Different from the main Hugin journal because cardinality and consumers differ.
+
+```json
+{
+  "ts": "2026-04-25T...",
+  "task_id": "20260425-...",
+  "parent_session_id": "<claude-code-session-uuid>",
+  "task_type": "summarize",
+  "runtime": "ollama" | "openrouter",
+  "model_requested": "qwen3:14b",
+  "model_effective": "qwen3:14b",
+  "host": "pi" | "mba" | "openrouter",
+  "sync": true | false,
+  "prompt": "<full prompt text>",
+  "prompt_chars": 1234,
+  "prompt_tokens": 432,
+  "output": "<full output text>",
+  "output_chars": 2345,
+  "completion_tokens": 567,
+  "duration_s": 4.2,
+  "load_ms": 120,
+  "cost_usd": 0.00021,
+  "exit_code": 0,
+  "fallback_triggered": false,
+  "rating": "pass",
+  "rating_reason": "correct summary, no edits needed",
+  "rated_at": "2026-04-25T...",
+  "sensitivity": "internal",
+  "zdr_enforced": true
+}
+```
+
+The `rating` and `rating_reason` fields are populated when `hugin_rate` is called — `null` until then. A periodic check can flag unrated tasks.
+
+## OpenRouter executor — minimum viable
+
+- New runtime `openrouter` in `runtime-registry.ts`, trust tier reused as `semi-trusted` (no new tier introduced — the debate flagged this as cross-cutting; for v1 we treat OR as Claude-equivalent trust).
+- HTTPS client to `https://openrouter.ai/api/v1/chat/completions`, OpenAI-compatible.
+- Reads `OPENROUTER_API_KEY` from env on Pi.
+- ZDR enforcement: at startup, fetch `/api/v1/models`, filter to `data_policy.zero_data_retention === true`, build allowlist. Reject any task targeting a non-allowlisted model.
+- Cost tracking from response `usage` block + OR's per-model pricing table (cached).
+- Same `Sensitivity:` cap as Claude (`internal`).
+- Same exfiltration scanner pass on output as other cloud runtimes.
+
+## Delegate skill — what it actually says
+
+The skill is the orchestration brain. It tells Claude:
+
+1. **When to consider delegating.** Heuristics: small focused prompt (< 4 KB), mechanical transformation (summarize/extract/classify/reformat), no need for repo context or multi-file reasoning, output verifiable by Claude after.
+2. **How to pick the runtime.**
+   - Pi `qwen2.5:3b` for tiny mechanical tasks (≤ 500 tokens output expected)
+   - MBA `qwen3:14b` for medium tasks (general reasoning, 32GB unified)
+   - OpenRouter `qwen3-coder` for code tasks (the Studio-coder proxy)
+   - OpenRouter `gpt-oss-120b` for reasoning-heavy tasks (the Studio-large proxy)
+3. **Sync vs async.** Sync if the task is the critical path; async if Claude can do other work meanwhile.
+4. **Verification protocol.** Always sanity-check the output before using it. Never let unverified delegated output flow into a commit, a Munin write, or another tool call without a Claude pass.
+5. **Rating discipline.** Call `hugin_rate` on *every* delegation. No exceptions — the corpus depends on it.
+6. **Failure handling.** On hard fail: rate as `wrong` with reason, then either retry on a different runtime or do it locally in Claude. Don't silently fall back.
+
+## Build order
+
+1. **MCP server skeleton** — `hugin-mcp` package in this repo, 5 tool stubs returning hardcoded results. Wire into Claude Code. Verify Claude can call all 5.
+2. **OpenRouter executor** — new runtime in Hugin, ZDR enforcement at startup, end-to-end test against `gpt-oss-120b`.
+3. **Orchestrator journal** — schema + append helper + integration into Hugin's task completion path. New separate file.
+4. **Wire MCP → Hugin** — `hugin_submit/await/run` call into Hugin's existing submit/result paths over Munin. `hugin_rate` writes to the orchestrator journal directly. `hugin_list` reads the journal.
+5. **Delegate skill** — `~/.claude/skills/delegate/SKILL.md` with the guidelines above.
+6. **Dogfood** — use it for a week on real work. Iterate the skill based on what Claude actually does. Look at the rated corpus for patterns.
+
+## Out of scope for v1
+
+- New trust tier (`cloud-third-party`). Reuse `semi-trusted` for OR.
+- `Priority:` field or scheduler changes.
+- `Group:` repurposing.
+- Pipeline integration (delegated tasks are flat; no nested pipelines).
+- The schema-v2 telemetry redesign for the *main* journal — orchestrator journal is separate.
+- Anthropic-fallback automation in MCP.
+
+## Limitations Magnus accepts up front
+
+- ZDR enforcement is on OR's self-declared metadata. We trust OR's policy claims.
+- No automated quality grading — Claude's self-rating is the only signal. Self-rating bias is a known risk; it's still better than no rating.
+- Studio model choices freeze on today's eval. When the Studio actually arrives, we re-test on hardware before treating OR results as ground truth.
+- Pi `qwen2.5:3b` is small; on-Pi delegation will mostly be a "is anything ever a fit for this tier?" question, not a primary throughput path.
+
+## Estimate
+
+| Piece | LOC | Wall-clock |
+|---|---|---|
+| MCP skeleton | ~250 | half-day |
+| OpenRouter executor + ZDR filter | ~350 | half-day |
+| Orchestrator journal | ~120 | hour |
+| MCP ↔ Hugin wiring | ~250 | half-day |
+| Delegate skill | ~300 lines markdown | hour |
+| **Total v1** | **~1,000 LOC + skill** | **2 days focused** |
+
+About half the original ~2,090 LOC estimate because we're punting on the trust-tier rework, schema v2, and pipeline integration.
+
+## Acceptance to start
+
+Magnus signs off → start at step 1 (MCP skeleton). Each step ends with a working artifact that's been smoke-tested before moving to the next.

--- a/src/finalize-delegated-output.ts
+++ b/src/finalize-delegated-output.ts
@@ -16,6 +16,10 @@
  *   a corrupted diff. The default `warn` policy still returns success with the
  *   raw diff intact, regardless of result_kind.
  *
+ * Policy surface mirrors the project-wide `ExfilPolicy` from src/index.ts so
+ * the broker/MCP path can reuse the same env-driven control without ad-hoc
+ * branching: `off | warn | flag | redact`.
+ *
  * See docs/orchestrator-v1-data-model.md §4 (result schema), §5 (scanner pass),
  * §7 (provenance chain). See docs/security/exfiltration-scanner.md for the
  * scanner policy semantics.
@@ -31,7 +35,7 @@ import type { Alias } from "./runtime-registry.js";
 export type DelegationRuntimeEffective = "ollama" | "openrouter" | "pi-harness";
 export type DelegationHostEffective = "pi" | "mba" | "openrouter";
 export type DelegationResultKind = "text" | "diff";
-export type ScannerPass = "clean" | "warn" | "redact";
+export type ScannerPass = "skipped" | "clean" | "warn" | "flag" | "redact";
 
 export interface DelegationDiff {
   base_sha: string;
@@ -50,10 +54,12 @@ export interface DelegationProvenance {
 }
 
 export interface DelegationResult {
+  result_schema_version: 1;
   task_id: string;
   alias_requested: Alias;
   model_effective: string;
   runtime_effective: DelegationRuntimeEffective;
+  runtime_row_id_effective: string;
   host_effective: DelegationHostEffective;
   result_kind: DelegationResultKind;
 
@@ -90,13 +96,14 @@ export type FinalizeOutcome =
   | { ok: true; result: DelegationResult }
   | { ok: false; error: DelegationError };
 
-export type ScannerPolicy = "warn" | "redact";
+export type ScannerPolicy = "off" | "warn" | "flag" | "redact";
 
 interface BaseInput {
   task_id: string;
   alias_requested: Alias;
   model_effective: string;
   runtime_effective: DelegationRuntimeEffective;
+  runtime_row_id_effective: string;
   host_effective: DelegationHostEffective;
   policy_version: string;
   harness_version?: string;
@@ -125,16 +132,29 @@ export type FinalizeInput = FinalizeTextInput | FinalizeDiffInput;
 /**
  * Single shared finalizer. Returns a `FinalizeOutcome` discriminated union.
  *
- * - Clean payloads → `{ ok: true, result }` with `scanner_pass: "clean"`.
- * - Matched payloads under `warn` policy → `{ ok: true, result }` with
- *   `scanner_pass: "warn"`; payload is unmodified.
- * - Text matched under `redact` policy → `{ ok: true, result }` with
- *   `scanner_pass: "redact"`; matched spans replaced.
- * - Diff matched under `redact` policy → `{ ok: false, error }` with
- *   `kind: "scanner_blocked"`. Redacted diffs are not valid patches.
+ * Policy semantics (mirrors ExfilPolicy in src/index.ts):
+ * - `off`: skip scanner entirely; payload returned untouched with
+ *   `scanner_pass: "skipped"`.
+ * - `warn` (default): scan; matched payloads return success with
+ *   `scanner_pass: "warn"`; payload unmodified.
+ * - `flag`: scan; matched payloads return success with `scanner_pass: "flag"`;
+ *   payload unmodified. Caller is expected to tag downstream records (e.g.
+ *   `security:exfil-suspected`) using the metadata.
+ * - `redact`:
+ *    - text matched → success with `scanner_pass: "redact"`; matched spans
+ *      replaced.
+ *    - diff matched → `scanner_blocked` error. Redacted diffs are not valid
+ *      patches.
  */
 export function finalizeDelegatedOutput(input: FinalizeInput): FinalizeOutcome {
   const policy: ScannerPolicy = input.scanner_policy ?? "warn";
+
+  if (policy === "off") {
+    return {
+      ok: true,
+      result: buildResult(input, "skipped", payloadOf(input)),
+    };
+  }
 
   const scannedPayload = scanPayload(input);
 
@@ -163,6 +183,14 @@ export function finalizeDelegatedOutput(input: FinalizeInput): FinalizeOutcome {
     policy,
   );
 
+  return { ok: true, result: buildResult(input, scannerPass, finalizedPayload) };
+}
+
+function buildResult(
+  input: FinalizeInput,
+  scannerPass: ScannerPass,
+  finalizedPayload: string,
+): DelegationResult {
   const provenance: DelegationProvenance = {
     source: "delegated",
     scanner_pass: scannerPass,
@@ -173,10 +201,12 @@ export function finalizeDelegatedOutput(input: FinalizeInput): FinalizeOutcome {
   }
 
   const base = {
+    result_schema_version: 1 as const,
     task_id: input.task_id,
     alias_requested: input.alias_requested,
     model_effective: input.model_effective,
     runtime_effective: input.runtime_effective,
+    runtime_row_id_effective: input.runtime_row_id_effective,
     host_effective: input.host_effective,
     result_kind: input.result_kind,
     prompt_tokens: input.prompt_tokens,
@@ -190,14 +220,11 @@ export function finalizeDelegatedOutput(input: FinalizeInput): FinalizeOutcome {
   } satisfies Omit<DelegationResult, "output" | "diff">;
 
   if (input.result_kind === "text") {
-    return { ok: true, result: { ...base, output: finalizedPayload } };
+    return { ...base, output: finalizedPayload };
   }
   return {
-    ok: true,
-    result: {
-      ...base,
-      diff: { ...input.raw_diff, unified_diff: finalizedPayload },
-    },
+    ...base,
+    diff: { ...input.raw_diff, unified_diff: finalizedPayload },
   };
 }
 
@@ -206,9 +233,14 @@ interface ScannedPayload {
   scan: ExfilScanResult;
 }
 
+function payloadOf(input: FinalizeInput): string {
+  return input.result_kind === "text"
+    ? input.raw_output
+    : input.raw_diff.unified_diff;
+}
+
 function scanPayload(input: FinalizeInput): ScannedPayload {
-  const text =
-    input.result_kind === "text" ? input.raw_output : input.raw_diff.unified_diff;
+  const text = payloadOf(input);
   const scan = scanForExfiltration(text);
   return { text, scan };
 }
@@ -216,7 +248,7 @@ function scanPayload(input: FinalizeInput): ScannedPayload {
 function applyScannerPolicy(
   text: string,
   scan: ExfilScanResult,
-  policy: ScannerPolicy,
+  policy: Exclude<ScannerPolicy, "off">,
 ): { scannerPass: ScannerPass; finalizedPayload: string } {
   if (scan.severity === "none") {
     return { scannerPass: "clean", finalizedPayload: text };
@@ -226,6 +258,9 @@ function applyScannerPolicy(
       scannerPass: "redact",
       finalizedPayload: redactExfiltration(text, scan),
     };
+  }
+  if (policy === "flag") {
+    return { scannerPass: "flag", finalizedPayload: text };
   }
   return { scannerPass: "warn", finalizedPayload: text };
 }

--- a/src/finalize-delegated-output.ts
+++ b/src/finalize-delegated-output.ts
@@ -1,0 +1,231 @@
+/**
+ * Shared finalization helper for orchestrator delegation output.
+ *
+ * Every byte of provider output that crosses the broker → MCP → Claude boundary
+ * passes through this helper. It runs the exfiltration scanner, packages the
+ * result with provenance metadata, and is the single place where raw provider
+ * bytes are converted into a typed DelegationResult.
+ *
+ * Outcome contract (post orch-v1-impl-review):
+ * - Text path: redact policy is allowed to mutate `output` and return success
+ *   with `scanner_pass: "redact"`. A redacted human-readable string is still
+ *   useful to the caller.
+ * - Diff path: redact policy escalates to a `scanner_blocked` error outcome.
+ *   A redacted unified diff is no longer a valid patch (`git apply` fails on
+ *   the replaced span), so the caller must not see a "completed" status with
+ *   a corrupted diff. The default `warn` policy still returns success with the
+ *   raw diff intact, regardless of result_kind.
+ *
+ * See docs/orchestrator-v1-data-model.md §4 (result schema), §5 (scanner pass),
+ * §7 (provenance chain). See docs/security/exfiltration-scanner.md for the
+ * scanner policy semantics.
+ */
+
+import {
+  redactExfiltration,
+  scanForExfiltration,
+  type ExfilScanResult,
+} from "./exfiltration-scanner.js";
+import type { Alias } from "./runtime-registry.js";
+
+export type DelegationRuntimeEffective = "ollama" | "openrouter" | "pi-harness";
+export type DelegationHostEffective = "pi" | "mba" | "openrouter";
+export type DelegationResultKind = "text" | "diff";
+export type ScannerPass = "clean" | "warn" | "redact";
+
+export interface DelegationDiff {
+  base_sha: string;
+  head_sha: string;
+  files_touched: string[];
+  unified_diff: string;
+  stats: { files: number; insertions: number; deletions: number };
+  worktree_path: string;
+}
+
+export interface DelegationProvenance {
+  source: "delegated";
+  scanner_pass: ScannerPass;
+  policy_version: string;
+  harness_version?: string;
+}
+
+export interface DelegationResult {
+  task_id: string;
+  alias_requested: Alias;
+  model_effective: string;
+  runtime_effective: DelegationRuntimeEffective;
+  host_effective: DelegationHostEffective;
+  result_kind: DelegationResultKind;
+
+  output?: string;
+  diff?: DelegationDiff;
+
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+  duration_s: number;
+  load_ms?: number;
+  cost_usd: number;
+  finalized_at: string;
+  provenance: DelegationProvenance;
+}
+
+export type DelegationErrorKind =
+  | "alias_unknown"
+  | "alias_unavailable"
+  | "policy_rejected"
+  | "executor_failed"
+  | "scanner_blocked"
+  | "timeout"
+  | "internal";
+
+export interface DelegationError {
+  task_id: string;
+  kind: DelegationErrorKind;
+  message: string;
+  retryable: boolean;
+}
+
+export type FinalizeOutcome =
+  | { ok: true; result: DelegationResult }
+  | { ok: false; error: DelegationError };
+
+export type ScannerPolicy = "warn" | "redact";
+
+interface BaseInput {
+  task_id: string;
+  alias_requested: Alias;
+  model_effective: string;
+  runtime_effective: DelegationRuntimeEffective;
+  host_effective: DelegationHostEffective;
+  policy_version: string;
+  harness_version?: string;
+  scanner_policy?: ScannerPolicy;
+
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+  duration_s: number;
+  load_ms?: number;
+  cost_usd: number;
+}
+
+export interface FinalizeTextInput extends BaseInput {
+  result_kind: "text";
+  raw_output: string;
+}
+
+export interface FinalizeDiffInput extends BaseInput {
+  result_kind: "diff";
+  raw_diff: Omit<DelegationDiff, "unified_diff"> & { unified_diff: string };
+}
+
+export type FinalizeInput = FinalizeTextInput | FinalizeDiffInput;
+
+/**
+ * Single shared finalizer. Returns a `FinalizeOutcome` discriminated union.
+ *
+ * - Clean payloads → `{ ok: true, result }` with `scanner_pass: "clean"`.
+ * - Matched payloads under `warn` policy → `{ ok: true, result }` with
+ *   `scanner_pass: "warn"`; payload is unmodified.
+ * - Text matched under `redact` policy → `{ ok: true, result }` with
+ *   `scanner_pass: "redact"`; matched spans replaced.
+ * - Diff matched under `redact` policy → `{ ok: false, error }` with
+ *   `kind: "scanner_blocked"`. Redacted diffs are not valid patches.
+ */
+export function finalizeDelegatedOutput(input: FinalizeInput): FinalizeOutcome {
+  const policy: ScannerPolicy = input.scanner_policy ?? "warn";
+
+  const scannedPayload = scanPayload(input);
+
+  if (
+    input.result_kind === "diff" &&
+    policy === "redact" &&
+    scannedPayload.scan.severity !== "none"
+  ) {
+    return {
+      ok: false,
+      error: {
+        task_id: input.task_id,
+        kind: "scanner_blocked",
+        message:
+          "Exfiltration scanner matched the unified diff under redact policy. " +
+          "A redacted diff is not a valid patch; the harness output must be " +
+          "rejected rather than partially applied.",
+        retryable: false,
+      },
+    };
+  }
+
+  const { scannerPass, finalizedPayload } = applyScannerPolicy(
+    scannedPayload.text,
+    scannedPayload.scan,
+    policy,
+  );
+
+  const provenance: DelegationProvenance = {
+    source: "delegated",
+    scanner_pass: scannerPass,
+    policy_version: input.policy_version,
+  };
+  if (input.harness_version) {
+    provenance.harness_version = input.harness_version;
+  }
+
+  const base = {
+    task_id: input.task_id,
+    alias_requested: input.alias_requested,
+    model_effective: input.model_effective,
+    runtime_effective: input.runtime_effective,
+    host_effective: input.host_effective,
+    result_kind: input.result_kind,
+    prompt_tokens: input.prompt_tokens,
+    completion_tokens: input.completion_tokens,
+    total_tokens: input.total_tokens,
+    duration_s: input.duration_s,
+    load_ms: input.load_ms,
+    cost_usd: input.cost_usd,
+    finalized_at: new Date().toISOString(),
+    provenance,
+  } satisfies Omit<DelegationResult, "output" | "diff">;
+
+  if (input.result_kind === "text") {
+    return { ok: true, result: { ...base, output: finalizedPayload } };
+  }
+  return {
+    ok: true,
+    result: {
+      ...base,
+      diff: { ...input.raw_diff, unified_diff: finalizedPayload },
+    },
+  };
+}
+
+interface ScannedPayload {
+  text: string;
+  scan: ExfilScanResult;
+}
+
+function scanPayload(input: FinalizeInput): ScannedPayload {
+  const text =
+    input.result_kind === "text" ? input.raw_output : input.raw_diff.unified_diff;
+  const scan = scanForExfiltration(text);
+  return { text, scan };
+}
+
+function applyScannerPolicy(
+  text: string,
+  scan: ExfilScanResult,
+  policy: ScannerPolicy,
+): { scannerPass: ScannerPass; finalizedPayload: string } {
+  if (scan.severity === "none") {
+    return { scannerPass: "clean", finalizedPayload: text };
+  }
+  if (policy === "redact") {
+    return {
+      scannerPass: "redact",
+      finalizedPayload: redactExfiltration(text, scan),
+    };
+  }
+  return { scannerPass: "warn", finalizedPayload: text };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2578,8 +2578,17 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     limit: 50,
   });
 
+  // Orchestrator v1 tasks (broker-submitted, tagged "orch-v1") are dispatched
+  // by the Pi-side broker, not by the legacy in-process poller. Filter them
+  // out so the dispatcher does not greedily claim a runtime:openrouter or
+  // runtime:pi-harness task and fail it as "missing prompt or runtime".
+  // See docs/orchestrator-v1-data-model.md §3 for the broker submit path.
+  const dispatchableResults = results.filter(
+    (r) => !r.tags.includes("orch-v1"),
+  );
+
   // Select the next eligible task respecting Group/Sequence ordering (FIFO within eligible set)
-  const taskResult = selectNextTask(results, runningResults);
+  const taskResult = selectNextTask(dispatchableResults, runningResults);
   if (!taskResult) return { hadTask: false, queueDepth: 0 };
 
   const taskNs = taskResult.namespace;

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,7 @@ import {
 import { routeTask, type RouterDecision } from "./router.js";
 import {
   buildRuntimeCandidates,
+  isLegacyDispatcherRuntime,
   type RuntimeCapability,
 } from "./runtime-registry.js";
 import {
@@ -2695,7 +2696,18 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
           preferredModel: parsedTask.model,
           availableRuntimes: candidates,
         });
-        parsedTask.runtime = decision.selectedRuntime.dispatcherRuntime;
+        // Auto-router is contractually required to exclude autoEligible:false
+        // runtimes (openrouter, pi-harness). Verify rather than cast — if this
+        // ever fires, the contract was violated upstream and the dispatcher
+        // cannot execute the selection.
+        const selectedRuntime = decision.selectedRuntime.dispatcherRuntime;
+        if (!isLegacyDispatcherRuntime(selectedRuntime)) {
+          throw new Error(
+            `Auto-router selected non-legacy runtime "${selectedRuntime}" — ` +
+              `autoEligible filter contract violated. selected_id=${decision.selectedRuntime.id}`,
+          );
+        }
+        parsedTask.runtime = selectedRuntime;
         parsedTask.routingDecision = decision;
         if (decision.selectedRuntime.ollamaHost) {
           parsedTask.ollamaHost = decision.selectedRuntime.ollamaHost;

--- a/src/pipeline-compiler.ts
+++ b/src/pipeline-compiler.ts
@@ -16,6 +16,7 @@ import { routeTask } from "./router.js";
 import {
   buildRuntimeCandidates,
   getRegistryEntryById,
+  isLegacyDispatcherRuntime,
   type RuntimeCapability,
 } from "./runtime-registry.js";
 import {
@@ -518,13 +519,26 @@ export function compilePipelineTask(
       return dependencyTaskId;
     });
 
+    // Pipeline phases are constrained to PipelineRuntimeId (claude-sdk/
+    // codex-spawn/ollama-pi/ollama-laptop), all of which carry legacy
+    // dispatcher runtimes. Orchestrator runtimes (openrouter, pi-harness) are
+    // not pipeline-eligible. Verify rather than cast.
+    const phaseDispatcherRuntime = runtime.dispatcherRuntime;
+    if (!isLegacyDispatcherRuntime(phaseDispatcherRuntime)) {
+      throw new Error(
+        `Pipeline runtime "${resolvedRuntimeId}" resolved to non-legacy dispatcher runtime ` +
+          `"${phaseDispatcherRuntime}" — orchestrator runtimes are not pipeline-eligible. ` +
+          `Phase "${phase.name}".`,
+      );
+    }
+
     return {
       name: phase.name,
       slug: slugifyPhaseName(phase.name),
       taskId,
       taskNamespace: `tasks/${taskId}`,
       runtime: resolvedRuntimeId,
-      dispatcherRuntime: runtime.dispatcherRuntime,
+      dispatcherRuntime: phaseDispatcherRuntime,
       ollamaHost: runtime.ollamaHost,
       model: runtime.defaultModel,
       context: phase.context,

--- a/src/router.ts
+++ b/src/router.ts
@@ -60,6 +60,17 @@ export function routeTask(input: RouterInput): RouterDecision {
     return true;
   });
 
+  // Step 2b: Filter out runtimes that are explicit-only (autoEligible: false).
+  // These can still be selected by alias via the orchestrator broker, but the
+  // generic auto-router never picks them.
+  candidates = candidates.filter((c) => {
+    if (c.autoEligible === false) {
+      eliminated.push({ id: c.id, reason: "explicit-only (autoEligible: false)" });
+      return false;
+    }
+    return true;
+  });
+
   // Step 3: Filter by capabilities (if specified)
   if (capabilities && capabilities.length > 0) {
     candidates = candidates.filter((c) => {

--- a/src/runtime-registry.ts
+++ b/src/runtime-registry.ts
@@ -1,11 +1,45 @@
 import type { OllamaHost } from "./ollama-hosts.js";
 import type { Sensitivity } from "./sensitivity.js";
 
-export type DispatcherRuntime = "claude" | "codex" | "ollama";
+// Legacy dispatcher runtimes — the three the in-process executor knows how to
+// run today (src/index.ts spawn/SDK paths). The dispatcher's TaskConfig.runtime
+// is constrained to this narrow set; orchestrator runtimes never flow through
+// the legacy dispatcher.
+export type LegacyDispatcherRuntime = "claude" | "codex" | "ollama";
+
+// Wider union covering every runtime the registry can describe, including
+// orchestrator-only runtimes that are reachable via the broker (Step 4) but
+// never dispatched in-process.
+export type DispatcherRuntime =
+  | LegacyDispatcherRuntime
+  | "openrouter"
+  | "pi-harness";
+
+const LEGACY_DISPATCHER_RUNTIMES: ReadonlySet<DispatcherRuntime> = new Set([
+  "claude",
+  "codex",
+  "ollama",
+]);
+
+export function isLegacyDispatcherRuntime(
+  runtime: DispatcherRuntime,
+): runtime is LegacyDispatcherRuntime {
+  return LEGACY_DISPATCHER_RUNTIMES.has(runtime);
+}
 export type RuntimeCapability = "tools" | "code" | "structured-output";
 export type TrustTier = "trusted" | "semi-trusted";
 export type CostModel = "subscription" | "per-token" | "free";
 export type ModelSize = "small" | "medium" | "large";
+
+export type Provider =
+  | "anthropic"
+  | "openai-spawn"
+  | "ollama-local"
+  | "openrouter"
+  | "pi-harness";
+export type Egress = "subscription" | "local" | "third-party";
+export type RuntimeFamily = "one-shot" | "harness";
+export type ReasoningLevel = "low" | "medium" | "high";
 
 export interface RuntimeDefinition {
   id: string;
@@ -16,6 +50,16 @@ export interface RuntimeDefinition {
   capabilities: RuntimeCapability[];
   ollamaHost?: "pi" | "laptop";
   defaultModel?: string;
+
+  // Orthogonal policy fields (orchestrator v1, see docs/orchestrator-v1-data-model.md §6)
+  provider?: Provider;
+  egress?: Egress;
+  zdrRequired?: boolean;
+  autoEligible?: boolean;
+  family?: RuntimeFamily;
+  reasoningLevel?: ReasoningLevel;
+  harnessCmd?: string;
+  harnessFlags?: readonly string[];
 }
 
 export interface RuntimeCandidate extends RuntimeDefinition {
@@ -31,6 +75,11 @@ export const RUNTIME_REGISTRY: readonly RuntimeDefinition[] = [
     costModel: "subscription",
     modelSize: "large",
     capabilities: ["tools", "code", "structured-output"],
+    provider: "anthropic",
+    egress: "subscription",
+    zdrRequired: false,
+    autoEligible: true,
+    family: "one-shot",
   },
   {
     id: "codex-spawn",
@@ -39,6 +88,11 @@ export const RUNTIME_REGISTRY: readonly RuntimeDefinition[] = [
     costModel: "subscription",
     modelSize: "large",
     capabilities: ["tools", "code"],
+    provider: "openai-spawn",
+    egress: "subscription",
+    zdrRequired: false,
+    autoEligible: true,
+    family: "one-shot",
   },
   {
     id: "ollama-pi",
@@ -49,6 +103,11 @@ export const RUNTIME_REGISTRY: readonly RuntimeDefinition[] = [
     capabilities: [],
     ollamaHost: "pi",
     defaultModel: "qwen2.5:3b",
+    provider: "ollama-local",
+    egress: "local",
+    zdrRequired: false,
+    autoEligible: true,
+    family: "one-shot",
   },
   {
     id: "ollama-laptop",
@@ -59,6 +118,40 @@ export const RUNTIME_REGISTRY: readonly RuntimeDefinition[] = [
     capabilities: [],
     ollamaHost: "laptop",
     defaultModel: "qwen3.5:35b-a3b",
+    provider: "ollama-local",
+    egress: "local",
+    zdrRequired: false,
+    autoEligible: true,
+    family: "one-shot",
+  },
+  {
+    id: "openrouter",
+    dispatcherRuntime: "openrouter",
+    trustTier: "semi-trusted",
+    costModel: "per-token",
+    modelSize: "large",
+    capabilities: ["code"],
+    provider: "openrouter",
+    egress: "third-party",
+    zdrRequired: true,
+    autoEligible: false,
+    family: "one-shot",
+    reasoningLevel: "medium",
+  },
+  {
+    id: "pi-harness",
+    dispatcherRuntime: "pi-harness",
+    trustTier: "semi-trusted",
+    costModel: "per-token",
+    modelSize: "large",
+    capabilities: ["code", "tools"],
+    provider: "pi-harness",
+    egress: "third-party",
+    zdrRequired: true,
+    autoEligible: false,
+    family: "harness",
+    harnessCmd: "pi",
+    harnessFlags: ["--no-session", "--provider", "openrouter"],
   },
 ];
 
@@ -89,11 +182,91 @@ export function buildRuntimeCandidates(
         models: host?.models ?? [],
       };
     }
-    // Cloud runtimes (claude, codex) are assumed always available
+    // Cloud runtimes (claude, codex, openrouter, pi-harness) are assumed always
+    // available at the registry level. Per-call availability (e.g. OpenRouter
+    // rate limits, harness binary missing) is enforced by the executor.
     return {
       ...def,
       available: true,
       models: [],
     };
   });
+}
+
+// ---------------------------------------------------------------------------
+// Stable aliases (orchestrator v1, see docs/orchestrator-v1-data-model.md §2)
+// ---------------------------------------------------------------------------
+
+export type Alias = "tiny" | "medium" | "large-reasoning" | "pi-large-coder";
+
+export interface AliasResolution {
+  alias: Alias;
+  family: RuntimeFamily;
+  harness?: "pi";
+  model: string;
+  runtimeId: string;
+  host?: "pi" | "mba" | "openrouter";
+  reasoningLevel?: ReasoningLevel;
+  notes?: string;
+}
+
+export interface AliasMap {
+  version: number;
+  effective_at: string;
+  aliases: Record<Alias, AliasResolution>;
+}
+
+export const ALIAS_MAP_V1: AliasMap = {
+  version: 1,
+  effective_at: "2026-04-26T00:00:00Z",
+  aliases: {
+    tiny: {
+      alias: "tiny",
+      family: "one-shot",
+      model: "qwen2.5:3b",
+      runtimeId: "ollama-pi",
+      host: "pi",
+      notes: "Only viable Pi-local model per ollama-performance-spike.",
+    },
+    medium: {
+      alias: "medium",
+      family: "one-shot",
+      model: "qwen3:14b",
+      runtimeId: "ollama-laptop",
+      host: "mba",
+      notes:
+        "Eval-validated. Registry default for ollama-laptop is currently qwen3.5:35b-a3b — alias pins the working model regardless.",
+    },
+    "large-reasoning": {
+      alias: "large-reasoning",
+      family: "one-shot",
+      model: "openai/gpt-oss-120b",
+      runtimeId: "openrouter",
+      host: "openrouter",
+      reasoningLevel: "medium",
+      notes: "Studio proxy. Reasoning level pinned for v1.",
+    },
+    "pi-large-coder": {
+      alias: "pi-large-coder",
+      family: "harness",
+      harness: "pi",
+      model: "qwen/qwen3-coder-next",
+      runtimeId: "pi-harness",
+      host: "pi",
+      notes:
+        "Validated 2026-04-26: 5/6 strict, 6/6 lenient on aider eval. pi --no-session calling OR for the model.",
+    },
+  },
+};
+
+export function getAliasMap(): AliasMap {
+  return ALIAS_MAP_V1;
+}
+
+export function resolveAlias(alias: Alias): AliasResolution {
+  const resolution = ALIAS_MAP_V1.aliases[alias];
+  if (!resolution) {
+    throw new Error(`Unknown alias: ${alias}`);
+  }
+  return resolution;
 }

--- a/src/task-result-schema.ts
+++ b/src/task-result-schema.ts
@@ -21,7 +21,16 @@ export const taskExecutionBodyKindSchema = z.enum([
 ]);
 export type TaskExecutionBodyKind = z.infer<typeof taskExecutionBodyKindSchema>;
 
-export const dispatcherRuntimeSchema = z.enum(["claude", "codex", "ollama", "auto"]);
+// The structured task result schema is the dispatcher's local view. It only
+// sees the legacy executor runtimes (claude/codex/ollama). Orchestrator-only
+// runtimes (openrouter, pi-harness) flow through a separate broker path and
+// produce DelegationResult, never StructuredTaskResult.
+export const dispatcherRuntimeSchema = z.enum([
+  "claude",
+  "codex",
+  "ollama",
+  "auto",
+]);
 export type DispatcherRuntime = z.infer<typeof dispatcherRuntimeSchema>;
 
 export const taskExecutionPipelineContextSchema = z.object({

--- a/tests/finalize-delegated-output.test.ts
+++ b/tests/finalize-delegated-output.test.ts
@@ -10,6 +10,7 @@ const baseTextInput: FinalizeTextInput = {
   alias_requested: "medium",
   model_effective: "qwen3:14b",
   runtime_effective: "ollama",
+  runtime_row_id_effective: "ollama-laptop",
   host_effective: "mba",
   result_kind: "text",
   raw_output: "Hello, world.",
@@ -23,6 +24,7 @@ const baseDiffInput: FinalizeDiffInput = {
   alias_requested: "pi-large-coder",
   model_effective: "qwen/qwen3-coder-next",
   runtime_effective: "pi-harness",
+  runtime_row_id_effective: "pi-harness",
   host_effective: "pi",
   result_kind: "diff",
   raw_diff: {
@@ -119,6 +121,50 @@ describe("finalizeDelegatedOutput — text path", () => {
     if (!outcome.ok) return;
     expect(() => new Date(outcome.result.finalized_at).toISOString()).not.toThrow();
   });
+
+  it("stamps result_schema_version=1 and runtime_row_id_effective", () => {
+    const outcome = finalizeDelegatedOutput(baseTextInput);
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.result.result_schema_version).toBe(1);
+    expect(outcome.result.runtime_row_id_effective).toBe("ollama-laptop");
+  });
+
+  it("policy=off skips the scanner and preserves payload exactly", () => {
+    const outcome = finalizeDelegatedOutput({
+      ...baseTextInput,
+      raw_output:
+        "-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBA...\n-----END RSA PRIVATE KEY-----",
+      scanner_policy: "off",
+    });
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.result.provenance.scanner_pass).toBe("skipped");
+    expect(outcome.result.output).toContain("BEGIN RSA PRIVATE KEY");
+  });
+
+  it("policy=flag preserves payload and reports scanner_pass=flag on match", () => {
+    const outcome = finalizeDelegatedOutput({
+      ...baseTextInput,
+      raw_output:
+        "-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBA...\n-----END RSA PRIVATE KEY-----",
+      scanner_policy: "flag",
+    });
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.result.provenance.scanner_pass).toBe("flag");
+    expect(outcome.result.output).toContain("BEGIN RSA PRIVATE KEY");
+  });
+
+  it("policy=flag reports scanner_pass=clean when payload has no matches", () => {
+    const outcome = finalizeDelegatedOutput({
+      ...baseTextInput,
+      scanner_policy: "flag",
+    });
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.result.provenance.scanner_pass).toBe("clean");
+  });
 });
 
 describe("finalizeDelegatedOutput — diff path", () => {
@@ -209,5 +255,45 @@ describe("finalizeDelegatedOutput — diff path", () => {
     expect(outcome.ok).toBe(true);
     if (!outcome.ok) return;
     expect(outcome.result.provenance.harness_version).toBe("pi@2.0.0-rc1");
+  });
+
+  it("diff under policy=off preserves payload and never escalates", () => {
+    const outcome = finalizeDelegatedOutput({
+      ...baseDiffInput,
+      scanner_policy: "off",
+      raw_diff: {
+        ...baseDiffInput.raw_diff,
+        unified_diff:
+          "-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBA...\n-----END RSA PRIVATE KEY-----",
+      },
+    });
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.result.provenance.scanner_pass).toBe("skipped");
+    expect(outcome.result.diff!.unified_diff).toContain("BEGIN RSA PRIVATE KEY");
+  });
+
+  it("diff under policy=flag preserves payload and never escalates", () => {
+    const outcome = finalizeDelegatedOutput({
+      ...baseDiffInput,
+      scanner_policy: "flag",
+      raw_diff: {
+        ...baseDiffInput.raw_diff,
+        unified_diff:
+          "-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBA...\n-----END RSA PRIVATE KEY-----",
+      },
+    });
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.result.provenance.scanner_pass).toBe("flag");
+    expect(outcome.result.diff!.unified_diff).toContain("BEGIN RSA PRIVATE KEY");
+  });
+
+  it("stamps result_schema_version=1 and runtime_row_id_effective on diff path", () => {
+    const outcome = finalizeDelegatedOutput(baseDiffInput);
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.result.result_schema_version).toBe(1);
+    expect(outcome.result.runtime_row_id_effective).toBe("pi-harness");
   });
 });

--- a/tests/finalize-delegated-output.test.ts
+++ b/tests/finalize-delegated-output.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from "vitest";
+import {
+  finalizeDelegatedOutput,
+  type FinalizeDiffInput,
+  type FinalizeTextInput,
+} from "../src/finalize-delegated-output.js";
+
+const baseTextInput: FinalizeTextInput = {
+  task_id: "20260426-104000-test",
+  alias_requested: "medium",
+  model_effective: "qwen3:14b",
+  runtime_effective: "ollama",
+  host_effective: "mba",
+  result_kind: "text",
+  raw_output: "Hello, world.",
+  policy_version: "zdr-v1+rlv-v1",
+  duration_s: 1.5,
+  cost_usd: 0,
+};
+
+const baseDiffInput: FinalizeDiffInput = {
+  task_id: "20260426-104000-harness",
+  alias_requested: "pi-large-coder",
+  model_effective: "qwen/qwen3-coder-next",
+  runtime_effective: "pi-harness",
+  host_effective: "pi",
+  result_kind: "diff",
+  raw_diff: {
+    base_sha: "abc123",
+    head_sha: "def456",
+    files_touched: ["src/foo.ts"],
+    unified_diff: "diff --git a/src/foo.ts b/src/foo.ts\n@@ -1 +1 @@\n-old\n+new\n",
+    stats: { files: 1, insertions: 1, deletions: 1 },
+    worktree_path: "/home/magnus/.hugin/worktrees/20260426-104000-harness",
+  },
+  policy_version: "zdr-v1+rlv-v1",
+  harness_version: "pi@1.2.3",
+  duration_s: 129,
+  cost_usd: 0.045,
+};
+
+describe("finalizeDelegatedOutput — text path", () => {
+  it("returns clean scanner_pass when output has no patterns", () => {
+    const outcome = finalizeDelegatedOutput(baseTextInput);
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    const r = outcome.result;
+    expect(r.result_kind).toBe("text");
+    expect(r.output).toBe("Hello, world.");
+    expect(r.diff).toBeUndefined();
+    expect(r.provenance.source).toBe("delegated");
+    expect(r.provenance.scanner_pass).toBe("clean");
+    expect(r.provenance.policy_version).toBe("zdr-v1+rlv-v1");
+    expect(r.provenance.harness_version).toBeUndefined();
+  });
+
+  it("propagates token counts, duration, cost", () => {
+    const outcome = finalizeDelegatedOutput({
+      ...baseTextInput,
+      prompt_tokens: 120,
+      completion_tokens: 80,
+      total_tokens: 200,
+      load_ms: 50,
+      duration_s: 3.25,
+      cost_usd: 0.0021,
+    });
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    const r = outcome.result;
+    expect(r.prompt_tokens).toBe(120);
+    expect(r.completion_tokens).toBe(80);
+    expect(r.total_tokens).toBe(200);
+    expect(r.load_ms).toBe(50);
+    expect(r.duration_s).toBe(3.25);
+    expect(r.cost_usd).toBeCloseTo(0.0021);
+  });
+
+  it("flags warn (default policy) when output contains an exfil pattern", () => {
+    const outcome = finalizeDelegatedOutput({
+      ...baseTextInput,
+      raw_output:
+        "-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBA...\n-----END RSA PRIVATE KEY-----",
+    });
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.result.provenance.scanner_pass).toBe("warn");
+    expect(outcome.result.output).toContain("-----BEGIN RSA PRIVATE KEY-----");
+  });
+
+  it("redacts when scanner_policy=redact and content has matches", () => {
+    const outcome = finalizeDelegatedOutput({
+      ...baseTextInput,
+      raw_output:
+        "-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBA...\n-----END RSA PRIVATE KEY-----",
+      scanner_policy: "redact",
+    });
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.result.provenance.scanner_pass).toBe("redact");
+    // The scanner regex matches the BEGIN header; redaction replaces that span.
+    expect(outcome.result.output).not.toContain("BEGIN RSA PRIVATE KEY");
+    expect(outcome.result.output).toMatch(/\[redacted: private-key\]/);
+  });
+
+  it("clean scan stays clean even under redact policy", () => {
+    const outcome = finalizeDelegatedOutput({
+      ...baseTextInput,
+      scanner_policy: "redact",
+    });
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.result.provenance.scanner_pass).toBe("clean");
+    expect(outcome.result.output).toBe("Hello, world.");
+  });
+
+  it("finalized_at is a parseable ISO timestamp", () => {
+    const outcome = finalizeDelegatedOutput(baseTextInput);
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(() => new Date(outcome.result.finalized_at).toISOString()).not.toThrow();
+  });
+});
+
+describe("finalizeDelegatedOutput — diff path", () => {
+  it("returns diff with scanned unified_diff and no top-level output", () => {
+    const outcome = finalizeDelegatedOutput(baseDiffInput);
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    const r = outcome.result;
+    expect(r.result_kind).toBe("diff");
+    expect(r.output).toBeUndefined();
+    expect(r.diff).toBeDefined();
+    expect(r.diff!.base_sha).toBe("abc123");
+    expect(r.diff!.head_sha).toBe("def456");
+    expect(r.diff!.files_touched).toEqual(["src/foo.ts"]);
+    expect(r.diff!.unified_diff).toContain("-old");
+    expect(r.diff!.stats).toEqual({ files: 1, insertions: 1, deletions: 1 });
+    expect(r.provenance.scanner_pass).toBe("clean");
+    expect(r.provenance.harness_version).toBe("pi@1.2.3");
+  });
+
+  it("flags warn when the diff contains an exfil pattern (default policy)", () => {
+    const outcome = finalizeDelegatedOutput({
+      ...baseDiffInput,
+      raw_diff: {
+        ...baseDiffInput.raw_diff,
+        unified_diff:
+          "+const k = '-----BEGIN OPENSSH PRIVATE KEY-----\\nb3BlbnNzaC1rZXkt...';\n",
+      },
+    });
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.result.provenance.scanner_pass).toBe("warn");
+    expect(outcome.result.diff!.unified_diff).toContain("BEGIN OPENSSH PRIVATE KEY");
+  });
+
+  it("escalates to scanner_blocked error when diff contains exfil pattern under redact policy", () => {
+    const outcome = finalizeDelegatedOutput({
+      ...baseDiffInput,
+      scanner_policy: "redact",
+      raw_diff: {
+        ...baseDiffInput.raw_diff,
+        unified_diff:
+          "-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBA...\n-----END RSA PRIVATE KEY-----",
+      },
+    });
+    expect(outcome.ok).toBe(false);
+    if (outcome.ok) return;
+    expect(outcome.error.kind).toBe("scanner_blocked");
+    expect(outcome.error.task_id).toBe("20260426-104000-harness");
+    expect(outcome.error.retryable).toBe(false);
+    expect(outcome.error.message).toMatch(/redact/i);
+    expect(outcome.error.message).toMatch(/diff/i);
+  });
+
+  it("does NOT escalate when diff is clean under redact policy", () => {
+    const outcome = finalizeDelegatedOutput({
+      ...baseDiffInput,
+      scanner_policy: "redact",
+    });
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.result.provenance.scanner_pass).toBe("clean");
+    expect(outcome.result.diff!.unified_diff).toBe(
+      baseDiffInput.raw_diff.unified_diff,
+    );
+  });
+
+  it("does NOT escalate when diff matches under default warn policy", () => {
+    const outcome = finalizeDelegatedOutput({
+      ...baseDiffInput,
+      raw_diff: {
+        ...baseDiffInput.raw_diff,
+        unified_diff:
+          "-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBA...\n-----END RSA PRIVATE KEY-----",
+      },
+    });
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.result.provenance.scanner_pass).toBe("warn");
+    expect(outcome.result.diff!.unified_diff).toContain("BEGIN RSA PRIVATE KEY");
+  });
+
+  it("propagates harness_version into provenance on success", () => {
+    const outcome = finalizeDelegatedOutput({
+      ...baseDiffInput,
+      harness_version: "pi@2.0.0-rc1",
+    });
+    expect(outcome.ok).toBe(true);
+    if (!outcome.ok) return;
+    expect(outcome.result.provenance.harness_version).toBe("pi@2.0.0-rc1");
+  });
+});

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -302,4 +302,73 @@ describe("routeTask", () => {
       }
     });
   });
+
+  describe("autoEligible filter (orchestrator v1)", () => {
+    const openrouter = makeCandidate({
+      id: "openrouter",
+      dispatcherRuntime: "openrouter",
+      trustTier: "semi-trusted",
+      costModel: "per-token",
+      modelSize: "large",
+      capabilities: ["code"],
+      autoEligible: false,
+    });
+
+    const piHarness = makeCandidate({
+      id: "pi-harness",
+      dispatcherRuntime: "pi-harness",
+      trustTier: "semi-trusted",
+      costModel: "per-token",
+      modelSize: "large",
+      capabilities: ["code", "tools"],
+      autoEligible: false,
+    });
+
+    it("excludes autoEligible:false runtimes from auto-routing", () => {
+      const input: RouterInput = {
+        effectiveSensitivity: "internal",
+        availableRuntimes: [...allRuntimes, openrouter, piHarness],
+      };
+      const decision = routeTask(input);
+      expect(decision.selectedRuntime.id).not.toBe("openrouter");
+      expect(decision.selectedRuntime.id).not.toBe("pi-harness");
+      const eliminatedIds = decision.eliminated.map((e) => e.id);
+      expect(eliminatedIds).toContain("openrouter");
+      expect(eliminatedIds).toContain("pi-harness");
+    });
+
+    it("records explicit-only reason for eliminated explicit-only runtimes", () => {
+      const input: RouterInput = {
+        effectiveSensitivity: "internal",
+        availableRuntimes: [...allRuntimes, openrouter],
+      };
+      const decision = routeTask(input);
+      const elim = decision.eliminated.find((e) => e.id === "openrouter");
+      expect(elim?.reason).toMatch(/explicit-only/);
+    });
+
+    it("falls through to autoEligible:true runtimes correctly", () => {
+      // Even when openrouter would otherwise win on size, ollama-pi (free, trusted)
+      // should still be picked for internal-sensitivity tasks.
+      const input: RouterInput = {
+        effectiveSensitivity: "internal",
+        availableRuntimes: [openrouter, ollamaPi],
+      };
+      const decision = routeTask(input);
+      expect(decision.selectedRuntime.id).toBe("ollama-pi");
+    });
+
+    it("undefined autoEligible is treated as eligible (backwards-compatible)", () => {
+      const legacy = makeCandidate({
+        id: "legacy-runtime",
+        // autoEligible omitted
+      });
+      const input: RouterInput = {
+        effectiveSensitivity: "internal",
+        availableRuntimes: [legacy],
+      };
+      const decision = routeTask(input);
+      expect(decision.selectedRuntime.id).toBe("legacy-runtime");
+    });
+  });
 });

--- a/tests/runtime-registry.test.ts
+++ b/tests/runtime-registry.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect } from "vitest";
 import {
+  ALIAS_MAP_V1,
   RUNTIME_REGISTRY,
   buildRuntimeCandidates,
+  getAliasMap,
   getRegistryEntryById,
   getRuntimeMaxSensitivity,
+  resolveAlias,
 } from "../src/runtime-registry.js";
 import type { OllamaHost } from "../src/ollama-hosts.js";
 
@@ -14,6 +17,8 @@ describe("RUNTIME_REGISTRY", () => {
     expect(ids).toContain("codex-spawn");
     expect(ids).toContain("ollama-pi");
     expect(ids).toContain("ollama-laptop");
+    expect(ids).toContain("openrouter");
+    expect(ids).toContain("pi-harness");
   });
 
   it("every entry has required fields", () => {
@@ -141,5 +146,99 @@ describe("buildRuntimeCandidates", () => {
   it("returns all registry entries", () => {
     const candidates = buildRuntimeCandidates([piOnline, laptopOffline]);
     expect(candidates.length).toBe(RUNTIME_REGISTRY.length);
+  });
+});
+
+describe("orchestrator v1 policy fields", () => {
+  it("openrouter is third-party, ZDR-required, explicit-only", () => {
+    const entry = getRegistryEntryById("openrouter");
+    expect(entry).toBeDefined();
+    expect(entry!.provider).toBe("openrouter");
+    expect(entry!.egress).toBe("third-party");
+    expect(entry!.zdrRequired).toBe(true);
+    expect(entry!.autoEligible).toBe(false);
+    expect(entry!.family).toBe("one-shot");
+    expect(entry!.reasoningLevel).toBe("medium");
+  });
+
+  it("pi-harness is third-party, ZDR-required, explicit-only, harness family", () => {
+    const entry = getRegistryEntryById("pi-harness");
+    expect(entry).toBeDefined();
+    expect(entry!.provider).toBe("pi-harness");
+    expect(entry!.family).toBe("harness");
+    expect(entry!.harnessCmd).toBe("pi");
+    expect(entry!.harnessFlags).toEqual(["--no-session", "--provider", "openrouter"]);
+    expect(entry!.zdrRequired).toBe(true);
+    expect(entry!.autoEligible).toBe(false);
+  });
+
+  it("existing one-shot runtimes are auto-eligible by default", () => {
+    for (const id of ["claude-sdk", "codex-spawn", "ollama-pi", "ollama-laptop"]) {
+      const entry = getRegistryEntryById(id);
+      expect(entry?.autoEligible).toBe(true);
+      expect(entry?.family).toBe("one-shot");
+    }
+  });
+
+  it("ollama entries are local-egress and not ZDR-flagged", () => {
+    const ollamaEntries = RUNTIME_REGISTRY.filter(
+      (r) => r.dispatcherRuntime === "ollama",
+    );
+    for (const entry of ollamaEntries) {
+      expect(entry.egress).toBe("local");
+      expect(entry.zdrRequired).toBe(false);
+    }
+  });
+});
+
+describe("alias map (v1)", () => {
+  it("getAliasMap returns ALIAS_MAP_V1", () => {
+    expect(getAliasMap()).toBe(ALIAS_MAP_V1);
+    expect(ALIAS_MAP_V1.version).toBe(1);
+  });
+
+  it("contains the four v1 aliases", () => {
+    const aliases = Object.keys(ALIAS_MAP_V1.aliases).sort();
+    expect(aliases).toEqual(["large-reasoning", "medium", "pi-large-coder", "tiny"]);
+  });
+
+  it("tiny resolves to ollama-pi/qwen2.5:3b", () => {
+    const r = resolveAlias("tiny");
+    expect(r.runtimeId).toBe("ollama-pi");
+    expect(r.model).toBe("qwen2.5:3b");
+    expect(r.family).toBe("one-shot");
+  });
+
+  it("medium resolves to ollama-laptop/qwen3:14b (eval-validated)", () => {
+    const r = resolveAlias("medium");
+    expect(r.runtimeId).toBe("ollama-laptop");
+    expect(r.model).toBe("qwen3:14b");
+    expect(r.family).toBe("one-shot");
+  });
+
+  it("large-reasoning resolves to openrouter/gpt-oss-120b @ medium", () => {
+    const r = resolveAlias("large-reasoning");
+    expect(r.runtimeId).toBe("openrouter");
+    expect(r.model).toBe("openai/gpt-oss-120b");
+    expect(r.reasoningLevel).toBe("medium");
+    expect(r.family).toBe("one-shot");
+  });
+
+  it("pi-large-coder resolves to pi-harness/qwen3-coder-next", () => {
+    const r = resolveAlias("pi-large-coder");
+    expect(r.runtimeId).toBe("pi-harness");
+    expect(r.model).toBe("qwen/qwen3-coder-next");
+    expect(r.family).toBe("harness");
+    expect(r.harness).toBe("pi");
+  });
+
+  it("every alias references a known runtime", () => {
+    for (const resolution of Object.values(ALIAS_MAP_V1.aliases)) {
+      expect(getRegistryEntryById(resolution.runtimeId)).toBeDefined();
+    }
+  });
+
+  it("resolveAlias throws on unknown alias", () => {
+    expect(() => resolveAlias("nonexistent" as never)).toThrow(/Unknown alias/);
   });
 });


### PR DESCRIPTION
## Summary

Lands orchestrator v1 Steps 1–3 (data-model spec, runtime registry extension, shared finalize helper) plus the five impl-review debate fixes (#13–#17) that block Step 4 (Pi-side broker).

- **Step 1** — `docs/orchestrator-v1-data-model.md`: request envelope, harness `WorktreeSpec`, 5-state await machine with `result_kind: text | diff`, append-only journal events + projection, runtime registry extension, end-to-end provenance chain. §11 records the Option B decision.
- **Step 2** — `src/runtime-registry.ts`: orthogonal `provider`/`egress`/`zdrRequired`/`autoEligible`/`family`/`reasoningLevel`/`harnessCmd`/`harnessFlags` fields; new `openrouter` and `pi-harness` rows; `ALIAS_MAP_V1` with `tiny`/`medium`/`large-reasoning`/`pi-large-coder`. Router gains `autoEligible: false` filter so orchestrator runtimes never auto-route.
- **Step 3** — `src/finalize-delegated-output.ts`: single helper used by every output-return surface (broker, executors, MCP). Returns `FinalizeOutcome` discriminated union with structured diff metadata and `provenance: { source: "delegated", scanner_pass, policy_version, harness_version? }`.

## Impl-review fixes (debate verdict, 17 critique points)

| # | Critique | Fix |
|---|----------|-----|
| C02 | Redacted diff cannot be applied as a patch | diff+redact returns `scanner_blocked` error; text+redact stays success |
| C03/C06/C07/C09/C12 | Durability + runtime-row identity | §12 spec: Munin canonical, two-phase complete (result-structured → status CAS), reconciliation sweep, `runtime_row_id` threaded through `BrokerAnnotations` and `DelegationResult` |
| C04/C10 | Worktree disk math | `copy_node_modules` default flipped `true → false`; §11.3.1 admission control (`HUGIN_WORKTREE_BUDGET_BYTES`, eager-reap → LRU eviction → reject) |
| C05/C08 | Protocol versioning | `envelope_version`, `result_schema_version`, `event_schema_version` (all pinned at 1); §3.1 idempotency-key reuse rules |
| C01/C06 | Widened `DispatcherRuntime` couples dispatcher to broker types | Split into narrow `LegacyDispatcherRuntime` and wider `DispatcherRuntime`; `isLegacyDispatcherRuntime` guard replaces narrow `as` casts in `src/index.ts` and `src/pipeline-compiler.ts` |

## Test plan

- [x] `npm run build` clean (`tsc` strict)
- [x] `npm test` — 432/432 passing
- [x] 12 new tests for `finalize-delegated-output` (text/diff paths, scanner transitions, escalation on diff+redact)
- [x] 9 new tests for runtime-registry alias map + policy fields
- [x] 4 new tests for `autoEligible` routing filter
- [ ] Step 4 (Pi-side broker) builds on this — verify integration end-to-end once that lands

## Out of scope

- Step 4 (Pi-side broker), Step 4b (worktree manager), Step 5 (OpenRouter executor), Step 5b (pi-harness executor), Step 6 (hugin-mcp), Step 7 (delegate skill), Step 8 (dogfood + audit) — separate PRs.
- No runtime behavior change for existing claude/codex/ollama tasks: orchestrator runtimes are explicit-only via the alias map; `autoEligible: false` keeps them out of auto-routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)