### PR TITLE
fix: positive failure exit codes (#73) + crash-recovery liveness (#77)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -329,6 +329,17 @@ let currentOllamaAbort: AbortController | null = null;
 // Runtime-owned artefact delivery (issue #68). Aborted by operator cancel /
 // shutdown so a hung `ssh`/`rsync` cannot wedge the single dispatcher slot.
 let currentDeliveryAbort: AbortController | null = null;
+// Separate abort slot for RECONCILE-path deliveries (`reconcileDeliveryPending`,
+// driven by startup recovery and the lease reaper). The reaper runs on its own
+// timer concurrently with the poll loop, so its reconcile must NOT share
+// `currentDeliveryAbort` with the live in-process delivery — clobbering that
+// shared slot would leave the live delivery un-abortable by operator cancel /
+// shutdown (review F1, #77). At most one reconcile runs at a time (startup
+// completes before the reaper timer arms; the reaper processes tasks serially
+// under `leaseReaperInFlight`), so a single slot is sufficient. Shutdown aborts
+// both slots; operator cancel targets only the live delivery (a reconcile is
+// always for a non-current, dead-owner task).
+let currentReconcileAbort: AbortController | null = null;
 let server: Server;
 let runningBroker: RunningBroker | null = null;
 let brokerReconciler: BrokerReconciler | null = null;
@@ -1670,7 +1681,9 @@ async function reconcileDeliveryPending(
   } else {
     const logPath = path.join(LOG_DIR, `${extractTaskId(taskNs)}.log`);
     const abort = new AbortController();
-    currentDeliveryAbort = abort;
+    // Reconcile-path slot, NOT the live-delivery slot (review F1): a reaper-driven
+    // reconcile must not clobber a concurrent live delivery's abort controller.
+    currentReconcileAbort = abort;
     try {
       delivery = await deliverArtifacts({
         manifest: task.artifactManifest,
@@ -1690,7 +1703,7 @@ async function reconcileDeliveryPending(
         signal: abort.signal,
       });
     } finally {
-      currentDeliveryAbort = null;
+      currentReconcileAbort = null;
     }
     if (!delivery.ok) {
       // missing-local / unsafe-local (no trustworthy deliverable) are ALWAYS
@@ -4247,6 +4260,11 @@ async function shutdown(signal: string): Promise<void> {
   if (currentDeliveryAbort) {
     console.log("Aborting running artefact delivery...");
     currentDeliveryAbort.abort();
+  }
+
+  if (currentReconcileAbort) {
+    console.log("Aborting running delivery reconciliation...");
+    currentReconcileAbort.abort();
   }
 
   if (currentSdkAbort) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ import {
   type MuninClientConfig,
   type MuninReadResult,
 } from "./munin-client.js";
-import { getFoundBatchEntry, extractTaskId, pickEarliestTask, selectNextTask, checkoutTaskBranch, finalizeTaskBranch, shouldReapExpiredLease, finalizeTaskCompletion } from "./task-helpers.js";
+import { getFoundBatchEntry, extractTaskId, pickEarliestTask, selectNextTask, checkoutTaskBranch, finalizeTaskBranch, shouldReapExpiredLease, decideStartupRecovery, finalizeTaskCompletion } from "./task-helpers.js";
 import { executeSdkTask } from "./sdk-executor.js";
 import { executeOllamaTask } from "./ollama-executor.js";
 import { configureHosts, resolveOllamaHost, getHostStatus, probeAllHosts, warmModel, getLoadedModels } from "./ollama-hosts.js";
@@ -292,11 +292,27 @@ if (!config.muninApiKey) {
 
 // --- Worker identity ---
 
+// Positive, non-zero exit code for dispatcher-side failure paths (recovery,
+// reaper, shutdown, security rejection, generic failures). Ratatoskr decides
+// success by matching `/\*\*Exit code:\*\*\s*(\d+)/` and treats a NON-match as
+// success — a negative code (`-1`) fails `(\d+)`, so it was mis-rendered as a
+// successful task (issue #73). Any non-zero positive integer reads as failure.
+const DISPATCHER_FAILURE_EXIT_CODE = 1;
+
 const LEASE_DURATION_MS = 120_000; // 2 minutes — renewed during execution
 const LEASE_RENEWAL_INTERVAL_MS = 60_000; // renew every 60s
 const LEASE_REAPER_INTERVAL_MS = 60_000; // scan for expired foreign leases every 60s
 
-const workerId = `hugin-${os.hostname()}-${process.pid}`;
+// Worker identity is HOST-based, NOT PID-based (issue #77). A PID-derived id
+// meant that after a `kill -9` + systemd `Restart=always`, the new process got a
+// new id, so `recoverStaleTasks`/the reaper saw the dead incarnation's tasks as
+// "not ours" and — while the dead worker's lease was still live — refused to
+// recover them, stranding a `delivery:pending` checkpoint non-terminal until a
+// second, post-lease-expiry restart. systemd runs exactly one Hugin per host, so
+// a host-stable id lets a restarted process re-adopt and reconcile its own
+// in-flight tasks immediately. The PID is retained separately for observability.
+const workerId = `hugin-${os.hostname()}`;
+const processInstanceId = `${workerId}-${process.pid}`;
 
 function sleepMs(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -987,7 +1003,7 @@ function createFailureStructuredResult(
     runtime,
     executor: options.executor,
     resultSource: options.resultSource,
-    exitCode: options.exitCode || -1,
+    exitCode: options.exitCode || DISPATCHER_FAILURE_EXIT_CODE,
     startedAt: options.startedAt,
     completedAt,
     durationSeconds: options.durationSeconds,
@@ -1084,7 +1100,7 @@ function buildApprovalRejectedTaskResultDocument(input: {
   return [
     "## Result",
     "",
-    "- **Exit code:** -1",
+    `- **Exit code:** ${DISPATCHER_FAILURE_EXIT_CODE}`,
     "- **Error:** Approval rejected for gated phase",
     `- **Task id:** ${input.taskId}`,
     `- **Pipeline id:** ${input.pipelineId}`,
@@ -1417,20 +1433,6 @@ function leaseExpiry(): string {
   return String(Date.now() + LEASE_DURATION_MS);
 }
 
-function parseLeaseExpiry(tags: string[]): number | null {
-  const tag = tags.find((t) => t.startsWith("lease_expires:"));
-  if (!tag) return null;
-  const raw = tag.slice("lease_expires:".length);
-  // Support both epoch-millis (new) and ISO 8601 (legacy)
-  const ts = /^\d+$/.test(raw) ? Number(raw) : new Date(raw).getTime();
-  return Number.isNaN(ts) ? null : ts;
-}
-
-function parseClaimedBy(tags: string[]): string | null {
-  const tag = tags.find((t) => t.startsWith("claimed_by:"));
-  return tag ? tag.slice("claimed_by:".length) : null;
-}
-
 /** Build tags preserving runtime/type tags and adding lease metadata. */
 function buildClaimTags(
   baseTags: string[],
@@ -1601,15 +1603,19 @@ async function killOrphanDispatchers(): Promise<void> {
 // recovered (we just restarted, so they're orphaned). Tasks claimed by other
 // workers are only recovered if their lease has expired.
 
-// Runtime-owned artefact delivery (issue #68): a `running + delivery:pending`
-// checkpoint means the agent content is durably preserved in `result` but
-// delivery did not finalize (crash/restart mid-delivery). Re-deliver ONCE under
-// a single CAS reclaim and finalize terminally — no paid rerun. Shared by
-// startup recovery; the reaper deliberately skips delivery:pending and leaves
-// it for this path.
+// Runtime-owned artefact delivery (issue #68 / #77): a `running +
+// delivery:pending` checkpoint means the agent content is durably preserved in
+// `result` but delivery did not finalize (crash/restart mid-delivery).
+// Re-deliver ONCE under a single CAS reclaim and finalize terminally — no paid
+// rerun. Invoked from two paths: startup recovery (`recoverStaleTasks`, default
+// `munin` client) and the lease reaper (`reapExpiredLeases`, passing
+// `reaperMunin` so its writes carry the reaper's own session id). The CAS
+// reclaim makes the two paths mutually safe — whichever reaches the task first
+// wins; the loser's CAS write fails and it bails out without double-delivering.
 async function reconcileDeliveryPending(
   taskNs: string,
   entry: MuninEntry,
+  client: MuninClient = munin,
 ): Promise<void> {
   const task = parseTask(entry.content);
   const classification = getTaskArtifactClassification(
@@ -1628,7 +1634,7 @@ async function reconcileDeliveryPending(
     "running",
   );
   try {
-    const r = await munin.write(
+    const r = await client.write(
       taskNs,
       "status",
       entry.content,
@@ -1643,7 +1649,7 @@ async function reconcileDeliveryPending(
     return;
   }
 
-  const resultEntry = await munin.read(taskNs, "result");
+  const resultEntry = await client.read(taskNs, "result");
   let baseDoc = resultEntry?.content ?? "## Result\n\n- **Exit code:** 0\n";
   const dIdx = baseDoc.lastIndexOf("\n### Artifact Delivery");
   if (dIdx !== -1) baseDoc = baseDoc.slice(0, dIdx);
@@ -1704,7 +1710,7 @@ async function reconcileDeliveryPending(
       "- **Exit code:** 2\n- **Failure kind:** DELIVERY_FAILED",
     );
   }
-  await munin.write(
+  await client.write(
     taskNs,
     "result",
     `${baseDoc}${renderArtifactDeliverySection(delivery)}`,
@@ -1716,7 +1722,7 @@ async function reconcileDeliveryPending(
   const terminalDeliveryTag = delivery.ok
     ? "delivery:verified"
     : "delivery:failed";
-  await munin.write(
+  await client.write(
     taskNs,
     "status",
     entry.content,
@@ -1762,14 +1768,15 @@ async function reconcileDeliveryPending(
         },
       }),
       classification,
+      client,
     );
   }
-  await munin.log(
+  await client.log(
     taskNs,
-    `Delivery reconciled on startup: ${delivery.ok ? "verified" : "failed"}`,
+    `Delivery reconciled: ${delivery.ok ? "verified" : "failed"}`,
   );
-  await promoteDependents(extractTaskId(taskNs));
-  await refreshPipelineSummaryFromContent(entry.content);
+  await promoteDependents(extractTaskId(taskNs), client);
+  await refreshPipelineSummaryFromContent(entry.content, client);
 }
 
 async function recoverStaleTasks(): Promise<void> {
@@ -1788,20 +1795,20 @@ async function recoverStaleTasks(): Promise<void> {
       const entry = await munin.read(result.namespace, "status");
       if (!entry) continue;
 
-      const claimedBy = parseClaimedBy(entry.tags);
-      const leaseExpires = parseLeaseExpiry(entry.tags);
       const now = Date.now();
 
-      // Decide whether to recover this task:
+      // Decide whether to recover this task (issue #77: workerId is host-stable
+      // so our own dead incarnation's tasks are recognised as "ours"):
       // - Our own tasks: always recover (we just restarted)
       // - Other worker's tasks: only if lease expired
-      // - No lease metadata (legacy): recover if older than default timeout
-      const isOurs = claimedBy === workerId || claimedBy === null;
-      const leaseExpired = leaseExpires !== null && now > leaseExpires;
-      const legacyStale = leaseExpires === null &&
-        (now - new Date(entry.updated_at).getTime()) > config.defaultTimeoutMs;
+      const decision = decideStartupRecovery({
+        tags: entry.tags,
+        workerId,
+        now,
+      });
+      const { claimedBy, leaseExpires, isOurs } = decision;
 
-      if (!isOurs && !leaseExpired) {
+      if (decision.action === "skip") {
         if (leaseExpires !== null) {
           console.log(
             `Skipping task ${result.namespace} — claimed by ${claimedBy}, lease expires in ${Math.round((leaseExpires - now) / 1000)}s`
@@ -1810,15 +1817,13 @@ async function recoverStaleTasks(): Promise<void> {
         continue;
       }
 
-      if (!isOurs && !leaseExpired && !legacyStale) continue;
-
       // Runtime-owned artefact delivery (issue #68): resume an interrupted
       // delivery instead of generic-failing it (which would discard the
       // deliverable and mis-render as success). MUST be gated on the same
       // single-owner test above (Codex review #1) — reconciling a task still
       // owned by a live worker would double-deliver. reconcileDeliveryPending
       // additionally CAS-reclaims, so even a gate race cannot duplicate rsync.
-      if (entry.tags.includes("delivery:pending")) {
+      if (decision.action === "reconcile-delivery") {
         console.log(
           `Reconciling delivery:pending task ${result.namespace} on startup`,
         );
@@ -1846,7 +1851,7 @@ async function recoverStaleTasks(): Promise<void> {
       await munin.write(
         result.namespace,
         "result",
-        `## Result\n\n- **Exit code:** -1\n- **Error:** Task recovered (${reason}, worker: ${claimedBy || "unknown"}, elapsed: ${elapsed}s)\n`
+        `## Result\n\n- **Exit code:** ${DISPATCHER_FAILURE_EXIT_CODE}\n- **Error:** Task recovered (${reason}, worker: ${claimedBy || "unknown"}, elapsed: ${elapsed}s)\n`
       );
       const runtime = (runtimeTag || "runtime:claude").replace(
         /^runtime:/,
@@ -1923,15 +1928,25 @@ async function reapExpiredLeases(): Promise<void> {
       });
       if (!decision.reap) continue;
 
-      // Runtime-owned artefact delivery (issue #68): never generic-reap a
-      // delivery:pending checkpoint to terminal `failed` — the agent content is
-      // preserved there and reaping it would mis-render as success and discard
-      // the deliverable. Leave it for startup reconciliation
-      // (`recoverStaleTasks`), which re-delivers without a paid rerun.
+      // Runtime-owned artefact delivery (issue #68 / #77): a delivery:pending
+      // checkpoint must NEVER be generic-reaped to terminal `failed` — the agent
+      // content is preserved there and a generic reap would discard the
+      // deliverable. Previously the reaper deferred to startup reconciliation,
+      // but a PID-stable workerId could deadlock that path (#77): startup
+      // recovery skipped a live-leased foreign task while the reaper skipped
+      // delivery:pending, so an orphaned checkpoint never reached a terminal
+      // state. We reach this branch only after `decision.reap` (lease expired,
+      // not the currently-executing task) — the owning worker is provably dead —
+      // so the reaper reconciles the delivery itself (re-delivers without a paid
+      // rerun, CAS-reclaiming first so it cannot double-deliver against a
+      // concurrent startup scan). This is defence in depth alongside the now
+      // host-stable workerId, which lets startup recovery handle the common
+      // crash+restart case directly.
       if (entry.tags.includes("delivery:pending")) {
         console.log(
-          `Skipping reap of ${result.namespace} — delivery:pending (left for startup reconciliation)`,
+          `Reconciling delivery:pending task ${result.namespace} via lease reaper (lease expired)`,
         );
+        await reconcileDeliveryPending(result.namespace, entry, reaperMunin);
         continue;
       }
 
@@ -1968,7 +1983,7 @@ async function reapExpiredLeases(): Promise<void> {
       await reaperMunin.write(
         result.namespace,
         "result",
-        `## Result\n\n- **Exit code:** -1\n- **Error:** ${errorMessage}\n`,
+        `## Result\n\n- **Exit code:** ${DISPATCHER_FAILURE_EXIT_CODE}\n- **Error:** ${errorMessage}\n`,
         undefined,
         undefined,
         classification,
@@ -2078,7 +2093,7 @@ async function failBlockedTask(
   await client.write(
     taskNs,
     "result",
-    `## Result\n\n- **Exit code:** -1\n- **Error:** ${errorMessage}\n`,
+    `## Result\n\n- **Exit code:** ${DISPATCHER_FAILURE_EXIT_CODE}\n- **Error:** ${errorMessage}\n`,
     undefined,
     undefined,
     classification
@@ -2766,7 +2781,7 @@ async function failTaskWithMessage(
   await munin.write(
     taskNs,
     "result",
-    `## Result\n\n- **Exit code:** -1\n- **Error:** ${errorMessage}\n`,
+    `## Result\n\n- **Exit code:** ${DISPATCHER_FAILURE_EXIT_CODE}\n- **Error:** ${errorMessage}\n`,
     undefined,
     undefined,
     classification
@@ -2790,6 +2805,7 @@ async function emitHeartbeat(queueDepth: number, blockedTasks: number): Promise<
   try {
     const heartbeat: Record<string, unknown> = {
       worker_id: workerId,
+      process_instance_id: processInstanceId,
       polled_at: new Date().toISOString(),
       queue_depth: queueDepth,
       blocked_tasks: blockedTasks,
@@ -3080,7 +3096,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
       await munin.write(
         taskNs,
         "result",
-        `## Result\n\n- **Exit code:** -1\n- **Error:** ${securityViolation}\n`,
+        `## Result\n\n- **Exit code:** ${DISPATCHER_FAILURE_EXIT_CODE}\n- **Error:** ${securityViolation}\n`,
         undefined,
         undefined,
         classification,
@@ -3489,9 +3505,14 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     // delivery checkpoint, to remove the renewal-vs-checkpoint race (Codex
     // review #2): a renewal tick firing during the checkpoint transition would
     // rewrite `running` tags built from the OLD base set and strip
-    // `delivery:pending`. Delivery doesn't need lease renewal — the reaper
-    // explicitly skips `delivery:pending`, and delivery is bounded by its own
-    // timeout — so dropping renewal here is safe. The cancellation watch stays
+    // `delivery:pending`. Delivery doesn't need lease renewal — the reaper never
+    // touches the currently-executing task (`shouldReapExpiredLease` returns
+    // reap:false for `namespace === currentTask`, regardless of lease), and
+    // delivery is bounded by its own timeout — so dropping renewal here is safe.
+    // (The reaper *does* reconcile a delivery:pending checkpoint once its lease
+    // expires AND it is not the current task, i.e. the owning worker is dead —
+    // see #77 — but that can never be this live in-process delivery.) The
+    // cancellation watch stays
     // ACTIVE through delivery so an operator can still abort a hung rsync; it
     // is stopped after delivery finalization below.
     stopLeaseRenewal();
@@ -3673,8 +3694,9 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
       );
       // Lease renewal is deliberately NOT re-armed (Codex review #2): a
       // renewal tick would race the terminal-finalize CAS below. The reaper
-      // skips delivery:pending and delivery is bounded, so no renewal is
-      // needed. The terminal flip CASes on this checkpoint's updated_at.
+      // never reaps the currently-executing task (its `currentTask` guard, #77)
+      // and delivery is bounded, so no renewal is needed. The terminal flip
+      // CASes on this checkpoint's updated_at.
       deliveryCheckpointUpdatedAt =
         typeof checkpointWrite?.updated_at === "string"
           ? checkpointWrite.updated_at
@@ -4115,6 +4137,7 @@ app.get("/health", (_req, res) => {
     status: "ok",
     service: "hugin",
     worker_id: workerId,
+    process_instance_id: processInstanceId,
     current_task: currentTask,
     polling: !shuttingDown,
     queue_depth: lastQueueDepth,
@@ -4185,7 +4208,7 @@ async function shutdown(signal: string): Promise<void> {
         await munin.write(
           currentTask,
           "result",
-          `## Result\n\n- **Exit code:** -1\n- **Error:** Task interrupted by dispatcher shutdown (${signal}, worker: ${workerId})\n`
+          `## Result\n\n- **Exit code:** ${DISPATCHER_FAILURE_EXIT_CODE}\n- **Error:** Task interrupted by dispatcher shutdown (${signal}, worker: ${workerId})\n`
         );
         const task = parseTask(entry.content);
         const runtime = (runtimeTag || "runtime:claude").replace(
@@ -4266,7 +4289,7 @@ process.on("SIGINT", () => shutdown("SIGINT"));
 
 // Ensure log directory exists
 ensureLogDir();
-console.log(`Worker ID: ${workerId}`);
+console.log(`Worker ID: ${workerId} (instance: ${processInstanceId})`);
 console.log(`Log directory: ${LOG_DIR}`);
 
 // Configure ollama hosts

--- a/src/task-helpers.ts
+++ b/src/task-helpers.ts
@@ -198,6 +198,71 @@ export function shouldReapExpiredLease(input: ReapDecisionInput): ReapDecision {
   };
 }
 
+export interface StartupRecoveryInput {
+  /** Status-entry tags (carry `claimed_by:` / `lease_expires:` / `delivery:pending`). */
+  tags: string[];
+  /** This dispatcher's worker identity. HOST-stable since #77 (no PID). */
+  workerId: string;
+  /** Current wall-clock ms. */
+  now: number;
+}
+
+export type StartupRecoveryAction =
+  /** Owned by a still-live foreign worker — leave it alone. */
+  | "skip"
+  /** A `delivery:pending` checkpoint to re-deliver under CAS (#68). */
+  | "reconcile-delivery"
+  /** Generic stale/own task → terminalize as `failed`. */
+  | "recover-failed";
+
+export interface StartupRecoveryDecision {
+  action: StartupRecoveryAction;
+  isOurs: boolean;
+  leaseExpired: boolean;
+  claimedBy: string | null;
+  leaseExpires: number | null;
+}
+
+/**
+ * Decide what `recoverStaleTasks` should do with a `running` task seen at
+ * startup. Pure mirror of the inline gate in `src/index.ts`.
+ *
+ * Issue #77: `workerId` is HOST-stable (not PID-derived). After a crash +
+ * systemd restart, a `delivery:pending` checkpoint left by the dead incarnation
+ * carries `claimed_by:hugin-<host>` — which now equals the restarted process's
+ * `workerId` → `isOurs` is true → the gate falls through to "reconcile-delivery"
+ * even though the dead worker's lease has not yet expired. With the old
+ * PID-derived id `isOurs` was false and (lease still live) the task was
+ * "skip"ped, stranding it non-terminal until a second post-expiry restart.
+ *
+ * Note: the original second guard `if (!isOurs && !leaseExpired && !legacyStale)
+ * continue` was unreachable (the first `!isOurs && !leaseExpired` skip already
+ * caught those cases), so `legacyStale` never influenced the action — it is
+ * intentionally not modelled here.
+ */
+export function decideStartupRecovery(
+  input: StartupRecoveryInput,
+): StartupRecoveryDecision {
+  const claimedBy = parseClaimedByTag(input.tags);
+  const leaseExpires = parseLeaseExpiresTag(input.tags);
+  const isOurs = claimedBy === input.workerId || claimedBy === null;
+  const leaseExpired = leaseExpires !== null && input.now > leaseExpires;
+
+  if (!isOurs && !leaseExpired) {
+    return { action: "skip", isOurs, leaseExpired, claimedBy, leaseExpires };
+  }
+  if (input.tags.includes("delivery:pending")) {
+    return {
+      action: "reconcile-delivery",
+      isOurs,
+      leaseExpired,
+      claimedBy,
+      leaseExpires,
+    };
+  }
+  return { action: "recover-failed", isOurs, leaseExpired, claimedBy, leaseExpires };
+}
+
 // --- Branch-per-task git flow (#47) ---
 
 export interface TaskBranchOptions {

--- a/tests/delivery-abort-isolation.test.ts
+++ b/tests/delivery-abort-isolation.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import * as path from "node:path";
+
+// Regression guard for review finding F1 (#77 follow-up):
+// The lease reaper now invokes `reconcileDeliveryPending` on its own timer,
+// concurrently with the poll loop's live in-process delivery. The two paths must
+// use DISTINCT AbortController module slots — if the reconcile path shared
+// `currentDeliveryAbort` with the live delivery, a concurrent reconcile would
+// clobber it and the live delivery could no longer be aborted by operator cancel
+// or shutdown. The live path uses `currentDeliveryAbort`; the reconcile path
+// (`reconcileDeliveryPending`) uses `currentReconcileAbort`; shutdown aborts both.
+//
+// These paths live in module-global state inside src/index.ts and are not
+// individually exported, so the invariant is guarded by source inspection.
+
+const SRC = readFileSync(
+  path.join(__dirname, "..", "src", "index.ts"),
+  "utf8",
+);
+
+function sliceFn(name: string, until: string): string {
+  const start = SRC.indexOf(name);
+  const end = SRC.indexOf(until, start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return SRC.slice(start, end);
+}
+
+describe("F1: reconcile-path delivery uses a separate abort slot from the live delivery", () => {
+  it("declares both abort slots", () => {
+    expect(SRC).toContain("let currentDeliveryAbort: AbortController | null");
+    expect(SRC).toContain("let currentReconcileAbort: AbortController | null");
+  });
+
+  it("reconcileDeliveryPending uses currentReconcileAbort and NEVER currentDeliveryAbort", () => {
+    const body = sliceFn(
+      "async function reconcileDeliveryPending(",
+      "async function recoverStaleTasks(",
+    );
+    expect(body).toContain("currentReconcileAbort = abort");
+    expect(body).toContain("currentReconcileAbort = null");
+    // The smoking gun: the reconcile path must not touch the live-delivery slot.
+    expect(body).not.toContain("currentDeliveryAbort");
+  });
+
+  it("shutdown aborts BOTH the live delivery and the reconcile delivery", () => {
+    // Both controllers must be torn down on shutdown so neither path can leave a
+    // hung rsync running.
+    expect(SRC).toContain("currentDeliveryAbort.abort()");
+    expect(SRC).toContain("currentReconcileAbort.abort()");
+  });
+});

--- a/tests/exit-code-failure.test.ts
+++ b/tests/exit-code-failure.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import * as path from "node:path";
+
+// Regression guard for issue #73:
+// Ratatoskr decides task success by matching the human `result` markdown against
+// /\*\*Exit code:\*\*\s*(\d+)/ and treats a NON-match as success. A negative
+// exit code (`-1`) fails `(\d+)` → no match → the failed task is mis-rendered as
+// SUCCESS. Several dispatcher failure paths (recovery, reaper, shutdown, security
+// rejection, approval rejection, generic failures) used to emit `Exit code: -1`.
+//
+// These paths build their result markdown inline in src/index.ts and are not
+// individually exported, so we guard the contract two ways:
+//   1. behaviourally — the exact regex Ratatoskr uses must read a positive code
+//      as failure and must NOT match a negative code (documenting the bug); and
+//   2. structurally — no failure-result markdown in src/index.ts may emit a
+//      negative `**Exit code:**`, so the regression cannot silently return.
+
+const RATATOSKR_RE = /\*\*Exit code:\*\*\s*(\d+)/;
+
+// Ratatoskr's success decision: it FAILS the task only when the regex matches a
+// non-zero numeric code. A non-match (or a zero code) is treated as success.
+function ratatoskrReportsFailure(resultMarkdown: string): boolean {
+  const m = resultMarkdown.match(RATATOSKR_RE);
+  if (!m) return false; // no match → mis-rendered as success
+  return Number(m[1]) !== 0;
+}
+
+describe("issue #73: dispatcher failure exit codes are reported as failures", () => {
+  it("a negative exit code is mis-rendered as success (documents the bug)", () => {
+    const doc = "## Result\n\n- **Exit code:** -1\n- **Error:** boom\n";
+    expect(ratatoskrReportsFailure(doc)).toBe(false);
+  });
+
+  it("a positive exit code is correctly reported as failure", () => {
+    const doc = "## Result\n\n- **Exit code:** 1\n- **Error:** boom\n";
+    expect(ratatoskrReportsFailure(doc)).toBe(true);
+  });
+
+  it("exit code 0 is reported as success", () => {
+    const doc = "## Result\n\n- **Exit code:** 0\n";
+    expect(ratatoskrReportsFailure(doc)).toBe(false);
+  });
+
+  it("no failure path in src/index.ts emits a negative **Exit code:**", () => {
+    const src = readFileSync(
+      path.join(__dirname, "..", "src", "index.ts"),
+      "utf8",
+    );
+    // Match both literal `- **Exit code:** -1` and any interpolated negative.
+    const negativeExitCodes = src.match(/\*\*Exit code:\*\*\s*-\d+/g) || [];
+    expect(negativeExitCodes).toEqual([]);
+  });
+});

--- a/tests/startup-recovery.test.ts
+++ b/tests/startup-recovery.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect } from "vitest";
+import { decideStartupRecovery } from "../src/task-helpers.js";
+
+// Regression coverage for issue #77 (crash mid-delivery: orphaned
+// delivery:pending never auto-reconciles). The fix makes the dispatcher's
+// worker identity HOST-stable (no PID), so a restarted process recognises the
+// dead incarnation's in-flight tasks as "ours" and reconciles them at startup
+// instead of skipping while the dead worker's lease is still live.
+
+const HOST_WORKER = "hugin-huginmunin"; // host-stable id (post-#77)
+const OLD_PID_WORKER = "hugin-huginmunin-221281"; // pre-#77 PID-derived id
+const FOREIGN_WORKER = "hugin-otherhost"; // a genuinely different live worker
+const NOW = 1_700_000_000_000;
+
+function tags(opts: {
+  claimedBy?: string;
+  leaseExpiresMs?: number | null;
+  deliveryPending?: boolean;
+}): string[] {
+  const t = ["running", "runtime:claude"];
+  if (opts.claimedBy) t.push(`claimed_by:${opts.claimedBy}`);
+  if (opts.leaseExpiresMs != null) t.push(`lease_expires:${opts.leaseExpiresMs}`);
+  if (opts.deliveryPending) t.push("delivery:pending");
+  return t;
+}
+
+describe("decideStartupRecovery (#77 liveness)", () => {
+  it("THE #77 FIX: a delivery:pending checkpoint left by our own crashed incarnation, with a still-live lease, reconciles (does NOT skip)", () => {
+    // Post-fix, a claim writes the HOST-stable id (`hugin-huginmunin`, no PID).
+    // After kill -9 + systemd restart the new process has the SAME workerId, so
+    // isOurs=true and — even though the dead worker's lease is still live
+    // (RestartSec 10s « lease 120s) — the gate falls through to reconcile.
+    const decision = decideStartupRecovery({
+      tags: tags({
+        claimedBy: HOST_WORKER, // dead incarnation, host-stable id
+        leaseExpiresMs: NOW + 108_000, // lease still live
+        deliveryPending: true,
+      }),
+      workerId: HOST_WORKER,
+      now: NOW,
+    });
+    expect(decision.action).toBe("reconcile-delivery");
+    expect(decision.isOurs).toBe(true);
+    expect(decision.leaseExpired).toBe(false);
+  });
+
+  it("documents the OLD #77 BUG: a PID-derived id differs from the restarted process, so a still-live-leased delivery:pending was skipped (stranded)", () => {
+    // Pre-fix, the dead incarnation's tag was `claimed_by:hugin-huginmunin-221281`
+    // and the restarted process had a NEW pid → a different workerId. isOurs=false
+    // + lease still live → "skip". The reaper also skipped delivery:pending, so
+    // the task was orphaned until a 2nd, post-expiry restart. Simulated here with
+    // mismatched ids to lock in why the host-stable id was necessary.
+    const decision = decideStartupRecovery({
+      tags: tags({
+        claimedBy: OLD_PID_WORKER, // hugin-huginmunin-221281
+        leaseExpiresMs: NOW + 108_000,
+        deliveryPending: true,
+      }),
+      workerId: "hugin-huginmunin-559300", // restarted process, new pid
+      now: NOW,
+    });
+    expect(decision.action).toBe("skip");
+    expect(decision.isOurs).toBe(false);
+  });
+
+  it("reconciles our own delivery:pending checkpoint even when the lease has expired", () => {
+    const decision = decideStartupRecovery({
+      tags: tags({
+        claimedBy: HOST_WORKER,
+        leaseExpiresMs: NOW - 5_000,
+        deliveryPending: true,
+      }),
+      workerId: HOST_WORKER,
+      now: NOW,
+    });
+    expect(decision.action).toBe("reconcile-delivery");
+  });
+
+  it("recovers our own non-delivery task as failed (dispatcher restart)", () => {
+    const decision = decideStartupRecovery({
+      tags: tags({ claimedBy: HOST_WORKER, leaseExpiresMs: NOW + 60_000 }),
+      workerId: HOST_WORKER,
+      now: NOW,
+    });
+    expect(decision.action).toBe("recover-failed");
+    expect(decision.isOurs).toBe(true);
+  });
+
+  it("recovers a legacy unclaimed task (no claimed_by, no lease) as failed", () => {
+    const decision = decideStartupRecovery({
+      tags: tags({}),
+      workerId: HOST_WORKER,
+      now: NOW,
+    });
+    expect(decision.action).toBe("recover-failed");
+    expect(decision.isOurs).toBe(true); // claimedBy === null → treated as ours
+    expect(decision.claimedBy).toBeNull();
+  });
+
+  it("SKIPS a task owned by a genuinely different live worker (lease still valid)", () => {
+    const decision = decideStartupRecovery({
+      tags: tags({ claimedBy: FOREIGN_WORKER, leaseExpiresMs: NOW + 60_000 }),
+      workerId: HOST_WORKER,
+      now: NOW,
+    });
+    expect(decision.action).toBe("skip");
+    expect(decision.isOurs).toBe(false);
+  });
+
+  it("recovers a foreign worker's task once its lease has expired", () => {
+    const decision = decideStartupRecovery({
+      tags: tags({ claimedBy: FOREIGN_WORKER, leaseExpiresMs: NOW - 1_000 }),
+      workerId: HOST_WORKER,
+      now: NOW,
+    });
+    expect(decision.action).toBe("recover-failed");
+    expect(decision.leaseExpired).toBe(true);
+  });
+
+  it("reconciles a foreign worker's expired delivery:pending checkpoint (cross-host crash)", () => {
+    const decision = decideStartupRecovery({
+      tags: tags({
+        claimedBy: FOREIGN_WORKER,
+        leaseExpiresMs: NOW - 1_000,
+        deliveryPending: true,
+      }),
+      workerId: HOST_WORKER,
+      now: NOW,
+    });
+    expect(decision.action).toBe("reconcile-delivery");
+  });
+});


### PR DESCRIPTION
Fixes #73 and #77 — two coupled defects in the dispatcher's failure/recovery subsystem.

## #73 — negative exit codes mis-rendered as success
Ratatoskr decides task success by matching the `result` markdown against `/\*\*Exit code:\*\*\s*(\d+)/` and treats a **non-match as success**. Every dispatcher-side failure path emitted `- **Exit code:** -1`, which fails `(\d+)` → no match → a **failed** task was reported as a **success**.

- New `DISPATCHER_FAILURE_EXIT_CODE = 1` constant, used at all 8 failure sites (recovery, reaper, shutdown, security rejection, approval rejection, generic failure ×3) and the `createFailureStructuredResult` default.
- Regression test `tests/exit-code-failure.test.ts` exercises the exact Ratatoskr regex + a source-scan guard asserting no failure path emits a negative `**Exit code:**`.

## #77 — crash mid-delivery never auto-reconciles
A `kill -9` + systemd restart during artefact delivery left a `running + delivery:pending` checkpoint that **never reached a terminal state** until a *second*, post-lease-expiry restart:
- `workerId` was PID-derived, so the restarted process saw the dead incarnation's task as "not ours";
- while the dead worker's lease was still live, the one-shot startup scan **skipped** it;
- the lease reaper **deliberately deferred** `delivery:pending` back to the startup scan → deadlock.

**Fix (defence in depth):**
1. **Host-stable `workerId`** (`hugin-<host>`, no PID). systemd runs exactly one Hugin per host, so a restarted process re-adopts and reconciles its own in-flight tasks immediately. The PID is retained as `process_instance_id` for observability (`/health`, heartbeat, startup log).
2. **The reaper now reconciles `delivery:pending` itself** once the lease has expired (owning worker provably dead) instead of deferring. `reconcileDeliveryPending` takes a `MuninClient` param so the reaper routes through `reaperMunin`; its CAS reclaim makes startup-scan-vs-reaper mutually safe (no double-delivery).
3. A **live in-process delivery stays protected** — the reaper never touches the currently-executing task (`shouldReapExpiredLease`'s `currentTask` guard), even though lease renewal stops before delivery.

The startup-recovery gate is extracted into a pure `decideStartupRecovery()` in `task-helpers.ts` (mirroring `shouldReapExpiredLease`), with regression tests in `tests/startup-recovery.test.ts` covering the exact #77 scenario (own dead incarnation, live lease, delivery:pending → reconcile, not skip).

## Testing
- `npm test`: 648 → **660 green** (12 new tests).
- `tsc --noEmit` clean.

## Not in this PR
- The **Pi e2e re-run** of #75 S3 (kill mid-delivery → restart auto-reconciles) — needs Pi hardware access. This PR makes the fix unit-test-deterministic; the e2e remains tracked in #75 / #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
