### PR TITLE
docs: design specs for autonomous dep-bumps (#26) + Privacy Filter eval (#56)

### DIFF
--- a/docs/design/autonomous-dependency-bumps.md
+++ b/docs/design/autonomous-dependency-bumps.md
@@ -1,0 +1,80 @@
+# Design: Autonomous dependency-bump PRs from security-scan results (#26)
+
+**Status:** Design / plan (not yet implemented)
+**Issue:** [#26](https://github.com/Magnus-Gille/hugin/issues/26)
+**Phase:** 2 — self-maintaining Grimnir
+
+## Goal
+
+When the weekly Grimnir security scan (`grimnir-security-scan.timer`) finds **fixable**
+`npm audit` vulnerabilities in a repo, Hugin should open a PR with the fix automatically.
+Never auto-merge — always leave for human review.
+
+## Existing substrate
+
+- `grimnir-security-scan.timer` already runs `npm audit` across all Grimnir repos and writes
+  results to Munin under `security/repos/<repo>`.
+- Hugin already runs tasks per-repo, has branch-per-task git flow (`checkoutTaskBranch` /
+  `finalizeTaskBranch` in `src/task-helpers.ts`, issue #47) that creates a branch, commits,
+  pushes, and opens a PR via the configured bot.
+- Result delivery + structured results + reply routing already exist.
+
+So #26 is mostly **orchestration glue**: read scan results → for each repo with fixable
+findings, synthesize a task whose prompt is "run `npm audit fix`, verify, summarize", and let
+the existing branch-per-task flow open the PR.
+
+## Recommended answers to the issue's open questions
+
+| Question | Recommendation | Rationale |
+|----------|---------------|-----------|
+| **Scope: patch / minor / major?** | Auto-fix **patch + minor** (i.e. plain `npm audit fix`, no `--force`). **Major** bumps (`--force`) are **flagged**, never auto-applied — they go into the PR body as "manual review needed", not the diff. | `npm audit fix` without `--force` is semver-safe by definition; `--force` pulls breaking majors and is exactly what needs a human. |
+| **Test gate** | Hard gate: the task runs the repo's `npm test` (and `npm run build` if present) AFTER `npm audit fix`. **If tests fail, do not open a PR** — write a `failed` result describing the regression so a human sees it. Repos with **no** test script: open the PR but label it `needs-manual-verification` and say so in the body. | A green PR a human can trust; a red one is noise. |
+| **Push access** | Pre-flight: verify the bot principal has push access to each target repo before attempting; skip + warn on repos it can't push to. Verified once at task build time via `gh repo view --json viewerPermission`. | Avoids half-done tasks that fail at push. |
+| **Rate limiting** | **One PR per repo per scan.** Batch all fixable advisories for a repo into a single `npm audit fix` + single PR. Skip a repo if it already has an open Hugin-authored dep-bump PR (idempotency by branch name `chore/audit-fix-<scan-date>`). | Prevents PR spam; one reviewable unit per repo. |
+| **Trigger** | **Scheduled**, chained after the weekly scan completes (a follow-on step in the scan timer, or a Hugin task-group submitted by the scan). Also expose an **on-demand** entry point (a Hugin task `type:dep-bump`) for manual kicks. | Matches the "after weekly scan" cadence; on-demand helps testing. |
+
+## Proposed mechanism
+
+1. **Trigger** (after weekly scan): a small driver (cron step, or a `type:dep-bump` Hugin task
+   group) reads `security/repos/*` from Munin.
+2. **Per-repo gate:** for each repo with `fixable > 0` advisories and push access and no
+   existing open audit-fix PR, submit one Hugin task:
+   - `Context: repo:<name>`, `type:dep-bump`, autonomous authority, `Sensitivity: internal`.
+   - Prompt: run `npm audit fix` (no `--force`), then `npm run build` (if present) and
+     `npm test` (if present); summarize what changed (packages, versions, advisories closed)
+     and list any remaining advisories that need `--force`/major bumps.
+3. **PR via existing flow:** the branch-per-task flow (#47) commits the lockfile/package.json
+   changes on `chore/audit-fix-<date>`, pushes, opens a PR with the synthesized body. **Never
+   auto-merge** (Hugin already never merges).
+4. **Test-failure handling:** if build/test fails, the task finalizes `failed`, no PR; the
+   structured result records the regression. A human triages.
+
+## New surface in Hugin
+
+- A `type:dep-bump` task convention (carried through the lifecycle via the existing `type:*`
+  tag plumbing).
+- A driver script `scripts/submit-dep-bumps.sh` (mirrors `scripts/submit-stale-status-review.sh`)
+  that queries Munin scan results and submits one task per eligible repo. Idempotent: skips
+  repos with an open `chore/audit-fix-*` PR.
+- PR body template: advisories closed, packages bumped (old→new), test/build status, and a
+  "remaining (needs major bump)" section for `--force`-only fixes.
+
+## Security considerations
+
+- The task runs `npm audit fix` + tests inside the repo working dir — standard task sandbox.
+  No new egress beyond the npm registry the build already uses.
+- `--force` is **never** run autonomously (breaking-change blast radius).
+- Bot push access is verified pre-flight; the bot must not have merge rights used automatically.
+- Lockfile integrity: the PR diff is the audit; a human reviews before merge.
+
+## Rough effort
+
+- Driver script + `type:dep-bump` convention + PR body template: ~0.5 day.
+- Wiring the post-scan trigger (in grimnir-security-scan) + idempotency check: ~0.5 day.
+- Tests (eligibility filter, idempotency, no-test-repo path): ~0.5 day.
+
+## Out of scope (follow-ups)
+
+- Auto-bumping non-`npm` ecosystems.
+- Auto-merge on green (explicitly excluded — human-in-the-loop is the point).
+- Grouping/deduping advisories across repos into a single dashboard PR.

--- a/docs/design/openai-privacy-filter-eval.md
+++ b/docs/design/openai-privacy-filter-eval.md
@@ -1,0 +1,89 @@
+# Design / Eval Plan: OpenAI Privacy Filter for local PII redaction (#56)
+
+**Status:** evaluation plan (empirical benchmarks pending — they gate the decision)
+**Issue:** [#56](https://github.com/Magnus-Gille/hugin/issues/56)
+
+## What we're evaluating
+
+[`openai/privacy-filter`](https://github.com/openai/privacy-filter) (OPF) — an Apache-2.0,
+bidirectional token classifier over a PII taxonomy. ~1.5B params total / ~50M active
+(MoE top-4 of 128 experts), 128K context, designed to run on CPU. Permissive license means it
+can sit **inside** the trusted runtime boundary (unlike a hosted API).
+
+The question is two-fold: (a) is OPF a meaningfully better PII substrate than Hugin's current
+regex scanners, and (b) where in the fleet should it run.
+
+## Why it's interesting for Hugin
+
+Hugin already enforces a `public/internal/private` sensitivity lattice (`src/sensitivity.ts`)
+and has two regex scanners — `src/prompt-injection-scanner.ts` (context-ref content) and
+`src/exfiltration-scanner.ts` (task output). Regex is brittle for PII (misses paraphrase,
+context, novel formats). A learned token classifier is a stronger substrate for the same jobs.
+
+## Candidate integration points (ranked by value/effort)
+
+| # | Integration | Value | Effort | Notes |
+|---|-------------|-------|--------|-------|
+| 1 | **Exfil-scanner upgrade** — OPF pass on task results before they land in Munin (augment, not replace, `exfiltration-scanner.ts`) | High | Med | Drop-in to the existing `HUGIN_EXFIL_POLICY` pipeline; new policy value `opf` alongside `warn/flag/redact`. Spans give precise redaction. |
+| 2 | **Sensitivity inference** — feed OPF-detected PII spans into `sensitivity.ts` to escalate `public → internal/private` automatically | High | Med | Makes the lattice signal much stronger than keyword+path. Escalate-only (never downgrade). |
+| 3 | **Context-ref sanitization** — when a cloud-capped runtime would be blocked by the sensitivity ceiling, optionally OPF-redact PII from context-refs and downgrade effective sensitivity | High | High | Big trust-story win, but redaction-then-cloud is the riskiest path (a miss = leak). Requires very high recall + an audit trail. Gate behind explicit opt-in. |
+| 4 | **Pre-Munin write filter** — generic OPF pass on anything a cloud runtime writes to Munin | Med | Med | Defense in depth; overlaps #1. |
+
+**Recommended first slice:** integration #1 (exfil-scanner augmentation) as a new
+`HUGIN_EXFIL_POLICY=opf` mode — lowest risk (it only *adds* detections to an existing
+pipeline), directly measurable against the regex baseline, and no behavior change unless opted in.
+Integration #3 (redact-then-cloud) should NOT ship until #1/#2 establish OPF's recall in practice.
+
+## Deployment options to evaluate
+
+| Host | Pros | Cons | Verdict to test |
+|------|------|------|-----------------|
+| **Hugin-Munin Pi** (ARM64, 8 GB) | Co-located with Hugin+Munin, no network hop, stays on-device for `private` tasks | 1.5B (50M active) on ARM Pi CPU is tight; latency unknown | Benchmark throughput/latency — likely viable for async scan, maybe not inline |
+| **MacBook** | Fast (Apple Silicon), already an orchestrator | Not always on; network hop from Pi; laptop sleeps | Good for dev/eval, poor for an always-on Pi-side filter |
+| **Mac Studio** | Always-on, fast, lots of RAM | Network hop from Pi; another host in the trust boundary | Best if Pi latency is unacceptable — run OPF as a small local service over Tailscale |
+
+The deployment decision hinges on **measured Pi latency**: if a 1–10 KB task result scans in
+well under the poll interval, run it on the Pi (simplest trust story). If not, run it as a
+Tailscale-local OPF service on the Mac Studio and have Hugin call it (still inside the tailnet,
+no third-party egress).
+
+## Evaluation protocol (the empirical work — gates the decision)
+
+1. **Stand up OPF** on each candidate host; record cold-start + warm inference.
+2. **Throughput/latency benchmark** per host: scan representative task results (1 KB, 10 KB,
+   100 KB) and context-refs; record p50/p95 latency and memory. The Pi number is the pivotal one.
+3. **Quality benchmark vs the regex baseline** on a labelled fixture set (synthetic + real-shaped
+   Grimnir content with known PII spans): precision/recall/F1 for OPF vs `exfiltration-scanner.ts`
+   regexes. Pay special attention to **recall** (a missed PII span before a cloud call = leak).
+4. **False-positive cost** on clean technical content (code, logs) — over-redaction degrades task
+   utility.
+5. **Decision matrix:** integration point #1 ships only if OPF beats regex recall at acceptable
+   latency on the chosen host and FP rate on clean content is tolerable.
+
+## Decision criteria (pre-registered)
+
+- **Adopt (integration #1)** if: OPF recall on the PII fixture ≥ regex baseline + materially
+  better on paraphrased/novel PII, p95 latency on the chosen host < poll interval, FP rate on
+  clean technical content < an agreed threshold.
+- **Defer** if: Pi latency is prohibitive AND no always-on Mac host is acceptable in the trust
+  boundary.
+- **Reject** if: quality gain over regex is marginal at the realized cost/latency.
+
+## Security considerations
+
+- OPF runs **inside** the trusted boundary (local, Apache-2.0) — no third-party egress, so it does
+  not itself widen the trust surface. A Mac-Studio deployment must stay Tailscale-only.
+- Redact-then-cloud (#3) is the only integration that can *cause* a leak (via a recall miss); it
+  must be opt-in, audited, and never the default — consistent with the cloud-runtime sensitivity cap.
+- Sensitivity inference (#2) must be **escalate-only**: OPF can raise sensitivity, never lower it.
+
+## Rough effort
+
+- Eval harness + fixtures + per-host benchmark: ~1–2 days (the real cost is curating a labelled
+  PII fixture set).
+- Integration #1 (`HUGIN_EXFIL_POLICY=opf`): ~1 day once the host + model-serving shape is chosen.
+
+## Next step
+
+This is an empirical evaluation; the gating action is **running the benchmark protocol on the Pi
+and Mac Studio**. Until those numbers exist, no integration ships.


### PR DESCRIPTION
**Plan/spec only — no feature code.** Design docs for two issues that need decisions/benchmarks before implementation.

## `docs/design/autonomous-dependency-bumps.md` (#26)
Answers the issue's open questions with recommended defaults and a mechanism that reuses the existing branch-per-task flow (#47) + Munin scan results:
- **Scope:** auto-fix patch + minor (`npm audit fix`, no `--force`); major bumps flagged, never auto-applied.
- **Test gate:** hard — run build + tests after the fix; no PR if they fail; no-test repos get a `needs-manual-verification` label.
- **Rate limiting:** one PR per repo per scan, idempotent by branch name.
- **Trigger:** scheduled post-scan + an on-demand `type:dep-bump` task.
- **Never auto-merge.**

## `docs/design/openai-privacy-filter-eval.md` (#56)
Evaluation plan for `openai/privacy-filter` as a local PII layer:
- Ranked integration points (recommended first slice: a new `HUGIN_EXFIL_POLICY=opf` mode — lowest risk).
- Deployment options (Pi / MacBook / Mac Studio) with the decision hinging on **measured Pi latency**.
- A pre-registered benchmark protocol + adopt/defer/reject criteria. **No integration ships until the Pi/Mac-Studio benchmarks exist** — that empirical step is the gating action.

Both issues stay **open**; these are their plans of record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
