### PR TITLE
fix: codex sandbox preflight + install bubblewrap on Pi (#59)

### DIFF
--- a/scripts/deploy-pi.sh
+++ b/scripts/deploy-pi.sh
@@ -101,6 +101,30 @@ else
   echo "  NAS reachability are fixed (else delivery-capable tasks will fail)."
 fi
 
+echo "==> Codex sandbox preflight (issue #59)..."
+# Codex's `codex exec` sandboxes shell commands and apply_patch through
+# bubblewrap. When the system `bwrap` is missing, Codex silently falls back to a
+# VENDORED bwrap that is incompatible with the Pi kernel: every shell command and
+# file write fails with `bwrap: loopback: Failed to create NETLINK_ROUTE socket`,
+# yet the task still exits 0 — so codex tasks "succeed" while delivering nothing
+# (issue #59). Ensure the system bwrap exists AND can actually create the
+# network namespace + loopback that Codex relies on. Non-fatal WARNING: this only
+# affects the codex runtime, so it must not block a deploy that runs claude/ollama
+# tasks. The runtime fix is `sudo apt install bubblewrap`.
+if ssh "$REMOTE" "
+  command -v bwrap >/dev/null 2>&1 || { echo 'NO_BWRAP'; exit 1; }
+  # Mirror codex's usage: unshare the network namespace and bring up loopback.
+  # This is the exact path that fails with the vendored bwrap on the Pi kernel.
+  bwrap --unshare-net --ro-bind / / --dev /dev /bin/true 2>/dev/null || { echo 'BWRAP_NETNS_FAIL'; exit 1; }
+"; then
+  echo "  OK: system bwrap present and network-namespace probe passed (codex sandbox healthy)"
+else
+  echo "  WARNING: codex sandbox preflight FAILED."
+  echo "  Codex tasks will exit 0 but deliver nothing (vendored-bwrap fallback is"
+  echo "  incompatible with the Pi kernel). Fix on the Pi: sudo apt install bubblewrap"
+  echo "  then re-run this probe. Until then, do not route code-capable tasks to codex."
+fi
+
 echo "==> Syncing global Claude config..."
 "$(dirname "$0")/sync-claude-config.sh" "$PI_HOST"
 


### PR DESCRIPTION
Fixes #59.

On the Hugin-Munin Pi, every `codex exec` shell command and `apply_patch` failed with `bwrap: loopback: Failed to create NETLINK_ROUTE socket: Address family not supported by protocol`. Codex was silently falling back to its **vendored** bubblewrap (the system `bubblewrap` package was not installed), and the vendored copy is incompatible with the Pi kernel. Tasks still exited 0 — so codex "succeeded" while delivering nothing (no shell, no file writes, no commit, no rsync, no issue filing).

## Root cause (confirmed on the Pi)
`bubblewrap` was absent from apt. Installing it (`sudo apt install bubblewrap` → 0.11.0) makes `codex exec` run `/bin/bash -lc '…'` and write files successfully, and the `--unshare-net` loopback probe that the vendored bwrap failed on now passes:
```
$ codex exec --sandbox workspace-write --skip-git-repo-check "echo BWRAP_OK > /tmp/p; cat /tmp/p"
  /bin/bash -lc '…' succeeded in 0ms  →  BWRAP_OK
$ bwrap --unshare-net --ro-bind / / --dev /dev /bin/true  →  ok
```
**The runtime fix (apt install bubblewrap) has been applied to the Pi.**

## This PR
Adds a non-fatal codex-sandbox preflight to `scripts/deploy-pi.sh` that (1) checks the system `bwrap` exists and (2) runs the exact network-namespace/loopback probe codex relies on — warning loudly with the apt fix if either fails. This makes the silent-success failure mode impossible to reintroduce undetected. Non-fatal because it only affects the codex runtime (claude/ollama tasks are unaffected).

## Acceptance (from the issue)
- ✅ `codex exec -c 'pwd'` returns successfully on the Pi
- ✅ `apply_patch`/file writes work
- ✅ no "vendored bubblewrap" warning
- ✅ deploy surfaces a clear error if the sandbox is broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)
