### PR TITLE
feat: hugin-mcp server (Step 6) — broker tools as MCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,10 @@ hugin/
 │   ├── provenance.ts               # External-vs-trusted provenance detection for context-refs
 │   ├── task-signing.ts             # HMAC-SHA256 task submission signing/verification
 │   ├── munin-client.ts    # HTTP client for Munin JSON-RPC API
+│   ├── mcp-server.ts             # hugin-mcp stdio entrypoint (orchestrator-side, on the laptop)
+│   ├── mcp/                      # hugin-mcp internals (broker client + tool definitions)
+│   │   ├── broker-client.ts      # HTTP client for /v1/delegate/* (bearer auth, AbortController timeout)
+│   │   └── tools.ts              # 5 MCP tools (hugin_submit/await/rate/list/models) with envelope autofill
 │   └── broker/                   # Orchestrator-v1 broker (Tailscale-only HTTP, /v1/delegate/*)
 │       ├── server.ts             # Express app + opt-in startup (HUGIN_BROKER_KEYS)
 │       ├── handlers.ts           # submit/await/rate/list/models endpoint handlers
@@ -180,3 +184,7 @@ MUNIN_API_KEY=<same key Munin uses>
 | `OPENROUTER_API_KEY` | — | OpenRouter API key. When set on a Pi-side broker, the orch-worker is enabled and dispatches `runtime: openrouter, family: one-shot` tasks. |
 | `OPENROUTER_REFERER` | `https://hugin.local` | `HTTP-Referer` header sent on OpenRouter requests (provider attribution). |
 | `OPENROUTER_APP_TITLE` | `hugin-orch-v1` | `X-Title` header sent on OpenRouter requests. |
+| `HUGIN_BROKER_URL` | — | hugin-mcp only (laptop side): URL of the Pi broker, e.g. `http://huginmunin.<tailnet>.ts.net:3033`. |
+| `HUGIN_BROKER_TOKEN` | — | hugin-mcp only: bearer token registered in the Pi's `HUGIN_BROKER_KEYS`. |
+| `HUGIN_MCP_SUBMITTER` | `claude-code` | hugin-mcp only: `orchestrator_submitter` principal stamped on each delegation envelope. |
+| `HUGIN_MCP_REQUEST_TIMEOUT_MS` | `60000` | hugin-mcp only: per-request HTTP timeout against the broker. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,6 +127,10 @@ hugin/
 │   ├── task-status-tags.ts       # Tag manipulation helpers for task lifecycle
 │   ├── task-graph.ts             # Task dependency graph for pipelines
 │   ├── result-format.ts          # Result formatting utilities
+│   ├── mcp-server.ts             # hugin-mcp stdio entrypoint (orchestrator-side, on the laptop)
+│   ├── mcp/                      # hugin-mcp internals (broker client + tool definitions)
+│   │   ├── broker-client.ts      # HTTP client for /v1/delegate/* (bearer auth, AbortController timeout)
+│   │   └── tools.ts              # 5 MCP tools (hugin_submit/await/rate/list/models) with envelope autofill
 │   └── broker/                   # Orchestrator-v1 broker (Tailscale-only HTTP, /v1/delegate/*)
 │       ├── server.ts             # Express app + opt-in startup (HUGIN_BROKER_KEYS)
 │       ├── handlers.ts           # submit/await/rate/list/models endpoint handlers
@@ -195,6 +199,37 @@ Security assessments, threat models, and audit reports live in `docs/security/`.
 - Filename: `<topic>.md` (e.g., `lethal-trifecta-assessment.md`)
 - Open findings should be filed as GitHub Issues, not left as prose in the doc
 - Hugin tasks that produce security reports should commit and push them, not leave them as untracked files
+
+## hugin-mcp (laptop side)
+
+`hugin-mcp` is a stdio MCP server that exposes the Pi-side broker's `/v1/delegate/*` endpoints to a local Claude Code or Claude Desktop session. It runs on the *orchestrator* laptop, not on the Pi.
+
+```
+Claude Code  ⟷  hugin-mcp (stdio)  ⟶  HTTP /v1/delegate/* (Tailscale)  ⟶  Pi broker
+```
+
+**Tools exposed:**
+- `hugin_submit` — submit a delegation task
+- `hugin_await` — read current task state
+- `hugin_rate` — append a rating event for a completed task
+- `hugin_list` — list recent delegated tasks
+- `hugin_models` — read the active alias map and runtime registry
+
+The MCP layer fills in protocol envelope fields (`envelope_version`, `alias_map_version`, `idempotency_key`, `orchestrator_session_id`, `orchestrator_submitter`) so callers only think about the task itself.
+
+**Required env (orchestrator side):**
+- `HUGIN_BROKER_URL` — e.g. `http://huginmunin.<tailnet>.ts.net:3033`
+- `HUGIN_BROKER_TOKEN` — bearer token registered in the Pi's `HUGIN_BROKER_KEYS`
+
+**Optional env:**
+- `HUGIN_MCP_SUBMITTER` — `orchestrator_submitter` principal (default: `claude-code`)
+- `HUGIN_MCP_REQUEST_TIMEOUT_MS` — per-request HTTP timeout (default: `60000`)
+
+**Wire it into Claude Code:**
+```bash
+npm run build  # produces dist/mcp-server.js
+claude mcp add-json hugin '{"command":"node","args":["/Users/magnus/repos/hugin/dist/mcp-server.js"],"env":{"HUGIN_BROKER_URL":"http://huginmunin:3033","HUGIN_BROKER_TOKEN":"..."}}' -s user
+```
 
 ## Environment variables
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.81",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "express": "^5.1.0",
         "zod": "^4.3.6"
       },
@@ -489,6 +490,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@img/sharp-darwin-arm64": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
@@ -799,6 +812,46 @@
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
@@ -1401,6 +1454,39 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1548,6 +1634,37 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/debug": {
@@ -1719,6 +1836,27 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -1771,6 +1909,46 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1939,6 +2117,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -1981,6 +2168,15 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -1996,12 +2192,39 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT"
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/loupe": {
       "version": "3.2.1",
@@ -2109,6 +2332,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -2149,6 +2381,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-to-regexp": {
@@ -2196,6 +2437,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/postcss": {
@@ -2277,6 +2527,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -2406,6 +2665,27 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -2846,6 +3126,21 @@
         }
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -2876,6 +3171,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,10 +3,14 @@
   "version": "0.1.0",
   "description": "Task dispatcher for the Grimnir AI system — polls Munin for tasks, spawns AI runtimes, reports results",
   "type": "module",
+  "bin": {
+    "hugin-mcp": "dist/mcp-server.js"
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
+    "start:mcp": "node dist/mcp-server.js",
     "test": "vitest run",
     "test:watch": "vitest"
   },
@@ -16,6 +20,7 @@
   "license": "MIT",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.81",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "express": "^5.1.0",
     "zod": "^4.3.6"
   },

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -25,7 +25,7 @@ import { randomUUID } from "node:crypto";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { BrokerClient } from "./mcp/broker-client.js";
-import { buildTools, type HuginTool } from "./mcp/tools.js";
+import { ALIAS_MAP_VERSION, buildTools, type HuginTool } from "./mcp/tools.js";
 
 const SERVER_NAME = "hugin-mcp";
 const SERVER_VERSION = "0.1.0";
@@ -37,6 +37,41 @@ function readRequiredEnv(name: string): string {
     process.exit(1);
   }
   return value;
+}
+
+/**
+ * Discover the broker's current `alias_map_version` so submit envelopes
+ * carry the live value instead of a hard-coded constant. The broker
+ * uses this to detect orchestrator skew when it bumps the alias map.
+ *
+ * If `/v1/delegate/models` is unreachable or returns an unexpected
+ * shape, fall back to the compiled-in {@link ALIAS_MAP_VERSION}: this
+ * keeps startup non-blocking on transient network errors, at the cost
+ * of submitting a possibly-stale version (which the broker will
+ * surface as a normal version-skew error on the first submit).
+ */
+async function discoverAliasMapVersion(broker: BrokerClient): Promise<number> {
+  try {
+    const response = await broker.models();
+    if (
+      response &&
+      typeof response === "object" &&
+      "alias_map_version" in response
+    ) {
+      const candidate = (response as { alias_map_version: unknown }).alias_map_version;
+      if (typeof candidate === "number" && Number.isInteger(candidate) && candidate > 0) {
+        return candidate;
+      }
+    }
+    process.stderr.write(
+      `hugin-mcp: /v1/delegate/models did not advertise alias_map_version; using ${ALIAS_MAP_VERSION}\n`,
+    );
+  } catch (err) {
+    process.stderr.write(
+      `hugin-mcp: failed to fetch alias_map_version (${err instanceof Error ? err.message : String(err)}); using ${ALIAS_MAP_VERSION}\n`,
+    );
+  }
+  return ALIAS_MAP_VERSION;
 }
 
 function readOptionalNumber(name: string, fallback: number): number {
@@ -57,10 +92,12 @@ export async function main(): Promise<void> {
   const requestTimeoutMs = readOptionalNumber("HUGIN_MCP_REQUEST_TIMEOUT_MS", 60_000);
 
   const broker = new BrokerClient({ baseUrl, bearerToken, requestTimeoutMs });
+  const aliasMapVersion = await discoverAliasMapVersion(broker);
   const tools = buildTools({
     broker,
     sessionId: randomUUID(),
     submitter,
+    aliasMapVersion,
   });
 
   const server = new McpServer({ name: SERVER_NAME, version: SERVER_VERSION });
@@ -88,12 +125,9 @@ export async function main(): Promise<void> {
   await server.connect(transport);
 }
 
-const isMain = import.meta.url === `file://${process.argv[1]}`;
-if (isMain) {
-  main().catch((err: unknown) => {
-    process.stderr.write(
-      `hugin-mcp fatal: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`,
-    );
-    process.exit(1);
-  });
-}
+main().catch((err: unknown) => {
+  process.stderr.write(
+    `hugin-mcp fatal: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`,
+  );
+  process.exit(1);
+});

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * hugin-mcp — stdio MCP server that exposes the Pi-side broker's
+ * `/v1/delegate/*` endpoints to a local Claude Code or Claude Desktop
+ * session.
+ *
+ * Wiring:
+ *   stdio  ↔  McpServer  ↔  buildTools()  ↔  BrokerClient  ↔  HTTP /v1/delegate
+ *
+ * The MCP layer fills in protocol envelope fields (envelope_version,
+ * alias_map_version, idempotency_key, orchestrator_session_id,
+ * orchestrator_submitter) so the model only has to think about the
+ * task. See `src/mcp/tools.ts`.
+ *
+ * Required env:
+ *   HUGIN_BROKER_URL    — e.g. http://huginmunin.tail-scale.ts.net:3033
+ *   HUGIN_BROKER_TOKEN  — bearer token registered in HUGIN_BROKER_KEYS
+ *
+ * Optional env:
+ *   HUGIN_MCP_SUBMITTER         — orchestrator_submitter principal (default: "claude-code")
+ *   HUGIN_MCP_REQUEST_TIMEOUT_MS — per-request HTTP timeout (default: 60_000)
+ */
+
+import { randomUUID } from "node:crypto";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { BrokerClient } from "./mcp/broker-client.js";
+import { buildTools, type HuginTool } from "./mcp/tools.js";
+
+const SERVER_NAME = "hugin-mcp";
+const SERVER_VERSION = "0.1.0";
+
+function readRequiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value || value.trim() === "") {
+    process.stderr.write(`hugin-mcp: missing required env ${name}\n`);
+    process.exit(1);
+  }
+  return value;
+}
+
+function readOptionalNumber(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    process.stderr.write(`hugin-mcp: invalid ${name}=${raw}, using ${fallback}\n`);
+    return fallback;
+  }
+  return parsed;
+}
+
+export async function main(): Promise<void> {
+  const baseUrl = readRequiredEnv("HUGIN_BROKER_URL");
+  const bearerToken = readRequiredEnv("HUGIN_BROKER_TOKEN");
+  const submitter = process.env.HUGIN_MCP_SUBMITTER ?? "claude-code";
+  const requestTimeoutMs = readOptionalNumber("HUGIN_MCP_REQUEST_TIMEOUT_MS", 60_000);
+
+  const broker = new BrokerClient({ baseUrl, bearerToken, requestTimeoutMs });
+  const tools = buildTools({
+    broker,
+    sessionId: randomUUID(),
+    submitter,
+  });
+
+  const server = new McpServer({ name: SERVER_NAME, version: SERVER_VERSION });
+
+  const allTools: HuginTool<Record<string, unknown>>[] = [
+    tools.submit as HuginTool<Record<string, unknown>>,
+    tools.await_ as HuginTool<Record<string, unknown>>,
+    tools.rate as HuginTool<Record<string, unknown>>,
+    tools.list as HuginTool<Record<string, unknown>>,
+    tools.models as HuginTool<Record<string, unknown>>,
+  ];
+  for (const tool of allTools) {
+    server.registerTool(
+      tool.name,
+      {
+        title: tool.title,
+        description: tool.description,
+        inputSchema: tool.inputShape,
+      },
+      async (input: Record<string, unknown>) => tool.handler(input),
+    );
+  }
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+const isMain = import.meta.url === `file://${process.argv[1]}`;
+if (isMain) {
+  main().catch((err: unknown) => {
+    process.stderr.write(
+      `hugin-mcp fatal: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`,
+    );
+    process.exit(1);
+  });
+}

--- a/src/mcp/broker-client.ts
+++ b/src/mcp/broker-client.ts
@@ -1,0 +1,139 @@
+/**
+ * HTTP client for the Pi-side orchestrator broker.
+ *
+ * Used by the hugin-mcp server (laptop-side). Wraps the five
+ * `/v1/delegate/*` endpoints with typed methods, bearer-token auth,
+ * and bounded timeouts.
+ *
+ * The broker is exposed only on the Tailscale interface (per
+ * docs/orchestrator-v1-data-model.md §1) so connection failures here
+ * almost always mean: Pi is asleep, Tailscale is down, or
+ * `HUGIN_BROKER_URL` is misconfigured. Errors carry enough context for
+ * the skill to render a useful message to the user.
+ */
+export interface BrokerClientConfig {
+  baseUrl: string;
+  bearerToken: string;
+  /**
+   * Per-request timeout. Independent of `hugin_await`'s `max_wait_s`,
+   * which is enforced server-side. Default 60s — high enough for slow
+   * journals, low enough to surface a stuck Tailscale promptly.
+   */
+  requestTimeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}
+
+export class BrokerHttpError extends Error {
+  constructor(
+    message: string,
+    public readonly httpStatus: number,
+    public readonly body?: unknown,
+  ) {
+    super(message);
+    this.name = "BrokerHttpError";
+  }
+}
+
+export class BrokerNetworkError extends Error {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = "BrokerNetworkError";
+  }
+}
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
+
+export class BrokerClient {
+  private readonly baseUrl: string;
+  private readonly bearerToken: string;
+  private readonly requestTimeoutMs: number;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(config: BrokerClientConfig) {
+    this.baseUrl = config.baseUrl.replace(/\/$/, "");
+    this.bearerToken = config.bearerToken;
+    this.requestTimeoutMs = config.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    this.fetchImpl = config.fetchImpl ?? fetch;
+  }
+
+  async submit(payload: Record<string, unknown>): Promise<unknown> {
+    return this.post("/v1/delegate/submit", payload);
+  }
+
+  async await_(payload: { task_id: string; max_wait_s?: number }): Promise<unknown> {
+    return this.post("/v1/delegate/await", payload);
+  }
+
+  async rate(payload: Record<string, unknown>): Promise<unknown> {
+    return this.post("/v1/delegate/rate", payload);
+  }
+
+  async list(payload: Record<string, unknown>): Promise<unknown> {
+    return this.post("/v1/delegate/list", payload);
+  }
+
+  async models(): Promise<unknown> {
+    return this.get("/v1/delegate/models");
+  }
+
+  private async post(path: string, body: unknown): Promise<unknown> {
+    return this.request(path, "POST", body);
+  }
+
+  private async get(path: string): Promise<unknown> {
+    return this.request(path, "GET");
+  }
+
+  private async request(path: string, method: string, body?: unknown): Promise<unknown> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.requestTimeoutMs);
+    let response: Response;
+    try {
+      response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+        method,
+        headers: {
+          authorization: `Bearer ${this.bearerToken}`,
+          "content-type": "application/json",
+          accept: "application/json",
+        },
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+        signal: controller.signal,
+      });
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") {
+        throw new BrokerNetworkError(
+          `request to ${path} timed out after ${this.requestTimeoutMs}ms`,
+          err,
+        );
+      }
+      throw new BrokerNetworkError(
+        `request to ${path} failed: ${err instanceof Error ? err.message : String(err)}`,
+        err,
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+
+    // 204 No Content (e.g. /rate) — return empty object.
+    if (response.status === 204) return {};
+
+    let parsed: unknown;
+    const text = await response.text();
+    if (text) {
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        parsed = { raw: text };
+      }
+    }
+
+    if (!response.ok) {
+      throw new BrokerHttpError(
+        `broker ${method} ${path} returned HTTP ${response.status}`,
+        response.status,
+        parsed,
+      );
+    }
+    return parsed;
+  }
+}

--- a/src/mcp/broker-client.ts
+++ b/src/mcp/broker-client.ts
@@ -44,13 +44,37 @@ export class BrokerNetworkError extends Error {
 const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
 
 export class BrokerClient {
-  private readonly baseUrl: string;
+  private readonly baseUrl: URL;
   private readonly bearerToken: string;
   private readonly requestTimeoutMs: number;
   private readonly fetchImpl: typeof fetch;
 
   constructor(config: BrokerClientConfig) {
-    this.baseUrl = config.baseUrl.replace(/\/$/, "");
+    let parsed: URL;
+    try {
+      parsed = new URL(config.baseUrl);
+    } catch {
+      throw new Error(`hugin-mcp: HUGIN_BROKER_URL is not a valid URL: ${config.baseUrl}`);
+    }
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new Error(
+        `hugin-mcp: HUGIN_BROKER_URL must be http(s); got ${parsed.protocol}`,
+      );
+    }
+    if (parsed.username || parsed.password) {
+      throw new Error(
+        "hugin-mcp: HUGIN_BROKER_URL must not contain userinfo; pass credentials via HUGIN_BROKER_TOKEN",
+      );
+    }
+    if (parsed.search || parsed.hash) {
+      throw new Error("hugin-mcp: HUGIN_BROKER_URL must not contain a query string or fragment");
+    }
+    if (parsed.pathname !== "/" && parsed.pathname !== "") {
+      throw new Error(
+        `hugin-mcp: HUGIN_BROKER_URL must not contain a path prefix; got ${parsed.pathname}`,
+      );
+    }
+    this.baseUrl = parsed;
     this.bearerToken = config.bearerToken;
     this.requestTimeoutMs = config.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
     this.fetchImpl = config.fetchImpl ?? fetch;
@@ -87,9 +111,10 @@ export class BrokerClient {
   private async request(path: string, method: string, body?: unknown): Promise<unknown> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), this.requestTimeoutMs);
+    const url = new URL(path, this.baseUrl).toString();
     let response: Response;
     try {
-      response = await this.fetchImpl(`${this.baseUrl}${path}`, {
+      response = await this.fetchImpl(url, {
         method,
         headers: {
           authorization: `Bearer ${this.bearerToken}`,

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -36,6 +36,14 @@ export interface ToolDeps {
    * Stable per-MCP-process session id. Persisted in journal events so
    * later analysis can group tasks submitted by the same Claude
    * session. Generated on server startup.
+   *
+   * Note: this value participates in the broker's idempotency hash
+   * (see `src/broker/idempotency.ts`). Retries that span MCP restarts
+   * will see a different session id and therefore a different hash —
+   * the broker will treat them as a collision rather than a replay.
+   * Within a single MCP process, retries with the same
+   * `idempotency_key` (returned in the submit response) replay
+   * cleanly.
    */
   sessionId: string;
   /**
@@ -43,6 +51,13 @@ export interface ToolDeps {
    * broker recognises (e.g. `claude-code`, `claude-desktop`).
    */
   submitter: string;
+  /**
+   * Alias-map version stamped on every submit envelope. Discovered
+   * from `/v1/delegate/models` at server startup; if unavailable,
+   * falls back to {@link ALIAS_MAP_VERSION}. The broker uses this to
+   * detect orchestrator skew when it bumps the alias map.
+   */
+  aliasMapVersion?: number;
   /** UUID generator (overridable for tests). */
   newId?: () => string;
 }
@@ -89,13 +104,6 @@ const submitInputSchema = z.object(submitInputShape);
 
 export const awaitInputShape = {
   task_id: z.string().min(1).describe("Task id returned by `hugin_submit`."),
-  max_wait_s: z
-    .number()
-    .int()
-    .min(0)
-    .max(900)
-    .optional()
-    .describe("Reserved; broker currently returns immediately."),
 };
 const awaitInputSchema = z.object(awaitInputShape);
 
@@ -133,6 +141,23 @@ function asResult(value: unknown, isError = false): {
 } {
   const text = typeof value === "string" ? value : JSON.stringify(value, null, 2);
   return isError ? { content: [{ type: "text", text }], isError: true } : { content: [{ type: "text", text }] };
+}
+
+/**
+ * Surface the idempotency_key used on a submit so the caller can
+ * replay the same logical request after a transient error. We add the
+ * key alongside whatever shape the broker returned, without
+ * overwriting any existing `idempotency_key` field.
+ */
+function withIdempotencyKey(response: unknown, idempotencyKey: string): unknown {
+  if (response && typeof response === "object" && !Array.isArray(response)) {
+    const obj = response as Record<string, unknown>;
+    if (obj.idempotency_key === undefined) {
+      return { ...obj, idempotency_key: idempotencyKey };
+    }
+    return obj;
+  }
+  return { response, idempotency_key: idempotencyKey };
 }
 
 function errorPayload(err: unknown): { error: { kind: string; message: string; http_status?: number; body?: unknown } } {
@@ -179,30 +204,34 @@ export function buildTools(deps: ToolDeps): {
     name: "hugin_submit",
     title: "Submit a delegation task to Hugin",
     description:
-      "Hand a task off to the Pi-side broker for execution on a cheaper or differently-capable runtime. Returns the assigned task_id.",
+      "Hand a task off to the Pi-side broker for execution on a cheaper or differently-capable runtime. Returns the assigned task_id and the `idempotency_key` used (auto-generated if not supplied) — pass that key back as `idempotency_key` to safely retry the same logical request.",
     inputShape: submitInputShape,
     handler: async (rawInput) => {
+      let idempotencyKey: string | undefined;
       try {
         const input = submitInputSchema.parse(rawInput);
+        idempotencyKey = input.idempotency_key ?? newId();
         const payload = {
           envelope_version: ENVELOPE_VERSION,
-          idempotency_key: input.idempotency_key ?? newId(),
+          idempotency_key: idempotencyKey,
           orchestrator_session_id: deps.sessionId,
           orchestrator_submitter: deps.submitter,
           parent_task_id: input.parent_task_id,
           task_type: input.task_type,
           prompt: input.prompt,
           alias_requested: input.alias_requested,
-          alias_map_version: ALIAS_MAP_VERSION,
+          alias_map_version: deps.aliasMapVersion ?? ALIAS_MAP_VERSION,
           worktree: input.worktree,
           sensitivity: input.sensitivity,
           timeout_ms: input.timeout_ms,
           max_output_tokens: input.max_output_tokens,
         };
         const response = await deps.broker.submit(payload);
-        return asResult(response);
+        return asResult(withIdempotencyKey(response, idempotencyKey));
       } catch (err) {
-        return asResult(errorPayload(err), true);
+        const payload = errorPayload(err) as Record<string, unknown>;
+        if (idempotencyKey) payload.idempotency_key = idempotencyKey;
+        return asResult(payload, true);
       }
     },
   };
@@ -211,7 +240,7 @@ export function buildTools(deps: ToolDeps): {
     name: "hugin_await",
     title: "Read the current state of a delegated task",
     description:
-      "Idempotent read of a task's status: `running` / `completed` / `failed` / `stale` / `unknown`. Safe to poll.",
+      "Idempotent read of a task's status: `running` / `completed` / `failed`. Returns immediately. While `running`, the response also carries lease info and an `orphan_suspected` flag (true once the lease has expired without completion). Safe to poll.",
     inputShape: awaitInputShape,
     handler: async (rawInput) => {
       try {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,0 +1,278 @@
+/**
+ * Tool definitions for hugin-mcp.
+ *
+ * Five tools mirror the broker's `/v1/delegate/*` endpoints:
+ *   hugin_submit, hugin_await, hugin_rate, hugin_list, hugin_models.
+ *
+ * The MCP layer is the only place that fills in protocol envelope
+ * fields (`envelope_version`, `alias_map_version`, `idempotency_key`,
+ * `orchestrator_session_id`, `orchestrator_submitter`). Callers supply
+ * the *task* — what to do, with which alias — and trust the MCP to
+ * tag it correctly. This keeps the skill-side prompt small.
+ */
+
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+import {
+  aliasSchema,
+  ratingSchema,
+  sensitivitySchema,
+  taskTypeSchema,
+  verificationOutcomeSchema,
+  worktreeSpecSchema,
+} from "../broker/types.js";
+import {
+  BrokerHttpError,
+  BrokerNetworkError,
+  type BrokerClient,
+} from "./broker-client.js";
+
+export const ALIAS_MAP_VERSION = 1;
+export const ENVELOPE_VERSION = 1 as const;
+
+export interface ToolDeps {
+  broker: BrokerClient;
+  /**
+   * Stable per-MCP-process session id. Persisted in journal events so
+   * later analysis can group tasks submitted by the same Claude
+   * session. Generated on server startup.
+   */
+  sessionId: string;
+  /**
+   * `orchestrator_submitter` — must match the principal the Pi-side
+   * broker recognises (e.g. `claude-code`, `claude-desktop`).
+   */
+  submitter: string;
+  /** UUID generator (overridable for tests). */
+  newId?: () => string;
+}
+
+export const submitInputShape = {
+  task_type: taskTypeSchema.describe(
+    "What kind of task this is. Steers the broker's accounting + rating UI.",
+  ),
+  prompt: z
+    .string()
+    .min(1)
+    .describe("The full task prompt to hand to the runtime."),
+  alias_requested: aliasSchema.describe(
+    "Logical alias (`tiny` / `medium` / `large-reasoning` / `pi-large-coder`). The broker resolves this to a runtime row.",
+  ),
+  worktree: worktreeSpecSchema
+    .optional()
+    .describe("Required for `pi-large-coder` (harness aliases). Omit for one-shots."),
+  sensitivity: sensitivitySchema
+    .optional()
+    .describe("Caps which runtimes can run this task. Defaults to `internal`."),
+  timeout_ms: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe("Per-task timeout. Defaults to 300_000 (5 min) for one-shot."),
+  max_output_tokens: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe("Cap on generated tokens. Optional."),
+  parent_task_id: z.string().min(1).optional().describe("Reserved; not used in v1."),
+  idempotency_key: z
+    .string()
+    .uuid()
+    .optional()
+    .describe(
+      "Override the auto-generated idempotency key. Useful when the caller knows the request is a retry of an earlier one.",
+    ),
+};
+const submitInputSchema = z.object(submitInputShape);
+
+export const awaitInputShape = {
+  task_id: z.string().min(1).describe("Task id returned by `hugin_submit`."),
+  max_wait_s: z
+    .number()
+    .int()
+    .min(0)
+    .max(900)
+    .optional()
+    .describe("Reserved; broker currently returns immediately."),
+};
+const awaitInputSchema = z.object(awaitInputShape);
+
+export const rateInputShape = {
+  task_id: z.string().min(1),
+  rating: ratingSchema.describe("`pass` / `partial` / `redo` / `wrong`."),
+  rating_reason: z.string().min(1),
+  verification_outcome: verificationOutcomeSchema,
+  retries_count: z.number().int().nonnegative().optional(),
+};
+const rateInputSchema = z.object(rateInputShape);
+
+export const listInputShape = {
+  limit: z.number().int().min(1).max(500).optional(),
+  since_ts: z.string().min(1).optional(),
+  outcome: z.enum(["completed", "failed", "running", "any"]).optional(),
+  alias: aliasSchema.optional(),
+};
+const listInputSchema = z.object(listInputShape);
+
+export const modelsInputShape = {};
+const modelsInputSchema = z.object(modelsInputShape);
+
+export interface HuginTool<I extends Record<string, unknown>> {
+  name: string;
+  title: string;
+  description: string;
+  inputShape: Record<string, z.ZodTypeAny>;
+  handler: (input: I) => Promise<{ content: { type: "text"; text: string }[]; isError?: boolean }>;
+}
+
+function asResult(value: unknown, isError = false): {
+  content: { type: "text"; text: string }[];
+  isError?: boolean;
+} {
+  const text = typeof value === "string" ? value : JSON.stringify(value, null, 2);
+  return isError ? { content: [{ type: "text", text }], isError: true } : { content: [{ type: "text", text }] };
+}
+
+function errorPayload(err: unknown): { error: { kind: string; message: string; http_status?: number; body?: unknown } } {
+  if (err instanceof BrokerHttpError) {
+    return {
+      error: {
+        kind: "broker_http_error",
+        message: err.message,
+        http_status: err.httpStatus,
+        body: err.body,
+      },
+    };
+  }
+  if (err instanceof BrokerNetworkError) {
+    return { error: { kind: "broker_network_error", message: err.message } };
+  }
+  if (err instanceof z.ZodError) {
+    return {
+      error: {
+        kind: "input_validation",
+        message: "tool input failed validation",
+        body: err.issues,
+      },
+    };
+  }
+  return {
+    error: {
+      kind: "internal",
+      message: err instanceof Error ? err.message : String(err),
+    },
+  };
+}
+
+export function buildTools(deps: ToolDeps): {
+  submit: HuginTool<z.infer<typeof submitInputSchema>>;
+  await_: HuginTool<z.infer<typeof awaitInputSchema>>;
+  rate: HuginTool<z.infer<typeof rateInputSchema>>;
+  list: HuginTool<z.infer<typeof listInputSchema>>;
+  models: HuginTool<z.infer<typeof modelsInputSchema>>;
+} {
+  const newId = deps.newId ?? randomUUID;
+
+  const submit: HuginTool<z.infer<typeof submitInputSchema>> = {
+    name: "hugin_submit",
+    title: "Submit a delegation task to Hugin",
+    description:
+      "Hand a task off to the Pi-side broker for execution on a cheaper or differently-capable runtime. Returns the assigned task_id.",
+    inputShape: submitInputShape,
+    handler: async (rawInput) => {
+      try {
+        const input = submitInputSchema.parse(rawInput);
+        const payload = {
+          envelope_version: ENVELOPE_VERSION,
+          idempotency_key: input.idempotency_key ?? newId(),
+          orchestrator_session_id: deps.sessionId,
+          orchestrator_submitter: deps.submitter,
+          parent_task_id: input.parent_task_id,
+          task_type: input.task_type,
+          prompt: input.prompt,
+          alias_requested: input.alias_requested,
+          alias_map_version: ALIAS_MAP_VERSION,
+          worktree: input.worktree,
+          sensitivity: input.sensitivity,
+          timeout_ms: input.timeout_ms,
+          max_output_tokens: input.max_output_tokens,
+        };
+        const response = await deps.broker.submit(payload);
+        return asResult(response);
+      } catch (err) {
+        return asResult(errorPayload(err), true);
+      }
+    },
+  };
+
+  const await_: HuginTool<z.infer<typeof awaitInputSchema>> = {
+    name: "hugin_await",
+    title: "Read the current state of a delegated task",
+    description:
+      "Idempotent read of a task's status: `running` / `completed` / `failed` / `stale` / `unknown`. Safe to poll.",
+    inputShape: awaitInputShape,
+    handler: async (rawInput) => {
+      try {
+        const input = awaitInputSchema.parse(rawInput);
+        const response = await deps.broker.await_(input);
+        return asResult(response);
+      } catch (err) {
+        return asResult(errorPayload(err), true);
+      }
+    },
+  };
+
+  const rate: HuginTool<z.infer<typeof rateInputSchema>> = {
+    name: "hugin_rate",
+    title: "Rate the outcome of a delegated task",
+    description:
+      "Append a rating event for a previously completed task. Used by the audit pipeline + future routing improvements.",
+    inputShape: rateInputShape,
+    handler: async (rawInput) => {
+      try {
+        const input = rateInputSchema.parse(rawInput);
+        const response = await deps.broker.rate(input);
+        return asResult(response);
+      } catch (err) {
+        return asResult(errorPayload(err), true);
+      }
+    },
+  };
+
+  const list: HuginTool<z.infer<typeof listInputSchema>> = {
+    name: "hugin_list",
+    title: "List recent delegated tasks",
+    description:
+      "Projection over the broker's journal. Useful to find a forgotten task_id or review what ran today.",
+    inputShape: listInputShape,
+    handler: async (rawInput) => {
+      try {
+        const input = listInputSchema.parse(rawInput);
+        const response = await deps.broker.list(input);
+        return asResult(response);
+      } catch (err) {
+        return asResult(errorPayload(err), true);
+      }
+    },
+  };
+
+  const models: HuginTool<z.infer<typeof modelsInputSchema>> = {
+    name: "hugin_models",
+    title: "Read the active alias map and runtime registry",
+    description:
+      "Returns the current alias map (`tiny`/`medium`/`large-reasoning`/`pi-large-coder`) and the runtime rows the broker can dispatch to.",
+    inputShape: modelsInputShape,
+    handler: async () => {
+      try {
+        const response = await deps.broker.models();
+        return asResult(response);
+      } catch (err) {
+        return asResult(errorPayload(err), true);
+      }
+    },
+  };
+
+  return { submit, await_, rate, list, models };
+}

--- a/tests/mcp/broker-client.test.ts
+++ b/tests/mcp/broker-client.test.ts
@@ -155,4 +155,54 @@ describe("BrokerClient", () => {
     const [url] = fetchImpl.mock.calls[0]!;
     expect(url).toBe("http://broker.test:3033/v1/delegate/models");
   });
+
+  it("rejects baseUrl with userinfo so the bearer token cannot be misrouted (F5)", () => {
+    expect(
+      () =>
+        new BrokerClient({
+          baseUrl: "http://attacker:pass@broker.test:3033",
+          bearerToken: "tk",
+        }),
+    ).toThrowError(/userinfo/);
+  });
+
+  it("rejects baseUrl with a query string (F5)", () => {
+    expect(
+      () =>
+        new BrokerClient({
+          baseUrl: "http://broker.test:3033/?evil=1",
+          bearerToken: "tk",
+        }),
+    ).toThrowError(/query string|fragment/);
+  });
+
+  it("rejects baseUrl with a path prefix (F5)", () => {
+    expect(
+      () =>
+        new BrokerClient({
+          baseUrl: "http://broker.test:3033/some/prefix",
+          bearerToken: "tk",
+        }),
+    ).toThrowError(/path prefix/);
+  });
+
+  it("rejects non-http(s) schemes (F5)", () => {
+    expect(
+      () =>
+        new BrokerClient({
+          baseUrl: "ftp://broker.test:3033",
+          bearerToken: "tk",
+        }),
+    ).toThrowError(/http\(s\)/);
+  });
+
+  it("rejects malformed URLs (F5)", () => {
+    expect(
+      () =>
+        new BrokerClient({
+          baseUrl: "not a url",
+          bearerToken: "tk",
+        }),
+    ).toThrowError(/not a valid URL/);
+  });
 });

--- a/tests/mcp/broker-client.test.ts
+++ b/tests/mcp/broker-client.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  BrokerClient,
+  BrokerHttpError,
+  BrokerNetworkError,
+} from "../../src/mcp/broker-client.js";
+
+function jsonResponse(body: unknown, init: { status?: number } = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("BrokerClient", () => {
+  it("posts JSON with bearer token to /v1/delegate/submit", async () => {
+    const fetchImpl = vi.fn(async (_url: string, _init?: RequestInit) =>
+      jsonResponse({ task_id: "t1" }),
+    );
+    const client = new BrokerClient({
+      baseUrl: "http://broker.test:3033/",
+      bearerToken: "secret-xyz",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    const result = await client.submit({ envelope_version: 1, prompt: "hi" });
+
+    expect(result).toEqual({ task_id: "t1" });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0]!;
+    expect(url).toBe("http://broker.test:3033/v1/delegate/submit");
+    expect(init?.method).toBe("POST");
+    const headers = init?.headers as Record<string, string>;
+    expect(headers.authorization).toBe("Bearer secret-xyz");
+    expect(headers["content-type"]).toBe("application/json");
+    expect(JSON.parse(init?.body as string)).toEqual({
+      envelope_version: 1,
+      prompt: "hi",
+    });
+  });
+
+  it("issues GET on /v1/delegate/models without a body", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({ alias_map: {}, runtimes: [] }),
+    );
+    const client = new BrokerClient({
+      baseUrl: "http://broker.test:3033",
+      bearerToken: "tk",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await client.models();
+
+    const [url, init] = fetchImpl.mock.calls[0]!;
+    expect(url).toBe("http://broker.test:3033/v1/delegate/models");
+    expect(init?.method).toBe("GET");
+    expect(init?.body).toBeUndefined();
+  });
+
+  it("returns {} for 204 No Content", async () => {
+    const fetchImpl = vi.fn(
+      async () => new Response(null, { status: 204 }),
+    );
+    const client = new BrokerClient({
+      baseUrl: "http://broker.test:3033",
+      bearerToken: "tk",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const result = await client.rate({ task_id: "t1", rating: "pass" });
+    expect(result).toEqual({});
+  });
+
+  it("throws BrokerHttpError with parsed body on non-2xx responses", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({ error: "bad-request", detail: "missing field" }, { status: 400 }),
+    );
+    const client = new BrokerClient({
+      baseUrl: "http://broker.test:3033",
+      bearerToken: "tk",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await expect(client.submit({})).rejects.toMatchObject({
+      name: "BrokerHttpError",
+      httpStatus: 400,
+      body: { error: "bad-request", detail: "missing field" },
+    });
+  });
+
+  it("falls back to {raw: text} when error body is not JSON", async () => {
+    const fetchImpl = vi.fn(
+      async () =>
+        new Response("upstream timeout", {
+          status: 503,
+          headers: { "content-type": "text/plain" },
+        }),
+    );
+    const client = new BrokerClient({
+      baseUrl: "http://broker.test:3033",
+      bearerToken: "tk",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    try {
+      await client.submit({});
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(BrokerHttpError);
+      const httpErr = err as BrokerHttpError;
+      expect(httpErr.httpStatus).toBe(503);
+      expect(httpErr.body).toEqual({ raw: "upstream timeout" });
+    }
+  });
+
+  it("wraps fetch errors in BrokerNetworkError", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+    const client = new BrokerClient({
+      baseUrl: "http://broker.test:3033",
+      bearerToken: "tk",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await expect(client.submit({})).rejects.toBeInstanceOf(BrokerNetworkError);
+  });
+
+  it("converts AbortError into BrokerNetworkError with timeout context", async () => {
+    const fetchImpl = vi.fn(async () => {
+      const err = new Error("aborted");
+      err.name = "AbortError";
+      throw err;
+    });
+    const client = new BrokerClient({
+      baseUrl: "http://broker.test:3033",
+      bearerToken: "tk",
+      requestTimeoutMs: 5,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await expect(client.submit({})).rejects.toMatchObject({
+      name: "BrokerNetworkError",
+      message: expect.stringContaining("timed out"),
+    });
+  });
+
+  it("strips a trailing slash from baseUrl", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({}));
+    const client = new BrokerClient({
+      baseUrl: "http://broker.test:3033/",
+      bearerToken: "tk",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    await client.models();
+    const [url] = fetchImpl.mock.calls[0]!;
+    expect(url).toBe("http://broker.test:3033/v1/delegate/models");
+  });
+});

--- a/tests/mcp/tools.test.ts
+++ b/tests/mcp/tools.test.ts
@@ -60,7 +60,103 @@ describe("buildTools — hugin_submit", () => {
       timeout_ms: undefined,
       max_output_tokens: undefined,
     });
-    expect(parseResult(result)).toEqual({ task_id: "t1", state: "pending" });
+    expect(parseResult(result)).toEqual({
+      task_id: "t1",
+      state: "pending",
+      idempotency_key: "11111111-1111-4111-8111-111111111111",
+    });
+  });
+
+  it("uses ToolDeps.aliasMapVersion when provided (F1 — broker-discovered version)", async () => {
+    const submit = vi.fn(async () => ({ task_id: "t1" }));
+    const broker = fakeBroker({ submit });
+    const tools = buildTools({
+      broker,
+      sessionId: "sess",
+      submitter: "claude-code",
+      newId: () => "11111111-1111-4111-8111-111111111111",
+      aliasMapVersion: 7,
+    });
+
+    await tools.submit.handler({
+      task_type: "summarize",
+      prompt: "p",
+      alias_requested: "tiny",
+    });
+
+    expect(submit.mock.calls[0]![0]).toMatchObject({ alias_map_version: 7 });
+  });
+
+  it("falls back to ALIAS_MAP_VERSION when ToolDeps.aliasMapVersion is omitted (F1)", async () => {
+    const submit = vi.fn(async () => ({ task_id: "t1" }));
+    const broker = fakeBroker({ submit });
+    const tools = buildTools({
+      broker,
+      sessionId: "sess",
+      submitter: "claude-code",
+      newId: () => "11111111-1111-4111-8111-111111111111",
+    });
+
+    await tools.submit.handler({
+      task_type: "summarize",
+      prompt: "p",
+      alias_requested: "tiny",
+    });
+
+    expect(submit.mock.calls[0]![0]).toMatchObject({
+      alias_map_version: ALIAS_MAP_VERSION,
+    });
+  });
+
+  it("echoes the auto-generated idempotency_key in error responses (F2)", async () => {
+    const submit = vi.fn(async () => {
+      throw new BrokerNetworkError("connection refused");
+    });
+    const broker = fakeBroker({ submit });
+    const tools = buildTools({
+      broker,
+      sessionId: "sess",
+      submitter: "claude-code",
+      newId: () => "99999999-9999-4999-8999-999999999999",
+    });
+
+    const result = await tools.submit.handler({
+      task_type: "summarize",
+      prompt: "p",
+      alias_requested: "tiny",
+    });
+
+    expect(result.isError).toBe(true);
+    const payload = parseResult(result) as {
+      idempotency_key: string;
+      error: { kind: string };
+    };
+    expect(payload.idempotency_key).toBe("99999999-9999-4999-8999-999999999999");
+    expect(payload.error.kind).toBe("broker_network_error");
+  });
+
+  it("does not overwrite an idempotency_key the broker echoed back (F2)", async () => {
+    const submit = vi.fn(async () => ({
+      task_id: "t1",
+      idempotency_key: "broker-echoed-key",
+    }));
+    const broker = fakeBroker({ submit });
+    const tools = buildTools({
+      broker,
+      sessionId: "sess",
+      submitter: "claude-code",
+      newId: () => "should-not-replace",
+    });
+
+    const result = await tools.submit.handler({
+      task_type: "summarize",
+      prompt: "p",
+      alias_requested: "tiny",
+    });
+
+    expect(parseResult(result)).toMatchObject({
+      idempotency_key: "broker-echoed-key",
+    });
   });
 
   it("uses the caller-supplied idempotency_key when provided", async () => {

--- a/tests/mcp/tools.test.ts
+++ b/tests/mcp/tools.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  ALIAS_MAP_VERSION,
+  ENVELOPE_VERSION,
+  buildTools,
+} from "../../src/mcp/tools.js";
+import {
+  BrokerHttpError,
+  BrokerNetworkError,
+  type BrokerClient,
+} from "../../src/mcp/broker-client.js";
+
+function fakeBroker(overrides: Partial<BrokerClient> = {}): BrokerClient {
+  const noop = vi.fn(async () => ({}));
+  return {
+    submit: noop,
+    await_: noop,
+    rate: noop,
+    list: noop,
+    models: noop,
+    ...overrides,
+  } as unknown as BrokerClient;
+}
+
+function parseResult(result: { content: { text: string }[]; isError?: boolean }): unknown {
+  return JSON.parse(result.content[0]!.text);
+}
+
+describe("buildTools — hugin_submit", () => {
+  it("forwards a one-shot envelope with auto-generated idempotency key", async () => {
+    const submit = vi.fn(async () => ({ task_id: "t1", state: "pending" }));
+    const broker = fakeBroker({ submit });
+    const tools = buildTools({
+      broker,
+      sessionId: "sess-fixed",
+      submitter: "claude-code",
+      newId: () => "11111111-1111-4111-8111-111111111111",
+    });
+
+    const result = await tools.submit.handler({
+      task_type: "summarize",
+      prompt: "Summarize this.",
+      alias_requested: "tiny",
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(submit).toHaveBeenCalledTimes(1);
+    expect(submit).toHaveBeenCalledWith({
+      envelope_version: ENVELOPE_VERSION,
+      idempotency_key: "11111111-1111-4111-8111-111111111111",
+      orchestrator_session_id: "sess-fixed",
+      orchestrator_submitter: "claude-code",
+      parent_task_id: undefined,
+      task_type: "summarize",
+      prompt: "Summarize this.",
+      alias_requested: "tiny",
+      alias_map_version: ALIAS_MAP_VERSION,
+      worktree: undefined,
+      sensitivity: undefined,
+      timeout_ms: undefined,
+      max_output_tokens: undefined,
+    });
+    expect(parseResult(result)).toEqual({ task_id: "t1", state: "pending" });
+  });
+
+  it("uses the caller-supplied idempotency_key when provided", async () => {
+    const submit = vi.fn(async () => ({ task_id: "t2" }));
+    const broker = fakeBroker({ submit });
+    const tools = buildTools({
+      broker,
+      sessionId: "sess",
+      submitter: "claude-code",
+      newId: () => "should-not-be-used",
+    });
+
+    await tools.submit.handler({
+      task_type: "summarize",
+      prompt: "p",
+      alias_requested: "tiny",
+      idempotency_key: "22222222-2222-4222-8222-222222222222",
+    });
+
+    expect(submit.mock.calls[0]![0]).toMatchObject({
+      idempotency_key: "22222222-2222-4222-8222-222222222222",
+    });
+  });
+
+  it("forwards worktree spec for pi-large-coder harness aliases", async () => {
+    const submit = vi.fn(async () => ({ task_id: "t3" }));
+    const broker = fakeBroker({ submit });
+    const tools = buildTools({
+      broker,
+      sessionId: "sess",
+      submitter: "claude-code",
+      newId: () => "33333333-3333-4333-8333-333333333333",
+    });
+
+    const result = await tools.submit.handler({
+      task_type: "code-edit",
+      prompt: "Edit src/foo.ts",
+      alias_requested: "pi-large-coder",
+      worktree: { repo: "hugin", base_ref: "main" },
+      sensitivity: "internal",
+      timeout_ms: 600_000,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(submit.mock.calls[0]![0]).toMatchObject({
+      alias_requested: "pi-large-coder",
+      worktree: { repo: "hugin", base_ref: "main" },
+      sensitivity: "internal",
+      timeout_ms: 600_000,
+    });
+  });
+
+  it("returns an isError result with input_validation kind when input is invalid", async () => {
+    const submit = vi.fn(async () => ({ task_id: "should-not-call" }));
+    const broker = fakeBroker({ submit });
+    const tools = buildTools({
+      broker,
+      sessionId: "sess",
+      submitter: "claude-code",
+    });
+
+    const result = await tools.submit.handler({
+      task_type: "summarize",
+      prompt: "",
+      alias_requested: "tiny",
+    } as unknown as Parameters<typeof tools.submit.handler>[0]);
+
+    expect(result.isError).toBe(true);
+    const payload = parseResult(result) as { error: { kind: string } };
+    expect(payload.error.kind).toBe("input_validation");
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it("maps BrokerHttpError into a structured error result", async () => {
+    const submit = vi.fn(async () => {
+      throw new BrokerHttpError("HTTP 503", 503, { error: "upstream" });
+    });
+    const broker = fakeBroker({ submit });
+    const tools = buildTools({
+      broker,
+      sessionId: "sess",
+      submitter: "claude-code",
+      newId: () => "44444444-4444-4444-8444-444444444444",
+    });
+
+    const result = await tools.submit.handler({
+      task_type: "summarize",
+      prompt: "p",
+      alias_requested: "tiny",
+    });
+
+    expect(result.isError).toBe(true);
+    const payload = parseResult(result) as {
+      error: { kind: string; http_status: number; body: unknown };
+    };
+    expect(payload.error.kind).toBe("broker_http_error");
+    expect(payload.error.http_status).toBe(503);
+    expect(payload.error.body).toEqual({ error: "upstream" });
+  });
+
+  it("maps BrokerNetworkError into a structured error result", async () => {
+    const submit = vi.fn(async () => {
+      throw new BrokerNetworkError("connection refused");
+    });
+    const broker = fakeBroker({ submit });
+    const tools = buildTools({
+      broker,
+      sessionId: "sess",
+      submitter: "claude-code",
+      newId: () => "55555555-5555-4555-8555-555555555555",
+    });
+
+    const result = await tools.submit.handler({
+      task_type: "summarize",
+      prompt: "p",
+      alias_requested: "tiny",
+    });
+
+    expect(result.isError).toBe(true);
+    const payload = parseResult(result) as { error: { kind: string } };
+    expect(payload.error.kind).toBe("broker_network_error");
+  });
+});
+
+describe("buildTools — hugin_await", () => {
+  it("forwards task_id to broker.await_", async () => {
+    const await_ = vi.fn(async () => ({ state: "completed" }));
+    const broker = fakeBroker({ await_ });
+    const tools = buildTools({ broker, sessionId: "sess", submitter: "claude-code" });
+
+    const result = await tools.await_.handler({ task_id: "t-123" });
+
+    expect(await_).toHaveBeenCalledWith({ task_id: "t-123" });
+    expect(parseResult(result)).toEqual({ state: "completed" });
+  });
+});
+
+describe("buildTools — hugin_rate", () => {
+  it("forwards full rating payload", async () => {
+    const rate = vi.fn(async () => ({}));
+    const broker = fakeBroker({ rate });
+    const tools = buildTools({ broker, sessionId: "sess", submitter: "claude-code" });
+
+    const result = await tools.rate.handler({
+      task_id: "t-1",
+      rating: "pass",
+      rating_reason: "looked correct",
+      verification_outcome: "accepted_unchanged",
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(rate).toHaveBeenCalledWith({
+      task_id: "t-1",
+      rating: "pass",
+      rating_reason: "looked correct",
+      verification_outcome: "accepted_unchanged",
+    });
+  });
+});
+
+describe("buildTools — hugin_list", () => {
+  it("forwards filters and serialises results", async () => {
+    const list = vi.fn(async () => ({ tasks: [{ task_id: "t1" }] }));
+    const broker = fakeBroker({ list });
+    const tools = buildTools({ broker, sessionId: "sess", submitter: "claude-code" });
+
+    const result = await tools.list.handler({ limit: 10, outcome: "completed", alias: "tiny" });
+
+    expect(list).toHaveBeenCalledWith({ limit: 10, outcome: "completed", alias: "tiny" });
+    expect(parseResult(result)).toEqual({ tasks: [{ task_id: "t1" }] });
+  });
+});
+
+describe("buildTools — hugin_models", () => {
+  it("calls broker.models with no arguments", async () => {
+    const models = vi.fn(async () => ({ alias_map: { tiny: "ollama-pi" }, runtimes: [] }));
+    const broker = fakeBroker({ models });
+    const tools = buildTools({ broker, sessionId: "sess", submitter: "claude-code" });
+
+    const result = await tools.models.handler({});
+
+    expect(models).toHaveBeenCalledTimes(1);
+    expect(parseResult(result)).toEqual({
+      alias_map: { tiny: "ollama-pi" },
+      runtimes: [],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `hugin-mcp`, a stdio MCP server that exposes the Pi-side broker's `/v1/delegate/*` endpoints as five tools (`hugin_submit`, `hugin_await`, `hugin_rate`, `hugin_list`, `hugin_models`) for Claude Code / Claude Desktop sessions.
- The MCP layer auto-fills protocol envelope fields (`envelope_version`, `alias_map_version`, `idempotency_key`, `orchestrator_session_id`, `orchestrator_submitter`) so callers only think about the task.
- New files: `src/mcp-server.ts` (entrypoint, also wired as `bin`), `src/mcp/broker-client.ts` (HTTP client with bearer auth, AbortController timeout, typed errors), `src/mcp/tools.ts` (tool definitions reusing zod schemas from `src/broker/types.ts`).

## Architecture
```
Claude Code  ⟷  hugin-mcp (stdio)  ⟶  HTTP /v1/delegate/* (Tailscale)  ⟶  Pi broker
```

The orchestrator (the AI session) lives on the laptop; the broker is a dispatcher on the Pi. Step 6 plugs the laptop into that wire.

## Env (laptop side)
| Var | Default | Purpose |
|---|---|---|
| `HUGIN_BROKER_URL` | — | Pi broker URL (Tailscale) |
| `HUGIN_BROKER_TOKEN` | — | Bearer token from `HUGIN_BROKER_KEYS` |
| `HUGIN_MCP_SUBMITTER` | `claude-code` | `orchestrator_submitter` principal |
| `HUGIN_MCP_REQUEST_TIMEOUT_MS` | `60000` | Per-request HTTP timeout |

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 570/570 passing (43 files), incl. 18 new mcp tests
  - `tests/mcp/broker-client.test.ts` — POST/GET wiring, bearer header, 204 No Content, `BrokerHttpError` body parsing (JSON + non-JSON), `BrokerNetworkError` mapping, AbortError → timeout message, trailing-slash normalisation
  - `tests/mcp/tools.test.ts` — envelope autofill (idempotency_key, sessionId, submitter, alias_map_version), caller-supplied idempotency_key wins, worktree spec for `pi-large-coder`, `input_validation` error path, `BrokerHttpError`/`BrokerNetworkError` → structured error result, all five tools forward correctly
- [ ] Manual: `claude mcp add-json hugin '{"command":"node","args":["…/dist/mcp-server.js"],"env":{…}}' -s user`, then `hugin_models` round-trip against the Pi broker

🤖 Generated with [Claude Code](https://claude.com/claude-code)