### PR TITLE
fix: drop ProtectSystem from hugin.service (unblocks #68 NAS delivery)

### DIFF
--- a/hugin.service
+++ b/hugin.service
@@ -13,8 +13,14 @@ EnvironmentFile=/home/magnus/repos/hugin/.env
 Environment=PATH=/home/magnus/.npm-global/bin:/usr/local/bin:/usr/bin:/bin
 
 # Sandboxing
-ProtectSystem=strict
-ReadWritePaths=/home/magnus /tmp
+# ProtectSystem is deliberately NOT set: under any value (true/full/strict) it
+# read-only-bind-mounts /usr, which makes OpenSSH 10's strict config-ownership
+# check misjudge the symlinked /etc/ssh/ssh_config.d/20-systemd-ssh-proxy.conf
+# (target under /usr/lib/systemd) as "Bad owner or permissions", breaking the
+# runtime-owned artefact delivery rsync/ssh to the NAS (issue #68 / #75).
+# Empirically bisected: ProtectSystem is the sole trigger; the directives below
+# retain meaningful hardening (no privilege escalation, restricted socket
+# families). ReadWritePaths is dropped with it (a no-op without ProtectSystem).
 NoNewPrivileges=true
 PrivateTmp=false
 RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6


### PR DESCRIPTION
`ProtectSystem=` (any value) read-only-bind-mounts `/usr`, making OpenSSH 10's strict config-ownership check misjudge the symlinked `/etc/ssh/ssh_config.d/20-systemd-ssh-proxy.conf` (target under `/usr/lib/systemd`) as "Bad owner or permissions". This silently broke runtime-owned artefact delivery ssh/rsync to the NAS (#68).

Empirically bisected on the Pi via `systemd-run --user`: no-sandbox OK, NoNewPrivileges OK, RestrictAddressFamilies OK, both together OK, `ProtectSystem=true` FAILS. `NoNewPrivileges` + `RestrictAddressFamilies` retained.

Surfaced by the #75 Pi e2e (S1); S2 (missing-local) already passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)