### PR TITLE
feat: methodology pipeline templates (#5)

### DIFF
--- a/src/pipeline-templates.ts
+++ b/src/pipeline-templates.ts
@@ -1,0 +1,106 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Templates live in <repo-root>/templates/. Resolved relative to this module
+// so the path works from both src/ (dev/vitest) and dist/ (production build).
+// Both locations are one level below the repo root, so ../templates is correct.
+const TEMPLATES_DIR = fileURLToPath(new URL("../templates", import.meta.url));
+
+const TEMPLATE_EXTENSION = ".pipeline.md";
+
+/**
+ * Returns the list of available template names (derived from files in the
+ * templates/ directory, without their `.pipeline.md` extension), sorted
+ * alphabetically.
+ */
+export function listPipelineTemplates(): string[] {
+  const entries = fs.readdirSync(TEMPLATES_DIR);
+  return entries
+    .filter((entry) => entry.endsWith(TEMPLATE_EXTENSION))
+    .map((entry) => entry.slice(0, -TEMPLATE_EXTENSION.length))
+    .sort();
+}
+
+/**
+ * Validates a template name: must be a simple alphanumeric slug with no path
+ * separators or traversal sequences. Returns the resolved absolute path on
+ * success, throws on invalid input.
+ */
+function resolveTemplatePath(name: string): string {
+  if (!name || !/^[a-z0-9-]+$/i.test(name)) {
+    throw new Error(
+      `Unknown template "${name}". Available: ${listPipelineTemplates().join(", ")}`,
+    );
+  }
+  const filename = `${name}${TEMPLATE_EXTENSION}`;
+  const resolved = path.resolve(TEMPLATES_DIR, filename);
+  // Confirm the resolved path is still inside TEMPLATES_DIR (belt-and-suspenders).
+  if (!resolved.startsWith(path.resolve(TEMPLATES_DIR) + path.sep)) {
+    throw new Error(
+      `Unknown template "${name}". Available: ${listPipelineTemplates().join(", ")}`,
+    );
+  }
+  if (!fs.existsSync(resolved)) {
+    throw new Error(
+      `Unknown template "${name}". Available: ${listPipelineTemplates().join(", ")}`,
+    );
+  }
+  return resolved;
+}
+
+/**
+ * Returns the raw template text for a named template.
+ * Throws if the name is unknown or contains path traversal sequences.
+ */
+export function loadPipelineTemplate(name: string): string {
+  const templatePath = resolveTemplatePath(name);
+  return fs.readFileSync(templatePath, "utf-8");
+}
+
+/**
+ * Returns the distinct placeholder names found in a template — the `var`
+ * parts of every `${var}` token. Useful for callers building the vars object
+ * before calling `instantiatePipelineTemplate`.
+ */
+export function requiredPlaceholders(name: string): string[] {
+  const raw = loadPipelineTemplate(name);
+  const matches = raw.matchAll(/\$\{([^}]+)\}/g);
+  const seen = new Set<string>();
+  for (const match of matches) {
+    if (match[1]) seen.add(match[1]);
+  }
+  return [...seen];
+}
+
+/**
+ * Instantiates a pipeline template by substituting every `${var}` token with
+ * the corresponding value from `vars`. Throws a descriptive error if any
+ * placeholder remains unsubstituted after applying all provided vars.
+ *
+ * Returns the final task document string, ready to pass to
+ * `compilePipelineTask`.
+ */
+export function instantiatePipelineTemplate(
+  name: string,
+  vars: Record<string, string>,
+): string {
+  const raw = loadPipelineTemplate(name);
+
+  // Replace all ${key} occurrences using the provided vars map.
+  let result = raw.replace(/\$\{([^}]+)\}/g, (match, key: string) => {
+    return Object.prototype.hasOwnProperty.call(vars, key) ? vars[key] ?? match : match;
+  });
+
+  // Detect any leftover placeholders.
+  const remaining = [...result.matchAll(/\$\{([^}]+)\}/g)].map((m) => m[1]).filter(Boolean);
+  if (remaining.length > 0) {
+    const unique = [...new Set(remaining)];
+    throw new Error(
+      `Template "${name}" has unsubstituted placeholder(s): ${unique.map((p) => `\${${p}}`).join(", ")}. ` +
+        `Provide values for all required placeholders: ${requiredPlaceholders(name).map((p) => `\${${p}}`).join(", ")}.`,
+    );
+  }
+
+  return result;
+}

--- a/templates/implementation.pipeline.md
+++ b/templates/implementation.pipeline.md
@@ -1,0 +1,67 @@
+## Task: ${title}
+
+- **Runtime:** pipeline
+- **Sensitivity:** internal
+- **Submitted by:** ${submittedBy}
+- **Submitted at:** ${submittedAt}
+
+### Pipeline
+
+Phase: Plan
+  Runtime: claude-sdk
+  Context: repo:${repo}
+  Timeout: 120000
+  Prompt: |
+    You are a software architect. Produce an implementation plan for the following feature:
+
+    ${featureDescription}
+
+    Your plan must include:
+    1. A brief description of the feature and its goals.
+    2. The files and modules that need to be created or modified.
+    3. The approach: key data structures, algorithms, and APIs involved.
+    4. Edge cases and failure modes to handle.
+    5. A testing strategy: unit tests, integration tests, and how to verify correctness.
+    6. Any risks or open questions before writing code.
+
+    Be specific. This plan will be handed to an implementer — vague instructions produce vague code.
+
+Phase: Implement
+  Depends-on: Plan
+  Runtime: claude-sdk
+  Context: repo:${repo}
+  Timeout: 300000
+  Capabilities: tools, code
+  Prompt: |
+    You are an implementer. Following the plan, implement the feature:
+
+    ${featureDescription}
+
+    Guidelines:
+    - Follow the existing code style and conventions in the repo.
+    - Write tests alongside the implementation (not after).
+    - Keep commits small and focused.
+    - Do not introduce unnecessary dependencies.
+    - If you discover the plan needs revision, note it but keep moving.
+
+    When done, summarize what you implemented and what remains.
+
+Phase: Review
+  Depends-on: Implement
+  Runtime: ollama-pi
+  Timeout: 180000
+  Prompt: |
+    You are a code reviewer. The following feature was just implemented:
+
+    ${featureDescription}
+
+    Review the implementation for:
+    - Correctness relative to the stated goals.
+    - Adherence to the plan from the planning phase.
+    - Code quality: naming, structure, error handling, test coverage.
+    - Any concerns or follow-up tasks that should be filed.
+
+    Produce a concise review verdict:
+    - What was done well.
+    - What needs fixing before the work is complete.
+    - Suggested follow-up tasks (not blockers, but improvements worth tracking).

--- a/templates/research.pipeline.md
+++ b/templates/research.pipeline.md
@@ -1,0 +1,59 @@
+## Task: ${title}
+
+- **Runtime:** pipeline
+- **Sensitivity:** internal
+- **Submitted by:** ${submittedBy}
+- **Submitted at:** ${submittedAt}
+
+### Pipeline
+
+Phase: Explore
+  Runtime: ollama-pi
+  Timeout: 120000
+  Prompt: |
+    You are a research assistant. Explore and gather information on the following topic:
+
+    ${topic}
+
+    Your goals:
+    - Identify the key concepts, definitions, and terminology.
+    - Find the main open questions, debates, or areas of uncertainty.
+    - Note any well-known prior work, papers, or frameworks relevant to this topic.
+    - Be factual and concise. Use bullet points where helpful.
+
+    Output a structured summary of what you have found.
+
+Phase: Synthesize
+  Depends-on: Explore
+  Runtime: claude-sdk
+  Timeout: 180000
+  Prompt: |
+    You are a research synthesizer. Review the exploration findings on the topic:
+
+    ${topic}
+
+    Using the exploration output as context, produce:
+    1. A concise executive summary (2-3 paragraphs).
+    2. A structured breakdown of the major themes or subtopics.
+    3. Gaps and open questions that merit further investigation.
+    4. Practical implications or next steps.
+
+    Write clearly for a technical audience. Avoid padding.
+
+Phase: Critique
+  Depends-on: Synthesize
+  Runtime: ollama-pi
+  Timeout: 120000
+  Prompt: |
+    You are a critical reviewer. Read the synthesis on the topic:
+
+    ${topic}
+
+    Challenge the synthesis:
+    - Are there claims that are overstated or under-evidenced?
+    - Are important perspectives or counterarguments missing?
+    - Is the framing biased in any way?
+    - What would weaken or strengthen the conclusions?
+
+    Produce a critique with specific, actionable observations.
+    Flag any points you are uncertain about rather than guessing.

--- a/templates/review.pipeline.md
+++ b/templates/review.pipeline.md
@@ -1,0 +1,65 @@
+## Task: ${title}
+
+- **Runtime:** pipeline
+- **Sensitivity:** internal
+- **Submitted by:** ${submittedBy}
+- **Submitted at:** ${submittedAt}
+
+### Pipeline
+
+Phase: Analyze
+  Runtime: claude-sdk
+  Context: repo:${repo}
+  Timeout: 180000
+  Prompt: |
+    You are a code reviewer. Analyze the following change:
+
+    ${diffSummary}
+
+    For each part of the change, assess:
+    - Correctness: does the logic do what it claims?
+    - Safety: are there error cases, race conditions, or edge cases not handled?
+    - Clarity: is the code readable and well-named?
+    - Test coverage: are the important paths tested?
+    - Design: does the change fit the existing architecture, or does it introduce inconsistencies?
+
+    Produce a structured analysis with specific file/line references where possible.
+    Rate each concern as: minor, moderate, or major.
+
+Phase: Adversarial
+  Depends-on: Analyze
+  Runtime: ollama-pi
+  Timeout: 120000
+  Prompt: |
+    You are an adversarial reviewer. Take a deliberately skeptical stance toward the change:
+
+    ${diffSummary}
+
+    Specifically look for:
+    - Security implications (injection, privilege escalation, data leakage, TOCTOU).
+    - Subtle behavioral regressions that might not appear in tests.
+    - Dependencies introduced that carry risk (size, maintenance, license).
+    - Interactions with concurrency, state, or external systems.
+
+    Be concrete. "This looks risky" is not useful — name the specific risk and the scenario that triggers it.
+    If you find no adversarial concerns, say so explicitly.
+
+Phase: Summarize
+  Depends-on: Adversarial
+  Runtime: claude-sdk
+  Timeout: 120000
+  Prompt: |
+    You are producing the final review summary for:
+
+    ${title}
+
+    Consolidate the analysis and adversarial review into a clear verdict:
+
+    ## Summary
+
+    - **Recommendation:** [approve / approve with minor fixes / request changes / reject]
+    - **Blocking concerns:** list any issues that must be resolved before merging.
+    - **Non-blocking suggestions:** list any improvements that are optional.
+    - **Positive observations:** note what the change does well.
+
+    Keep the summary actionable and specific. Avoid repeating the full analysis verbatim.

--- a/tests/pipeline-templates.test.ts
+++ b/tests/pipeline-templates.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from "vitest";
+import {
+  instantiatePipelineTemplate,
+  listPipelineTemplates,
+  loadPipelineTemplate,
+  requiredPlaceholders,
+} from "../src/pipeline-templates.js";
+import { compilePipelineTask } from "../src/pipeline-compiler.js";
+import type { OllamaHost } from "../src/ollama-hosts.js";
+
+const defaultOllamaHosts: OllamaHost[] = [
+  {
+    name: "pi",
+    baseUrl: "http://127.0.0.1:11434",
+    available: true,
+    models: ["qwen2.5:3b"],
+    lastChecked: Date.now(),
+  },
+  {
+    name: "laptop",
+    baseUrl: "http://100.1.2.3:11434",
+    available: false,
+    models: [],
+    lastChecked: Date.now(),
+  },
+];
+
+describe("listPipelineTemplates", () => {
+  it("returns the three canonical template names", () => {
+    const names = listPipelineTemplates();
+    expect(names).toHaveLength(3);
+    expect(names).toContain("research");
+    expect(names).toContain("review");
+    expect(names).toContain("implementation");
+  });
+
+  it("returns names sorted alphabetically", () => {
+    const names = listPipelineTemplates();
+    expect(names).toEqual([...names].sort());
+  });
+});
+
+describe("loadPipelineTemplate", () => {
+  it("returns raw template text for a known template", () => {
+    const raw = loadPipelineTemplate("research");
+    expect(typeof raw).toBe("string");
+    expect(raw.length).toBeGreaterThan(100);
+    expect(raw).toContain("${");
+  });
+
+  it("throws on unknown template name", () => {
+    expect(() => loadPipelineTemplate("nonexistent")).toThrow(/unknown template/i);
+  });
+
+  it("guards against path traversal", () => {
+    expect(() => loadPipelineTemplate("../src/index")).toThrow(/unknown template/i);
+    expect(() => loadPipelineTemplate("../../etc/passwd")).toThrow(/unknown template/i);
+  });
+});
+
+describe("requiredPlaceholders", () => {
+  it("finds placeholders in research template", () => {
+    const placeholders = requiredPlaceholders("research");
+    expect(placeholders).toContain("title");
+    expect(placeholders).toContain("topic");
+    expect(placeholders).toContain("submittedBy");
+    expect(placeholders).toContain("submittedAt");
+  });
+
+  it("finds placeholders in review template", () => {
+    const placeholders = requiredPlaceholders("review");
+    expect(placeholders).toContain("title");
+    expect(placeholders).toContain("submittedBy");
+    expect(placeholders).toContain("submittedAt");
+  });
+
+  it("finds placeholders in implementation template", () => {
+    const placeholders = requiredPlaceholders("implementation");
+    expect(placeholders).toContain("title");
+    expect(placeholders).toContain("submittedBy");
+    expect(placeholders).toContain("submittedAt");
+  });
+
+  it("returns distinct values (no duplicates)", () => {
+    for (const name of listPipelineTemplates()) {
+      const placeholders = requiredPlaceholders(name);
+      expect(new Set(placeholders).size).toBe(placeholders.length);
+    }
+  });
+});
+
+describe("instantiatePipelineTemplate", () => {
+  it("throws with a helpful message when a placeholder is left unsubstituted", () => {
+    expect(() =>
+      instantiatePipelineTemplate("research", {
+        // omit required vars intentionally
+        submittedBy: "test",
+        submittedAt: "2026-05-29T10:00:00Z",
+      })
+    ).toThrow(/unsubstituted placeholder/i);
+  });
+
+  it("substitutes all placeholders in research template", () => {
+    const vars = {
+      title: "Quantum error correction survey",
+      topic: "quantum error correction codes",
+      submittedBy: "claude-code",
+      submittedAt: "2026-05-29T10:00:00Z",
+    };
+    const result = instantiatePipelineTemplate("research", vars);
+    expect(result).not.toContain("${");
+    expect(result).toContain("Quantum error correction survey");
+    expect(result).toContain("quantum error correction codes");
+  });
+
+  it("substitutes all placeholders in review template", () => {
+    const vars = {
+      title: "Review heimdall PR #42",
+      diffSummary: "Adds OAuth2 login flow to the API gateway",
+      repo: "heimdall",
+      submittedBy: "claude-code",
+      submittedAt: "2026-05-29T10:00:00Z",
+    };
+    const result = instantiatePipelineTemplate("review", vars);
+    expect(result).not.toContain("${");
+    expect(result).toContain("Review heimdall PR #42");
+  });
+
+  it("substitutes all placeholders in implementation template", () => {
+    const vars = {
+      title: "Implement rate limiter",
+      featureDescription: "A token-bucket rate limiter for the broker endpoint",
+      repo: "hugin",
+      submittedBy: "claude-code",
+      submittedAt: "2026-05-29T10:00:00Z",
+    };
+    const result = instantiatePipelineTemplate("implementation", vars);
+    expect(result).not.toContain("${");
+    expect(result).toContain("Implement rate limiter");
+  });
+});
+
+// Key correctness tests: each template must produce a document that compiles
+// into a valid PipelineIR with the expected structure.
+describe("template compilation correctness", () => {
+  it("research template compiles into 3-phase PipelineIR with correct dependencies", () => {
+    const vars = {
+      title: "AI safety alignment survey",
+      topic: "AI safety and alignment research directions",
+      submittedBy: "claude-code",
+      submittedAt: "2026-05-29T10:00:00Z",
+    };
+    const doc = instantiatePipelineTemplate("research", vars);
+    const ir = compilePipelineTask(
+      "test-research-001",
+      "tasks/test-research-001",
+      doc,
+      defaultOllamaHosts,
+    );
+
+    expect(ir.phases.length).toBeGreaterThanOrEqual(3);
+    // First phase has no dependencies
+    expect(ir.phases[0]?.dependsOn).toHaveLength(0);
+    // Subsequent phases depend on earlier ones
+    expect(ir.phases[1]?.dependsOn.length).toBeGreaterThan(0);
+    expect(ir.phases[2]?.dependsOn.length).toBeGreaterThan(0);
+    // All phases have prompts
+    for (const phase of ir.phases) {
+      expect(phase.prompt.length).toBeGreaterThan(10);
+    }
+  });
+
+  it("review template compiles into 3-phase PipelineIR with correct dependencies", () => {
+    const vars = {
+      title: "Code review for PR #99",
+      diffSummary: "Refactors authentication middleware",
+      repo: "hugin",
+      submittedBy: "claude-code",
+      submittedAt: "2026-05-29T10:00:00Z",
+    };
+    const doc = instantiatePipelineTemplate("review", vars);
+    const ir = compilePipelineTask(
+      "test-review-001",
+      "tasks/test-review-001",
+      doc,
+      defaultOllamaHosts,
+    );
+
+    expect(ir.phases.length).toBeGreaterThanOrEqual(3);
+    expect(ir.phases[0]?.dependsOn).toHaveLength(0);
+    expect(ir.phases[1]?.dependsOn.length).toBeGreaterThan(0);
+    expect(ir.phases[2]?.dependsOn.length).toBeGreaterThan(0);
+  });
+
+  it("implementation template compiles into 3-phase PipelineIR with correct dependencies", () => {
+    const vars = {
+      title: "Implement webhook delivery",
+      featureDescription: "HTTP webhook delivery for task completion events",
+      repo: "hugin",
+      submittedBy: "claude-code",
+      submittedAt: "2026-05-29T10:00:00Z",
+    };
+    const doc = instantiatePipelineTemplate("implementation", vars);
+    const ir = compilePipelineTask(
+      "test-impl-001",
+      "tasks/test-impl-001",
+      doc,
+      defaultOllamaHosts,
+    );
+
+    expect(ir.phases.length).toBeGreaterThanOrEqual(3);
+    expect(ir.phases[0]?.dependsOn).toHaveLength(0);
+    expect(ir.phases[1]?.dependsOn.length).toBeGreaterThan(0);
+    expect(ir.phases[2]?.dependsOn.length).toBeGreaterThan(0);
+  });
+
+  it("research template sensitivity is internal by default", () => {
+    const vars = {
+      title: "Test",
+      topic: "test topic",
+      submittedBy: "claude-code",
+      submittedAt: "2026-05-29T10:00:00Z",
+    };
+    const doc = instantiatePipelineTemplate("research", vars);
+    const ir = compilePipelineTask(
+      "test-research-002",
+      "tasks/test-research-002",
+      doc,
+      defaultOllamaHosts,
+    );
+    expect(ir.sensitivity).toBe("internal");
+  });
+});


### PR DESCRIPTION
Closes #5.

Reusable, versioned-in-git pipeline templates for the three common task patterns, plus a loader that instantiates a template into a valid Hugin pipeline-task document.

## What's added
- **`templates/`** — three pipeline templates (`research`, `review`, `implementation`), each a full pipeline-task document with `${placeholder}` tokens:
  - **research**: Explore (ollama-pi) → Synthesize (claude-sdk) → Critique (ollama-pi)
  - **review**: Analyze (claude-sdk) → Adversarial (ollama-pi) → Summarize (claude-sdk)
  - **implementation**: Plan (claude-sdk) → Implement (claude-sdk, `Capabilities: tools, code`) → Review (ollama-pi)
- **`src/pipeline-templates.ts`** — `listPipelineTemplates()`, `loadPipelineTemplate(name)`, `requiredPlaceholders(name)`, `instantiatePipelineTemplate(name, vars)`. Template name is slug-validated and path-traversal-guarded; instantiation throws listing any unsubstituted placeholders. `TEMPLATES_DIR` resolves via `import.meta.url` so it works from both `src/` (vitest) and `dist/` (prod).
- **`tests/pipeline-templates.test.ts`** — 17 tests. The key correctness test instantiates each template with sample vars and asserts it **compiles** via `compilePipelineTask(...)` into a valid `PipelineIR` with the expected phases + dependency wiring.

## Testing
- `npm test`: **665 green** (+17). `tsc --noEmit` clean.

Implemented by a delegated Sonnet sub-agent; reviewed and verified (tsc + full suite + manual read of the module and templates) before opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
