### PR TITLE
orch-v1 Step 5b: orch-worker (claim → execute → two-phase complete)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,14 @@ hugin/
 │   ├── exfiltration-scanner.ts   # Regex scanner for data-leak patterns in task output
 │   ├── provenance.ts               # External-vs-trusted provenance detection for context-refs
 │   ├── task-signing.ts             # HMAC-SHA256 task submission signing/verification
-│   └── munin-client.ts    # HTTP client for Munin JSON-RPC API
+│   ├── munin-client.ts    # HTTP client for Munin JSON-RPC API
+│   └── broker/                   # Orchestrator-v1 broker (Tailscale-only HTTP, /v1/delegate/*)
+│       ├── server.ts             # Express app + opt-in startup (HUGIN_BROKER_KEYS)
+│       ├── handlers.ts           # submit/await/rate/list/models endpoint handlers
+│       ├── orch-worker.ts        # Polls Munin for orch-v1 tasks, claims via CAS, dispatches to OpenRouter
+│       ├── openrouter-executor.ts # OpenRouter one-shot delegation runner
+│       ├── reconciliation.ts     # Periodic sweep: backfill journal events for orch-v1 tasks
+│       └── task-store.ts         # Munin operations: submit / read / two-phase complete
 ├── tests/
 │   ├── dispatcher.test.ts
 │   └── sdk-executor.test.ts
@@ -165,3 +172,11 @@ MUNIN_API_KEY=<same key Munin uses>
 | `HUGIN_SIGNING_POLICY` | `off` | Task signature verification: `off` (skip), `warn` (log missing/invalid, never reject), `require` (reject unsigned/invalid). See `docs/security/task-signing.md`. |
 | `HUGIN_SUBMITTER_KEYS` | — | Inline JSON keystore for task signing: `{"<keyId>": "<hex-secret>"}` (64-char hex preferred; base64 accepted). |
 | `HUGIN_SUBMITTER_KEYS_FILE` | — | Path to a JSON keystore file. Takes precedence over `HUGIN_SUBMITTER_KEYS`. |
+| `HUGIN_BROKER_HOST` | `127.0.0.1` | Bind address for the orchestrator-v1 broker (`/v1/delegate/*`). Set to the Tailscale interface IP in production. |
+| `HUGIN_BROKER_PORT` | `3033` | Port for the broker endpoint. |
+| `HUGIN_BROKER_KEYS` | — | Inline JSON keystore: `{"<principal>": "<token>"}`. Setting either this or `HUGIN_BROKER_KEYS_FILE` enables the broker. |
+| `HUGIN_BROKER_KEYS_FILE` | — | Path to a JSON keystore file for the broker. Takes precedence over `HUGIN_BROKER_KEYS`. |
+| `HUGIN_BROKER_RECONCILIATION_INTERVAL_MS` | `60000` | Interval between reconciliation sweeps (backfills journal events for orch-v1 tasks visible in Munin). |
+| `OPENROUTER_API_KEY` | — | OpenRouter API key. When set on a Pi-side broker, the orch-worker is enabled and dispatches `runtime: openrouter, family: one-shot` tasks. |
+| `OPENROUTER_REFERER` | `https://hugin.local` | `HTTP-Referer` header sent on OpenRouter requests (provider attribution). |
+| `OPENROUTER_APP_TITLE` | `hugin-orch-v1` | `X-Title` header sent on OpenRouter requests. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,7 @@ hugin/
 │       ├── task-store.ts         # Munin operations: submit / read / two-phase complete
 │       ├── alias-resolution.ts   # Alias → AliasResolved annotation + policy_version
 │       ├── reconciliation.ts     # Periodic sweep: backfill journal events for orch-v1 tasks
+│       ├── orch-worker.ts        # Poll loop: claims orch-v1 pending tasks → OpenRouter executor → two-phase complete
 │       └── types.ts              # Zod schemas for the wire contract
 ├── tests/                        # 19 test files mirroring src/
 ├── docs/                         # Engineering plans, evaluations, security docs
@@ -221,3 +222,6 @@ Security assessments, threat models, and audit reports live in `docs/security/`.
 | `HUGIN_BROKER_KEYS` | — | Inline JSON keystore: `{"<principal>": "<token>"}`. Setting either this or `HUGIN_BROKER_KEYS_FILE` enables the broker. |
 | `HUGIN_BROKER_KEYS_FILE` | — | Path to a JSON keystore file for the broker. Takes precedence over `HUGIN_BROKER_KEYS`. |
 | `HUGIN_BROKER_RECONCILIATION_INTERVAL_MS` | `60000` | Interval between reconciliation sweeps (backfills journal events for orch-v1 tasks visible in Munin). |
+| `OPENROUTER_API_KEY` | — | Enables the orch-v1 OpenRouter worker (Step 5b). Required to actually execute one-shot delegations; without it the broker still accepts submissions but tasks stay `pending`. |
+| `OPENROUTER_REFERER` | `https://hugin.local` | `HTTP-Referer` header value sent to OpenRouter (used for ranking/attribution). |
+| `OPENROUTER_APP_TITLE` | `hugin-orch-v1` | `X-Title` header value sent to OpenRouter. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,8 @@ npm run build
 npm test
 ```
 
+For substantive code changes, default to red/green TDD: write the failing test first, confirm it fails, then implement until it passes. Skip for refactors with no behavior change, config tweaks, and trivial fixes.
+
 ## How to run locally
 
 ```bash

--- a/src/broker/handlers.ts
+++ b/src/broker/handlers.ts
@@ -238,18 +238,18 @@ export function createAwaitHandler(deps: BrokerHandlerDependencies) {
       return;
     }
 
+    const lease = readLeaseInfo(status.tags, status.updated_at);
+    const nowMs = nowFn(deps)().getTime();
+    const orphanSuspected =
+      lease.lease_expires_at !== null &&
+      Date.parse(lease.lease_expires_at) < nowMs;
     res.status(200).json({
       status: "running",
-      lease: emptyLeaseInfo(),
-      orphan_suspected: false,
+      lease,
+      orphan_suspected: orphanSuspected,
     });
   };
 }
-
-// Lease metadata stays empty until the orch-v1 executor lands (Step 5).
-// Once an executor claims a task it will populate `claimed_by`, lease
-// expiry, and heartbeat — at that point this handler will compute
-// `running` vs `stale` from the expiry timestamp.
 
 export function createRateHandler(deps: BrokerHandlerDependencies) {
   return async (req: AuthenticatedRequest, res: Response): Promise<void> => {
@@ -373,11 +373,43 @@ function pickLifecycleTag(tags: string[]): string | undefined {
   return undefined;
 }
 
-function emptyLeaseInfo() {
+interface LeaseInfo {
+  claimed_by: string | null;
+  claimed_at: string | null;
+  lease_expires_at: string | null;
+  last_heartbeat_at: string | null;
+  queue_depth_when_submitted: number;
+}
+
+/**
+ * Reconstruct lease metadata from the status entry's tags. The orch-v1
+ * worker writes `claimed_by:<id>` and `lease_expires:<epoch-ms>` on
+ * every CAS claim (see src/broker/orch-worker.ts:buildClaimTags). The
+ * status entry's `updated_at` is the most reliable proxy for
+ * `claimed_at` since the claim is the most recent write that touched it.
+ *
+ * Tasks still in `pending` (no lease yet) return all-null fields.
+ * Heartbeat is not yet tracked for one-shot openrouter calls; that
+ * field stays null until a long-running runtime needs it.
+ */
+function readLeaseInfo(tags: string[], updatedAt: string): LeaseInfo {
+  const claimedByTag = tags.find((t) => t.startsWith("claimed_by:"));
+  const leaseExpiresTag = tags.find((t) => t.startsWith("lease_expires:"));
+  const claimedBy = claimedByTag
+    ? claimedByTag.slice("claimed_by:".length)
+    : null;
+  let leaseExpiresAt: string | null = null;
+  if (leaseExpiresTag) {
+    const raw = leaseExpiresTag.slice("lease_expires:".length);
+    const ms = /^\d+$/.test(raw) ? Number(raw) : Date.parse(raw);
+    if (!Number.isNaN(ms)) {
+      leaseExpiresAt = new Date(ms).toISOString();
+    }
+  }
   return {
-    claimed_by: null,
-    claimed_at: null,
-    lease_expires_at: null,
+    claimed_by: claimedBy,
+    claimed_at: claimedBy ? updatedAt : null,
+    lease_expires_at: leaseExpiresAt,
     last_heartbeat_at: null,
     queue_depth_when_submitted: 0,
   };

--- a/src/broker/orch-worker.ts
+++ b/src/broker/orch-worker.ts
@@ -1,0 +1,379 @@
+/**
+ * Orchestrator-v1 worker (§12.2 → §12.3).
+ *
+ * Polls Munin for pending orch-v1 tasks, claims one at a time via a
+ * CAS lease, hands the envelope to the OpenRouter executor, and writes
+ * the result through the two-phase complete in `BrokerTaskStore`.
+ *
+ * Scope (Step 5b):
+ *   - One task per worker tick. No parallelism. Multiple workers can
+ *     run side-by-side because the claim is CAS-guarded by the status
+ *     entry's `updated_at`.
+ *   - Only handles `runtime: openrouter`, `family: one-shot`. Tasks
+ *     resolved to other runtimes are left in `pending` for a future
+ *     pi-harness worker (Step 5b/pi-harness).
+ *   - Lease metadata uses the same `claimed_by:<id>` / `lease_expires:<ms>`
+ *     tags as the legacy dispatcher so the existing reaper can recover
+ *     orphaned orch-v1 tasks.
+ *
+ * Out of scope:
+ *   - Lease renewal / heartbeat. One-shot OpenRouter calls are bounded
+ *     by `timeout_ms` (default 300s), well under a fresh lease window.
+ *   - Retry / queue-back. The journal carries `retryable: true` for
+ *     callers that want to resubmit, but the worker itself does not
+ *     re-enqueue.
+ *   - Pi-harness execution. That is Step 5b/pi-harness — separate
+ *     executor, separate worker.
+ */
+
+import type { MuninClient, MuninEntry } from "../munin-client.js";
+import type {
+  DelegationResult,
+  ScannerPolicy,
+} from "../finalize-delegated-output.js";
+import type { OpenRouterClient } from "../openrouter-client.js";
+import { executeOpenRouterDelegation } from "./openrouter-executor.js";
+import type { DelegationJournal } from "./journal.js";
+import {
+  BrokerTaskStore,
+  ORCH_V1_TAG,
+  RESULT_ERROR_KEY,
+  STATUS_KEY,
+  flipLifecycleTags,
+} from "./task-store.js";
+import {
+  delegationEnvelopeSchema,
+  type DelegationEnvelope,
+  type DelegationError,
+} from "./types.js";
+
+export const DEFAULT_POLL_INTERVAL_MS = 30_000;
+export const DEFAULT_LEASE_DURATION_MS = 600_000; // 10 min — covers the 5-min one-shot timeout + buffer.
+
+export interface OrchWorkerConfig {
+  munin: MuninClient;
+  taskStore: BrokerTaskStore;
+  journal: DelegationJournal;
+  openrouterClient: OpenRouterClient;
+  scannerPolicy?: ScannerPolicy;
+  workerId: string;
+  pollIntervalMs?: number;
+  leaseDurationMs?: number;
+  now?: () => Date;
+}
+
+export interface OrchWorkerTick {
+  startedAt: string;
+  finishedAt: string;
+  task_id?: string;
+  outcome: "idle" | "claimed_lost" | "completed" | "failed" | "skipped" | "error";
+  message?: string;
+}
+
+interface PendingCandidate {
+  task_id: string;
+  namespace: string;
+  status: MuninEntry;
+}
+
+export class OrchWorker {
+  private timer: NodeJS.Timeout | null = null;
+  private running = false;
+  private readonly pollIntervalMs: number;
+  private readonly leaseDurationMs: number;
+  private readonly now: () => Date;
+
+  constructor(private readonly config: OrchWorkerConfig) {
+    this.pollIntervalMs = config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.leaseDurationMs = config.leaseDurationMs ?? DEFAULT_LEASE_DURATION_MS;
+    this.now = config.now ?? (() => new Date());
+  }
+
+  start(): void {
+    if (this.timer) return;
+    const tick = (): void => {
+      void this.runOnce().catch((err) => {
+        console.error(
+          `[orch-worker] tick failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+    };
+    this.timer = setInterval(tick, this.pollIntervalMs);
+    // Fire immediately so a freshly-submitted task is not stuck waiting
+    // a full poll interval.
+    tick();
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  async runOnce(): Promise<OrchWorkerTick> {
+    if (this.running) {
+      return mkTick(this.now(), this.now(), {
+        outcome: "skipped",
+        message: "tick already running",
+      });
+    }
+    this.running = true;
+    const startedAt = this.now();
+    try {
+      const candidate = await this.pickPending();
+      if (!candidate) {
+        return mkTick(startedAt, this.now(), { outcome: "idle" });
+      }
+
+      let envelope: DelegationEnvelope;
+      try {
+        envelope = delegationEnvelopeSchema.parse(JSON.parse(candidate.status.content));
+      } catch (err) {
+        return await this.failUnparseable(candidate, err, startedAt);
+      }
+
+      if (!this.canHandle(envelope)) {
+        return mkTick(startedAt, this.now(), {
+          task_id: candidate.task_id,
+          outcome: "skipped",
+          message: `runtime=${envelope.alias_resolved.runtime} family=${envelope.alias_resolved.family} not handled by this worker`,
+        });
+      }
+
+      const claimed = await this.claim(candidate);
+      if (!claimed) {
+        return mkTick(startedAt, this.now(), {
+          task_id: candidate.task_id,
+          outcome: "claimed_lost",
+          message: "another worker beat us to the CAS",
+        });
+      }
+
+      const outcome = await executeOpenRouterDelegation(envelope, {
+        client: this.config.openrouterClient,
+        scannerPolicy: this.config.scannerPolicy,
+        now: () => this.now().getTime(),
+      });
+
+      // Re-read status so the two-phase complete CAS sees the current
+      // updated_at after our claim write landed.
+      const claimedStatus = await this.config.taskStore.readStatus(candidate.task_id);
+      if (!claimedStatus) {
+        return mkTick(startedAt, this.now(), {
+          task_id: candidate.task_id,
+          outcome: "error",
+          message: "status entry vanished between claim and complete",
+        });
+      }
+
+      if (outcome.ok) {
+        await this.config.taskStore.completeSuccess(
+          candidate.task_id,
+          outcome.result as unknown as Parameters<BrokerTaskStore["completeSuccess"]>[1],
+          claimedStatus,
+        );
+        await this.appendCompleted(envelope, outcome.result);
+        return mkTick(startedAt, this.now(), {
+          task_id: candidate.task_id,
+          outcome: "completed",
+        });
+      }
+
+      await this.config.taskStore.completeFailure(
+        candidate.task_id,
+        outcome.error,
+        claimedStatus,
+      );
+      await this.appendCompleted(envelope, undefined, outcome.error);
+      return mkTick(startedAt, this.now(), {
+        task_id: candidate.task_id,
+        outcome: "failed",
+        message: outcome.error.message,
+      });
+    } finally {
+      this.running = false;
+    }
+  }
+
+  private async pickPending(): Promise<PendingCandidate | undefined> {
+    const { results } = await this.config.munin.query({
+      query: "task",
+      tags: ["pending", ORCH_V1_TAG],
+      namespace: "tasks/",
+      entry_type: "state",
+      limit: 50,
+    });
+    const statusRows = results
+      .filter((r) => r.key === STATUS_KEY)
+      .sort((a, b) => a.created_at.localeCompare(b.created_at));
+    for (const row of statusRows) {
+      const taskId = row.namespace.replace(/^tasks\//, "");
+      const status = await this.config.taskStore.readStatus(taskId);
+      if (!status) continue;
+      // The query is eventually-consistent; another worker may already
+      // have flipped this past `pending`.
+      if (pickLifecycleTag(status.tags) !== "pending") continue;
+      return { task_id: taskId, namespace: row.namespace, status };
+    }
+    return undefined;
+  }
+
+  private canHandle(envelope: DelegationEnvelope): boolean {
+    return (
+      envelope.alias_resolved.runtime === "openrouter" &&
+      envelope.alias_resolved.family === "one-shot"
+    );
+  }
+
+  private async claim(candidate: PendingCandidate): Promise<boolean> {
+    const claimTags = buildClaimTags(
+      candidate.status.tags,
+      this.config.workerId,
+      this.now().getTime() + this.leaseDurationMs,
+    );
+    try {
+      await this.config.munin.write(
+        candidate.namespace,
+        STATUS_KEY,
+        candidate.status.content,
+        claimTags,
+        candidate.status.updated_at,
+        "internal",
+      );
+      return true;
+    } catch (err) {
+      // Munin reports CAS conflicts as generic write rejections — we
+      // can't distinguish "lost race" from other failures here. Treat
+      // any failure as "skip and retry on next tick"; the lease reaper
+      // catches genuinely stuck tasks.
+      console.info(
+        `[orch-worker] claim failed for ${candidate.task_id}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return false;
+    }
+  }
+
+  private async failUnparseable(
+    candidate: PendingCandidate,
+    err: unknown,
+    startedAt: Date,
+  ): Promise<OrchWorkerTick> {
+    const message = `stored envelope is not parseable: ${err instanceof Error ? err.message : String(err)}`;
+    const error: DelegationError = {
+      task_id: candidate.task_id,
+      kind: "internal",
+      message,
+      retryable: false,
+    };
+    try {
+      await this.config.munin.write(
+        candidate.namespace,
+        RESULT_ERROR_KEY,
+        JSON.stringify(error),
+        [ORCH_V1_TAG, "result-error"],
+        undefined,
+        "internal",
+      );
+      const newTags = flipLifecycleTags(candidate.status.tags, "failed");
+      await this.config.munin.write(
+        candidate.namespace,
+        STATUS_KEY,
+        candidate.status.content,
+        newTags,
+        candidate.status.updated_at,
+        "internal",
+      );
+    } catch (writeErr) {
+      console.warn(
+        `[orch-worker] failed to flip ${candidate.task_id} to failed after parse error: ${writeErr instanceof Error ? writeErr.message : String(writeErr)}`,
+      );
+    }
+    return mkTick(startedAt, this.now(), {
+      task_id: candidate.task_id,
+      outcome: "error",
+      message,
+    });
+  }
+
+  private async appendCompleted(
+    envelope: DelegationEnvelope,
+    result?: DelegationResult,
+    error?: DelegationError,
+  ): Promise<void> {
+    try {
+      await this.config.journal.append({
+        event_schema_version: 1,
+        event_type: "delegation_completed",
+        event_ts: this.now().toISOString(),
+        task_id: envelope.task_id,
+        outcome: result ? "completed" : "failed",
+        output: result?.output,
+        output_chars: result?.output?.length,
+        prompt_tokens: result?.prompt_tokens,
+        completion_tokens: result?.completion_tokens,
+        total_tokens: result?.total_tokens,
+        duration_s: result?.duration_s,
+        cost_usd: result?.cost_usd,
+        model_effective: result?.model_effective ?? envelope.alias_resolved.model_requested,
+        runtime_effective: result?.runtime_effective ?? envelope.alias_resolved.runtime,
+        runtime_row_id_effective:
+          result?.runtime_row_id_effective ?? envelope.alias_resolved.runtime_row_id,
+        host_effective: result?.host_effective ?? envelope.alias_resolved.host,
+        scanner_pass: result?.provenance?.scanner_pass,
+        error_kind: error?.kind,
+        error_message: error?.message,
+      });
+    } catch (err) {
+      console.warn(
+        `[orch-worker] journal append failed for ${envelope.task_id}; reconciliation will backfill: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}
+
+function mkTick(
+  startedAt: Date,
+  finishedAt: Date,
+  body: Omit<OrchWorkerTick, "startedAt" | "finishedAt">,
+): OrchWorkerTick {
+  return {
+    startedAt: startedAt.toISOString(),
+    finishedAt: finishedAt.toISOString(),
+    ...body,
+  };
+}
+
+function pickLifecycleTag(tags: string[]): string | undefined {
+  for (const tag of ["completed", "failed", "running", "pending"]) {
+    if (tags.includes(tag)) return tag;
+  }
+  return undefined;
+}
+
+/**
+ * Strip the old lifecycle tag and any prior lease metadata, then add
+ * `running` plus fresh `claimed_by:` / `lease_expires:` tags. The
+ * existing lease reaper (src/index.ts) parses the same tag format.
+ */
+export function buildClaimTags(
+  currentTags: string[],
+  workerId: string,
+  leaseExpiresAtMs: number,
+): string[] {
+  const filtered = currentTags.filter(
+    (t) =>
+      t !== "pending" &&
+      t !== "running" &&
+      t !== "completed" &&
+      t !== "failed" &&
+      !t.startsWith("claimed_by:") &&
+      !t.startsWith("lease_expires:"),
+  );
+  return [
+    "running",
+    ...filtered,
+    `claimed_by:${workerId}`,
+    `lease_expires:${leaseExpiresAtMs}`,
+  ];
+}

--- a/src/broker/orch-worker.ts
+++ b/src/broker/orch-worker.ts
@@ -32,7 +32,10 @@ import type {
   ScannerPolicy,
 } from "../finalize-delegated-output.js";
 import type { OpenRouterClient } from "../openrouter-client.js";
-import { executeOpenRouterDelegation } from "./openrouter-executor.js";
+import {
+  ONE_SHOT_DEFAULT_TIMEOUT_MS,
+  executeOpenRouterDelegation,
+} from "./openrouter-executor.js";
 import type { DelegationJournal } from "./journal.js";
 import {
   BrokerTaskStore,
@@ -48,7 +51,13 @@ import {
 } from "./types.js";
 
 export const DEFAULT_POLL_INTERVAL_MS = 30_000;
-export const DEFAULT_LEASE_DURATION_MS = 600_000; // 10 min — covers the 5-min one-shot timeout + buffer.
+/**
+ * Buffer added to the envelope's `timeout_ms` when computing the lease
+ * window. A lease must outlive the executor call by enough margin to
+ * cover the two-phase complete writes; otherwise the reaper could
+ * recover a task that is still running.
+ */
+export const LEASE_BUFFER_MS = 60_000;
 
 export interface OrchWorkerConfig {
   munin: MuninClient;
@@ -58,6 +67,10 @@ export interface OrchWorkerConfig {
   scannerPolicy?: ScannerPolicy;
   workerId: string;
   pollIntervalMs?: number;
+  /**
+   * Override the lease window. When omitted, the worker derives the
+   * lease from the envelope's `timeout_ms` plus `LEASE_BUFFER_MS`.
+   */
   leaseDurationMs?: number;
   now?: () => Date;
 }
@@ -76,16 +89,22 @@ interface PendingCandidate {
   status: MuninEntry;
 }
 
+interface PickResult {
+  candidate: PendingCandidate;
+  envelope?: DelegationEnvelope;
+  parseError?: unknown;
+}
+
 export class OrchWorker {
   private timer: NodeJS.Timeout | null = null;
   private running = false;
   private readonly pollIntervalMs: number;
-  private readonly leaseDurationMs: number;
+  private readonly leaseDurationOverrideMs: number | undefined;
   private readonly now: () => Date;
 
   constructor(private readonly config: OrchWorkerConfig) {
     this.pollIntervalMs = config.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
-    this.leaseDurationMs = config.leaseDurationMs ?? DEFAULT_LEASE_DURATION_MS;
+    this.leaseDurationOverrideMs = config.leaseDurationMs;
     this.now = config.now ?? (() => new Date());
   }
 
@@ -121,32 +140,35 @@ export class OrchWorker {
     this.running = true;
     const startedAt = this.now();
     try {
-      const candidate = await this.pickPending();
-      if (!candidate) {
+      const picked = await this.pickPending();
+      if (!picked) {
         return mkTick(startedAt, this.now(), { outcome: "idle" });
       }
 
-      let envelope: DelegationEnvelope;
-      try {
-        envelope = delegationEnvelopeSchema.parse(JSON.parse(candidate.status.content));
-      } catch (err) {
-        return await this.failUnparseable(candidate, err, startedAt);
+      if (picked.parseError) {
+        return await this.failUnparseable(picked.candidate, picked.parseError, startedAt);
       }
 
-      if (!this.canHandle(envelope)) {
-        return mkTick(startedAt, this.now(), {
-          task_id: candidate.task_id,
-          outcome: "skipped",
-          message: `runtime=${envelope.alias_resolved.runtime} family=${envelope.alias_resolved.family} not handled by this worker`,
-        });
-      }
+      // pickPending only returns rows where canHandle(envelope) is true
+      // (or rows that failed to parse, handled above). Anything that is
+      // for a different runtime/family is left in `pending` for whichever
+      // worker handles it.
+      const envelope = picked.envelope!;
+      const candidate = picked.candidate;
 
-      const claimed = await this.claim(candidate);
-      if (!claimed) {
+      const claim = await this.claim(candidate, envelope);
+      if (claim.kind === "lost") {
         return mkTick(startedAt, this.now(), {
           task_id: candidate.task_id,
           outcome: "claimed_lost",
           message: "another worker beat us to the CAS",
+        });
+      }
+      if (claim.kind === "error") {
+        return mkTick(startedAt, this.now(), {
+          task_id: candidate.task_id,
+          outcome: "error",
+          message: `claim write failed (non-CAS): ${claim.message}`,
         });
       }
 
@@ -196,7 +218,15 @@ export class OrchWorker {
     }
   }
 
-  private async pickPending(): Promise<PendingCandidate | undefined> {
+  /**
+   * Walk the FIFO-ordered pending queue, parsing each envelope and
+   * returning the first one this worker can handle. Rows for runtimes
+   * or families this worker does not handle are skipped — leaving them
+   * in `pending` for whichever worker (e.g. pi-harness) does. Rows that
+   * fail to parse are returned immediately so the worker can flip them
+   * to `failed` rather than letting them block the queue.
+   */
+  private async pickPending(): Promise<PickResult | undefined> {
     const { results } = await this.config.munin.query({
       query: "task",
       tags: ["pending", ORCH_V1_TAG],
@@ -214,7 +244,19 @@ export class OrchWorker {
       // The query is eventually-consistent; another worker may already
       // have flipped this past `pending`.
       if (pickLifecycleTag(status.tags) !== "pending") continue;
-      return { task_id: taskId, namespace: row.namespace, status };
+      const candidate: PendingCandidate = {
+        task_id: taskId,
+        namespace: row.namespace,
+        status,
+      };
+      let envelope: DelegationEnvelope;
+      try {
+        envelope = delegationEnvelopeSchema.parse(JSON.parse(status.content));
+      } catch (parseError) {
+        return { candidate, parseError };
+      }
+      if (!this.canHandle(envelope)) continue;
+      return { candidate, envelope };
     }
     return undefined;
   }
@@ -226,11 +268,26 @@ export class OrchWorker {
     );
   }
 
-  private async claim(candidate: PendingCandidate): Promise<boolean> {
+  private leaseDurationFor(envelope: DelegationEnvelope): number {
+    if (this.leaseDurationOverrideMs !== undefined) {
+      return this.leaseDurationOverrideMs;
+    }
+    const timeout = envelope.timeout_ms ?? ONE_SHOT_DEFAULT_TIMEOUT_MS;
+    return timeout + LEASE_BUFFER_MS;
+  }
+
+  private async claim(
+    candidate: PendingCandidate,
+    envelope: DelegationEnvelope,
+  ): Promise<
+    | { kind: "ok" }
+    | { kind: "lost"; message: string }
+    | { kind: "error"; message: string }
+  > {
     const claimTags = buildClaimTags(
       candidate.status.tags,
       this.config.workerId,
-      this.now().getTime() + this.leaseDurationMs,
+      this.now().getTime() + this.leaseDurationFor(envelope),
     );
     try {
       await this.config.munin.write(
@@ -241,16 +298,20 @@ export class OrchWorker {
         candidate.status.updated_at,
         "internal",
       );
-      return true;
+      return { kind: "ok" };
     } catch (err) {
-      // Munin reports CAS conflicts as generic write rejections — we
-      // can't distinguish "lost race" from other failures here. Treat
-      // any failure as "skip and retry on next tick"; the lease reaper
-      // catches genuinely stuck tasks.
-      console.info(
-        `[orch-worker] claim failed for ${candidate.task_id}: ${err instanceof Error ? err.message : String(err)}`,
+      const message = err instanceof Error ? err.message : String(err);
+      if (isCasConflict(message)) {
+        console.info(`[orch-worker] CAS conflict on ${candidate.task_id}: ${message}`);
+        return { kind: "lost", message };
+      }
+      // Non-CAS failure (auth, network, 5xx) — surface as `error` so
+      // operators see infrastructure problems rather than misreading
+      // them as benign "lost the race" outcomes.
+      console.warn(
+        `[orch-worker] claim write failed for ${candidate.task_id} (non-CAS): ${message}`,
       );
-      return false;
+      return { kind: "error", message };
     }
   }
 
@@ -349,6 +410,16 @@ function pickLifecycleTag(tags: string[]): string | undefined {
     if (tags.includes(tag)) return tag;
   }
   return undefined;
+}
+
+/**
+ * Distinguish a Munin CAS conflict (another writer beat us) from any
+ * other write failure (auth, network, 5xx). Munin surfaces CAS
+ * conflicts via the `cas_conflict` error code in the rejection
+ * message — see `MuninClient.write` in src/munin-client.ts.
+ */
+function isCasConflict(message: string): boolean {
+  return /cas_conflict/i.test(message);
 }
 
 /**

--- a/src/broker/reconciliation.ts
+++ b/src/broker/reconciliation.ts
@@ -21,10 +21,10 @@
  * those cases are wired but only fire when leases exist.
  */
 
-import type { DelegationJournal } from "./journal.js";
+import type { DelegationCompletedEvent, DelegationJournal } from "./journal.js";
 import { projectDelegations } from "./journal.js";
 import type { BrokerTaskStore } from "./task-store.js";
-import type { DelegationEnvelope } from "./types.js";
+import type { DelegationEnvelope, DelegationError } from "./types.js";
 import { delegationEnvelopeSchema } from "./types.js";
 import { hashPayload } from "./idempotency.js";
 
@@ -97,7 +97,8 @@ export class BrokerReconciler {
       const events = await this.config.journal.readAll();
       const projection = projectDelegations(events);
       const inFlight = await this.config.taskStore.listInFlight();
-      stats.scanned = inFlight.length;
+      const terminal = await this.config.taskStore.listTerminal();
+      stats.scanned = inFlight.length + terminal.length;
 
       for (const task of inFlight) {
         const taskId = extractTaskId(task.namespace);
@@ -113,11 +114,135 @@ export class BrokerReconciler {
           }
         }
       }
+
+      for (const task of terminal) {
+        const taskId = extractTaskId(task.namespace);
+        const row = projection.get(taskId);
+        // Backfill submitted if we have no record at all (terminal task
+        // whose submitted event also went missing).
+        if (!row) {
+          try {
+            await this.backfillSubmitted(taskId);
+            stats.submittedBackfilled++;
+          } catch (err) {
+            stats.errors++;
+            console.warn(
+              `[broker-reconciler] backfill submitted failed for ${taskId}: ${err instanceof Error ? err.message : String(err)}`,
+            );
+            continue;
+          }
+        }
+        if (!row?.outcome) {
+          try {
+            await this.backfillCompleted(taskId, task.tags);
+            stats.completedBackfilled++;
+          } catch (err) {
+            stats.errors++;
+            console.warn(
+              `[broker-reconciler] backfill completed failed for ${taskId}: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        }
+      }
     } finally {
       stats.finishedAt = this.now().toISOString();
       this.running = false;
     }
     return stats;
+  }
+
+  /**
+   * Append a `delegation_completed` event for a terminal task that is
+   * missing one. Pulls telemetry from the persisted result key
+   * (`result-structured` for completed tasks, `result-error` for failed
+   * ones) so the event reflects what actually happened, not just the
+   * status flip. The status entry's `updated_at` is the most reliable
+   * proxy for `event_ts` since the flip is the most recent write.
+   */
+  private async backfillCompleted(taskId: string, tags: string[]): Promise<void> {
+    const status = await this.config.taskStore.readStatus(taskId);
+    if (!status) return;
+    let envelope: DelegationEnvelope | undefined;
+    try {
+      envelope = delegationEnvelopeSchema.parse(JSON.parse(status.content));
+    } catch {
+      // Status couldn't be parsed — fall through; we still emit a
+      // best-effort event with the runtime/host inferred from tags
+      // where possible. This is rare and indicates upstream corruption.
+    }
+    const isCompleted = tags.includes("completed");
+    const isFailed = tags.includes("failed");
+    if (!isCompleted && !isFailed) return;
+
+    const event: DelegationCompletedEvent = {
+      event_schema_version: 1,
+      event_type: "delegation_completed",
+      event_ts: status.updated_at,
+      task_id: taskId,
+      outcome: isCompleted ? "completed" : "failed",
+    };
+
+    if (envelope) {
+      event.model_effective = envelope.alias_resolved.model_requested;
+      event.runtime_effective = envelope.alias_resolved.runtime;
+      event.runtime_row_id_effective = envelope.alias_resolved.runtime_row_id;
+      event.host_effective = envelope.alias_resolved.host;
+    }
+
+    if (isCompleted) {
+      const result = await this.config.taskStore.readStructuredResult(taskId);
+      if (result) {
+        try {
+          const parsed = JSON.parse(result.content) as Record<string, unknown> & {
+            output?: string;
+            prompt_tokens?: number;
+            completion_tokens?: number;
+            total_tokens?: number;
+            duration_s?: number;
+            cost_usd?: number;
+            model_effective?: string;
+            runtime_effective?: string;
+            runtime_row_id_effective?: string;
+            host_effective?: string;
+            provenance?: { scanner_pass?: DelegationCompletedEvent["scanner_pass"] };
+          };
+          if (typeof parsed.output === "string") {
+            event.output = parsed.output;
+            event.output_chars = parsed.output.length;
+          }
+          event.prompt_tokens = parsed.prompt_tokens;
+          event.completion_tokens = parsed.completion_tokens;
+          event.total_tokens = parsed.total_tokens;
+          event.duration_s = parsed.duration_s;
+          event.cost_usd = parsed.cost_usd;
+          if (parsed.model_effective) event.model_effective = parsed.model_effective;
+          if (parsed.runtime_effective) event.runtime_effective = parsed.runtime_effective;
+          if (parsed.runtime_row_id_effective)
+            event.runtime_row_id_effective = parsed.runtime_row_id_effective;
+          if (parsed.host_effective) event.host_effective = parsed.host_effective;
+          event.scanner_pass = parsed.provenance?.scanner_pass;
+        } catch (err) {
+          console.warn(
+            `[broker-reconciler] result-structured for ${taskId} did not parse as JSON: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+    } else {
+      const stored = await this.config.taskStore.readErrorResult(taskId);
+      if (stored) {
+        try {
+          const parsed = JSON.parse(stored.content) as DelegationError;
+          event.error_kind = parsed.kind;
+          event.error_message = parsed.message;
+        } catch (err) {
+          console.warn(
+            `[broker-reconciler] result-error for ${taskId} did not parse as JSON: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+    }
+
+    await this.config.journal.append(event);
   }
 
   private async backfillSubmitted(taskId: string): Promise<void> {

--- a/src/broker/task-store.ts
+++ b/src/broker/task-store.ts
@@ -150,8 +150,24 @@ export class BrokerTaskStore {
    * Used by the reconciliation sweep.
    */
   async listInFlight(): Promise<{ namespace: string; tags: string[] }[]> {
+    return this.listByLifecycle(["pending", "running"]);
+  }
+
+  /**
+   * Find every orch-v1 task in a terminal lifecycle (`completed` or
+   * `failed`). The reconciliation sweep uses this to backfill
+   * `delegation_completed` events when the worker crashed between the
+   * Munin write and the journal append.
+   */
+  async listTerminal(): Promise<{ namespace: string; tags: string[] }[]> {
+    return this.listByLifecycle(["completed", "failed"]);
+  }
+
+  private async listByLifecycle(
+    lifecycleTags: string[],
+  ): Promise<{ namespace: string; tags: string[] }[]> {
     const collected: { namespace: string; tags: string[] }[] = [];
-    for (const tag of ["pending", "running"]) {
+    for (const tag of lifecycleTags) {
       const { results } = await this.munin.query({
         query: "task",
         tags: [tag, ORCH_V1_TAG],

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,8 @@ import { BrokerTaskStore } from "./broker/task-store.js";
 import { DelegationJournal } from "./broker/journal.js";
 import { IdempotencyIndex } from "./broker/idempotency.js";
 import { BrokerReconciler } from "./broker/reconciliation.js";
+import { OrchWorker } from "./broker/orch-worker.js";
+import { OpenRouterClient } from "./openrouter-client.js";
 
 export type ExfilPolicy = "off" | "warn" | "flag" | "redact";
 
@@ -297,6 +299,7 @@ let currentOllamaAbort: AbortController | null = null;
 let server: Server;
 let runningBroker: RunningBroker | null = null;
 let brokerReconciler: BrokerReconciler | null = null;
+let orchWorker: OrchWorker | null = null;
 let leaseRenewalTimer: ReturnType<typeof setInterval> | null = null;
 let cancelWatchTimer: ReturnType<typeof setInterval> | null = null;
 let leaseReaperTimer: ReturnType<typeof setInterval> | null = null;
@@ -3636,6 +3639,7 @@ async function shutdown(signal: string): Promise<void> {
   // Release the port immediately so a replacement instance can start.
   server?.close();
   brokerReconciler?.stop();
+  orchWorker?.stop();
   if (runningBroker) {
     runningBroker.close().catch((err) => {
       console.error(
@@ -3801,6 +3805,31 @@ if (brokerEnv.enabled) {
       console.log(
         `Broker reconciler: every ${config.brokerReconciliationIntervalMs}ms (journal: ${brokerHome})`,
       );
+
+      const orKey = process.env.OPENROUTER_API_KEY?.trim();
+      if (orKey) {
+        const orClient = new OpenRouterClient({
+          apiKey: orKey,
+          referer: process.env.OPENROUTER_REFERER || "https://hugin.local",
+          appTitle: process.env.OPENROUTER_APP_TITLE || "hugin-orch-v1",
+        });
+        orchWorker = new OrchWorker({
+          munin,
+          taskStore,
+          journal,
+          openrouterClient: orClient,
+          workerId: `orch-${workerId}`,
+          pollIntervalMs: config.pollIntervalMs,
+        });
+        orchWorker.start();
+        console.log(
+          `Orch worker (openrouter): polling every ${config.pollIntervalMs}ms`,
+        );
+      } else {
+        console.log(
+          "Orch worker (openrouter): disabled (set OPENROUTER_API_KEY to enable)",
+        );
+      }
     })
     .catch((err) => {
       console.error(

--- a/tests/broker/handlers.test.ts
+++ b/tests/broker/handlers.test.ts
@@ -213,7 +213,7 @@ describe("POST /v1/delegate/await", () => {
     expect(body.status).toBe("unknown");
   });
 
-  it("returns running for a pending task", async () => {
+  it("returns running for a pending task with empty lease info", async () => {
     harness.munin.reads["tasks/t1/status"] = {
       id: "1",
       namespace: "tasks/t1",
@@ -230,6 +230,65 @@ describe("POST /v1/delegate/await", () => {
     });
     const body = await res.json();
     expect(body.status).toBe("running");
+    expect(body.lease.claimed_by).toBeNull();
+    expect(body.lease.lease_expires_at).toBeNull();
+    expect(body.orphan_suspected).toBe(false);
+  });
+
+  it("populates lease info from claimed_by/lease_expires tags on a running task (F4)", async () => {
+    const future = Date.now() + 600_000;
+    harness.munin.reads["tasks/t1/status"] = {
+      id: "1",
+      namespace: "tasks/t1",
+      key: "status",
+      content: "envelope",
+      tags: [
+        "running",
+        ORCH_V1_TAG,
+        "claimed_by:orch-worker-A",
+        `lease_expires:${future}`,
+      ],
+      created_at: "2026-04-26T12:00:00Z",
+      updated_at: "2026-04-26T12:00:01Z",
+    };
+    const res = await fetch(`${harness.url}/v1/delegate/await`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify({ task_id: "t1" }),
+    });
+    const body = await res.json();
+    expect(body.status).toBe("running");
+    expect(body.lease.claimed_by).toBe("orch-worker-A");
+    expect(body.lease.claimed_at).toBe("2026-04-26T12:00:01Z");
+    expect(body.lease.lease_expires_at).toBe(new Date(future).toISOString());
+    expect(body.orphan_suspected).toBe(false);
+  });
+
+  it("flags orphan_suspected when the lease has already expired (F4)", async () => {
+    const past = Date.now() - 600_000;
+    harness.munin.reads["tasks/t1/status"] = {
+      id: "1",
+      namespace: "tasks/t1",
+      key: "status",
+      content: "envelope",
+      tags: [
+        "running",
+        ORCH_V1_TAG,
+        "claimed_by:orch-worker-stale",
+        `lease_expires:${past}`,
+      ],
+      created_at: "2026-04-26T12:00:00Z",
+      updated_at: "2026-04-26T12:00:01Z",
+    };
+    const res = await fetch(`${harness.url}/v1/delegate/await`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify({ task_id: "t1" }),
+    });
+    const body = await res.json();
+    expect(body.status).toBe("running");
+    expect(body.lease.claimed_by).toBe("orch-worker-stale");
+    expect(body.orphan_suspected).toBe(true);
   });
 
   it("returns completed with structured result", async () => {

--- a/tests/broker/orch-worker.test.ts
+++ b/tests/broker/orch-worker.test.ts
@@ -1,0 +1,481 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { OrchWorker, buildClaimTags } from "../../src/broker/orch-worker.js";
+import {
+  BrokerTaskStore,
+  ORCH_V1_TAG,
+  RESULT_ERROR_KEY,
+  RESULT_STRUCTURED_KEY,
+  STATUS_KEY,
+  buildSubmitTags,
+} from "../../src/broker/task-store.js";
+import { DelegationJournal } from "../../src/broker/journal.js";
+import type {
+  DelegationEnvelope,
+  DelegationError,
+} from "../../src/broker/types.js";
+import type { OpenRouterClient } from "../../src/openrouter-client.js";
+import type {
+  MuninClient,
+  MuninEntry,
+  MuninQueryResult,
+} from "../../src/munin-client.js";
+
+interface WriteCall {
+  namespace: string;
+  key: string;
+  content: string;
+  tags?: string[];
+  expectedUpdatedAt?: string;
+  classification?: string;
+}
+
+class FakeMunin {
+  writes: WriteCall[] = [];
+  // Per-key store keyed by `namespace/key` → MuninEntry
+  store = new Map<string, MuninEntry>();
+  // What query() returns; tests set this directly to control selection.
+  queryResults: MuninQueryResult[] = [];
+  // If true, the next write() rejects (simulates CAS conflict).
+  rejectNextWrite: { remaining: number; error: Error } | null = null;
+
+  async write(
+    namespace: string,
+    key: string,
+    content: string,
+    tags?: string[],
+    expectedUpdatedAt?: string,
+    classification?: string,
+  ): Promise<Record<string, unknown>> {
+    if (this.rejectNextWrite && this.rejectNextWrite.remaining > 0) {
+      this.rejectNextWrite.remaining--;
+      throw this.rejectNextWrite.error;
+    }
+    const k = `${namespace}/${key}`;
+    const now = new Date().toISOString();
+    const prior = this.store.get(k);
+    const entry: MuninEntry = {
+      id: prior?.id ?? `id-${k}-${this.writes.length}`,
+      namespace,
+      key,
+      content,
+      tags: tags ?? [],
+      classification,
+      created_at: prior?.created_at ?? now,
+      updated_at: `t${this.writes.length + 1}`,
+    };
+    this.store.set(k, entry);
+    this.writes.push({ namespace, key, content, tags, expectedUpdatedAt, classification });
+    return { ok: true };
+  }
+
+  async read(
+    namespace: string,
+    key: string,
+  ): Promise<(MuninEntry & { found: true }) | null> {
+    const entry = this.store.get(`${namespace}/${key}`);
+    return entry ? ({ ...entry, found: true } as MuninEntry & { found: true }) : null;
+  }
+
+  async query(_opts: {
+    query: string;
+    tags?: string[];
+    namespace?: string;
+    limit?: number;
+    entry_type?: string;
+  }): Promise<{ results: MuninQueryResult[]; total: number }> {
+    return { results: this.queryResults, total: this.queryResults.length };
+  }
+}
+
+function makeEnvelope(taskId: string, overrides: Partial<DelegationEnvelope> = {}): DelegationEnvelope {
+  return {
+    envelope_version: 1,
+    idempotency_key: "11111111-1111-4111-8111-111111111111",
+    orchestrator_session_id: "sess-1",
+    orchestrator_submitter: "claude-code",
+    task_type: "summarize",
+    prompt: "Summarize the README.",
+    alias_requested: "large-reasoning",
+    alias_map_version: 1,
+    task_id: taskId,
+    broker_principal: "claude-code",
+    received_at: "2026-04-26T12:00:00Z",
+    alias_resolved: {
+      alias: "large-reasoning",
+      family: "one-shot",
+      model_requested: "openai/gpt-oss-120b",
+      runtime: "openrouter",
+      runtime_row_id: "openrouter",
+      host: "openrouter",
+      reasoning_level: "medium",
+    },
+    policy_version: "zdr-v1+rlv-v1",
+    ...overrides,
+  };
+}
+
+function seedPendingTask(
+  munin: FakeMunin,
+  envelope: DelegationEnvelope,
+  createdAt: string,
+): MuninQueryResult {
+  const ns = `tasks/${envelope.task_id}`;
+  const tags = buildSubmitTags(envelope);
+  const content = JSON.stringify(envelope);
+  const entry: MuninEntry = {
+    id: `id-${envelope.task_id}`,
+    namespace: ns,
+    key: STATUS_KEY,
+    content,
+    tags,
+    created_at: createdAt,
+    updated_at: createdAt,
+  };
+  munin.store.set(`${ns}/${STATUS_KEY}`, entry);
+  return {
+    id: entry.id,
+    namespace: ns,
+    key: STATUS_KEY,
+    entry_type: "state",
+    content_preview: content.slice(0, 80),
+    tags,
+    created_at: createdAt,
+    updated_at: createdAt,
+  };
+}
+
+function stubClient(
+  handler: (req: { model: string; prompt: string }) => Promise<{
+    output: string;
+    finishReason: string;
+    modelEffective: string;
+    usage: {
+      prompt_tokens?: number;
+      completion_tokens?: number;
+      total_tokens?: number;
+    };
+    raw: unknown;
+  }>,
+): OpenRouterClient {
+  return { chat: handler } as unknown as OpenRouterClient;
+}
+
+let tmpDir: string;
+let journalPath: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(path.join(tmpdir(), "orch-worker-test-"));
+  journalPath = path.join(tmpDir, "events.jsonl");
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("OrchWorker.runOnce", () => {
+  it("returns idle when no pending tasks exist", async () => {
+    const munin = new FakeMunin();
+    const taskStore = new BrokerTaskStore(munin as unknown as MuninClient);
+    const journal = new DelegationJournal({ path: journalPath });
+    const client = stubClient(async () => {
+      throw new Error("should not be called");
+    });
+    const worker = new OrchWorker({
+      munin: munin as unknown as MuninClient,
+      taskStore,
+      journal,
+      openrouterClient: client,
+      workerId: "w1",
+    });
+
+    const tick = await worker.runOnce();
+    expect(tick.outcome).toBe("idle");
+    expect(munin.writes.length).toBe(0);
+  });
+
+  it("claims a pending openrouter task, executes it, and writes result + status flip", async () => {
+    const munin = new FakeMunin();
+    const env = makeEnvelope("20260426-120000-orch-aaaa1111");
+    const queryRow = seedPendingTask(munin, env, "2026-04-26T12:00:00Z");
+    munin.queryResults = [queryRow];
+
+    const taskStore = new BrokerTaskStore(munin as unknown as MuninClient);
+    const journal = new DelegationJournal({ path: journalPath });
+    const client = stubClient(async (req) => ({
+      output: "the answer",
+      finishReason: "stop",
+      modelEffective: req.model,
+      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+      raw: {},
+    }));
+
+    const worker = new OrchWorker({
+      munin: munin as unknown as MuninClient,
+      taskStore,
+      journal,
+      openrouterClient: client,
+      workerId: "worker-A",
+      now: () => new Date("2026-04-26T12:00:01Z"),
+    });
+
+    const tick = await worker.runOnce();
+    expect(tick.outcome).toBe("completed");
+    expect(tick.task_id).toBe(env.task_id);
+
+    // Three writes expected: claim (running + lease), result-structured, status-flip-completed.
+    const ns = `tasks/${env.task_id}`;
+    const writesForTask = munin.writes.filter((w) => w.namespace === ns);
+    expect(writesForTask.length).toBe(3);
+
+    const claim = writesForTask[0]!;
+    expect(claim.key).toBe(STATUS_KEY);
+    expect(claim.tags).toContain("running");
+    expect(claim.tags).toContain("claimed_by:worker-A");
+    expect(claim.tags?.some((t) => t.startsWith("lease_expires:"))).toBe(true);
+    expect(claim.expectedUpdatedAt).toBe("2026-04-26T12:00:00Z");
+
+    const resultWrite = writesForTask[1]!;
+    expect(resultWrite.key).toBe(RESULT_STRUCTURED_KEY);
+    const parsedResult = JSON.parse(resultWrite.content);
+    expect(parsedResult.output).toBe("the answer");
+    expect(parsedResult.runtime_effective).toBe("openrouter");
+
+    const flip = writesForTask[2]!;
+    expect(flip.key).toBe(STATUS_KEY);
+    expect(flip.tags).toContain("completed");
+    expect(flip.tags).not.toContain("running");
+
+    // Journal got a delegation_completed event with telemetry.
+    const events = await journal.readAll();
+    const completed = events.filter((e) => e.event_type === "delegation_completed");
+    expect(completed.length).toBe(1);
+    const e = completed[0]!;
+    if (e.event_type !== "delegation_completed") throw new Error("type narrow");
+    expect(e.outcome).toBe("completed");
+    expect(e.task_id).toBe(env.task_id);
+    expect(e.total_tokens).toBe(15);
+    expect(e.runtime_effective).toBe("openrouter");
+  });
+
+  it("writes result-error and flips to failed when the executor returns an error", async () => {
+    const munin = new FakeMunin();
+    const env = makeEnvelope("20260426-120000-orch-bbbb2222");
+    munin.queryResults = [seedPendingTask(munin, env, "2026-04-26T12:00:00Z")];
+
+    const taskStore = new BrokerTaskStore(munin as unknown as MuninClient);
+    const journal = new DelegationJournal({ path: journalPath });
+    const client = stubClient(async () => ({
+      output: "",
+      finishReason: "length",
+      modelEffective: "openai/gpt-oss-120b",
+      usage: { prompt_tokens: 8, completion_tokens: 0, total_tokens: 8 },
+      raw: {},
+    }));
+
+    const worker = new OrchWorker({
+      munin: munin as unknown as MuninClient,
+      taskStore,
+      journal,
+      openrouterClient: client,
+      workerId: "worker-A",
+    });
+
+    const tick = await worker.runOnce();
+    expect(tick.outcome).toBe("failed");
+
+    const ns = `tasks/${env.task_id}`;
+    const writesForTask = munin.writes.filter((w) => w.namespace === ns);
+    // claim + result-error + status flip → 3 writes
+    expect(writesForTask.length).toBe(3);
+    expect(writesForTask[1]!.key).toBe(RESULT_ERROR_KEY);
+    const err = JSON.parse(writesForTask[1]!.content) as DelegationError;
+    expect(err.kind).toBe("executor_failed");
+    expect(err.message).toContain("empty completion");
+    expect(writesForTask[2]!.tags).toContain("failed");
+
+    const events = await journal.readAll();
+    const completed = events.find((e) => e.event_type === "delegation_completed");
+    expect(completed).toBeDefined();
+    if (completed?.event_type !== "delegation_completed") throw new Error("type narrow");
+    expect(completed.outcome).toBe("failed");
+    expect(completed.error_kind).toBe("executor_failed");
+  });
+
+  it("skips tasks whose resolved runtime is not openrouter", async () => {
+    const munin = new FakeMunin();
+    const env = makeEnvelope("20260426-120000-orch-cccc3333", {
+      alias_resolved: {
+        alias: "pi-large-coder",
+        family: "harness",
+        harness: "pi",
+        model_requested: "qwen/qwen3-coder-next",
+        runtime: "openrouter",
+        runtime_row_id: "openrouter",
+        host: "openrouter",
+      },
+    });
+    munin.queryResults = [seedPendingTask(munin, env, "2026-04-26T12:00:00Z")];
+
+    const taskStore = new BrokerTaskStore(munin as unknown as MuninClient);
+    const journal = new DelegationJournal({ path: journalPath });
+    let chatCalled = false;
+    const client = stubClient(async () => {
+      chatCalled = true;
+      throw new Error("should not be called");
+    });
+
+    const worker = new OrchWorker({
+      munin: munin as unknown as MuninClient,
+      taskStore,
+      journal,
+      openrouterClient: client,
+      workerId: "w1",
+    });
+
+    const tick = await worker.runOnce();
+    expect(tick.outcome).toBe("skipped");
+    expect(chatCalled).toBe(false);
+    // No writes — task stays pending for a future executor.
+    expect(munin.writes.length).toBe(0);
+  });
+
+  it("returns claimed_lost when the CAS write fails", async () => {
+    const munin = new FakeMunin();
+    const env = makeEnvelope("20260426-120000-orch-dddd4444");
+    munin.queryResults = [seedPendingTask(munin, env, "2026-04-26T12:00:00Z")];
+    munin.rejectNextWrite = {
+      remaining: 1,
+      error: new Error("Munin write rejected for tasks/.../status: cas_conflict — updated_at mismatch"),
+    };
+
+    const taskStore = new BrokerTaskStore(munin as unknown as MuninClient);
+    const journal = new DelegationJournal({ path: journalPath });
+    const client = stubClient(async () => {
+      throw new Error("should not be called");
+    });
+
+    const worker = new OrchWorker({
+      munin: munin as unknown as MuninClient,
+      taskStore,
+      journal,
+      openrouterClient: client,
+      workerId: "w1",
+    });
+
+    const tick = await worker.runOnce();
+    expect(tick.outcome).toBe("claimed_lost");
+  });
+
+  it("flips an unparseable envelope straight to failed without claiming", async () => {
+    const munin = new FakeMunin();
+    const ns = "tasks/20260426-120000-orch-eeee5555";
+    const tags = ["pending", "runtime:openrouter", "alias:large-reasoning", ORCH_V1_TAG];
+    const entry: MuninEntry = {
+      id: "id-bad",
+      namespace: ns,
+      key: STATUS_KEY,
+      content: "{not valid json",
+      tags,
+      created_at: "2026-04-26T12:00:00Z",
+      updated_at: "2026-04-26T12:00:00Z",
+    };
+    munin.store.set(`${ns}/${STATUS_KEY}`, entry);
+    munin.queryResults = [
+      {
+        id: entry.id,
+        namespace: ns,
+        key: STATUS_KEY,
+        entry_type: "state",
+        content_preview: entry.content,
+        tags,
+        created_at: entry.created_at,
+        updated_at: entry.updated_at,
+      },
+    ];
+
+    const taskStore = new BrokerTaskStore(munin as unknown as MuninClient);
+    const journal = new DelegationJournal({ path: journalPath });
+    const client = stubClient(async () => {
+      throw new Error("should not be called");
+    });
+
+    const worker = new OrchWorker({
+      munin: munin as unknown as MuninClient,
+      taskStore,
+      journal,
+      openrouterClient: client,
+      workerId: "w1",
+    });
+
+    const tick = await worker.runOnce();
+    expect(tick.outcome).toBe("error");
+    const writesForTask = munin.writes.filter((w) => w.namespace === ns);
+    // result-error + status-flip-failed (no running claim).
+    expect(writesForTask.length).toBe(2);
+    expect(writesForTask[0]!.key).toBe(RESULT_ERROR_KEY);
+    expect(writesForTask[1]!.tags).toContain("failed");
+  });
+
+  it("picks the FIFO oldest pending task when several are queued", async () => {
+    const munin = new FakeMunin();
+    const env1 = makeEnvelope("20260426-120000-orch-old00001");
+    const env2 = makeEnvelope("20260426-120100-orch-new00002");
+    // Insert in reversed timestamp order to prove sort.
+    munin.queryResults = [
+      seedPendingTask(munin, env2, "2026-04-26T12:01:00Z"),
+      seedPendingTask(munin, env1, "2026-04-26T12:00:00Z"),
+    ];
+
+    const taskStore = new BrokerTaskStore(munin as unknown as MuninClient);
+    const journal = new DelegationJournal({ path: journalPath });
+    const client = stubClient(async (req) => ({
+      output: "ok",
+      finishReason: "stop",
+      modelEffective: req.model,
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      raw: {},
+    }));
+
+    const worker = new OrchWorker({
+      munin: munin as unknown as MuninClient,
+      taskStore,
+      journal,
+      openrouterClient: client,
+      workerId: "w1",
+    });
+
+    const tick = await worker.runOnce();
+    expect(tick.outcome).toBe("completed");
+    expect(tick.task_id).toBe(env1.task_id);
+  });
+});
+
+describe("buildClaimTags", () => {
+  it("strips lifecycle + prior lease tags and adds the new ones", () => {
+    const out = buildClaimTags(
+      [
+        "pending",
+        "runtime:openrouter",
+        "alias:tiny",
+        ORCH_V1_TAG,
+        "claimed_by:old-worker",
+        "lease_expires:1234",
+      ],
+      "new-worker",
+      9999,
+    );
+    expect(out).toContain("running");
+    expect(out).not.toContain("pending");
+    expect(out).toContain("runtime:openrouter");
+    expect(out).toContain("alias:tiny");
+    expect(out).toContain(ORCH_V1_TAG);
+    expect(out).toContain("claimed_by:new-worker");
+    expect(out).toContain("lease_expires:9999");
+    // No leftover prior lease.
+    expect(out).not.toContain("claimed_by:old-worker");
+    expect(out).not.toContain("lease_expires:1234");
+  });
+});

--- a/tests/broker/orch-worker.test.ts
+++ b/tests/broker/orch-worker.test.ts
@@ -304,7 +304,7 @@ describe("OrchWorker.runOnce", () => {
     expect(completed.error_kind).toBe("executor_failed");
   });
 
-  it("skips tasks whose resolved runtime is not openrouter", async () => {
+  it("returns idle (not skipped) when the only pending task is for another worker", async () => {
     const munin = new FakeMunin();
     const env = makeEnvelope("20260426-120000-orch-cccc3333", {
       alias_resolved: {
@@ -336,10 +336,130 @@ describe("OrchWorker.runOnce", () => {
     });
 
     const tick = await worker.runOnce();
-    expect(tick.outcome).toBe("skipped");
+    expect(tick.outcome).toBe("idle");
     expect(chatCalled).toBe(false);
-    // No writes — task stays pending for a future executor.
+    // No writes — task stays pending for the harness worker.
     expect(munin.writes.length).toBe(0);
+  });
+
+  it("scans past unhandleable rows to pick a handleable openrouter task behind them (F1)", async () => {
+    // Older harness task at the front of the queue must not block a
+    // newer openrouter task — otherwise the openrouter worker stalls
+    // until a harness worker drains the harness one.
+    const munin = new FakeMunin();
+    const harness = makeEnvelope("20260426-120000-orch-har00001", {
+      alias_resolved: {
+        alias: "pi-large-coder",
+        family: "harness",
+        harness: "pi",
+        model_requested: "qwen/qwen3-coder-next",
+        runtime: "openrouter",
+        runtime_row_id: "openrouter",
+        host: "openrouter",
+      },
+    });
+    const oneShot = makeEnvelope("20260426-120100-orch-or000002");
+    munin.queryResults = [
+      seedPendingTask(munin, harness, "2026-04-26T12:00:00Z"),
+      seedPendingTask(munin, oneShot, "2026-04-26T12:01:00Z"),
+    ];
+
+    const taskStore = new BrokerTaskStore(munin as unknown as MuninClient);
+    const journal = new DelegationJournal({ path: journalPath });
+    const client = stubClient(async (req) => ({
+      output: "ok",
+      finishReason: "stop",
+      modelEffective: req.model,
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+      raw: {},
+    }));
+
+    const worker = new OrchWorker({
+      munin: munin as unknown as MuninClient,
+      taskStore,
+      journal,
+      openrouterClient: client,
+      workerId: "w1",
+    });
+
+    const tick = await worker.runOnce();
+    expect(tick.outcome).toBe("completed");
+    expect(tick.task_id).toBe(oneShot.task_id);
+    // Harness task untouched.
+    const harnessWrites = munin.writes.filter(
+      (w) => w.namespace === `tasks/${harness.task_id}`,
+    );
+    expect(harnessWrites.length).toBe(0);
+  });
+
+  it("derives the lease window from envelope.timeout_ms when set (F3)", async () => {
+    const munin = new FakeMunin();
+    // Pick a timeout larger than the executor's default (300s) to prove
+    // the worker is using the envelope value, not the default.
+    const env = makeEnvelope("20260426-120000-orch-tmo00001", {
+      timeout_ms: 900_000,
+    });
+    munin.queryResults = [seedPendingTask(munin, env, "2026-04-26T12:00:00Z")];
+
+    const taskStore = new BrokerTaskStore(munin as unknown as MuninClient);
+    const journal = new DelegationJournal({ path: journalPath });
+    const client = stubClient(async (req) => ({
+      output: "ok",
+      finishReason: "stop",
+      modelEffective: req.model,
+      usage: {},
+      raw: {},
+    }));
+
+    const fixedNow = new Date("2026-04-26T12:00:01Z");
+    const worker = new OrchWorker({
+      munin: munin as unknown as MuninClient,
+      taskStore,
+      journal,
+      openrouterClient: client,
+      workerId: "w1",
+      now: () => fixedNow,
+    });
+
+    await worker.runOnce();
+    const claim = munin.writes.find(
+      (w) => w.namespace === `tasks/${env.task_id}` && w.tags?.includes("running"),
+    );
+    expect(claim).toBeDefined();
+    const expiry = claim!.tags!.find((t) => t.startsWith("lease_expires:"));
+    expect(expiry).toBeDefined();
+    const expiryMs = Number(expiry!.slice("lease_expires:".length));
+    // 900s timeout + 60s buffer = 960s after fixedNow.
+    expect(expiryMs).toBe(fixedNow.getTime() + 900_000 + 60_000);
+  });
+
+  it("returns error (not claimed_lost) when the claim write fails for non-CAS reasons (F5)", async () => {
+    const munin = new FakeMunin();
+    const env = makeEnvelope("20260426-120000-orch-net00001");
+    munin.queryResults = [seedPendingTask(munin, env, "2026-04-26T12:00:00Z")];
+    munin.rejectNextWrite = {
+      remaining: 1,
+      error: new Error("Munin write rejected for tasks/.../status: network — connect ECONNREFUSED"),
+    };
+
+    const taskStore = new BrokerTaskStore(munin as unknown as MuninClient);
+    const journal = new DelegationJournal({ path: journalPath });
+    const client = stubClient(async () => {
+      throw new Error("should not be called");
+    });
+
+    const worker = new OrchWorker({
+      munin: munin as unknown as MuninClient,
+      taskStore,
+      journal,
+      openrouterClient: client,
+      workerId: "w1",
+    });
+
+    const tick = await worker.runOnce();
+    expect(tick.outcome).toBe("error");
+    expect(tick.message).toContain("non-CAS");
+    expect(tick.message).toContain("ECONNREFUSED");
   });
 
   it("returns claimed_lost when the CAS write fails", async () => {

--- a/tests/broker/reconciliation.test.ts
+++ b/tests/broker/reconciliation.test.ts
@@ -125,6 +125,124 @@ describe("BrokerReconciler.runOnce", () => {
     expect(stats.submittedBackfilled).toBe(0);
   });
 
+  it("backfills delegation_completed for completed tasks missing the event (F2)", async () => {
+    const munin = new FakeMunin();
+    munin.inflight = [
+      { namespace: "tasks/done1", tags: ["completed", ORCH_V1_TAG] },
+    ];
+    munin.reads["tasks/done1/status"] = {
+      content: JSON.stringify(envelope("done1")),
+      tags: ["completed", ORCH_V1_TAG],
+      created_at: "2026-04-26T12:00:00Z",
+      updated_at: "2026-04-26T12:00:05Z",
+    };
+    munin.reads["tasks/done1/result-structured"] = {
+      content: JSON.stringify({
+        task_id: "done1",
+        result_schema_version: 1,
+        output: "the answer",
+        prompt_tokens: 10,
+        completion_tokens: 5,
+        total_tokens: 15,
+        duration_s: 1.2,
+        cost_usd: 0.0005,
+        model_effective: "qwen2.5:3b",
+        runtime_effective: "ollama",
+        runtime_row_id_effective: "ollama-pi",
+        host_effective: "pi",
+        provenance: { scanner_pass: "clean" },
+      }),
+      tags: [ORCH_V1_TAG, "result-structured"],
+      created_at: "2026-04-26T12:00:04Z",
+      updated_at: "2026-04-26T12:00:04Z",
+    };
+    const journal = new DelegationJournal({ path: path.join(tmpDir, "events.jsonl") });
+    const taskStore = new BrokerTaskStore(munin as unknown as MuninClient);
+    const reconciler = new BrokerReconciler({ taskStore, journal });
+
+    const stats = await reconciler.runOnce();
+    expect(stats.completedBackfilled).toBe(1);
+    expect(stats.submittedBackfilled).toBe(1);
+    const events = await journal.readAll();
+    const completed = events.find((e) => e.event_type === "delegation_completed");
+    expect(completed).toBeDefined();
+    if (completed?.event_type !== "delegation_completed") throw new Error("type narrow");
+    expect(completed.task_id).toBe("done1");
+    expect(completed.outcome).toBe("completed");
+    expect(completed.total_tokens).toBe(15);
+    expect(completed.cost_usd).toBe(0.0005);
+    expect(completed.scanner_pass).toBe("clean");
+    expect(completed.event_ts).toBe("2026-04-26T12:00:05Z");
+  });
+
+  it("backfills delegation_completed for failed tasks with error metadata (F2)", async () => {
+    const munin = new FakeMunin();
+    munin.inflight = [
+      { namespace: "tasks/bad1", tags: ["failed", ORCH_V1_TAG] },
+    ];
+    munin.reads["tasks/bad1/status"] = {
+      content: JSON.stringify(envelope("bad1")),
+      tags: ["failed", ORCH_V1_TAG],
+      created_at: "2026-04-26T12:00:00Z",
+      updated_at: "2026-04-26T12:00:05Z",
+    };
+    munin.reads["tasks/bad1/result-error"] = {
+      content: JSON.stringify({
+        task_id: "bad1",
+        kind: "executor_failed",
+        message: "OpenRouter returned HTTP 503",
+        retryable: true,
+      }),
+      tags: [ORCH_V1_TAG, "result-error"],
+      created_at: "ts",
+      updated_at: "ts",
+    };
+    const journal = new DelegationJournal({ path: path.join(tmpDir, "events.jsonl") });
+    const taskStore = new BrokerTaskStore(munin as unknown as MuninClient);
+    const reconciler = new BrokerReconciler({ taskStore, journal });
+
+    const stats = await reconciler.runOnce();
+    expect(stats.completedBackfilled).toBe(1);
+    const events = await journal.readAll();
+    const completed = events.find((e) => e.event_type === "delegation_completed");
+    expect(completed).toBeDefined();
+    if (completed?.event_type !== "delegation_completed") throw new Error("type narrow");
+    expect(completed.outcome).toBe("failed");
+    expect(completed.error_kind).toBe("executor_failed");
+    expect(completed.error_message).toContain("503");
+  });
+
+  it("does not re-backfill delegation_completed when the journal already has it (F2)", async () => {
+    const munin = new FakeMunin();
+    munin.inflight = [
+      { namespace: "tasks/done1", tags: ["completed", ORCH_V1_TAG] },
+    ];
+    munin.reads["tasks/done1/status"] = {
+      content: JSON.stringify(envelope("done1")),
+      tags: ["completed", ORCH_V1_TAG],
+      created_at: "2026-04-26T12:00:00Z",
+      updated_at: "2026-04-26T12:00:05Z",
+    };
+    munin.reads["tasks/done1/result-structured"] = {
+      content: JSON.stringify({
+        task_id: "done1",
+        result_schema_version: 1,
+        output: "ok",
+      }),
+    };
+    const journal = new DelegationJournal({ path: path.join(tmpDir, "events.jsonl") });
+    const taskStore = new BrokerTaskStore(munin as unknown as MuninClient);
+    const reconciler = new BrokerReconciler({ taskStore, journal });
+
+    await reconciler.runOnce();
+    const stats2 = await reconciler.runOnce();
+    expect(stats2.completedBackfilled).toBe(0);
+    expect(stats2.submittedBackfilled).toBe(0);
+    const events = await journal.readAll();
+    const completed = events.filter((e) => e.event_type === "delegation_completed");
+    expect(completed.length).toBe(1);
+  });
+
   it("counts errors and continues on bad envelopes", async () => {
     const munin = new FakeMunin();
     munin.inflight = [{ namespace: "tasks/bad", tags: ["pending", ORCH_V1_TAG] }];


### PR DESCRIPTION
## Summary

- New `src/broker/orch-worker.ts`: poll loop that claims orch-v1 `pending` tasks via CAS lease, dispatches to `executeOpenRouterDelegation`, and finalizes through the two-phase complete in `BrokerTaskStore`. Emits a `delegation_completed` journal event on every terminal outcome.
- Wires the worker into `src/index.ts` startup behind `OPENROUTER_API_KEY`. Without the key the broker still accepts submissions but tasks stay `pending`.
- Lease tags (`claimed_by:<id>` / `lease_expires:<ms>`) match the legacy dispatcher format so the existing reaper recovers orphaned orch-v1 tasks for free.

## Scope (intentionally narrow)

- One task per worker tick. Multiple workers can run side-by-side because the claim is CAS-guarded by the status entry's `updated_at`.
- Only handles `runtime: openrouter`, `family: one-shot`. Other runtimes left in `pending` for the upcoming pi-harness worker.
- No lease renewal: one-shot calls are bounded by `timeout_ms` (default 300 s), well under the 10-minute lease.
- No retry / queue-back: the journal records `retryable: true` for callers that want to resubmit.

## Test plan

- [x] `npm run build` (TypeScript strict)
- [x] `npm test` — 544 passing (8 new in `tests/broker/orch-worker.test.ts`):
  - idle when no pending
  - happy path: claim → execute → result-structured → status flip → journal `delegation_completed`
  - failure path: `executor_failed` → result-error → status `failed` → journal event with `error_kind`
  - skip when resolved runtime is not openrouter (no writes, task stays pending)
  - CAS loss returns `claimed_lost`
  - unparseable envelope flipped to `failed` without claiming
  - FIFO selection picks the oldest pending
  - `buildClaimTags` strips lifecycle + prior lease tags and emits the new ones
- [ ] End-to-end smoke against a real OpenRouter call once `OPENROUTER_API_KEY` is provisioned on the Pi (Step 8 dogfooding).

## Follow-ups (separate PRs)

- Step 5b/pi-harness: the matching worker for `family: harness` tasks (worktree spawn + diff capture).
- Step 6: `hugin-mcp` server exposing submit/await/rate/list/models to the orchestrator side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)