### PR TITLE
orch-v1 Step 5a: OpenRouter client + ZDR allowlist + executor

### DIFF
--- a/src/broker/openrouter-executor.ts
+++ b/src/broker/openrouter-executor.ts
@@ -1,0 +1,183 @@
+/**
+ * OpenRouter executor for orchestrator-v1 one-shot delegations.
+ *
+ * Pipeline:
+ *   1. Pull the resolved alias / model / reasoning level out of the
+ *      delegation envelope.
+ *   2. Hand the prompt to `OpenRouterClient.chat` (which itself
+ *      enforces the pinned ZDR allowlist before any HTTP call).
+ *   3. Translate the raw provider output through
+ *      `finalizeDelegatedOutput` so every byte that crosses the
+ *      broker → MCP boundary is scanner-checked and provenance-tagged.
+ *
+ * Errors are returned as `DelegationError` rather than thrown, so the
+ * worker that drives this executor can route success and failure
+ * through the same two-phase commit machinery (see §12.3).
+ *
+ * The harness path (`pi-harness`) lives in a separate executor (Step 5b)
+ * because its I/O surface is fundamentally different (spawn + worktree
+ * + diff capture vs. pure HTTP).
+ */
+
+import {
+  finalizeDelegatedOutput,
+  type DelegationError,
+  type DelegationResult,
+  type ScannerPolicy,
+} from "../finalize-delegated-output.js";
+import {
+  OpenRouterError,
+  type OpenRouterChatResponse,
+  type OpenRouterClient,
+} from "../openrouter-client.js";
+import type { DelegationEnvelope } from "./types.js";
+
+export interface OpenRouterExecutorDeps {
+  client: OpenRouterClient;
+  scannerPolicy?: ScannerPolicy;
+  now?: () => number;
+}
+
+export type OpenRouterExecutorOutcome =
+  | { ok: true; result: DelegationResult }
+  | { ok: false; error: DelegationError };
+
+/**
+ * Run a one-shot delegation against OpenRouter. Returns a
+ * discriminated outcome — never throws for expected failure modes
+ * (timeout, provider 5xx, ZDR rejection, scanner blocked). Truly
+ * unexpected exceptions still propagate so the caller can mark the
+ * task `failed` with `kind: "internal"`.
+ */
+export async function executeOpenRouterDelegation(
+  envelope: DelegationEnvelope,
+  deps: OpenRouterExecutorDeps,
+): Promise<OpenRouterExecutorOutcome> {
+  if (envelope.alias_resolved.runtime !== "openrouter") {
+    return {
+      ok: false,
+      error: {
+        task_id: envelope.task_id,
+        kind: "internal",
+        message: `executor expected runtime 'openrouter', got '${envelope.alias_resolved.runtime}'`,
+        retryable: false,
+      },
+    };
+  }
+  if (envelope.alias_resolved.family !== "one-shot") {
+    return {
+      ok: false,
+      error: {
+        task_id: envelope.task_id,
+        kind: "internal",
+        message: `OpenRouter executor only handles one-shot family; got '${envelope.alias_resolved.family}'`,
+        retryable: false,
+      },
+    };
+  }
+
+  const start = (deps.now ?? Date.now)();
+
+  let chatResponse: OpenRouterChatResponse;
+  try {
+    chatResponse = await deps.client.chat({
+      model: envelope.alias_resolved.model_requested,
+      prompt: envelope.prompt,
+      reasoningLevel: envelope.alias_resolved.reasoning_level,
+      maxOutputTokens: envelope.max_output_tokens,
+      timeoutMs: envelope.timeout_ms,
+    });
+  } catch (err) {
+    return { ok: false, error: mapClientError(envelope, err) };
+  }
+
+  const durationS = ((deps.now ?? Date.now)() - start) / 1000;
+
+  return finalizeDelegatedOutput({
+    result_kind: "text",
+    raw_output: chatResponse.output,
+    task_id: envelope.task_id,
+    alias_requested: envelope.alias_resolved.alias,
+    model_effective: chatResponse.modelEffective || envelope.alias_resolved.model_requested,
+    runtime_effective: "openrouter",
+    runtime_row_id_effective: envelope.alias_resolved.runtime_row_id,
+    host_effective: "openrouter",
+    policy_version: envelope.policy_version,
+    scanner_policy: deps.scannerPolicy,
+    prompt_tokens: chatResponse.usage.prompt_tokens,
+    completion_tokens: chatResponse.usage.completion_tokens,
+    total_tokens: chatResponse.usage.total_tokens,
+    duration_s: durationS,
+    cost_usd: 0,
+  });
+}
+
+function mapClientError(
+  envelope: DelegationEnvelope,
+  err: unknown,
+): DelegationError {
+  if (err instanceof OpenRouterError) {
+    if (err.code === "zdr_blocked") {
+      return {
+        task_id: envelope.task_id,
+        kind: "policy_rejected",
+        message: err.message,
+        retryable: false,
+      };
+    }
+    if (err.code === "timeout") {
+      return {
+        task_id: envelope.task_id,
+        kind: "timeout",
+        message: err.message,
+        retryable: true,
+      };
+    }
+    if (err.code === "network") {
+      return {
+        task_id: envelope.task_id,
+        kind: "executor_failed",
+        message: err.message,
+        retryable: true,
+      };
+    }
+    if (err.code === "provider") {
+      return {
+        task_id: envelope.task_id,
+        kind: "executor_failed",
+        message: `${err.message}${err.providerMessage ? `: ${err.providerMessage}` : ""}`,
+        retryable: isRetryableHttpStatus(err.httpStatus),
+      };
+    }
+    if (err.code === "parse") {
+      return {
+        task_id: envelope.task_id,
+        kind: "executor_failed",
+        message: err.message,
+        retryable: false,
+      };
+    }
+  }
+  // Catch-all: the ZDR gate raises a plain Error with `code: "zdr_blocked"`.
+  if ((err as Error & { code?: string }).code === "zdr_blocked") {
+    return {
+      task_id: envelope.task_id,
+      kind: "policy_rejected",
+      message: (err as Error).message,
+      retryable: false,
+    };
+  }
+  return {
+    task_id: envelope.task_id,
+    kind: "internal",
+    message: err instanceof Error ? err.message : String(err),
+    retryable: false,
+  };
+}
+
+function isRetryableHttpStatus(status: number | undefined): boolean {
+  if (status === undefined) return false;
+  if (status === 429) return true;
+  if (status >= 500 && status < 600) return true;
+  return false;
+}

--- a/src/broker/openrouter-executor.ts
+++ b/src/broker/openrouter-executor.ts
@@ -30,7 +30,15 @@ import {
   type OpenRouterChatResponse,
   type OpenRouterClient,
 } from "../openrouter-client.js";
+import { computeOpenRouterCostUsd } from "../openrouter-pricing.js";
 import type { DelegationEnvelope } from "./types.js";
+
+/**
+ * Spec-defined default timeout for one-shot delegations
+ * (docs/orchestrator-v1-data-model.md §3, line 96). Used when the
+ * envelope omits `timeout_ms`.
+ */
+export const ONE_SHOT_DEFAULT_TIMEOUT_MS = 300_000;
 
 export interface OpenRouterExecutorDeps {
   client: OpenRouterClient;
@@ -77,6 +85,7 @@ export async function executeOpenRouterDelegation(
   }
 
   const start = (deps.now ?? Date.now)();
+  const timeoutMs = envelope.timeout_ms ?? ONE_SHOT_DEFAULT_TIMEOUT_MS;
 
   let chatResponse: OpenRouterChatResponse;
   try {
@@ -85,20 +94,41 @@ export async function executeOpenRouterDelegation(
       prompt: envelope.prompt,
       reasoningLevel: envelope.alias_resolved.reasoning_level,
       maxOutputTokens: envelope.max_output_tokens,
-      timeoutMs: envelope.timeout_ms,
+      timeoutMs,
     });
   } catch (err) {
     return { ok: false, error: mapClientError(envelope, err) };
   }
 
+  if (chatResponse.output.trim().length === 0) {
+    return {
+      ok: false,
+      error: {
+        task_id: envelope.task_id,
+        kind: "executor_failed",
+        message:
+          `OpenRouter returned an empty completion (finish_reason=${chatResponse.finishReason ?? "null"})`,
+        retryable: true,
+      },
+    };
+  }
+
   const durationS = ((deps.now ?? Date.now)() - start) / 1000;
+  const modelEffective =
+    chatResponse.modelEffective || envelope.alias_resolved.model_requested;
+  const cost = computeOpenRouterCostUsd(modelEffective, chatResponse.usage);
+  if (cost === null) {
+    console.warn(
+      `[orch-v1/openrouter] cost_usd unknown for model '${modelEffective}' — pricing snapshot does not cover it; reporting 0`,
+    );
+  }
 
   return finalizeDelegatedOutput({
     result_kind: "text",
     raw_output: chatResponse.output,
     task_id: envelope.task_id,
     alias_requested: envelope.alias_resolved.alias,
-    model_effective: chatResponse.modelEffective || envelope.alias_resolved.model_requested,
+    model_effective: modelEffective,
     runtime_effective: "openrouter",
     runtime_row_id_effective: envelope.alias_resolved.runtime_row_id,
     host_effective: "openrouter",
@@ -108,7 +138,7 @@ export async function executeOpenRouterDelegation(
     completion_tokens: chatResponse.usage.completion_tokens,
     total_tokens: chatResponse.usage.total_tokens,
     duration_s: durationS,
-    cost_usd: 0,
+    cost_usd: cost ?? 0,
   });
 }
 

--- a/src/openrouter-client.ts
+++ b/src/openrouter-client.ts
@@ -1,0 +1,244 @@
+/**
+ * Minimal OpenRouter HTTP client for orchestrator v1.
+ *
+ * Scope:
+ *   - Single chat-completions request (non-streaming) with optional
+ *     reasoning level. The orchestrator v1 executor is one-shot, so
+ *     streaming is intentionally omitted.
+ *   - Hard ZDR allowlist enforcement before the request hits the wire.
+ *   - Structured error mapping (`zdr_blocked` / `network` / `provider`
+ *     / `parse`) so the executor can translate to DelegationErrorKind
+ *     without re-parsing strings.
+ *
+ * The client does NOT handle retries, scanner policy, or finalization —
+ * those are the executor's job. This module is intentionally thin: a
+ * fetch wrapper plus the ZDR gate.
+ *
+ * Auth: the API key is passed in via the constructor / options rather
+ * than read from process.env directly, so the executor controls
+ * lifetime and so tests can supply a dummy key without touching env.
+ */
+
+import { assertZdrAllowed } from "./openrouter-zdr.js";
+
+export const OPENROUTER_DEFAULT_BASE_URL = "https://openrouter.ai/api/v1";
+export const OPENROUTER_USER_AGENT = "hugin-orch-v1";
+
+export type OpenRouterErrorCode =
+  | "zdr_blocked"
+  | "network"
+  | "provider"
+  | "parse"
+  | "timeout";
+
+export class OpenRouterError extends Error {
+  readonly code: OpenRouterErrorCode;
+  readonly httpStatus?: number;
+  readonly providerMessage?: string;
+  constructor(
+    code: OpenRouterErrorCode,
+    message: string,
+    options: { httpStatus?: number; providerMessage?: string } = {},
+  ) {
+    super(message);
+    this.name = "OpenRouterError";
+    this.code = code;
+    this.httpStatus = options.httpStatus;
+    this.providerMessage = options.providerMessage;
+  }
+}
+
+export interface OpenRouterClientConfig {
+  apiKey: string;
+  baseUrl?: string;
+  /**
+   * Optional fetch implementation override (used by tests). Defaults to
+   * the global `fetch`.
+   */
+  fetchImpl?: typeof fetch;
+  /** HTTP-Referer header — OpenRouter uses it for ranking/attribution. */
+  referer?: string;
+  /** X-Title header — OpenRouter uses it for ranking/attribution. */
+  appTitle?: string;
+}
+
+export interface OpenRouterChatRequest {
+  model: string;
+  prompt: string;
+  /**
+   * Optional system prompt prepended as a separate message. Kept
+   * explicit (vs. concatenating into prompt) so OpenRouter's role
+   * parsing stays correct.
+   */
+  systemPrompt?: string;
+  temperature?: number;
+  maxOutputTokens?: number;
+  /**
+   * Pinned per-row reasoning level (low / medium / high). For models
+   * that don't accept the field (most non-gpt-oss families) the API
+   * silently ignores it.
+   */
+  reasoningLevel?: "low" | "medium" | "high";
+  timeoutMs?: number;
+  abortSignal?: AbortSignal;
+}
+
+export interface OpenRouterUsage {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+}
+
+export interface OpenRouterChatResponse {
+  output: string;
+  finishReason: string | null;
+  modelEffective: string;
+  usage: OpenRouterUsage;
+  /** Raw response JSON, for diagnostic surfaces. */
+  raw: unknown;
+}
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+export class OpenRouterClient {
+  private readonly apiKey: string;
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly referer?: string;
+  private readonly appTitle?: string;
+
+  constructor(config: OpenRouterClientConfig) {
+    if (!config.apiKey) {
+      throw new Error("OpenRouterClient requires an apiKey");
+    }
+    this.apiKey = config.apiKey;
+    this.baseUrl = (config.baseUrl ?? OPENROUTER_DEFAULT_BASE_URL).replace(/\/$/, "");
+    this.fetchImpl = config.fetchImpl ?? fetch;
+    this.referer = config.referer;
+    this.appTitle = config.appTitle;
+  }
+
+  async chat(request: OpenRouterChatRequest): Promise<OpenRouterChatResponse> {
+    assertZdrAllowed(request.model);
+
+    const messages: Array<{ role: "system" | "user"; content: string }> = [];
+    if (request.systemPrompt) {
+      messages.push({ role: "system", content: request.systemPrompt });
+    }
+    messages.push({ role: "user", content: request.prompt });
+
+    const body: Record<string, unknown> = {
+      model: request.model,
+      messages,
+      stream: false,
+    };
+    if (request.temperature !== undefined) body.temperature = request.temperature;
+    if (request.maxOutputTokens !== undefined) {
+      body.max_tokens = request.maxOutputTokens;
+    }
+    if (request.reasoningLevel) {
+      body.reasoning = { effort: request.reasoningLevel };
+    }
+
+    const controller = new AbortController();
+    const timeoutMs = request.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    if (request.abortSignal) {
+      if (request.abortSignal.aborted) controller.abort();
+      else request.abortSignal.addEventListener("abort", () => controller.abort(), { once: true });
+    }
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(`${this.baseUrl}/chat/completions`, {
+        method: "POST",
+        headers: this.buildHeaders(),
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+    } catch (err) {
+      clearTimeout(timer);
+      if ((err as Error & { name?: string }).name === "AbortError") {
+        throw new OpenRouterError("timeout", `OpenRouter request timed out after ${timeoutMs}ms`);
+      }
+      throw new OpenRouterError(
+        "network",
+        `OpenRouter network error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    clearTimeout(timer);
+
+    if (!response.ok) {
+      const text = await safeReadText(response);
+      throw new OpenRouterError(
+        "provider",
+        `OpenRouter returned HTTP ${response.status}`,
+        { httpStatus: response.status, providerMessage: text },
+      );
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = await response.json();
+    } catch (err) {
+      throw new OpenRouterError(
+        "parse",
+        `OpenRouter response was not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    return mapChatResponse(parsed);
+  }
+
+  private buildHeaders(): Record<string, string> {
+    const h: Record<string, string> = {
+      authorization: `Bearer ${this.apiKey}`,
+      "content-type": "application/json",
+      "user-agent": OPENROUTER_USER_AGENT,
+    };
+    if (this.referer) h["http-referer"] = this.referer;
+    if (this.appTitle) h["x-title"] = this.appTitle;
+    return h;
+  }
+}
+
+async function safeReadText(response: Response): Promise<string | undefined> {
+  try {
+    return await response.text();
+  } catch {
+    return undefined;
+  }
+}
+
+interface OpenRouterChoice {
+  message?: { content?: unknown };
+  finish_reason?: string | null;
+}
+
+interface OpenRouterRawResponse {
+  model?: string;
+  choices?: OpenRouterChoice[];
+  usage?: OpenRouterUsage;
+}
+
+export function mapChatResponse(raw: unknown): OpenRouterChatResponse {
+  if (!raw || typeof raw !== "object") {
+    throw new OpenRouterError("parse", "OpenRouter response was not an object");
+  }
+  const r = raw as OpenRouterRawResponse;
+  const choice = r.choices?.[0];
+  const content = choice?.message?.content;
+  if (typeof content !== "string") {
+    throw new OpenRouterError(
+      "parse",
+      "OpenRouter response missing choices[0].message.content (string)",
+    );
+  }
+  return {
+    output: content,
+    finishReason: choice?.finish_reason ?? null,
+    modelEffective: r.model ?? "",
+    usage: r.usage ?? {},
+    raw,
+  };
+}

--- a/src/openrouter-client.ts
+++ b/src/openrouter-client.ts
@@ -98,7 +98,14 @@ export interface OpenRouterChatResponse {
   raw: unknown;
 }
 
-const DEFAULT_TIMEOUT_MS = 120_000;
+/**
+ * Last-resort safety net only. The executor is expected to resolve a
+ * runtime-default timeout (300_000 ms for one-shot, 900_000 ms for
+ * harness, per docs/orchestrator-v1-data-model.md §3) and pass it
+ * explicitly. This fallback exists so the client cannot hang forever
+ * if a future caller forgets, but it is *not* the documented default.
+ */
+const DEFAULT_TIMEOUT_MS = 600_000;
 
 export class OpenRouterClient {
   private readonly apiKey: string;
@@ -148,46 +155,61 @@ export class OpenRouterClient {
       else request.abortSignal.addEventListener("abort", () => controller.abort(), { once: true });
     }
 
-    let response: Response;
+    // The same AbortController must remain armed through both the fetch
+    // (headers) and the body read. fetch() resolves once headers arrive;
+    // a stalled body would otherwise hang indefinitely with the timer
+    // already cleared.
     try {
-      response = await this.fetchImpl(`${this.baseUrl}/chat/completions`, {
-        method: "POST",
-        headers: this.buildHeaders(),
-        body: JSON.stringify(body),
-        signal: controller.signal,
-      });
-    } catch (err) {
-      clearTimeout(timer);
-      if ((err as Error & { name?: string }).name === "AbortError") {
-        throw new OpenRouterError("timeout", `OpenRouter request timed out after ${timeoutMs}ms`);
+      let response: Response;
+      try {
+        response = await this.fetchImpl(`${this.baseUrl}/chat/completions`, {
+          method: "POST",
+          headers: this.buildHeaders(),
+          body: JSON.stringify(body),
+          signal: controller.signal,
+        });
+      } catch (err) {
+        if (isAbortError(err)) {
+          throw new OpenRouterError(
+            "timeout",
+            `OpenRouter request timed out after ${timeoutMs}ms`,
+          );
+        }
+        throw new OpenRouterError(
+          "network",
+          `OpenRouter network error: ${err instanceof Error ? err.message : String(err)}`,
+        );
       }
-      throw new OpenRouterError(
-        "network",
-        `OpenRouter network error: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
-    clearTimeout(timer);
 
-    if (!response.ok) {
-      const text = await safeReadText(response);
-      throw new OpenRouterError(
-        "provider",
-        `OpenRouter returned HTTP ${response.status}`,
-        { httpStatus: response.status, providerMessage: text },
-      );
-    }
+      if (!response.ok) {
+        const text = await safeReadText(response, controller.signal);
+        throw new OpenRouterError(
+          "provider",
+          `OpenRouter returned HTTP ${response.status}`,
+          { httpStatus: response.status, providerMessage: text },
+        );
+      }
 
-    let parsed: unknown;
-    try {
-      parsed = await response.json();
-    } catch (err) {
-      throw new OpenRouterError(
-        "parse",
-        `OpenRouter response was not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
+      let parsed: unknown;
+      try {
+        parsed = await response.json();
+      } catch (err) {
+        if (isAbortError(err)) {
+          throw new OpenRouterError(
+            "timeout",
+            `OpenRouter response body stalled and timed out after ${timeoutMs}ms`,
+          );
+        }
+        throw new OpenRouterError(
+          "parse",
+          `OpenRouter response was not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
 
-    return mapChatResponse(parsed);
+      return mapChatResponse(parsed);
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   private buildHeaders(): Record<string, string> {
@@ -202,12 +224,19 @@ export class OpenRouterClient {
   }
 }
 
-async function safeReadText(response: Response): Promise<string | undefined> {
+async function safeReadText(
+  response: Response,
+  _signal?: AbortSignal,
+): Promise<string | undefined> {
   try {
     return await response.text();
   } catch {
     return undefined;
   }
+}
+
+function isAbortError(err: unknown): boolean {
+  return (err as Error & { name?: string })?.name === "AbortError";
 }
 
 interface OpenRouterChoice {

--- a/src/openrouter-pricing.ts
+++ b/src/openrouter-pricing.ts
@@ -1,0 +1,72 @@
+/**
+ * Per-model pricing snapshot for OpenRouter.
+ *
+ * Used by the OpenRouter executor to translate token usage into
+ * `cost_usd` for the DelegationResult. The registry marks the
+ * `openrouter` runtime as `costModel: "per-token"`, so emitting a
+ * literal `0` would produce systematically wrong telemetry — instead
+ * we look the model up in the table below and compute it.
+ *
+ * **This is a manual snapshot, not a live feed.** OpenRouter publishes
+ * prices at https://openrouter.ai/models; bump `PRICING_SNAPSHOT_DATE`
+ * any time you refresh the table. If the model is not in the table
+ * the calculator returns `null`, signalling "unknown" — the caller
+ * should treat that as a non-fatal observability gap, not a hard error.
+ *
+ * The table covers the pinned ZDR allowlist (see openrouter-zdr.ts).
+ * Add a new row first if/when the allowlist grows.
+ */
+
+export const PRICING_SNAPSHOT_DATE = "2026-04-26";
+
+export interface ModelPricing {
+  /** USD per million prompt (input) tokens. */
+  promptPerMTokens: number;
+  /** USD per million completion (output) tokens. */
+  completionPerMTokens: number;
+}
+
+export interface CostUsage {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+}
+
+/**
+ * Snapshot of OpenRouter list prices for the v1 ZDR-allowlisted models.
+ * Keep slug case identical to the allowlist.
+ */
+export const OPENROUTER_PRICING: Readonly<Record<string, ModelPricing>> = {
+  "openai/gpt-oss-120b": {
+    promptPerMTokens: 0.05,
+    completionPerMTokens: 0.3,
+  },
+  "qwen/qwen3-coder": {
+    promptPerMTokens: 0.3,
+    completionPerMTokens: 1.2,
+  },
+  "qwen/qwen3-coder-next": {
+    promptPerMTokens: 0.3,
+    completionPerMTokens: 1.2,
+  },
+};
+
+/**
+ * Compute `cost_usd` from token usage. Returns `null` if the model is
+ * not in the snapshot (caller decides whether that is allowed).
+ *
+ * Both token counts default to 0 individually so a partial usage
+ * record (e.g. only `total_tokens` reported) still produces a number,
+ * just an undercount — better than throwing.
+ */
+export function computeOpenRouterCostUsd(
+  model: string,
+  usage: CostUsage,
+): number | null {
+  const pricing = OPENROUTER_PRICING[model];
+  if (!pricing) return null;
+  const prompt = usage.prompt_tokens ?? 0;
+  const completion = usage.completion_tokens ?? 0;
+  const promptCost = (prompt / 1_000_000) * pricing.promptPerMTokens;
+  const completionCost = (completion / 1_000_000) * pricing.completionPerMTokens;
+  return promptCost + completionCost;
+}

--- a/src/openrouter-zdr.ts
+++ b/src/openrouter-zdr.ts
@@ -1,0 +1,65 @@
+/**
+ * Pinned ZDR (zero-data-retention) allowlist for OpenRouter.
+ *
+ * Per docs/orchestrator-v1-data-model.md §6, every model that flows
+ * through the `openrouter` and `pi-harness` runtimes must be on this
+ * list. The list is *intentionally* small: orchestrator v1 only ships
+ * two delegated aliases (`large-reasoning`, `pi-large-coder`), so the
+ * allowlist mirrors them plus a tightly scoped set of qwen3-coder
+ * variants that the pi-harness eval used.
+ *
+ * The version string `zdr-v1` is part of the broker's `policy_version`
+ * field (`zdr-v1+rlv-v1`). Bump the version any time the allowlist
+ * changes — clients must be able to detect when the policy under which
+ * a result was produced has shifted.
+ *
+ * The allowlist is a hard gate, not a hint. The OpenRouter HTTP client
+ * rejects any request whose model is not on this list before the
+ * request hits the network — there is no "warn" or "log" mode.
+ */
+
+/**
+ * Monotonic version stamp for the allowlist contents below. Bump on any
+ * addition, removal, or substantive renaming. Kept short so it can be
+ * concatenated into the broker's combined `policy_version` string
+ * (`zdr-v1+rlv-v1`).
+ */
+export const ZDR_ALLOWLIST_VERSION = "zdr-v1";
+
+/**
+ * Models permitted to flow through the OpenRouter executor.
+ *
+ * Each entry is the OpenRouter slug (`<provider>/<model>` or
+ * `<model>` for OpenAI's first-party). Slugs are matched case-
+ * sensitively against the resolved alias model.
+ */
+export const ZDR_ALLOWLIST: readonly string[] = [
+  "openai/gpt-oss-120b",
+  "qwen/qwen3-coder",
+  "qwen/qwen3-coder-next",
+];
+
+const ZDR_ALLOWLIST_SET: ReadonlySet<string> = new Set(ZDR_ALLOWLIST);
+
+/**
+ * Returns true when `model` is on the pinned ZDR allowlist.
+ */
+export function isZdrAllowed(model: string): boolean {
+  return ZDR_ALLOWLIST_SET.has(model);
+}
+
+/**
+ * Throws a stable Error with `code: "zdr_blocked"` if `model` is not on
+ * the allowlist. Caller (executor) maps this to a `policy_rejected`
+ * DelegationError so the broker can surface it cleanly to the MCP.
+ */
+export function assertZdrAllowed(model: string): void {
+  if (!isZdrAllowed(model)) {
+    const err = new Error(
+      `model '${model}' is not on the pinned ZDR allowlist (${ZDR_ALLOWLIST_VERSION}). ` +
+        `Allowed: ${ZDR_ALLOWLIST.join(", ")}`,
+    );
+    (err as Error & { code?: string }).code = "zdr_blocked";
+    throw err;
+  }
+}

--- a/tests/broker/openrouter-executor.test.ts
+++ b/tests/broker/openrouter-executor.test.ts
@@ -212,6 +212,62 @@ describe("executeOpenRouterDelegation", () => {
     expect(out.error.message).toContain("one-shot");
   });
 
+  it("rejects empty/whitespace-only completions as executor_failed (retryable)", async () => {
+    const client = stubClient(async () => ({
+      output: "   \n\t  ",
+      finishReason: "length",
+      modelEffective: "openai/gpt-oss-120b",
+      usage: { prompt_tokens: 8, completion_tokens: 0, total_tokens: 8 },
+      raw: {},
+    }));
+    const out = await executeOpenRouterDelegation(envelope(), { client });
+    expect(out.ok).toBe(false);
+    if (out.ok) throw new Error("expected error");
+    expect(out.error.kind).toBe("executor_failed");
+    expect(out.error.retryable).toBe(true);
+    expect(out.error.message).toContain("empty completion");
+    expect(out.error.message).toContain("finish_reason=length");
+  });
+
+  it("computes cost_usd from token usage against the pricing snapshot", async () => {
+    const client = stubClient(async () => ({
+      output: "ok",
+      finishReason: "stop",
+      modelEffective: "openai/gpt-oss-120b",
+      usage: { prompt_tokens: 1_000_000, completion_tokens: 1_000_000, total_tokens: 2_000_000 },
+      raw: {},
+    }));
+    const out = await executeOpenRouterDelegation(envelope(), { client });
+    expect(out.ok).toBe(true);
+    if (!out.ok) throw new Error("expected ok");
+    // 1M prompt @ $0.05/M + 1M completion @ $0.30/M = $0.35
+    expect(out.result.cost_usd).toBeCloseTo(0.35, 6);
+  });
+
+  it("falls back to cost_usd=0 with a warning when the model is not in the pricing snapshot", async () => {
+    const warns: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (msg: unknown) => {
+      warns.push(String(msg));
+    };
+    try {
+      const client = stubClient(async () => ({
+        output: "ok",
+        finishReason: "stop",
+        modelEffective: "some/unlisted-model",
+        usage: { prompt_tokens: 100, completion_tokens: 50, total_tokens: 150 },
+        raw: {},
+      }));
+      const out = await executeOpenRouterDelegation(envelope(), { client });
+      expect(out.ok).toBe(true);
+      if (!out.ok) throw new Error("expected ok");
+      expect(out.result.cost_usd).toBe(0);
+      expect(warns.some((w) => w.includes("some/unlisted-model"))).toBe(true);
+    } finally {
+      console.warn = origWarn;
+    }
+  });
+
   it("respects scanner_policy: redact replaces matches in output", async () => {
     const client = stubClient(async () => ({
       output: "Here is a key: sk-ant-api03-secrettokensecrettokensecrettokensecrettokensecrettokensecrettokensecret-tokenAA",

--- a/tests/broker/openrouter-executor.test.ts
+++ b/tests/broker/openrouter-executor.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from "vitest";
+import { executeOpenRouterDelegation } from "../../src/broker/openrouter-executor.js";
+import {
+  OpenRouterClient,
+  OpenRouterError,
+  type OpenRouterChatRequest,
+  type OpenRouterChatResponse,
+} from "../../src/openrouter-client.js";
+import type { DelegationEnvelope } from "../../src/broker/types.js";
+
+function envelope(overrides: Partial<DelegationEnvelope> = {}): DelegationEnvelope {
+  return {
+    envelope_version: 1,
+    idempotency_key: "11111111-1111-4111-8111-111111111111",
+    orchestrator_session_id: "sess-1",
+    orchestrator_submitter: "claude-code",
+    task_type: "summarize",
+    prompt: "Summarize the README.",
+    alias_requested: "large-reasoning",
+    alias_map_version: 1,
+    task_id: "20260426-120000-orch-deadbeef",
+    broker_principal: "claude-code",
+    received_at: "2026-04-26T12:00:00Z",
+    alias_resolved: {
+      alias: "large-reasoning",
+      family: "one-shot",
+      model_requested: "openai/gpt-oss-120b",
+      runtime: "openrouter",
+      runtime_row_id: "openrouter",
+      host: "openrouter",
+      reasoning_level: "medium",
+    },
+    policy_version: "zdr-v1+rlv-v1",
+    ...overrides,
+  };
+}
+
+function stubClient(
+  handler: (req: OpenRouterChatRequest) => Promise<OpenRouterChatResponse> | OpenRouterChatResponse,
+): OpenRouterClient {
+  const c = new OpenRouterClient({
+    apiKey: "k",
+    fetchImpl: async () =>
+      new Response(JSON.stringify({ choices: [{ message: { content: "x" } }] })),
+  });
+  // Override the chat method directly for fine-grained control over what
+  // the executor sees back from the client (and to assert on the request).
+  (c as unknown as { chat: typeof handler }).chat = handler;
+  return c;
+}
+
+describe("executeOpenRouterDelegation", () => {
+  it("returns a DelegationResult with provenance on success", async () => {
+    const client = stubClient(async (req) => ({
+      output: "the answer",
+      finishReason: "stop",
+      modelEffective: req.model,
+      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      raw: {},
+    }));
+    const out = await executeOpenRouterDelegation(envelope(), { client });
+    expect(out.ok).toBe(true);
+    if (!out.ok) throw new Error("expected ok");
+    expect(out.result.output).toBe("the answer");
+    expect(out.result.runtime_effective).toBe("openrouter");
+    expect(out.result.runtime_row_id_effective).toBe("openrouter");
+    expect(out.result.host_effective).toBe("openrouter");
+    expect(out.result.model_effective).toBe("openai/gpt-oss-120b");
+    expect(out.result.alias_requested).toBe("large-reasoning");
+    expect(out.result.prompt_tokens).toBe(10);
+    expect(out.result.completion_tokens).toBe(5);
+    expect(out.result.total_tokens).toBe(15);
+    expect(out.result.provenance.policy_version).toBe("zdr-v1+rlv-v1");
+    expect(out.result.provenance.scanner_pass).toBe("clean");
+    expect(out.result.result_kind).toBe("text");
+  });
+
+  it("forwards reasoning level + max_output_tokens + timeout_ms from the envelope", async () => {
+    let captured: OpenRouterChatRequest | undefined;
+    const client = stubClient(async (req) => {
+      captured = req;
+      return {
+        output: "ok",
+        finishReason: "stop",
+        modelEffective: req.model,
+        usage: {},
+        raw: {},
+      };
+    });
+    await executeOpenRouterDelegation(
+      envelope({ max_output_tokens: 256, timeout_ms: 30_000 }),
+      { client },
+    );
+    expect(captured?.reasoningLevel).toBe("medium");
+    expect(captured?.maxOutputTokens).toBe(256);
+    expect(captured?.timeoutMs).toBe(30_000);
+    expect(captured?.model).toBe("openai/gpt-oss-120b");
+  });
+
+  it("maps zdr_blocked to policy_rejected (non-retryable)", async () => {
+    const client = stubClient(async () => {
+      throw new OpenRouterError("zdr_blocked", "model 'evil/foo' is not on the pinned ZDR allowlist");
+    });
+    const out = await executeOpenRouterDelegation(envelope(), { client });
+    expect(out.ok).toBe(false);
+    if (out.ok) throw new Error("expected error");
+    expect(out.error.kind).toBe("policy_rejected");
+    expect(out.error.retryable).toBe(false);
+  });
+
+  it("maps timeout to kind 'timeout' (retryable)", async () => {
+    const client = stubClient(async () => {
+      throw new OpenRouterError("timeout", "OpenRouter request timed out after 30s");
+    });
+    const out = await executeOpenRouterDelegation(envelope(), { client });
+    expect(out.ok).toBe(false);
+    if (out.ok) throw new Error("expected error");
+    expect(out.error.kind).toBe("timeout");
+    expect(out.error.retryable).toBe(true);
+  });
+
+  it("maps network failures to executor_failed (retryable)", async () => {
+    const client = stubClient(async () => {
+      throw new OpenRouterError("network", "connect ECONNREFUSED");
+    });
+    const out = await executeOpenRouterDelegation(envelope(), { client });
+    expect(out.ok).toBe(false);
+    if (out.ok) throw new Error("expected error");
+    expect(out.error.kind).toBe("executor_failed");
+    expect(out.error.retryable).toBe(true);
+  });
+
+  it("treats provider 5xx as retryable, 4xx (non-429) as not", async () => {
+    const client500 = stubClient(async () => {
+      throw new OpenRouterError("provider", "OpenRouter returned HTTP 503", {
+        httpStatus: 503,
+        providerMessage: "upstream busy",
+      });
+    });
+    const out500 = await executeOpenRouterDelegation(envelope(), { client: client500 });
+    expect(out500.ok).toBe(false);
+    if (out500.ok) throw new Error("expected error");
+    expect(out500.error.kind).toBe("executor_failed");
+    expect(out500.error.retryable).toBe(true);
+    expect(out500.error.message).toContain("upstream busy");
+
+    const client400 = stubClient(async () => {
+      throw new OpenRouterError("provider", "OpenRouter returned HTTP 400", {
+        httpStatus: 400,
+      });
+    });
+    const out400 = await executeOpenRouterDelegation(envelope(), { client: client400 });
+    expect(out400.ok).toBe(false);
+    if (out400.ok) throw new Error("expected error");
+    expect(out400.error.retryable).toBe(false);
+
+    const client429 = stubClient(async () => {
+      throw new OpenRouterError("provider", "OpenRouter returned HTTP 429", {
+        httpStatus: 429,
+      });
+    });
+    const out429 = await executeOpenRouterDelegation(envelope(), { client: client429 });
+    expect(out429.ok).toBe(false);
+    if (out429.ok) throw new Error("expected error");
+    expect(out429.error.retryable).toBe(true);
+  });
+
+  it("rejects envelopes whose resolved runtime is not openrouter", async () => {
+    const client = stubClient(async () => {
+      throw new Error("should not be called");
+    });
+    const out = await executeOpenRouterDelegation(
+      envelope({
+        alias_resolved: {
+          alias: "tiny",
+          family: "one-shot",
+          model_requested: "qwen2.5:3b",
+          runtime: "ollama",
+          runtime_row_id: "ollama-pi",
+          host: "pi",
+        },
+      }),
+      { client },
+    );
+    expect(out.ok).toBe(false);
+    if (out.ok) throw new Error("expected error");
+    expect(out.error.kind).toBe("internal");
+    expect(out.error.message).toContain("openrouter");
+  });
+
+  it("rejects harness-family envelopes (deferred to pi-harness executor)", async () => {
+    const client = stubClient(async () => {
+      throw new Error("should not be called");
+    });
+    const out = await executeOpenRouterDelegation(
+      envelope({
+        alias_resolved: {
+          alias: "pi-large-coder",
+          family: "harness",
+          harness: "pi",
+          model_requested: "qwen/qwen3-coder-next",
+          runtime: "openrouter",
+          runtime_row_id: "openrouter",
+          host: "openrouter",
+        },
+      }),
+      { client },
+    );
+    expect(out.ok).toBe(false);
+    if (out.ok) throw new Error("expected error");
+    expect(out.error.kind).toBe("internal");
+    expect(out.error.message).toContain("one-shot");
+  });
+
+  it("respects scanner_policy: redact replaces matches in output", async () => {
+    const client = stubClient(async () => ({
+      output: "Here is a key: sk-ant-api03-secrettokensecrettokensecrettokensecrettokensecrettokensecrettokensecret-tokenAA",
+      finishReason: "stop",
+      modelEffective: "openai/gpt-oss-120b",
+      usage: {},
+      raw: {},
+    }));
+    const out = await executeOpenRouterDelegation(envelope(), {
+      client,
+      scannerPolicy: "redact",
+    });
+    expect(out.ok).toBe(true);
+    if (!out.ok) throw new Error("expected ok");
+    expect(out.result.provenance.scanner_pass).toBe("redact");
+    expect(out.result.output).not.toContain("sk-ant-api03-secrettokensecrettokensecrettokensecrettokensecrettokensecrettokensecret-token");
+  });
+});

--- a/tests/openrouter-client.test.ts
+++ b/tests/openrouter-client.test.ts
@@ -164,6 +164,42 @@ describe("OpenRouterClient", () => {
     }
   });
 
+  it("maps stalled response body to code 'timeout' (timer covers body parse)", async () => {
+    // Headers arrive promptly; body never resolves until the abort fires.
+    const fetchImpl: typeof fetch = async (_url, init) => {
+      const sig = (init?.signal as AbortSignal | undefined) ?? null;
+      const body = new ReadableStream<Uint8Array>({
+        start(controller) {
+          if (sig?.aborted) {
+            controller.error(Object.assign(new Error("aborted"), { name: "AbortError" }));
+            return;
+          }
+          sig?.addEventListener("abort", () => {
+            controller.error(Object.assign(new Error("aborted"), { name: "AbortError" }));
+          });
+          // Never enqueues — body hangs until abort.
+        },
+      });
+      return new Response(body, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+    const client = new OpenRouterClient({ apiKey: "k", fetchImpl });
+    try {
+      await client.chat({
+        model: "openai/gpt-oss-120b",
+        prompt: "hi",
+        timeoutMs: 20,
+      });
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(OpenRouterError);
+      expect((err as OpenRouterError).code).toBe("timeout");
+      expect((err as OpenRouterError).message).toMatch(/stalled|timed out/);
+    }
+  });
+
   it("maps malformed JSON body to code 'parse'", async () => {
     const fetchImpl: typeof fetch = async () =>
       new Response("not json", {

--- a/tests/openrouter-client.test.ts
+++ b/tests/openrouter-client.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest";
+import {
+  OpenRouterClient,
+  OpenRouterError,
+  mapChatResponse,
+} from "../src/openrouter-client.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("OpenRouterClient", () => {
+  it("rejects requests for non-allowlisted models before fetching", async () => {
+    let called = false;
+    const fetchImpl: typeof fetch = async () => {
+      called = true;
+      return jsonResponse({});
+    };
+    const client = new OpenRouterClient({ apiKey: "k", fetchImpl });
+    await expect(
+      client.chat({ model: "openai/gpt-4o", prompt: "hi" }),
+    ).rejects.toThrowError(/not on the pinned ZDR allowlist/);
+    expect(called).toBe(false);
+  });
+
+  it("constructor refuses an empty apiKey", () => {
+    expect(() => new OpenRouterClient({ apiKey: "" })).toThrowError(/apiKey/);
+  });
+
+  it("sends a well-formed chat request and parses the choice text", async () => {
+    let captured: { url: string; init: RequestInit } | undefined;
+    const fetchImpl: typeof fetch = async (url, init) => {
+      captured = { url: url.toString(), init: init ?? {} };
+      return jsonResponse({
+        model: "openai/gpt-oss-120b",
+        choices: [
+          {
+            message: { content: "answer" },
+            finish_reason: "stop",
+          },
+        ],
+        usage: { prompt_tokens: 7, completion_tokens: 2, total_tokens: 9 },
+      });
+    };
+    const client = new OpenRouterClient({
+      apiKey: "test-key",
+      fetchImpl,
+      referer: "https://hugin.local",
+      appTitle: "hugin-test",
+    });
+    const res = await client.chat({
+      model: "openai/gpt-oss-120b",
+      prompt: "hello",
+      systemPrompt: "be terse",
+      reasoningLevel: "medium",
+    });
+
+    expect(res.output).toBe("answer");
+    expect(res.finishReason).toBe("stop");
+    expect(res.modelEffective).toBe("openai/gpt-oss-120b");
+    expect(res.usage).toEqual({ prompt_tokens: 7, completion_tokens: 2, total_tokens: 9 });
+
+    expect(captured).toBeDefined();
+    expect(captured!.url).toBe("https://openrouter.ai/api/v1/chat/completions");
+    expect(captured!.init.method).toBe("POST");
+    const headers = captured!.init.headers as Record<string, string>;
+    expect(headers.authorization).toBe("Bearer test-key");
+    expect(headers["content-type"]).toBe("application/json");
+    expect(headers["http-referer"]).toBe("https://hugin.local");
+    expect(headers["x-title"]).toBe("hugin-test");
+
+    const body = JSON.parse(captured!.init.body as string);
+    expect(body.model).toBe("openai/gpt-oss-120b");
+    expect(body.stream).toBe(false);
+    expect(body.messages).toEqual([
+      { role: "system", content: "be terse" },
+      { role: "user", content: "hello" },
+    ]);
+    expect(body.reasoning).toEqual({ effort: "medium" });
+  });
+
+  it("forwards temperature and max_tokens when provided", async () => {
+    let body: Record<string, unknown> = {};
+    const fetchImpl: typeof fetch = async (_url, init) => {
+      body = JSON.parse((init?.body as string) ?? "{}");
+      return jsonResponse({
+        choices: [{ message: { content: "ok" } }],
+      });
+    };
+    const client = new OpenRouterClient({ apiKey: "k", fetchImpl });
+    await client.chat({
+      model: "openai/gpt-oss-120b",
+      prompt: "hi",
+      temperature: 0.2,
+      maxOutputTokens: 256,
+    });
+    expect(body.temperature).toBe(0.2);
+    expect(body.max_tokens).toBe(256);
+  });
+
+  it("maps non-2xx responses to OpenRouterError code 'provider'", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("boom", { status: 502 });
+    const client = new OpenRouterClient({ apiKey: "k", fetchImpl });
+    try {
+      await client.chat({ model: "openai/gpt-oss-120b", prompt: "hi" });
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(OpenRouterError);
+      const e = err as OpenRouterError;
+      expect(e.code).toBe("provider");
+      expect(e.httpStatus).toBe(502);
+      expect(e.providerMessage).toBe("boom");
+    }
+  });
+
+  it("maps fetch network failure to code 'network'", async () => {
+    const fetchImpl: typeof fetch = async () => {
+      throw new TypeError("fetch failed");
+    };
+    const client = new OpenRouterClient({ apiKey: "k", fetchImpl });
+    try {
+      await client.chat({ model: "openai/gpt-oss-120b", prompt: "hi" });
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(OpenRouterError);
+      expect((err as OpenRouterError).code).toBe("network");
+    }
+  });
+
+  it("maps abort due to timeout to code 'timeout'", async () => {
+    const fetchImpl: typeof fetch = async (_url, init) => {
+      await new Promise<void>((resolve, reject) => {
+        const sig = (init?.signal as AbortSignal | undefined) ?? null;
+        if (sig?.aborted) {
+          const err = new Error("aborted");
+          err.name = "AbortError";
+          reject(err);
+          return;
+        }
+        sig?.addEventListener("abort", () => {
+          const err = new Error("aborted");
+          err.name = "AbortError";
+          reject(err);
+        });
+        setTimeout(resolve, 1000).unref?.();
+      });
+      return jsonResponse({});
+    };
+    const client = new OpenRouterClient({ apiKey: "k", fetchImpl });
+    try {
+      await client.chat({
+        model: "openai/gpt-oss-120b",
+        prompt: "hi",
+        timeoutMs: 10,
+      });
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(OpenRouterError);
+      expect((err as OpenRouterError).code).toBe("timeout");
+    }
+  });
+
+  it("maps malformed JSON body to code 'parse'", async () => {
+    const fetchImpl: typeof fetch = async () =>
+      new Response("not json", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    const client = new OpenRouterClient({ apiKey: "k", fetchImpl });
+    try {
+      await client.chat({ model: "openai/gpt-oss-120b", prompt: "hi" });
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(OpenRouterError);
+      expect((err as OpenRouterError).code).toBe("parse");
+    }
+  });
+});
+
+describe("mapChatResponse", () => {
+  it("returns output text from the first choice", () => {
+    const out = mapChatResponse({
+      model: "openai/gpt-oss-120b",
+      choices: [{ message: { content: "yes" }, finish_reason: "stop" }],
+      usage: { total_tokens: 3 },
+    });
+    expect(out.output).toBe("yes");
+    expect(out.finishReason).toBe("stop");
+    expect(out.modelEffective).toBe("openai/gpt-oss-120b");
+    expect(out.usage.total_tokens).toBe(3);
+  });
+
+  it("throws code='parse' when content is missing", () => {
+    expect(() =>
+      mapChatResponse({ choices: [{ message: {} }] }),
+    ).toThrowError(/missing choices/);
+  });
+
+  it("throws code='parse' on non-object input", () => {
+    expect(() => mapChatResponse(null)).toThrowError(/not an object/);
+    expect(() => mapChatResponse("string")).toThrowError(/not an object/);
+  });
+});

--- a/tests/openrouter-zdr.test.ts
+++ b/tests/openrouter-zdr.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  ZDR_ALLOWLIST,
+  ZDR_ALLOWLIST_VERSION,
+  assertZdrAllowed,
+  isZdrAllowed,
+} from "../src/openrouter-zdr.js";
+import { ALIAS_MAP_V1 } from "../src/runtime-registry.js";
+
+describe("ZDR allowlist", () => {
+  it("uses a versioned identifier matching the broker policy_version", () => {
+    expect(ZDR_ALLOWLIST_VERSION).toBe("zdr-v1");
+  });
+
+  it("permits the v1 cloud-delegated alias models", () => {
+    const aliasModels = Object.values(ALIAS_MAP_V1.aliases)
+      .filter((a) => a.runtimeId === "openrouter" || a.runtimeId === "pi-harness")
+      .map((a) => a.model);
+    expect(aliasModels.length).toBeGreaterThan(0);
+    for (const model of aliasModels) {
+      expect(isZdrAllowed(model)).toBe(true);
+    }
+  });
+
+  it("rejects models not on the allowlist", () => {
+    expect(isZdrAllowed("openai/gpt-4o")).toBe(false);
+    expect(isZdrAllowed("anthropic/claude-3-5-sonnet")).toBe(false);
+    expect(isZdrAllowed("")).toBe(false);
+  });
+
+  it("matches case-sensitively (uppercase variants are not allowed)", () => {
+    expect(isZdrAllowed("OPENAI/GPT-OSS-120B")).toBe(false);
+  });
+
+  it("assertZdrAllowed throws with code 'zdr_blocked' for non-allowlisted models", () => {
+    try {
+      assertZdrAllowed("openai/gpt-4o");
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect((err as Error & { code?: string }).code).toBe("zdr_blocked");
+      expect((err as Error).message).toContain("not on the pinned ZDR allowlist");
+      expect((err as Error).message).toContain(ZDR_ALLOWLIST_VERSION);
+    }
+  });
+
+  it("assertZdrAllowed is silent for allowlisted models", () => {
+    expect(() => assertZdrAllowed(ZDR_ALLOWLIST[0]!)).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- Pinned ZDR allowlist (`zdr-v1`) gating every OpenRouter request before it hits the wire.
- Minimal `OpenRouterClient` with structured error codes (`zdr_blocked` / `network` / `provider` / `parse` / `timeout`) and reasoning-level forwarding for gpt-oss-style models.
- `executeOpenRouterDelegation()` — one-shot executor that takes a broker `DelegationEnvelope`, calls the client, and routes raw output through the existing `finalizeDelegatedOutput()` helper so scanner pass + provenance metadata stay consistent with the ollama path.

This is the executor half of Step 5. The orch-worker (claim Munin tasks tagged `orch-v1`, dispatch to this executor, two-phase complete per §12.3) lands in 5b. So this PR is an isolated, non-wired addition: no runtime behaviour change in production yet.

## Notes
- Allowlist contents: `openai/gpt-oss-120b`, `qwen/qwen3-coder`, `qwen/qwen3-coder-next`. The `qwen3-coder` plain slug is included for the future case where the `-next` pin is rolled forward; the alias map currently uses `-next` for `pi-large-coder` and `gpt-oss-120b` for `large-reasoning`.
- Errors map to `DelegationError` rather than throwing: 5xx + 429 are flagged retryable, 4xx (non-429) and parse failures are not.
- `cost_usd: 0` for now — accurate cost lookup requires the OpenRouter pricing catalog work in Step 6 territory; the result schema reserves the field.
- Auth + base URL come in via constructor, not env, so the executor can be tested without env state and so the worker (5b) can choose whether to read from `HUGIN_OPENROUTER_API_KEY` or a keystore.

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 532/532 passing (27 new tests across allowlist, client, executor)
- [ ] Smoke test once 5b wires the worker (out of scope here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)