### PR TITLE
docs: skill-distillation debate record

### DIFF
--- a/docs/decisions/skill-distillation/INDEX.md
+++ b/docs/decisions/skill-distillation/INDEX.md
@@ -1,0 +1,5 @@
+# Debate Index
+
+| Date | Topic | Reviewer | Rounds | Key decision | Critique points | Self-review catch rate |
+|------|-------|----------|--------|--------------|----------------|-----------------------|
+| 2026-05-29 | [eval-gated skill distillation](skill-distillation-summary.md) | codex/gpt-5.5 | 2 | Build as versioned RouteBinding + load-bearing TaskClassifier, not a promotion flag; gate active routing on Hugin #77 | 14 | 7/14 (50%) |

--- a/docs/decisions/skill-distillation/skill-distillation-claude-draft.md
+++ b/docs/decisions/skill-distillation/skill-distillation-claude-draft.md
@@ -1,0 +1,85 @@
+# Eval-Gated Skill Distillation as a Hugin Sub-Capability
+
+**Debate type:** architecture
+**Premise (fixed, not up for debate):** We are building this. Do not argue "gather data first" or "validate the premise." Argue *how* to build it well.
+
+## The concept
+
+From Tunguz's "Pi agent skill distillation": frontier models author atomic `SKILL.md`
+procedures *and* the evals that grade them; a smaller local model executes the
+Plan→Tool→Observe→Refine loop using those skills; a local markdown KB is retrieved
+first to fetch the right playbook. Distillation here means transferring *procedures*
+(retrievable text), not compressing weights.
+
+## Grimnir mapping (established)
+
+- **L1 procedural KB** → Munin (SQLite + FTS5 + sqlite-vec + CAS). Superior to QMD's flat markdown.
+- **L2 skills + evals** → existing `~/.claude/skills/`. The frontier-authored **eval loop** is the gap.
+- **L3 agent loop / local executor** → Hugin (Pi task dispatcher) in its **fire-and-forget batch lane**.
+
+## Proposed design: "eval-gated skill promotion"
+
+1. **Author** — Opus writes `SKILL.md` + a deterministic grader (the eval).
+2. **Validate** — run the grader against a specific local `(harness, wrapper, model)` cell
+   using the existing eval matrix from `home-server-inference-evaluation`.
+3. **Promote** — on pass, tag the skill local-executable in Hugin's runtime registry
+   (`validatedSkills` field alongside the proposed `parsesToolCalls` flag).
+4. **Route** — Hugin sends matching *batch* tasks to the local cell; cloud fallback otherwise.
+
+## Assumptions (load-bearing)
+
+- A1. A skill that passes a frontier-written eval *on the target local cell* will generalize
+  to real batch tasks of the same class. (The eval is a sufficient proxy for fitness.)
+- A2. Skills can be authored at a granularity a 30B local model executes reliably — i.e. the
+  procedure carries enough of the reasoning that the small model is mostly doing
+  pattern-following, not open-ended planning.
+- A3. The promotion unit is the `(skill, harness, wrapper, model)` tuple, not the skill alone.
+  A skill is never "validated" in the abstract.
+- A4. Munin retrieval (hybrid FTS5 + vector) is good enough to fetch the right playbook with
+  high precision; we do not need a separate procedural index.
+- A5. Most failures are detectable mid-loop (tool-call parse failure, schema violation, eval
+  assertion failure) cheaply enough to trigger cloud escalation before wasting the full
+  10min–3h batch budget.
+
+## Failure modes
+
+- **F1 — Eval overfit / Goodhart.** Opus writes both skill and grader; it can author a grader
+  the skill trivially passes. The eval becomes a rubber stamp, not a gate. Blast radius: every
+  promoted skill is suspect; silent quality rot in the batch lane.
+- **F2 — Cell drift.** A skill validated on `(pi, LM Studio, Qwen3-Coder-30B-4bit)` is silently
+  reused after the wrapper updates or the model is requantized. Promotion outlives its validity.
+- **F3 — Retrieval miss.** Wrong playbook retrieved → local model executes a plausible-but-wrong
+  procedure confidently. Worse than no skill, because it looks authoritative.
+- **F4 — Mid-loop botch with no cheap detector.** Local model drifts off-procedure in a way the
+  grader can't catch until the end; we burn hours then escalate to cloud anyway → distillation
+  is net-negative on cost and latency.
+- **F5 — Authoring burden.** Every skill now needs a maintained eval. If the eval cost dominates,
+  the library stops growing and the capability rots.
+
+## Alternatives rejected
+
+- **AR1 — Fine-tune / LoRA the local model on the skills** (true weight distillation). Rejected:
+  loses inspectability/versionability, re-trains on every skill change, no per-skill gating.
+- **AR2 — No eval gate; promote skills by hand.** Rejected: that's the status quo and gives no
+  confidence the local cell can actually run the skill. The eval *is* the contribution.
+- **AR3 — Dedicated procedural index separate from Munin.** Rejected (tentatively): duplicates
+  Munin's retrieval substrate; Munin is already superior to QMD. Open to challenge.
+- **AR4 — Interactive local execution.** Rejected by hardware reality: 10min–3h/task on 32GB Air.
+  Batch-only is non-negotiable on current hardware.
+
+## Unknowns
+
+- U1. Right grading modality: exact-match assertions, LLM-judge, or hybrid? Determinism vs. coverage.
+- U2. Promotion/demotion lifecycle when *either* the skill *or* the cell changes — who triggers
+  re-validation, and is a stale promotion fail-closed (demote on any change) or fail-open?
+- U3. Whether the smallest viable slice should be a coding skill (verifiable by tests) or a
+  non-coding skill (email triage, file ops) where the grader is harder but the value is clearer.
+- U4. How much of the "skill" should be procedure text vs. embedded few-shot exemplars for a
+  30B model to be reliable.
+
+## Smallest vertical slice (proposed)
+
+One skill (a coding skill with a test-suite grader, e.g. "apply a lint-fix across a repo"),
+one local cell `(pi, LM Studio, Qwen3-Coder-30B)`, one eval. Prove: author → grade → promote →
+Hugin routes a batch task to it → cloud fallback on grader failure. If this slice's *total*
+cost/latency beats just running the task on cloud, the architecture is justified.

--- a/docs/decisions/skill-distillation/skill-distillation-claude-response-1.md
+++ b/docs/decisions/skill-distillation/skill-distillation-claude-response-1.md
@@ -1,0 +1,100 @@
+# Claude's Response — Round 1
+
+The critique is mostly right and improves the design materially. The central move —
+**route binding, not skill-promotion flag** — is correct and I adopt it. Below: concessions,
+partial concessions, and the few places I push back.
+
+## Concessions (adopted wholesale)
+
+- **C1 — "eval-gated skill promotion" is the wrong primitive (Finding 2).** Conceded. The unit is a
+  versioned `RouteBinding: (taskClass, skillPackageProfile, cellManifest, evalSuite) → policy + calibrated metrics`,
+  with states `draft → candidate → shadow → active → stale → quarantined → disabled`. A boolean
+  `validatedSkills` flag discards the partial-pass/latency signal the prior eval work proved is the
+  actual texture of local performance (24/27, not "works"). This is the headline change.
+
+- **C2 — `SKILL.md` is not portable; author a runtime-neutral procedure package (Finding 3).** Conceded,
+  and strengthened by the `skills-in-munin` decision Codex surfaced that I failed to load: the portable
+  unit is a *rewritten derivative*, not the Claude skill. Source artifact = runtime-neutral procedure
+  package; compile a strict `pi-local-30b` profile (bounded inputs, explicit I/O schema, tool allowlist,
+  one-step checkpoints, examples + anti-examples, abort conditions). Promotion applies to the *profile*.
+
+- **C3 — Anti-Goodhart eval structure (Finding 6).** Conceded. Naming F1 wasn't a fix. Adopt: split into
+  positive / negative / retrieval / mutation fixtures; require ≥1 *independent* oracle per route (test
+  suite, schema validator, snapshot diff, static analyzer); LLM-judge is advisory only; record the
+  *stage* a failure was caught at (retrieval / preflight / parser / schema / tests / timeout / grader).
+
+- **C4 — Fail-closed retrieval contract + procedural schema in Munin (Finding 4).** Conceded. Munin stays
+  the substrate, but procedural retrieval gets its own collection/schema (trigger phrases, required
+  inputs/tools, contraindications, egress class, expected artifacts, eval confidence, version hashes,
+  hard negatives). Contract: no result over threshold → cloud/approval; top-two too close → abstain;
+  Munin down → do not run local; stale/quarantined binding → not selectable. My AR3 ("no dedicated
+  index") survives — but only because the index becomes a *schema inside Munin*, not generic memory.
+
+- **C5 — Escalation is a state transition, not an exception handler (Finding 7).** Conceded, and this is
+  the most useful correction. Local execution runs in an **isolated worktree** (Hugin already has
+  worktree isolation), output is a *patch/artifact* never a live-tree mutation, preflight gates
+  (parser smoke test, tool env, route active, context budget), step budgets + early-abort detectors,
+  cloud fallback consumes the *original snapshot + validated intermediate*, never a dirty workspace.
+
+- **C6 — Immutable, content-addressed promotion records; mutable pointer to active binding (Finding 5).**
+  Conceded. The registry stores a small "which binding is active" pointer; the evidence (all the hashes —
+  package, profile, eval, grader, wrapper, model file, quantization, context cap, thinking format, parser
+  test result, hardware envelope, tool-env manifest) is an immutable run record. Demotion fail-closes on
+  any hash drift.
+
+- **C7 — Policy-aware fallback (Finding 8).** Conceded. I missed that Hugin routing already carries
+  `provider / egress / zdrRequired / autoEligible`. Fallback is not unconditional: the binding carries
+  `cloudAllowed`, `autoEscalateAllowed`, `requiresUserApproval`, `zdrRequired`, `egressClass`,
+  `maxCloudCost`, `fallbackOnFailureKinds`, decided *before* execution.
+
+## Partial concessions
+
+- **PC1 — #77 as precondition (Finding 1).** Partially accept. #77 (crash-recovery liveness) gates the
+  **`active`** state for real-task routing — agreed, a stranded hour-long lease is exactly the lane this
+  lives in. But it does *not* gate the whole build: the slice can be built and run end-to-end in
+  **`shadow`** against a fixture repo while #77 is open, because shadow runs aren't load-bearing for user
+  tasks. So: #77 is a precondition for **promotion to `active`**, not for building or shadow-validating.
+  This keeps the build unblocked while honoring the real runtime constraint. I'll add a "kill-during-local-
+  execution" acceptance test to the slice regardless.
+
+- **PC2 — Munin-superior-to-QMD claim (Finding 4 / Unsupported Claims).** Concede the *argument* was
+  sloppy — QMD is a serious retrieval system (FTS5, sqlite-vec, RRF, AST chunking, reranking), not "flat
+  markdown." Correction: Munin is the right substrate because it's *already deployed, audited, and
+  authenticated* in this stack, not because QMD is primitive. The procedural-schema work (C4) is
+  effectively importing QMD's *shape* into Munin. Claim rewritten, conclusion unchanged.
+
+- **PC3 — Full contract surface now (Findings 2/5/8, Scale).** Accept the *data model* must accommodate the
+  full matrix (task class × profile × eval × harness × wrapper × model × context cap × hardware × tool env)
+  — but the first slice populates **one row**. Codex agrees ("put the matrix in the data model now, then
+  start with one row"), so this is alignment, not conflict. Guarding against over-engineering: the eight
+  fallback-policy fields and thirteen run-record fields are *schema columns*, most defaulted, not eight
+  subsystems to build in slice one.
+
+## Defenses (push back)
+
+- **D1 — "Beats cloud on cost/latency is the wrong success criterion" (Unsupported Claims).** Partial
+  push-back. For *slice one* Codex is right: the gate is correctness, fail-closed behavior, reproducible
+  promotion, crash recovery, clean fallback. I concede that. **But** for the *capability* to earn its
+  maintenance burden (F5, combinatorial revalidation), it must eventually win on **privacy/offline/egress-
+  constrained tasks** — the `zdrRequired`/`egressClass` lane Codex itself raised. So cost/latency-vs-cloud
+  is not the architecture gate, but "is there a real task class where local is *required or cheaper*" is the
+  strategic gate that decides whether the matrix is worth maintaining at all. Recorded as a non-slice-one
+  success metric, not dropped.
+
+- **D2 — Capacity model / scheduler.** Accept the need (one heavy local job at a time on the 32GB Air,
+  queued evals, no eval starving production). Minor scope note: Hugin already serializes the batch lane;
+  the new requirement is just "evals share the same single-heavy-job semaphore," not a new scheduler.
+
+## Revised positions table
+
+| # | Original | Revised |
+|---|----------|---------|
+| Primitive | eval-gated skill promotion (bool flag) | versioned `RouteBinding` with lifecycle states + calibrated metrics |
+| Skill artifact | existing `SKILL.md` | runtime-neutral procedure package → compiled `pi-local-30b` profile |
+| Eval | Opus writes skill + grader | split fixtures + ≥1 independent oracle + failure-stage recording |
+| Retrieval | trust Munin hybrid search | procedural schema in Munin + fail-closed abstention contract |
+| Promotion record | `validatedSkills` registry field | immutable content-addressed run record + mutable active pointer |
+| Escalation | "cloud fallback otherwise" | worktree-isolated execution + preflight + budgets + snapshot-based state transition |
+| Fallback | unconditional cloud | policy-gated (`zdrRequired`/`egressClass`/approval) decided pre-execution |
+| #77 | ignored | precondition for `active` routing, not for build/shadow |
+| Slice gate | beats cloud on cost/latency | route retrieved→executed→graded→delivered→failed→recovered→demoted→escalated reproducibly |

--- a/docs/decisions/skill-distillation/skill-distillation-claude-self-review.md
+++ b/docs/decisions/skill-distillation/skill-distillation-claude-self-review.md
@@ -1,0 +1,49 @@
+# Self-Review
+
+## Debate Type
+Primary: architecture
+
+## Universal checklist
+
+- **Assumptions that might not hold:** A1 (eval-as-proxy) is the weakest. A frontier-written eval
+  proves the skill *can* be executed on a curated input, not that retrieval will surface it on the
+  right task or that real inputs match the eval distribution. A4 (Munin retrieval sufficiency) is
+  asserted, not shown — procedural retrieval has a different precision requirement than the
+  decision/context retrieval Munin is tuned for. Wrong playbook is worse than no playbook (F3).
+
+- **Failure modes — exhaustive?** Missing: **versioning/provenance of the promotion record** (which
+  Opus version authored skill + eval; reproducibility of the validation run). Missing: **eval
+  environment parity** — the grader must run in the same tool/MCP environment the local model will
+  have at execution time, or the gate tests a different system than it ships. Missing: **concurrency/
+  resource contention** — the eval matrix and live batch tasks competing for the same ~21GB Metal cap.
+
+- **Strongest argument against my position:** "eval-gated skill promotion" may be the wrong primitive.
+  The real unit might be the **task class → (skill, cell) binding** with a measured success rate, not a
+  binary promoted/not flag. A binary gate throws away the calibration signal (passed 24/27) that the
+  prior eval work showed is the actual texture of local-model performance.
+
+- **Missing baseline:** The slice's success criterion ("beats cloud on cost/latency") ignores that
+  cloud is fast *and* cheap for many tasks now. The honest baseline may be "beats cloud on
+  cost/latency *for tasks where data privacy or offline operation is required*" — otherwise the whole
+  thing is dominated by just calling cloud.
+
+- **Hidden operational burden:** Every skill change forces an eval re-run on every registered cell
+  (combinatorial). The registry's `validatedSkills` becomes a matrix that must be invalidated
+  correctly on three independent change axes (skill, wrapper, model). This is the real maintenance
+  cost and the draft understates it (F5 names it but doesn't size it).
+
+## Architecture-specific checklist
+
+- **Scale assumptions:** Library assumed to stay small enough that re-validation is tractable. Unstated.
+- **Coupling introduced:** Hugin routing now depends on Munin retrieval quality + eval matrix +
+  wrapper capability flags. Three new coupling points; degradation in any silently degrades routing.
+- **Degradation under partial failure:** If Munin retrieval is down, does Hugin fail-closed to cloud
+  (safe, costs money) or skip the skill (risky)? Undecided in draft.
+- **Reversibility:** High — it's additive to Hugin; can be turned off by clearing `validatedSkills`.
+  This is a genuine strength worth stating.
+
+## Points I expect Codex to raise (pre-registering to test self-review catch rate)
+- Goodhart on self-authored evals (F1) needs a structural fix, not just naming.
+- Binary promotion vs. calibrated success-rate routing.
+- Eval/execution environment parity.
+- Demotion lifecycle is under-specified (U2).

--- a/docs/decisions/skill-distillation/skill-distillation-codex-critique.md
+++ b/docs/decisions/skill-distillation/skill-distillation-codex-critique.md
@@ -1,0 +1,401 @@
+# Context Loaded
+
+## Memory Calls
+
+Called the requested Munin tools in order, then stopped using memory tools:
+
+1. `memory_read(namespace: 'projects/hugin', key: 'status')`
+2. `memory_read(namespace: 'decisions/local-llm-harness', key: 'lessons')`
+3. `memory_query(query: 'skill distillation local model eval Hugin routing', tags: ['decision'], limit: 5)`
+4. `memory_read(namespace: 'research/qmd-analysis', key: 'architecture')`
+
+Model: Codex, GPT-5-based coding agent.
+
+## Notable Gaps Or Conflicts With Memory
+
+- The draft assumes Hugin can already route batch work to the local executor (`debate/skill-distillation-claude-draft.md:18`, `debate/skill-distillation-claude-draft.md:27`, `debate/skill-distillation-claude-draft.md:80`), but Munin says the broker is not enabled on Pi and #77 crash-recovery liveness is still blocking completion of the current Pi e2e. That is not a reason to stop this build, but it is a build-order constraint the design currently hides.
+- The draft says Munin is "superior to QMD's flat markdown" (`debate/skill-distillation-claude-draft.md:16`). The QMD architecture memory contradicts the "flat markdown" characterization: QMD has hybrid FTS/vector retrieval, query expansion, chunk reranking, context hierarchy, LLM caching, AST-aware chunking, and graceful degradation. Munin may still be the right substrate, but the argument in the draft is not supported.
+- The draft maps L2 directly to existing `~/.claude/skills/` (`debate/skill-distillation-claude-draft.md:17`). The memory query surfaced a prior decision on `decisions/skills-in-munin/round-2-verdict`: the portable unit is not a Claude skill in the abstract, but at best a rewritten derivative. The draft needs to treat this as a first-class constraint.
+- The local harness lessons strongly support the tuple instinct in A3 (`debate/skill-distillation-claude-draft.md:36`), but they also show the tuple is still underspecified. The actual unit is closer to `(task class, skill package, harness config, wrapper, model file, thinking format, context cap, hardware envelope, tool environment)`.
+- The Hugin routing decision in memory includes provider, egress, `zdrRequired`, and `autoEligible` as orthogonal fields. The draft's "cloud fallback otherwise" path (`debate/skill-distillation-claude-draft.md:27`, `debate/skill-distillation-claude-draft.md:84`) does not yet respect those policy axes.
+
+# Critique
+
+## Strengths
+
+The draft gets several important things right.
+
+First, it scopes "distillation" to procedures, not weights (`debate/skill-distillation-claude-draft.md:8` to `debate/skill-distillation-claude-draft.md:12`). That preserves inspectability, reversibility, and per-skill gating.
+
+Second, A3 is the right instinct: a skill is never validated in the abstract (`debate/skill-distillation-claude-draft.md:36` to `debate/skill-distillation-claude-draft.md:37`). This aligns directly with the local harness lessons: wrapper behavior, tool-call parsing, model family, thinking format, context cap, and harness behavior form one operational cell.
+
+Third, batch-only routing is correctly treated as non-negotiable on current hardware (`debate/skill-distillation-claude-draft.md:67` to `debate/skill-distillation-claude-draft.md:68`). Munin's local harness lessons show 10 minutes to nearly 3 hours per task for Qwen3-Coder-30B on the 32 GB Air. The draft does not pretend that is interactive.
+
+Fourth, the failure modes are not cosmetic. Eval overfit, cell drift, retrieval miss, late failure, and authoring burden are the right family of risks (`debate/skill-distillation-claude-draft.md:44` to `debate/skill-distillation-claude-draft.md:57`). The self-review also correctly identifies binary promotion and environment parity as missing depth (`debate/skill-distillation-claude-self-review.md:14` to `debate/skill-distillation-claude-self-review.md:23`).
+
+The problem is not that the design is naive. The problem is that it compresses several hard contracts into labels like `validatedSkills`, "Munin retrieval", and "cloud fallback". Those need to become explicit build artifacts.
+
+## Major Findings
+
+### 1. Hugin's current runtime state is a build blocker for the proposed vertical slice
+
+The proposed slice ends with "Hugin routes a batch task to it" (`debate/skill-distillation-claude-draft.md:83` to `debate/skill-distillation-claude-draft.md:84`). Munin says Hugin is not at that operational point yet: the broker is not enabled on Pi, and #77 crash-recovery liveness remains unresolved. The specific failure is highly relevant here: a delivery crash plus auto-restart can leave a task non-terminal until a second post-lease-expiry restart.
+
+That matters more for skill distillation than for a toy dispatcher because this design is explicitly accepting 10 minute to 3 hour local runs (`debate/skill-distillation-claude-draft.md:40` to `debate/skill-distillation-claude-draft.md:42`, `debate/skill-distillation-claude-draft.md:67` to `debate/skill-distillation-claude-draft.md:68`). A liveness bug in that lane does not merely slow the run. It can strand a route decision, delay fallback, and make the system look "in progress" when it should have terminalized and escalated.
+
+Concrete design change:
+
+- Make #77-class crash recovery an explicit precondition for the e2e slice.
+- Add a "kill during local skill execution" acceptance test to the slice, not just "cloud fallback on grader failure" (`debate/skill-distillation-claude-draft.md:84`).
+- Require stable worker identity, lease expiry reconciliation, idempotent artifact delivery, and startup reconciliation before any promoted local route can be considered active.
+- Treat local execution as a task state machine with terminal states, not as a best-effort subprocess behind the router.
+
+This is not a "validate the premise first" objection. It is a sequencing requirement for building the premise without inheriting a known runtime failure.
+
+### 2. "Eval-gated skill promotion" is the wrong primitive
+
+The draft's proposed primitive is "promote a skill" by tagging it local-executable in Hugin's runtime registry (`debate/skill-distillation-claude-draft.md:20` to `debate/skill-distillation-claude-draft.md:27`). A3 partially corrects this by saying the promotion unit is `(skill, harness, wrapper, model)` (`debate/skill-distillation-claude-draft.md:36` to `debate/skill-distillation-claude-draft.md:37`). The self-review goes further and notes that the real unit may be `task class -> (skill, cell) binding` with a measured success rate (`debate/skill-distillation-claude-self-review.md:20` to `debate/skill-distillation-claude-self-review.md:23`).
+
+The self-review is right. A binary `validatedSkills` flag throws away the signal the prior local eval work showed is decisive: partial pass rates, per-task durations, failure modes, context sensitivity, and wrapper-specific behavior. The local harness lessons did not say "Qwen3-Coder works" or "does not work"; they said specific cells produce specific score and latency profiles under specific wrapper and context settings.
+
+Better decomposition:
+
+- `SkillPackage`: portable procedure, tool contract, examples, safety constraints, eval suite references.
+- `TaskClass`: the class of user/task inputs the skill claims to handle, with routing predicates and contraindications.
+- `CellManifest`: harness, wrapper, model file/hash, quantization, context cap, thinking format, tool-call parsing behavior, hardware envelope, tool/MCP environment, and timeout budgets.
+- `EvalSuite`: deterministic fixtures, negative fixtures, retrieval fixtures, mutation tests, grader code, expected artifacts, and allowed nondeterminism.
+- `RouteBinding`: `(taskClass, skillPackageVersion, cellManifestVersion, evalSuiteVersion) -> policy`, with calibrated metrics and current state.
+
+The thing Hugin should route on is the `RouteBinding`, not a skill-level flag. A route binding can be active, shadow, quarantined, stale, or disabled. It can carry thresholds and telemetry. A skill cannot.
+
+### 3. The draft treats Claude `SKILL.md` as too portable
+
+The draft maps L2 directly to existing `~/.claude/skills/` (`debate/skill-distillation-claude-draft.md:17`) and says Opus writes `SKILL.md` plus a deterministic grader (`debate/skill-distillation-claude-draft.md:22`). The memory query surfaced a prior decision that directly challenges this: the portable unit is not a Claude skill, but at best a rewritten derivative.
+
+This is not academic. Claude skills often assume Claude-specific context loading, tool affordances, instruction-following ability, and interaction shape. A 30B local model executing through `pi` and LM Studio is a different runtime. The draft acknowledges granularity risk in A2 (`debate/skill-distillation-claude-draft.md:33` to `debate/skill-distillation-claude-draft.md:35`), but it still anchors the artifact on raw `SKILL.md`.
+
+Concrete design change:
+
+- Define a runtime-neutral "procedure package" as the source artifact.
+- Generate or store target profiles from that package: `claude-skill`, `pi-local-30b`, perhaps `codex`.
+- The `pi-local-30b` profile should be stricter than a Claude skill: bounded inputs, explicit allowed tools, short step list, checkpoint after each step, fixed output schema, examples, anti-examples, and abort conditions.
+- Promotion should apply to a package profile, not to the human-facing Claude skill file.
+
+This preserves compatibility with `~/.claude/skills/` while avoiding the false abstraction that an existing Claude skill is automatically the thing a local 30B model can execute.
+
+### 4. The Munin vs QMD argument is underbuilt and partly false
+
+The draft asserts that Munin is the procedural KB and is "superior to QMD's flat markdown" (`debate/skill-distillation-claude-draft.md:16`). It then assumes Munin retrieval is enough to fetch the right playbook (`debate/skill-distillation-claude-draft.md:38` to `debate/skill-distillation-claude-draft.md:39`) and tentatively rejects a dedicated procedural index as duplication (`debate/skill-distillation-claude-draft.md:65` to `debate/skill-distillation-claude-draft.md:66`).
+
+That is too casual. The QMD memory describes a serious retrieval system, not flat markdown: content-addressed SQLite storage, FTS5, sqlite-vec, query expansion, RRF fusion, chunk reranking, hierarchical context, AST-aware chunking, and graceful fallback. The lesson is not "use QMD instead." The lesson is that procedural retrieval has a shape, and the draft does not specify that shape.
+
+Munin can still be the substrate, but it needs a procedural index layer or procedural collection schema inside Munin. That is different from building a separate storage system.
+
+Minimum procedural retrieval fields:
+
+- skill id and profile id
+- task class
+- trigger phrases
+- required inputs
+- required tools
+- contraindications
+- privacy/egress constraints
+- expected artifacts
+- eval confidence and known failure modes
+- examples and hard negatives
+- version hashes
+
+The retrieve-first contract should also be fail-closed:
+
+- If no result clears a confidence threshold, route to cloud or ask for explicit route policy.
+- If the top two skills are too close, abstain rather than letting the local model improvise.
+- If Munin is unavailable, do not run local by default.
+- If retrieval returns a skill whose route binding is stale or quarantined, do not run it.
+
+Wrong playbook retrieval is already identified as worse than no skill (`debate/skill-distillation-claude-draft.md:51` to `debate/skill-distillation-claude-draft.md:52`). The architecture should reflect that, not simply trust hybrid search.
+
+### 5. Versioning and provenance need to be immutable run records, not registry fields
+
+Cell drift is correctly named (`debate/skill-distillation-claude-draft.md:49` to `debate/skill-distillation-claude-draft.md:50`), and U2 asks who triggers revalidation (`debate/skill-distillation-claude-draft.md:72` to `debate/skill-distillation-claude-draft.md:74`). But the proposed registry mechanism, `validatedSkills` alongside `parsesToolCalls` (`debate/skill-distillation-claude-draft.md:25` to `debate/skill-distillation-claude-draft.md:26`), is not enough to answer that question.
+
+The local harness lessons show why. Tool-call parsing lives in the wrapper, thinking-format flags are silent foot-guns, LM Studio's context cap changes memory behavior, and model plus harness plus wrapper must be treated as a single operational unit. A promotion record that omits any of those is not reproducible.
+
+Promotion records should be immutable and content-addressed. Store at least:
+
+- skill package hash and profile hash
+- eval suite hash and grader hash
+- prompt/system instruction hash
+- harness name and version
+- wrapper name and version
+- model id, file hash, quantization, and context cap
+- thinking format and reasoning flags
+- tool-call parser capability and observed parser test result
+- OS, hardware class, memory cap, and concurrency budget
+- tool/MCP environment manifest
+- execution timeout and step budgets
+- result metrics, logs, artifacts, and failure classifications
+
+Then maintain a mutable pointer saying which route binding is currently active. The mutable pointer can be small. The evidence behind it cannot be.
+
+### 6. The eval design needs a structural anti-Goodhart fix
+
+F1 identifies the core problem: Opus writes both the skill and the grader (`debate/skill-distillation-claude-draft.md:46` to `debate/skill-distillation-claude-draft.md:48`). U1 leaves grading modality open (`debate/skill-distillation-claude-draft.md:72`). Naming the risk is not enough.
+
+A deterministic grader is necessary but not sufficient. If the same frontier author creates the procedure and the only acceptance test, the system can converge on skills that pass stylized fixtures but fail real tasks.
+
+Build-level fix:
+
+- Split evals into positive fixtures, negative fixtures, retrieval fixtures, and mutation tests.
+- Require at least one independent oracle per promoted route: test suite, schema validator, snapshot diff, static analyzer, or independent judge model.
+- Treat LLM-judge as advisory unless paired with deterministic checks.
+- Add "should abstain" cases where retrieval must not select the skill.
+- Add adversarial inputs that look similar to the skill's trigger but require a different procedure.
+- Record not just pass/fail, but the reason a failure was caught: retrieval, preflight, tool-call parser, schema, tests, timeout, or final grader.
+
+This is still build design. It does not say "collect more data before deciding." It says the eval package has to test the route, not just the happy path execution.
+
+### 7. Mid-loop cloud escalation is not yet a safe state transition
+
+A5 assumes most failures are detectable mid-loop cheaply enough to avoid wasting the full local budget (`debate/skill-distillation-claude-draft.md:40` to `debate/skill-distillation-claude-draft.md:42`). F4 admits the opposite can happen (`debate/skill-distillation-claude-draft.md:53` to `debate/skill-distillation-claude-draft.md:55`). The vertical slice then says cloud fallback on grader failure (`debate/skill-distillation-claude-draft.md:84`).
+
+That is not a complete failure model. Once a local coding skill has mutated a workspace, cloud fallback is not a clean retry unless the task ran in an isolated worktree or produced a patch artifact that can be discarded. Once a local process has held a lease for an hour and crashed, fallback is not clean unless Hugin can terminalize or reconcile the run. Once retrieval selected the wrong skill, the grader may fail only after the local model has done expensive or destructive work.
+
+Concrete design change:
+
+- Run local skill execution in an isolated worktree or sandbox.
+- Treat local output as an artifact or patch, not as direct mutation of the user's live working tree.
+- Add preflight checks before model execution: route binding active, tool environment present, wrapper parser smoke test, context budget, and input schema.
+- Add step budgets: maximum tokens, maximum wall time, maximum tool calls, maximum no-op turns, maximum invalid tool calls.
+- Add early abort detectors: no tool calls after N turns, invalid tool args twice, no file changes by checkpoint, repeated same observation, context near cap, wrapper content-only response when tool calls are required.
+- Cloud fallback should consume the original task snapshot plus any validated intermediate artifact, not a dirty workspace.
+
+Without these mechanics, "cloud escalation" is a phrase, not an architecture.
+
+### 8. Cloud fallback must respect Hugin route policy
+
+The draft says Hugin sends matching batch tasks to local and uses cloud fallback otherwise (`debate/skill-distillation-claude-draft.md:27`). The vertical slice also includes cloud fallback on grader failure (`debate/skill-distillation-claude-draft.md:84`).
+
+The Hugin decision memory says routing has orthogonal provider, egress, `zdrRequired`, and `autoEligible` fields. That means fallback cannot be unconditional. Some tasks may be local-only because of privacy, offline constraints, egress rules, or ZDR requirements. Others may be cloud-eligible but not auto-eligible.
+
+The route binding needs a fallback policy:
+
+- `cloudAllowed`
+- `autoEscalateAllowed`
+- `requiresUserApproval`
+- `zdrRequired`
+- `egressClass`
+- `maxCloudCost`
+- `fallbackProviderSet`
+- `fallbackOnFailureKinds`
+
+This should be decided before execution, not after a local failure when the system is under pressure to recover.
+
+## Additional Architecture Risks
+
+### Scale and load assumptions
+
+The draft says every skill needs a maintained eval (`debate/skill-distillation-claude-draft.md:56` to `debate/skill-distillation-claude-draft.md:57`), and the self-review notices combinatorial revalidation (`debate/skill-distillation-claude-self-review.md:30` to `debate/skill-distillation-claude-self-review.md:33`). The design still does not size the matrix.
+
+The matrix is not just `skills x cells`. It is:
+
+`task classes x skill profiles x eval suites x harness configs x wrappers x model versions x context caps x hardware envelopes x tool environments`.
+
+The first build does not need to solve the full matrix, but it should avoid a schema that pretends the matrix is a list of strings. Put the matrix in the data model now, then start with one row.
+
+Also, the local harness lessons show the 32 GB Air has a real Metal wired-memory ceiling. Eval runs and live batch jobs must not compete blindly. The scheduler needs a capacity model: one local heavy job at a time unless proven otherwise, queued evals, and no eval run starving production work.
+
+### Coupling
+
+The design couples Hugin routing to all of these:
+
+- Munin retrieval quality
+- skill package structure
+- eval suite quality
+- local wrapper behavior
+- model context and memory behavior
+- Hugin artifact delivery
+- cloud fallback policy
+
+That coupling is acceptable only if each boundary has an explicit contract. The current draft mostly names the components but does not define the contracts. The highest-risk hidden coupling is retrieval-to-execution: a retrieval miss can become a local execution decision.
+
+### Partial failure and degradation
+
+Define behavior for these cases:
+
+- Munin unavailable
+- Munin returns low-confidence or tied skills
+- skill package found but route binding stale
+- local wrapper up but tool-call parsing fails
+- local model starts but context cap is exceeded
+- local job exceeds duration budget
+- local job mutates workspace but grader fails
+- Hugin delivery crashes mid-run
+- cloud fallback disallowed by policy
+- eval runner unavailable during revalidation
+
+Default should be fail-closed for local execution. That usually means cloud route if policy allows, queue for user approval if policy requires it, or mark blocked if neither is legal.
+
+### Operational burden
+
+This feature needs first-class telemetry from day one:
+
+- route decision and alternatives considered
+- retrieval query, top candidates, scores, and abstention reason
+- route binding id and version hashes
+- cell manifest id
+- wrapper parser preflight result
+- wall time, token count, tool-call count, invalid tool-call count
+- checkpoint progress
+- grader result
+- fallback reason
+- final artifact id
+- cloud cost, if escalated
+
+Without this, incident response will be guesswork. A bad promoted route will look like "local is flaky" rather than "skill profile v3 on LM Studio wrapper vX with context cap Y fails retrieval-negative case Z."
+
+### Reversibility
+
+The self-review says reversibility is high because this is additive and can be disabled by clearing `validatedSkills` (`debate/skill-distillation-claude-self-review.md:42` to `debate/skill-distillation-claude-self-review.md:43`). That is too optimistic if the system is built around a `validatedSkills` field.
+
+Reversibility is high only if:
+
+- route bindings are separate from skill packages
+- local routing is behind a feature flag
+- local execution writes only isolated artifacts until accepted
+- disabling a route binding leaves cloud routing intact
+- stale or quarantined bindings cannot be selected by retrieval
+- schema migrations do not make existing tasks depend on local-only fields
+
+Clearing a flag is not enough once retrieval, task classification, Hugin routing, and eval lifecycle have been coupled.
+
+### Security and policy
+
+The draft does not mention tool allowlists, sandboxing, secrets, egress, signing, or artifact trust. Munin's Hugin status lists HMAC signing secrets, signing policy, and exfil/external policies as carry-forward work. Skill distillation increases the importance of those policies because a frontier-authored procedure and grader can effectively grant operational permissions to a smaller local model.
+
+Minimum policy controls:
+
+- skill-level tool allowlist
+- task-level egress policy
+- no secret access unless explicitly required and audited
+- sandboxed grader execution
+- signed skill/eval packages or at least content-addressed manifests
+- artifact provenance: which route binding produced this output
+- cloud fallback policy checked before execution
+
+## Unsupported Claims And Missing Baselines
+
+- "Munin is superior to QMD's flat markdown" is unsupported and partly contradicted by the QMD memory (`debate/skill-distillation-claude-draft.md:16`).
+- "The eval is a sufficient proxy for fitness" is the weakest load-bearing assumption (`debate/skill-distillation-claude-draft.md:31` to `debate/skill-distillation-claude-draft.md:32`). The design should not depend on a single frontier-written grader as the proxy.
+- "Most failures are detectable mid-loop cheaply" is asserted, not established (`debate/skill-distillation-claude-draft.md:40` to `debate/skill-distillation-claude-draft.md:42`). Build detectors, budgets, and rollback around the assumption being false sometimes.
+- The vertical slice's "beats cloud on cost/latency" criterion (`debate/skill-distillation-claude-draft.md:84` to `debate/skill-distillation-claude-draft.md:85`) is the wrong success criterion for a premise-fixed build. Track cloud cost/latency as a baseline, but do not make the architecture's first slice justify itself that way. The first slice should prove route correctness, fail-closed behavior, reproducible promotion, crash recovery, and clean fallback.
+- The draft omits a baseline for "no skill retrieved" and "wrong skill retrieved." Retrieval baselines are part of the build, not a pre-build validation exercise.
+
+## Direct Answers To The Six Debate Questions
+
+### 1. Is "eval-gated skill promotion" the right primitive?
+
+No. The right primitive is a versioned route binding:
+
+`(task class, skill package profile, cell manifest, eval suite) -> active routing policy and calibrated metrics`.
+
+Skill promotion is too broad. Cell promotion is too broad. A boolean gate is too lossy. The route binding should carry score distribution, latency, failure modes, stale status, fallback policy, and provenance.
+
+### 2. How should skills be authored so a 30B local model executes them reliably?
+
+Do not author them as general Claude skills and hope the local model follows them. Author a runtime-neutral procedure package, then compile or adapt a strict `pi-local-30b` profile.
+
+The 30B-safe profile should have:
+
+- short bounded procedure
+- explicit input schema
+- explicit output schema
+- tool allowlist
+- one-step-at-a-time checkpoints
+- examples and anti-examples
+- "do not proceed if" abort conditions
+- maximum context budget
+- expected artifacts
+- local grader hooks after intermediate steps where possible
+
+The local model should be treated less like a planner and more like a constrained operator executing a playbook with guardrails.
+
+### 3. Where should evals live, and how should versioning/promotion/demotion work?
+
+Evals should live adjacent to the skill package in the source repo, not inside Hugin's runtime registry as opaque metadata. Hugin should store or reference immutable validation run records and maintain only the active route pointer.
+
+Suggested lifecycle:
+
+- `draft`: package exists, no active route.
+- `candidate`: eval suite exists and can run.
+- `shadow`: route is evaluated but not selected for real work.
+- `active`: route can be selected when policy allows.
+- `stale`: one of the package, eval, cell, wrapper, model, tool environment, or policy hashes changed.
+- `quarantined`: production failure or regression detected.
+- `disabled`: manually turned off.
+
+Demotion should be fail-closed on hash drift. Re-promotion should require a new immutable validation run.
+
+### 4. Munin retrieval vs dedicated procedural index, and the retrieve-first contract
+
+Use Munin as the storage and retrieval substrate, but add a procedural schema or collection. Do not rely on generic memory retrieval alone.
+
+The retrieve-first contract should be:
+
+- retrieve candidates from procedural metadata and examples
+- require active route binding before execution
+- require confidence threshold and top-result margin
+- abstain on ambiguity
+- include negative retrieval tests in the eval suite
+- route to cloud or approval path when retrieval is unavailable or ambiguous, subject to policy
+
+This gets the benefit of Munin without pretending procedural retrieval is the same as general project-context retrieval.
+
+### 5. What is the mid-loop failure to cloud escalation path?
+
+Make it a state transition, not an exception handler.
+
+Required path:
+
+1. Snapshot the task and workspace before local execution.
+2. Run local in an isolated worktree or sandbox.
+3. Preflight wrapper, parser, tool environment, route policy, and context budget.
+4. Execute with step budgets and heartbeats.
+5. Abort early on parser failure, repeated invalid tool calls, no progress, timeout, context cap, or checkpoint failure.
+6. Run grader on isolated output.
+7. If pass, publish artifact through Hugin.
+8. If fail and policy allows, escalate cloud from the original snapshot plus any validated intermediate artifact.
+9. If cloud is not allowed, terminalize as blocked with reason.
+
+The important point is that fallback cannot depend on a dirty local workspace or an ambiguous in-progress Hugin task.
+
+### 6. What is the smallest end-to-end vertical slice?
+
+The proposed lint-fix slice is close, but still too broad if it spans arbitrary repos. Make the first slice narrower and more hostile to false confidence.
+
+Better slice:
+
+- one deterministic coding procedure, such as a single-file TypeScript import normalization or markdown frontmatter normalization
+- one `pi-local-30b` skill profile
+- one LM Studio/Qwen3-Coder cell manifest with exact wrapper/model/context/thinking settings
+- one procedural Munin entry with hard-negative retrieval fixtures
+- one isolated fixture repo
+- one grader with deterministic tests and diff checks
+- one Hugin route binding in shadow, then active
+- one successful local run
+- one forced local failure that falls back according to policy
+- one kill/restart test that proves Hugin does not strand the task
+- one stale-hash test that demotes the route
+
+Success criterion for the first slice should be: the route can be retrieved, selected, executed, graded, delivered, failed, recovered, demoted, and escalated reproducibly. Cost/latency versus cloud should be recorded, but it should not be the first slice's justification gate.
+
+## Bottom Line
+
+Build this as a route-binding system, not a skill-promotion flag.
+
+Keep Munin, but give procedural retrieval its own schema and abstention contract.
+
+Keep Hugin, but make #77-class crash recovery, sandboxed execution, and policy-aware fallback part of the first vertical slice.
+
+Keep frontier-authored evals, but make them adversarial, versioned, reproducible, and independent enough that they cannot become a rubber stamp.
+
+The premise is sound enough to build. The current draft's main risk is that it would build the first version around convenient nouns - skill, eval, Munin, fallback - instead of the contracts that make those nouns safe to route production work through.

--- a/docs/decisions/skill-distillation/skill-distillation-codex-rebuttal-1.md
+++ b/docs/decisions/skill-distillation/skill-distillation-codex-rebuttal-1.md
@@ -1,0 +1,114 @@
+Context loaded
+
+## Tools Called
+
+Munin requires `memory_orient` before other memory calls, so I oriented first, then ran the requested calls and stopped using memory tools:
+
+1. `memory_read(namespace: 'projects/hugin', key: 'status')`
+2. `memory_query(query: 'skills in munin portable skill derivative decision', tags: ['decision'], limit: 3)`
+
+Model: Codex, GPT-5-based coding agent.
+
+## Round1 -> Round2 Memory Drift
+
+No material drift for this debate. Hugin is still in the same relevant state Round 1 depended on: Orch-v1 steps 1-7 complete, broker not enabled on Pi, #68 not fully green, and #77 crash-recovery liveness still gates the runtime lane. The skills query still surfaces the prior `decisions/skills-in-munin/round-2-verdict` result: the portable unit is not a raw Claude skill, but a rewritten derivative. The query also now ranks `meta/skills/policy` first, but that does not change the architecture conclusion.
+
+# Rebuttal
+
+Claude's response is materially better than the draft. The important concession is real: the design has moved from "promote a skill" to a versioned `RouteBinding` carrying policy and metrics (`debate/skill-distillation-claude-response-1.md:9` to `debate/skill-distillation-claude-response-1.md:13`). That directly fixes the biggest primitive error in the draft, where promotion was a `validatedSkills` field next to `parsesToolCalls` (`debate/skill-distillation-claude-draft.md:25` to `debate/skill-distillation-claude-draft.md:26`).
+
+The portability concession is also genuine and adequate at the concept level. Claude explicitly adopts the prior memory decision that the portable unit is a rewritten derivative, not an existing Claude `SKILL.md` (`debate/skill-distillation-claude-response-1.md:15` to `debate/skill-distillation-claude-response-1.md:19`). That closes the specific abstraction leak I objected to in Round 1, where the draft mapped L2 directly to existing `~/.claude/skills/` (`debate/skill-distillation-claude-draft.md:17`).
+
+The anti-Goodhart, retrieval, run-record, and fallback concessions are also directionally strong: independent oracle, negative/retrieval/mutation fixtures, procedural schema inside Munin, fail-closed retrieval, immutable validation evidence, and policy-aware fallback (`debate/skill-distillation-claude-response-1.md:21` to `debate/skill-distillation-claude-response-1.md:48`). These are not cosmetic concessions. They are the right contract family.
+
+But several concessions are still shallow because they are stated as design vocabulary rather than buildable invariants.
+
+## PC1: #77 Gates More Than `active`
+
+Claude is right that #77 does not need to block every line of code in this project. A fixture-only offline harness can build procedure packages, eval suites, and local profiles while #77 remains open. That part of PC1 is valid (`debate/skill-distillation-claude-response-1.md:52` to `debate/skill-distillation-claude-response-1.md:56`).
+
+The dodge is treating "shadow" as automatically safe and meaningful. There are two different things hiding under that word:
+
+- Offline shadow: run the local cell against fixture repos outside production Hugin routing. Safe, useful for authoring evals, but not evidence that Hugin can route, recover, deliver, or fallback.
+- Hugin-integrated shadow: let Hugin select the binding and run the local lane, but do not expose the result to real user tasks. This exercises the real state machine and therefore inherits #77's liveness problem.
+
+Claude says #77 gates `active`, not shadow, and promises a kill-during-local-execution acceptance test (`debate/skill-distillation-claude-response-1.md:56` to `debate/skill-distillation-claude-response-1.md:58`). That test is exactly why the distinction matters. If the test goes through Hugin while #77 is open, a crash can still strand the run; if it bypasses Hugin, it is not testing the system the feature will rely on. In Round 1, the point was not "do not build." It was that a 10 minute to 3 hour local run can be left non-terminal, delaying fallback and corrupting telemetry (`debate/skill-distillation-codex-critique.md:40` to `debate/skill-distillation-codex-critique.md:53`).
+
+So the corrected version is:
+
+- #77 does not block offline package/profile/eval work.
+- #77 blocks counting any Hugin-integrated shadow run as readiness evidence for `active`.
+- #77 blocks the first real end-to-end claim that Hugin can retrieve, select, execute, deliver, fail, recover, demote, and escalate reproducibly.
+- The kill/restart acceptance test should either be marked expected-failing until #77 is fixed, or be the first test that proves #77 is fixed.
+
+Shadow mode is safe only if it is explicitly non-promoting, fixture-scoped, cleanup-bounded, and labeled "runtime recovery not yet proven." Otherwise "shadow" becomes a way to launder a known liveness bug into the evidence base.
+
+## PC3: "One Row Now" Is Correct, But Not Enough
+
+Claude's PC3 is partly adequate. It accepts that the data model must accommodate the full matrix: task class, profile, eval, harness, wrapper, model, context cap, hardware, and tool environment (`debate/skill-distillation-claude-response-1.md:66` to `debate/skill-distillation-claude-response-1.md:71`). That matches the Round 1 instruction to put the matrix in the model now, then populate one row (`debate/skill-distillation-codex-critique.md:197` to `debate/skill-distillation-codex-critique.md:205`).
+
+The shallow part is the phrase "schema columns." If the first slice only adds nullable/defaulted fields while the router still behaves like a boolean promotion path, the concession has not landed. The first row must be consumed by the route decision and execution path.
+
+Minimum commitment for the first row:
+
+- `TaskClass` has a versioned classifier or deterministic predicate, hard negatives, and contraindications.
+- `SkillPackageProfile` is content-addressed and distinct from raw `SKILL.md`.
+- `CellManifest` records wrapper, model hash, context cap, thinking/tool-call behavior, hardware, and tool environment.
+- `EvalSuite` is versioned and contains retrieval-negative, execution-positive, execution-negative, and mutation fixtures.
+- `ValidationRun` is immutable evidence, not mutable registry state.
+- `RouteBinding` is the only selectable object and cannot point at stale hashes.
+- `RouteDecision` is recorded for every attempted selection, including abstentions.
+
+"One row" is fine. "One row that exercises the full contract" is the bar. Otherwise the build will recreate `validatedSkills` with a nicer name.
+
+## D1: Beats Cloud Is A Strategic Signal, Not A Gate
+
+Claude's D1 is valid where it concedes the first slice gate: correctness, fail-closed behavior, reproducible promotion, crash recovery, and clean fallback come before cost/latency (`debate/skill-distillation-claude-response-1.md:75` to `debate/skill-distillation-claude-response-1.md:78`). That is the right ordering.
+
+The defense becomes fuzzy when it says the capability must eventually win on "privacy/offline/egress-constrained tasks" and then phrases the strategic test as "required or cheaper" (`debate/skill-distillation-claude-response-1.md:78` to `debate/skill-distillation-claude-response-1.md:82`). Those are different gates:
+
+- Privacy/offline/egress-required is categorical. Cloud cannot be used, so local capability can be worth maintaining even if it is slower.
+- Cheaper/faster is economic. It only matters after reliability, scheduling, revalidation churn, and human review costs are included.
+
+So yes: record cloud cost/latency from slice one. No: do not let that become the build's strategic framing. The better strategic criterion is: there is at least one recurring task class where a local route is policy-required or sustainably cheaper after maintenance cost, and that task class has a bounded route-binding matrix.
+
+## D2: A Semaphore Is Necessary, Not Sufficient
+
+Claude's D2 is partly valid. If Hugin already serializes the batch lane, then the first capacity control can indeed be "evals and production local jobs share the same single-heavy-job gate" (`debate/skill-distillation-claude-response-1.md:84` to `debate/skill-distillation-claude-response-1.md:86`). That is a sensible initial implementation.
+
+But this dodges the actual scheduler concern by reducing it to concurrency. A semaphore prevents two 30B runs from competing at once. It does not specify:
+
+- priority between production work and eval work
+- cancellation behavior
+- lease expiry and heartbeat semantics
+- stale-run reconciliation
+- starvation limits
+- retry policy
+- resource profiles for CPU/GPU/Metal memory
+- whether evals can block cloud-eligible user work
+
+This is not a demand for a new scheduler subsystem. It is a demand that the single semaphore be attached to a policy: priority, leases, timeouts, and reaper behavior. #77 is already proof that "only one worker" is not enough when a long-running task can be stranded.
+
+## New Risk: RouteBinding Makes Task Classification Load-Bearing
+
+The route-binding redesign fixes the wrong primitive, but it introduces a new load-bearing component neither side has named clearly enough: task classification.
+
+The new route key starts with `taskClass` (`debate/skill-distillation-claude-response-1.md:9` to `debate/skill-distillation-claude-response-1.md:11`). PC3 repeats that the model must include task class as the first matrix dimension (`debate/skill-distillation-claude-response-1.md:66` to `debate/skill-distillation-claude-response-1.md:68`). But the system still has to decide that an incoming task belongs to that class before it can select a binding. That decision is now part of routing, policy, safety, and cost.
+
+A bad classifier can:
+
+- select the wrong local procedure even when retrieval works
+- bypass a cloud/ZDR/egress policy by assigning the wrong class
+- send an ambiguous task into the local lane instead of abstaining
+- inflate shadow metrics by evaluating only easy in-class fixtures
+- make demotion look like a model failure when the real bug was classification
+
+Round 1 named retrieval-to-execution coupling as the highest-risk hidden coupling (`debate/skill-distillation-codex-critique.md:207` to `debate/skill-distillation-codex-critique.md:220`). RouteBinding sharpens that: retrieval is not enough. There must be a first-class `TaskClassifier` or route predicate artifact with versioned rules, examples, hard negatives, confidence thresholds, top-two margins, and recorded abstentions. It belongs in the eval suite too: every binding needs "should classify" and "should not classify" cases before execution is even attempted.
+
+If this is left implicit, the project will have a precise binding record attached to an unexamined classification guess. That is worse than the original boolean flag because it will look rigorously versioned while the most important selection step remains opaque.
+
+## Final Verdict
+
+The single most important next step is to fix Hugin #77 and prove it with a kill-during-local-execution acceptance test wired through the same task lifecycle the skill lane will use.
+
+Do not block offline package/eval/profile authoring on #77. But the first implementation step that matters for the actual architecture is runtime liveness: stable worker identity, lease-expiry reconciliation, startup recovery, terminal state correctness, and idempotent artifact delivery. Until that is green, Hugin-integrated shadow cannot safely produce promotion evidence, and the first vertical slice cannot honestly claim route -> execute -> fail -> recover -> fallback.

--- a/docs/decisions/skill-distillation/skill-distillation-critique-log.json
+++ b/docs/decisions/skill-distillation/skill-distillation-critique-log.json
@@ -1,0 +1,128 @@
+[
+  {
+    "id": "skill-distillation-C01",
+    "source": "codex-round-1",
+    "text": "Hugin #77 crash-recovery liveness + broker-not-enabled is a build-order constraint the design hides; a 10min-3h local run can be stranded non-terminal, delaying fallback and corrupting telemetry.",
+    "classification": "valid",
+    "impact": "partially_changed",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "skill-distillation-C02",
+    "source": "codex-round-1",
+    "text": "'eval-gated skill promotion' (boolean validatedSkills flag) is the wrong primitive; it discards partial-pass/latency signal. Use a versioned RouteBinding (taskClass, profile, cellManifest, evalSuite) -> policy + calibrated metrics with lifecycle states.",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "critical",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "skill-distillation-C03",
+    "source": "codex-round-1",
+    "text": "Draft treats Claude SKILL.md as portable; prior decision skills-in-munin says portable unit is a rewritten derivative. Author a runtime-neutral procedure package, compile a strict pi-local-30b profile; promote the profile not the Claude file.",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "skill-distillation-C04",
+    "source": "codex-round-1",
+    "text": "Munin-superior-to-QMD claim is unsupported/partly false (QMD is a serious retrieval system). Procedural retrieval needs its own schema/collection inside Munin + a fail-closed abstention contract; do not trust generic hybrid search.",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "skill-distillation-C05",
+    "source": "codex-round-1",
+    "text": "validatedSkills registry field cannot answer revalidation. Promotion records must be immutable, content-addressed (all hashes: package/profile/eval/grader/wrapper/model/quant/context-cap/thinking-format/parser-result/hardware/tool-env) with only a small mutable active pointer.",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "skill-distillation-C06",
+    "source": "codex-round-1",
+    "text": "Naming Goodhart risk (F1) isn't a fix. Split evals into positive/negative/retrieval/mutation fixtures; require >=1 independent oracle per route; LLM-judge advisory only; record the stage a failure was caught.",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "critical",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "skill-distillation-C07",
+    "source": "codex-round-1",
+    "text": "Mid-loop cloud escalation must be a state transition, not an exception handler: isolated worktree/sandbox, output as patch/artifact never live mutation, preflight gates, step budgets, early-abort detectors, fallback consumes original snapshot + validated intermediate.",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "critical",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "skill-distillation-C08",
+    "source": "codex-round-1",
+    "text": "Cloud fallback cannot be unconditional; Hugin routing carries provider/egress/zdrRequired/autoEligible. RouteBinding needs a pre-execution fallback policy (cloudAllowed, autoEscalateAllowed, requiresUserApproval, zdrRequired, egressClass, maxCloudCost, fallbackOnFailureKinds).",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "skill-distillation-C09",
+    "source": "codex-round-1",
+    "text": "No security/policy controls named: tool allowlists, sandboxing, secrets, egress, signing, artifact trust. Frontier-authored skill+grader effectively grants operational permissions to the local model.",
+    "classification": "valid",
+    "impact": "acknowledged",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "skill-distillation-C10",
+    "source": "codex-round-1",
+    "text": "Slice 'beats cloud on cost/latency' is the wrong gate for a premise-fixed build; gate on route correctness, fail-closed behavior, reproducible promotion, crash recovery, clean fallback. Record cost/latency as baseline only.",
+    "classification": "partially_valid",
+    "impact": "partially_changed",
+    "severity": "minor",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "skill-distillation-C11",
+    "source": "codex-round-2",
+    "text": "RouteBinding makes TASK CLASSIFICATION load-bearing and neither side named it. A bad classifier picks wrong procedures, bypasses ZDR/egress policy, fails to abstain on ambiguity, inflates shadow metrics. Need a first-class versioned TaskClassifier/route-predicate artifact with hard negatives, thresholds, margins, recorded abstentions, and 'should/should-not classify' eval cases.",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "critical",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "skill-distillation-C12",
+    "source": "codex-round-2",
+    "text": "PC1 dodge: 'shadow' conflates offline-fixture shadow (safe) with Hugin-integrated shadow (inherits #77). Hugin-integrated shadow runs cannot count as readiness evidence until #77 is fixed; the kill/restart test must be either expected-failing or the test that proves #77 fixed.",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": false
+  },
+  {
+    "id": "skill-distillation-C13",
+    "source": "codex-round-2",
+    "text": "PC3 shallow if first row only adds nullable columns while router stays boolean. The first row must be CONSUMED by the route decision + execution path (TaskClass predicate, content-addressed profile, CellManifest, versioned EvalSuite, immutable ValidationRun, RouteBinding as only selectable object, RouteDecision recorded incl. abstentions).",
+    "classification": "valid",
+    "impact": "changed",
+    "severity": "major",
+    "caught_by_self_review": true
+  },
+  {
+    "id": "skill-distillation-C14",
+    "source": "codex-round-2",
+    "text": "D2 dodge: a semaphore prevents concurrent 30B runs but doesn't specify priority, cancellation, lease/heartbeat, stale reconciliation, starvation limits, retry, or whether evals block cloud-eligible user work. Attach a policy to the semaphore.",
+    "classification": "partially_valid",
+    "impact": "acknowledged",
+    "severity": "minor",
+    "caught_by_self_review": false
+  }
+]

--- a/docs/decisions/skill-distillation/skill-distillation-summary.md
+++ b/docs/decisions/skill-distillation/skill-distillation-summary.md
@@ -1,0 +1,71 @@
+# Debate Summary — Eval-Gated Skill Distillation as a Hugin Sub-Capability
+
+**Date:** 2026-05-29
+**Participants:** Claude (Opus 4.8) vs. Reviewer: codex / gpt-5.5 (xhigh effort)
+**Rounds:** 2
+**Premise (fixed):** the capability *will* be built; debate was about *how*, not *whether*.
+
+## Outcome in one line
+
+The draft's primitive was wrong. Build it as a **versioned `RouteBinding` system with a
+load-bearing task classifier**, not an "eval-gated skill promotion" flag — and gate real-task
+routing on Hugin #77 (crash-recovery liveness).
+
+## Concessions accepted by both sides
+
+1. **Primitive = `RouteBinding`, not a boolean flag.** `(taskClass, skillPackageProfile, cellManifest, evalSuite) → policy + calibrated metrics`, lifecycle `draft → candidate → shadow → active → stale → quarantined → disabled`. A boolean discards the partial-pass/latency texture the prior local-eval work proved is decisive.
+2. **Skill artifact = runtime-neutral procedure package → compiled `pi-local-30b` profile.** Not a raw `~/.claude/skills/` `SKILL.md` (confirmed by prior `decisions/skills-in-munin` verdict). The 30B profile is stricter: bounded I/O schema, tool allowlist, one-step checkpoints, examples + anti-examples, abort conditions.
+3. **Anti-Goodhart eval structure.** Split positive / negative / retrieval / mutation fixtures; ≥1 *independent* oracle per route; LLM-judge advisory only; record the *stage* a failure was caught at.
+4. **Procedural retrieval schema inside Munin + fail-closed contract.** Below threshold → cloud/approval; top-two too close → abstain; Munin down → no local; stale/quarantined binding → not selectable.
+5. **Immutable, content-addressed validation run records** + small mutable "active binding" pointer. Demotion fail-closes on any hash drift.
+6. **Escalation as a state transition:** worktree-isolated execution, output as patch/artifact, preflight gates, step budgets + early-abort detectors, fallback consumes the original snapshot — never a dirty workspace.
+7. **Policy-aware fallback** respecting Hugin's `provider/egress/zdrRequired/autoEligible`, decided pre-execution.
+
+## Defenses accepted by the reviewer
+
+- **D1 (partial):** cost/latency-vs-cloud is *not* the slice-one gate (correctness/fail-closed/recovery/fallback are) — accepted. Claude's "strategic gate" reframed by Codex into two distinct gates: **policy-required** (categorical, local can be worth it even if slower) vs. **cheaper-after-maintenance** (economic). Adopted.
+- **D2 (partial):** a shared single-heavy-job semaphore is the right *first* capacity control — accepted, with the caveat that the semaphore must carry a policy (priority, leases, timeouts, reaper), since #77 already proves "one worker" is insufficient.
+- **PC1 (partial):** #77 does not block *offline* package/eval/profile authoring — accepted. But "shadow" must be split: offline-fixture shadow is safe; **Hugin-integrated shadow inherits #77** and cannot count as readiness evidence until #77 is fixed.
+
+## New issue from Round 2
+
+- **Task classification is now load-bearing and was unnamed by both sides.** Moving the route key to start with `taskClass` means *deciding an incoming task's class* becomes part of routing, policy, safety, and cost. A bad classifier can bypass ZDR/egress policy, pick the wrong procedure, fail to abstain, or inflate shadow metrics. Requires a first-class versioned `TaskClassifier`/route-predicate artifact with hard negatives, thresholds, top-two margins, recorded abstentions, and "should / should-not classify" eval cases. **Without it, the system looks rigorously versioned while its most important selection step stays opaque — worse than the original flag.**
+
+## Unresolved / preference-level
+
+- Exact grading modality per skill class (deterministic vs. LLM-judge mix) — deferred to per-skill design (U1).
+- Whether slice-one skill should be coding (test-graded) or non-coding — leaning coding for a deterministic grader; not contested.
+
+## Final verdict
+
+- **Claude:** primitive corrected to `RouteBinding`; #77 gates `active` and any Hugin-integrated shadow evidence, but not offline authoring; task classifier added as a first-class artifact.
+- **Codex:** *the single most important next step is to fix Hugin #77 and prove it with a kill-during-local-execution acceptance test wired through the same task lifecycle the skill lane will use.* Offline package/eval/profile authoring may proceed in parallel, but runtime liveness (stable worker identity, lease-expiry reconciliation, startup recovery, terminal-state correctness, idempotent delivery) is the gating build step for any honest end-to-end claim.
+
+## Action items
+
+| # | Action | Owner |
+|---|--------|-------|
+| A1 | Land Hugin #77 (crash-recovery liveness) + kill-during-local-execution acceptance test | Hugin |
+| A2 | Design `RouteBinding` data model (full matrix as schema; consume one row end-to-end) | Hugin |
+| A3 | Define runtime-neutral procedure-package format + `pi-local-30b` profile compiler | skills |
+| A4 | Add procedural-retrieval schema + fail-closed abstention contract to Munin | Munin |
+| A5 | Spec first-class `TaskClassifier` artifact (predicate, hard negatives, thresholds, abstention log) | Hugin |
+| A6 | Eval suite format: positive/negative/retrieval/mutation fixtures + independent oracle + failure-stage recording | skills |
+| A7 | Slice-one: one procedure, one cell manifest, fixture repo, offline shadow → (post-#77) Hugin-integrated active | Hugin |
+
+## Debate files
+
+- `skill-distillation-claude-draft.md`
+- `skill-distillation-claude-self-review.md`
+- `skill-distillation-codex-critique.md`
+- `skill-distillation-claude-response-1.md`
+- `skill-distillation-codex-rebuttal-1.md`
+- `skill-distillation-critique-log.json`
+- `skill-distillation-summary.md`
+
+## Costs
+
+| Invocation   | Wall-clock time | Model    |
+|--------------|-----------------|----------|
+| codex R1     | ~5 min          | gpt-5.5  |
+| codex R2     | ~5 min          | gpt-5.5  |


### PR DESCRIPTION
Adds the cross-model debate record (Claude Opus 4.8 vs Codex gpt-5.5, 2 rounds) for **skill distillation as a Hugin sub-capability** under `docs/decisions/skill-distillation/`.

This is the source-of-truth artifact referenced by issues #78–#84. Merging makes those issue references resolve to `main` blob URLs.

**Outcome:** reject the naive "eval-gated skill promotion" boolean; build a versioned `RouteBinding` primitive `(taskClass, skillPackageProfile, cellManifest, evalSuite) → policy + calibrated metrics` with a first-class `TaskClassifier`. Gating step is #78 (land #77 crash-recovery liveness).

Files: full debate trail (draft, self-review, both Codex rounds, response, critique-log, summary, INDEX).

🤖 Generated with [Claude Code](https://claude.com/claude-code)