### PR TITLE
fix: harden update-cli.sh — cross-major bumps, failure logging, smoke test (#60)

### DIFF
--- a/scripts/update-cli.sh
+++ b/scripts/update-cli.sh
@@ -3,31 +3,51 @@ set -euo pipefail
 
 # Update Claude Code and Codex CLI tools
 # Intended to run daily via cron on the Pi
-# Logs version changes to syslog
+# Logs version changes and failures to syslog (tag: hugin-update)
+# Writes a one-line version status to Munin (meta/hugin/cli-versions)
 
 export PATH="/usr/local/bin:/usr/bin:/bin:$HOME/.npm-global/bin:$PATH"
 
+# Source the Pi .env for MUNIN_API_KEY (best-effort; Munin write is non-fatal)
+if [ -f "$HOME/hugin/.env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . "$HOME/hugin/.env"
+  set +a
+fi
+
+MUNIN_URL="${MUNIN_URL:-http://localhost:3030}"
+
+# Tracks whether any package install failed (script exits non-zero at the end)
+FAILED=0
+
+installed_version() {
+  local pkg="$1"
+  npm ls -g "$pkg" --depth=0 --json 2>/dev/null | node -e "
+    let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
+      try { const j=JSON.parse(d); console.log(j.dependencies?.['${pkg}']?.version || 'not-installed'); }
+      catch { console.log('not-installed'); }
+    });
+  "
+}
+
 update_package() {
   local pkg="$1"
-  local old_version
+  local old_version new_version
 
-  old_version=$(npm ls -g "$pkg" --depth=0 --json 2>/dev/null | node -e "
-    let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
-      try { const j=JSON.parse(d); console.log(j.dependencies?.['${pkg}']?.version || 'not-installed'); }
-      catch { console.log('not-installed'); }
-    });
-  ")
+  old_version=$(installed_version "$pkg")
 
   echo "Updating $pkg (current: $old_version)..."
-  npm update -g "$pkg" 2>&1
+  # `npm i -g <pkg>@latest` forces cross-major upgrades; `npm update` would
+  # silently stay within the pinned caret range and skip major releases.
+  if ! npm i -g "${pkg}@latest" 2>&1; then
+    echo "FAILED: $pkg install returned non-zero"
+    logger -t hugin-update "FAILED: $pkg install returned non-zero"
+    FAILED=1
+    return
+  fi
 
-  local new_version
-  new_version=$(npm ls -g "$pkg" --depth=0 --json 2>/dev/null | node -e "
-    let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
-      try { const j=JSON.parse(d); console.log(j.dependencies?.['${pkg}']?.version || 'not-installed'); }
-      catch { console.log('not-installed'); }
-    });
-  ")
+  new_version=$(installed_version "$pkg")
 
   if [ "$old_version" = "$new_version" ]; then
     echo "$pkg: already up-to-date ($new_version)"
@@ -37,9 +57,94 @@ update_package() {
   fi
 }
 
+# Post-update smoke test: the CLI must actually run. A corrupt install
+# (truncated tarball, broken bin shim) passes `npm i` but fails --version.
+# Prints the version to stdout (captured by the caller); all human/log
+# output goes to stderr so it still reaches the cron log.
+smoke_test() {
+  local label="$1" cmd="$2"
+  local out
+  if out=$("$cmd" --version 2>&1); then
+    echo "$label smoke test OK: $out" >&2
+    logger -t hugin-update "$label --version OK: $out"
+    echo "$out"
+  else
+    echo "FAILED: $label --version did not run (got: $out)" >&2
+    logger -t hugin-update "FAILED: $label --version did not run"
+    echo "broken"
+  fi
+}
+
+# Best-effort one-line status to Munin so the other Grimnir environments
+# can see CLI drift without SSH'ing to the Pi. Never fails the script.
+write_munin_status() {
+  local claude_v="$1" codex_v="$2"
+  if [ -z "${MUNIN_API_KEY:-}" ]; then
+    echo "MUNIN_API_KEY not set — skipping Munin status write"
+    return
+  fi
+
+  local content
+  content="claude-code: ${claude_v} | codex: ${codex_v} | updated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  local content_json
+  content_json=$(python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))" <<< "$content") || {
+    echo "Failed to JSON-encode Munin content — skipping"
+    return
+  }
+
+  local body
+  body=$(cat <<JSON_EOF
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "memory_write",
+    "arguments": {
+      "namespace": "meta/hugin",
+      "key": "cli-versions",
+      "content": ${content_json},
+      "tags": ["meta", "cli-versions", "hugin"]
+    }
+  }
+}
+JSON_EOF
+)
+
+  local response
+  if response=$(curl -s --max-time 10 -X POST "${MUNIN_URL}/mcp" \
+    -H "Authorization: Bearer ${MUNIN_API_KEY}" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -d "$body"); then
+    if echo "$response" | grep -q '"error"'; then
+      echo "Munin status write returned an error (non-fatal): $response"
+    else
+      echo "Wrote CLI versions to Munin: meta/hugin/cli-versions"
+    fi
+  else
+    echo "Munin status write failed (non-fatal, host unreachable?)"
+  fi
+}
+
 echo "==> Updating CLI tools ($(date))"
 
 update_package "@anthropic-ai/claude-code"
 update_package "@openai/codex"
+
+echo "==> Running post-update smoke tests"
+CLAUDE_VERSION=$(smoke_test "claude" "claude")
+CODEX_VERSION=$(smoke_test "codex" "codex")
+if [ "$CLAUDE_VERSION" = "broken" ]; then FAILED=1; fi
+if [ "$CODEX_VERSION" = "broken" ]; then FAILED=1; fi
+
+write_munin_status "$CLAUDE_VERSION" "$CODEX_VERSION"
+
+if [ "$FAILED" -ne 0 ]; then
+  echo "==> Update check completed WITH FAILURES"
+  logger -t hugin-update "update-cli.sh completed with failures"
+  exit 1
+fi
 
 echo "==> Update check complete"

--- a/scripts/update-cli.sh
+++ b/scripts/update-cli.sh
@@ -18,17 +18,26 @@ fi
 
 MUNIN_URL="${MUNIN_URL:-http://localhost:3030}"
 
-# Tracks whether any package install failed (script exits non-zero at the end)
+# Tracks whether any package install / smoke test failed
+# (script exits non-zero at the end if set).
 FAILED=0
 
+# Always succeeds and always prints something. `npm ls` exits non-zero for a
+# missing package or a damaged global tree; under `set -euo pipefail` a bare
+# `v=$(installed_version ...)` would otherwise abort the script before our own
+# failure handling runs (the exact silent-failure mode #60 is removing).
 installed_version() {
-  local pkg="$1"
-  npm ls -g "$pkg" --depth=0 --json 2>/dev/null | node -e "
+  local pkg="$1" json ver
+  json=$(npm ls -g "$pkg" --depth=0 --json 2>/dev/null || true)
+  ver=$(node -e "
     let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
       try { const j=JSON.parse(d); console.log(j.dependencies?.['${pkg}']?.version || 'not-installed'); }
       catch { console.log('not-installed'); }
     });
-  "
+  " <<< "$json" 2>/dev/null || true)
+  [ -z "$ver" ] && ver="not-installed"
+  echo "$ver"
+  return 0
 }
 
 update_package() {
@@ -59,7 +68,7 @@ update_package() {
 
 # Post-update smoke test: the CLI must actually run. A corrupt install
 # (truncated tarball, broken bin shim) passes `npm i` but fails --version.
-# Prints the version to stdout (captured by the caller); all human/log
+# Prints "ok" or "broken" to stdout (captured by the caller); all human/log
 # output goes to stderr so it still reaches the cron log.
 smoke_test() {
   local label="$1" cmd="$2"
@@ -67,7 +76,7 @@ smoke_test() {
   if out=$("$cmd" --version 2>&1); then
     echo "$label smoke test OK: $out" >&2
     logger -t hugin-update "$label --version OK: $out"
-    echo "$out"
+    echo "ok"
   else
     echo "FAILED: $label --version did not run (got: $out)" >&2
     logger -t hugin-update "FAILED: $label --version did not run"
@@ -76,20 +85,20 @@ smoke_test() {
 }
 
 # Best-effort one-line status to Munin so the other Grimnir environments
-# can see CLI drift without SSH'ing to the Pi. Never fails the script.
+# can see CLI drift without SSH'ing to the Pi. Never fails the script, but
+# logs its own failures to syslog so they aren't swallowed by silent cron.
 write_munin_status() {
-  local claude_v="$1" codex_v="$2"
+  local content="$1"
   if [ -z "${MUNIN_API_KEY:-}" ]; then
     echo "MUNIN_API_KEY not set — skipping Munin status write"
+    logger -t hugin-update "Munin status skipped: MUNIN_API_KEY not set"
     return
   fi
-
-  local content
-  content="claude-code: ${claude_v} | codex: ${codex_v} | updated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
   local content_json
   content_json=$(python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))" <<< "$content") || {
     echo "Failed to JSON-encode Munin content — skipping"
+    logger -t hugin-update "Munin status skipped: JSON encode failed"
     return
   }
 
@@ -112,20 +121,32 @@ write_munin_status() {
 JSON_EOF
 )
 
-  local response
-  if response=$(curl -s --max-time 10 -X POST "${MUNIN_URL}/mcp" \
-    -H "Authorization: Bearer ${MUNIN_API_KEY}" \
+  # --fail-with-body: non-2xx HTTP exits non-zero (but still prints the body).
+  # The bearer token is fed via --config on stdin so it never appears in argv
+  # (process args are world-readable via /proc on Linux).
+  local response status=0
+  response=$(curl --config - -sS --fail-with-body --max-time 10 \
+    -X POST "${MUNIN_URL}/mcp" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json, text/event-stream" \
-    -d "$body"); then
-    if echo "$response" | grep -q '"error"'; then
-      echo "Munin status write returned an error (non-fatal): $response"
-    else
-      echo "Wrote CLI versions to Munin: meta/hugin/cli-versions"
-    fi
-  else
-    echo "Munin status write failed (non-fatal, host unreachable?)"
+    -d "$body" <<CURLCFG
+header = "Authorization: Bearer ${MUNIN_API_KEY}"
+CURLCFG
+  ) || status=$?
+
+  if [ "$status" -ne 0 ]; then
+    echo "Munin status write failed (non-fatal, curl exit ${status}): ${response}"
+    logger -t hugin-update "FAILED: Munin status write (curl exit ${status})"
+    return
   fi
+
+  if echo "$response" | grep -q '"error"'; then
+    echo "Munin status write returned a JSON-RPC error (non-fatal): $response"
+    logger -t hugin-update "FAILED: Munin status write (JSON-RPC error)"
+    return
+  fi
+
+  echo "Wrote CLI versions to Munin: meta/hugin/cli-versions"
 }
 
 echo "==> Updating CLI tools ($(date))"
@@ -134,12 +155,18 @@ update_package "@anthropic-ai/claude-code"
 update_package "@openai/codex"
 
 echo "==> Running post-update smoke tests"
-CLAUDE_VERSION=$(smoke_test "claude" "claude")
-CODEX_VERSION=$(smoke_test "codex" "codex")
-if [ "$CLAUDE_VERSION" = "broken" ]; then FAILED=1; fi
-if [ "$CODEX_VERSION" = "broken" ]; then FAILED=1; fi
+CLAUDE_SMOKE=$(smoke_test "claude" "claude")
+CODEX_SMOKE=$(smoke_test "codex" "codex")
+if [ "$CLAUDE_SMOKE" = "broken" ]; then FAILED=1; fi
+if [ "$CODEX_SMOKE" = "broken" ]; then FAILED=1; fi
 
-write_munin_status "$CLAUDE_VERSION" "$CODEX_VERSION"
+# Record the actually-installed npm versions (not smoke health) so the Munin
+# entry reflects "currently-installed versions" per #60's acceptance text;
+# smoke health is appended as an annotation.
+CLAUDE_PKG_VER=$(installed_version "@anthropic-ai/claude-code")
+CODEX_PKG_VER=$(installed_version "@openai/codex")
+MUNIN_CONTENT="claude-code: ${CLAUDE_PKG_VER} (smoke: ${CLAUDE_SMOKE}) | codex: ${CODEX_PKG_VER} (smoke: ${CODEX_SMOKE}) | updated: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+write_munin_status "$MUNIN_CONTENT"
 
 if [ "$FAILED" -ne 0 ]; then
   echo "==> Update check completed WITH FAILURES"

--- a/scripts/update-cli.sh
+++ b/scripts/update-cli.sh
@@ -121,22 +121,28 @@ write_munin_status() {
 JSON_EOF
 )
 
-  # --fail-with-body: non-2xx HTTP exits non-zero (but still prints the body).
+  # Capture the HTTP status via -w '%{http_code}' rather than --fail-with-body
+  # (the latter needs curl >= 7.76; older Raspberry Pi OS images ship 7.74).
   # The bearer token is fed via --config on stdin so it never appears in argv
-  # (process args are world-readable via /proc on Linux).
-  local response status=0
-  response=$(curl --config - -sS --fail-with-body --max-time 10 \
+  # (process args are world-readable via /proc on Linux). Body -> temp file,
+  # status code -> stdout; a connection failure yields http_code "000".
+  local body_file http_code response
+  body_file=$(mktemp)
+  http_code=$(curl --config - -sS --max-time 10 \
+    -o "$body_file" -w '%{http_code}' \
     -X POST "${MUNIN_URL}/mcp" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json, text/event-stream" \
     -d "$body" <<CURLCFG
 header = "Authorization: Bearer ${MUNIN_API_KEY}"
 CURLCFG
-  ) || status=$?
+  ) || http_code="000"
+  response=$(cat "$body_file" 2>/dev/null || true)
+  rm -f "$body_file"
 
-  if [ "$status" -ne 0 ]; then
-    echo "Munin status write failed (non-fatal, curl exit ${status}): ${response}"
-    logger -t hugin-update "FAILED: Munin status write (curl exit ${status})"
+  if [ "$http_code" -lt 200 ] || [ "$http_code" -ge 300 ]; then
+    echo "Munin status write failed (non-fatal, HTTP ${http_code}): ${response}"
+    logger -t hugin-update "FAILED: Munin status write (HTTP ${http_code})"
     return
   fi
 


### PR DESCRIPTION
## Summary

Addresses all three weak spots in `scripts/update-cli.sh` from #60:

1. **Missed major bumps** — `npm update -g` → `npm i -g <pkg>@latest`, forcing cross-major upgrades.
2. **Silent failures** — install wrapped in exit-code check; `logger -t hugin-update 'FAILED: ...'` on non-zero; script exits 1.
3. **No smoke test** — `claude --version` / `codex --version` run after update; a broken install fails the script + emits a syslog entry.

Bonus: writes a one-line status to Munin (`meta/hugin/cli-versions`) so other Grimnir environments see CLI drift without SSH. Best-effort — Munin/network failure never fails the update.

## Implementation notes

- `smoke_test` prints the version to stdout, all human/log lines to stderr, so cron output is preserved while the caller captures only the version.
- `FAILED` is set in the parent shell (command substitution runs in a subshell, so the sentinel `broken` is detected by the caller).
- `.env` sourced for `MUNIN_API_KEY`; absent key just skips the Munin write.

## Verification

- `bash -n` syntax check: clean
- Helper logic unit-tested locally (stdout/stderr separation, broken-sentinel → FAILED=1)
- Full acceptance (cron syslog entry on broken install, major bump applied, Munin entry) requires a Pi cron run — code paths verified by inspection + local harness

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)