### PR TITLE
feat: autonomous dependency-bump driver (#26)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,6 +162,7 @@ hugin/
     ├── enable-broker.sh          # One-shot: generate broker token on Pi, write to .env, restart, register hugin-mcp locally
     ├── submit-daily-analysis.sh  # Submit daily journal analysis as ollama task
     ├── submit-stale-status-review.sh
+    ├── submit-dep-bumps.sh       # Autonomous dep-bump tasks from security-scan results (#26)
     ├── sync-claude-config.sh     # Sync ~/.claude/ config to Pi
     ├── update-cli.sh             # Auto-update CLI tools (daily cron)
     ├── on-task-stop.mjs          # Task stop hook

--- a/scripts/submit-dep-bumps.sh
+++ b/scripts/submit-dep-bumps.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+# Submit autonomous dependency-bump tasks to Hugin for repos with fixable npm audit findings.
+#
+# Reads weekly security-scan results from Munin (security/repos/<repo>) and,
+# for each repo with fixable vulnerabilities, submits one Hugin task (runtime:claude,
+# type:dep-bump) that runs `npm audit fix`, verifies build/test, and opens a PR.
+#
+# Idempotency: skips repos that already have an open `chore/audit-fix-*` PR (requires gh CLI).
+# If gh is unavailable, the check is skipped and a warning is printed.
+#
+# Usage:
+#   MUNIN_API_KEY=<key> ./scripts/submit-dep-bumps.sh [repo1 repo2 ...]
+#
+#   If no repos are given, all repos found under security/repos/* in Munin are used.
+
+set -euo pipefail
+
+MUNIN_URL="${MUNIN_URL:-http://localhost:3030}"
+MUNIN_API_KEY="${MUNIN_API_KEY:?MUNIN_API_KEY is required}"
+
+SCAN_DATE="$(date -u +%Y%m%d)"
+SUBMITTED=0
+SKIPPED=0
+FAILED=0
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+munin_call() {
+  # Usage: munin_call <json-body>
+  # Prints raw JSON response.
+  curl -s -X POST "${MUNIN_URL}/mcp" \
+    -H "Authorization: Bearer ${MUNIN_API_KEY}" \
+    -H "Content-Type: application/json" \
+    -H "Accept: application/json, text/event-stream" \
+    -d "$1"
+}
+
+json_encode() {
+  # Encode stdin as a JSON string (including quotes).
+  python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))"
+}
+
+extract_repos_from_query() {
+  # Given a Munin memory_query JSON response, extract unique repo names
+  # from namespaces matching security/repos/<repo>.
+  python3 -c "
+import json, sys, re
+resp = json.load(sys.stdin)
+results = resp.get('result', {}).get('content', [{}])[0].get('text', '{}')
+data = json.loads(results)
+entries = data.get('results', [])
+repos = set()
+for e in entries:
+    m = re.match(r'^security/repos/([^/]+)$', e.get('namespace',''))
+    if m:
+        repos.add(m.group(1))
+for r in sorted(repos):
+    print(r)
+"
+}
+
+extract_fixable_from_read() {
+  # Given a Munin memory_read JSON response content string, extract
+  # the fixable vulnerability count.  Returns 0 if not parseable.
+  python3 -c "
+import json, sys, re
+resp = json.load(sys.stdin)
+results = resp.get('result', {}).get('content', [{}])[0].get('text', '{}')
+data = json.loads(results)
+content = data.get('content', '')
+# Try to find 'fixable: N' pattern in the content (written by the scan)
+m = re.search(r'\"fixable\":\s*(\d+)', content)
+if m:
+    print(m.group(1))
+    sys.exit(0)
+# Also try plain text 'fixable N'
+m = re.search(r'\bfixable[:\s]+(\d+)', content, re.IGNORECASE)
+if m:
+    print(m.group(1))
+    sys.exit(0)
+print('0')
+"
+}
+
+has_open_audit_pr() {
+  # Usage: has_open_audit_pr <repo>
+  # Returns 0 (true) if an open chore/audit-fix-* PR exists for the repo, 1 otherwise.
+  local repo="$1"
+  if ! command -v gh &>/dev/null; then
+    echo "  [warn] gh CLI not found — skipping idempotency check for ${repo}" >&2
+    return 1  # can't check, assume no PR
+  fi
+  # `gh pr list --head` matches an EXACT branch, not a prefix, so list open PRs
+  # and match the chore/audit-fix-* branch family ourselves.
+  local count
+  count=$(gh pr list \
+    --repo "Magnus-Gille/${repo}" \
+    --state open \
+    --json headRefName \
+    --jq '[.[] | select(.headRefName | startswith("chore/audit-fix-"))] | length' \
+    2>/dev/null || echo "0")
+  [ "${count:-0}" -gt 0 ]
+}
+
+submit_task() {
+  local repo="$1"
+  local task_id task_ns task_content task_json body response
+
+  task_id="$(date -u +%Y%m%d-%H%M%S)-dep-bump-${repo}"
+  task_ns="tasks/${task_id}"
+
+  # Build task content — the agent will run npm audit fix, verify, and let
+  # the existing branch-per-task flow open the PR.
+  task_content=$(cat <<TASK_EOF
+## Task: Autonomous dependency bump for ${repo}
+
+- **Runtime:** claude
+- **Context:** repo:${repo}
+- **Model:** sonnet
+- **Timeout:** 600000
+- **Submitted by:** hugin
+- **Submitted at:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
+- **Sensitivity:** internal
+
+### Prompt
+You are running an autonomous dependency security fix for the **${repo}** repository.
+The weekly Grimnir security scan found fixable npm audit vulnerabilities.
+
+**Your task:**
+
+1. Run \`npm audit fix\` (NO \`--force\` — never use --force).
+2. If a \`build\` script exists in package.json, run \`npm run build\`.
+   - If build FAILS: do NOT open a PR. Report the regression and list the failing output.
+3. If a \`test\` script exists in package.json, run \`npm test\`.
+   - If tests FAIL: do NOT open a PR. Report the regression with the failing test output.
+   - If no test script exists: note this as "needs-manual-verification" in the PR body.
+4. If build and tests pass (or no scripts exist):
+   - The existing Hugin branch-per-task flow will commit changes to branch \`chore/audit-fix-${SCAN_DATE}\`, push, and open a PR.
+   - Do NOT auto-merge. Leave the PR for human review.
+5. In your result, summarize:
+   - Which advisories were closed (CVE/GHSA IDs if available)
+   - Which packages were bumped (package@old-version → package@new-version)
+   - Any remaining advisories that require a major version bump (\`--force\`) — list these as "manual review needed"
+   - Build/test status
+
+**Rules:**
+- NEVER run \`npm audit fix --force\`
+- NEVER run any command that modifies git history (rebase, amend, etc.)
+- NEVER attempt to merge the PR
+- If \`npm audit fix\` reports "0 vulnerabilities" or makes no changes, report that and exit cleanly (no PR needed)
+TASK_EOF
+)
+
+  task_json=$(json_encode <<< "$task_content")
+
+  body=$(cat <<JSON_EOF
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "memory_write",
+    "arguments": {
+      "namespace": "${task_ns}",
+      "key": "status",
+      "content": ${task_json},
+      "tags": ["pending", "runtime:claude", "type:dep-bump"]
+    }
+  }
+}
+JSON_EOF
+)
+
+  response=$(munin_call "$body")
+
+  if echo "$response" | grep -q '"error"'; then
+    echo "  [error] Failed to submit task for ${repo}: $response" >&2
+    return 1
+  fi
+
+  echo "  Submitted: ${task_ns}"
+}
+
+# ── discover repos ───────────────────────────────────────────────────────────
+
+if [ $# -gt 0 ]; then
+  REPOS=("$@")
+  echo "Scope: explicit repos: ${REPOS[*]}"
+else
+  echo "Querying Munin for repos under security/repos/* ..."
+  QUERY_BODY=$(cat <<JSON_EOF
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "memory_query",
+    "arguments": {
+      "namespace": "security/repos",
+      "limit": 100
+    }
+  }
+}
+JSON_EOF
+)
+  QUERY_RESPONSE=$(munin_call "$QUERY_BODY")
+
+  if echo "$QUERY_RESPONSE" | grep -q '"error"'; then
+    echo "ERROR: Failed to query Munin security/repos: $QUERY_RESPONSE" >&2
+    exit 1
+  fi
+
+  mapfile -t REPOS < <(echo "$QUERY_RESPONSE" | extract_repos_from_query)
+
+  if [ "${#REPOS[@]}" -eq 0 ]; then
+    echo "No repos found under security/repos/* in Munin. Nothing to do."
+    exit 0
+  fi
+  echo "Found ${#REPOS[@]} repo(s): ${REPOS[*]}"
+fi
+
+# ── per-repo processing ──────────────────────────────────────────────────────
+
+for repo in "${REPOS[@]}"; do
+  echo ""
+  echo "── ${repo} ──"
+
+  # Read the security scan entry for this repo
+  READ_BODY=$(cat <<JSON_EOF
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "memory_read",
+    "arguments": {
+      "namespace": "security/repos/${repo}",
+      "key": "audit"
+    }
+  }
+}
+JSON_EOF
+)
+
+  READ_RESPONSE=$(munin_call "$READ_BODY")
+
+  if echo "$READ_RESPONSE" | grep -q '"error"'; then
+    echo "  [warn] Could not read security/repos/${repo}/audit from Munin, skipping"
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  # Check for "found: false" (entry doesn't exist)
+  if echo "$READ_RESPONSE" | python3 -c "
+import json,sys
+resp = json.load(sys.stdin)
+text = resp.get('result',{}).get('content',[{}])[0].get('text','{}')
+data = json.loads(text)
+sys.exit(0 if data.get('found') else 1)
+" 2>/dev/null; then
+    :  # found=true, continue
+  else
+    echo "  [skip] No audit entry in Munin for ${repo}"
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  fixable=$(echo "$READ_RESPONSE" | extract_fixable_from_read)
+  echo "  Fixable vulnerabilities: ${fixable}"
+
+  if [ "$fixable" -eq 0 ] 2>/dev/null; then
+    echo "  [skip] No fixable vulnerabilities"
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  # Idempotency: check for existing open audit-fix PR
+  if has_open_audit_pr "$repo"; then
+    echo "  [skip] Open chore/audit-fix-* PR already exists for ${repo}"
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  # Submit the task
+  if submit_task "$repo"; then
+    SUBMITTED=$((SUBMITTED + 1))
+  else
+    FAILED=$((FAILED + 1))
+  fi
+done
+
+# ── summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "Done. Submitted: ${SUBMITTED}, Skipped: ${SKIPPED}, Failed: ${FAILED}"
+
+if [ "$FAILED" -gt 0 ]; then
+  exit 1
+fi

--- a/src/dep-bump-eligibility.ts
+++ b/src/dep-bump-eligibility.ts
@@ -1,0 +1,98 @@
+/**
+ * Eligibility helpers for autonomous dependency-bump tasks (#26).
+ *
+ * Pure functions — no I/O, no side effects.
+ * The driver script (scripts/submit-dep-bumps.sh) re-implements these in
+ * Python 3 for inline bash use; this module provides the same logic in
+ * TypeScript for unit testing and future programmatic callers.
+ */
+
+/**
+ * A Munin memory_query JSON-RPC response shape (minimal — only what we need).
+ */
+interface MuninQueryRpcResponse {
+  result?: {
+    content?: Array<{ text?: string }>;
+  };
+}
+
+/**
+ * A Munin memory_read JSON-RPC response shape (minimal).
+ */
+interface MuninReadRpcResponse {
+  result?: {
+    content?: Array<{ text?: string }>;
+  };
+}
+
+/**
+ * Extract repo names from a Munin memory_query response for namespace
+ * "security/repos".  Returns each unique repo slug found in namespaces
+ * matching `security/repos/<repo>`, sorted ascending.
+ */
+export function parseReposFromQueryResponse(raw: unknown): string[] {
+  const resp = raw as MuninQueryRpcResponse;
+  const text = resp?.result?.content?.[0]?.text ?? "{}";
+  let data: Record<string, unknown>;
+  try {
+    data = JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    return [];
+  }
+  const entries = (data.results as Array<Record<string, unknown>>) ?? [];
+  const repos = new Set<string>();
+  for (const entry of entries) {
+    const ns = entry.namespace;
+    if (typeof ns === "string") {
+      const m = ns.match(/^security\/repos\/([^/]+)$/);
+      if (m) repos.add(m[1]);
+    }
+  }
+  return [...repos].sort();
+}
+
+/**
+ * Extract the fixable vulnerability count from a Munin memory_read response
+ * for a `security/repos/<repo>/audit` entry.
+ *
+ * The security scanner writes audit results in one of two formats:
+ *   - JSON with a top-level `"fixable": N` field (preferred)
+ *   - Plain text with pattern `fixable: N`
+ *
+ * Returns 0 if the entry is not found, not parseable, or reports no fixable issues.
+ */
+export function parseFixableCount(raw: unknown): number {
+  const resp = raw as MuninReadRpcResponse;
+  const text = resp?.result?.content?.[0]?.text ?? "{}";
+  let data: Record<string, unknown>;
+  try {
+    data = JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    return 0;
+  }
+  if (!data.found) return 0;
+  const content = typeof data.content === "string" ? data.content : "";
+
+  // Try JSON field `"fixable": N` in the content string
+  const jsonMatch = content.match(/"fixable":\s*(\d+)/);
+  if (jsonMatch) return parseInt(jsonMatch[1], 10);
+
+  // Try plain text `fixable: N` or `fixable N`
+  const textMatch = content.match(/\bfixable[:\s]+(\d+)/i);
+  if (textMatch) return parseInt(textMatch[1], 10);
+
+  return 0;
+}
+
+/**
+ * Given a Munin query response and a map of repo→fixable counts,
+ * return the list of repos that are eligible for a dep-bump task.
+ *
+ * Eligibility: fixable count > 0.
+ */
+export function filterEligibleRepos(
+  repos: string[],
+  fixableCounts: Map<string, number>,
+): string[] {
+  return repos.filter((r) => (fixableCounts.get(r) ?? 0) > 0);
+}

--- a/tests/submit-dep-bumps.test.ts
+++ b/tests/submit-dep-bumps.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseReposFromQueryResponse,
+  parseFixableCount,
+  filterEligibleRepos,
+} from "../src/dep-bump-eligibility.js";
+
+// ── parseReposFromQueryResponse ───────────────────────────────────────────────
+
+describe("parseReposFromQueryResponse", () => {
+  it("returns empty array for empty/null input", () => {
+    expect(parseReposFromQueryResponse(null)).toEqual([]);
+    expect(parseReposFromQueryResponse({})).toEqual([]);
+  });
+
+  it("returns empty array when no results", () => {
+    const resp = {
+      result: {
+        content: [{ text: JSON.stringify({ results: [] }) }],
+      },
+    };
+    expect(parseReposFromQueryResponse(resp)).toEqual([]);
+  });
+
+  it("extracts repo slugs from security/repos/<repo> namespaces", () => {
+    const resp = {
+      result: {
+        content: [
+          {
+            text: JSON.stringify({
+              results: [
+                { namespace: "security/repos/hugin", key: "audit" },
+                { namespace: "security/repos/munin-memory", key: "audit" },
+                { namespace: "security/repos/heimdall", key: "audit" },
+              ],
+            }),
+          },
+        ],
+      },
+    };
+    expect(parseReposFromQueryResponse(resp)).toEqual([
+      "heimdall",
+      "hugin",
+      "munin-memory",
+    ]);
+  });
+
+  it("deduplicates repos appearing multiple times", () => {
+    const resp = {
+      result: {
+        content: [
+          {
+            text: JSON.stringify({
+              results: [
+                { namespace: "security/repos/hugin", key: "audit" },
+                { namespace: "security/repos/hugin", key: "audit-summary" },
+              ],
+            }),
+          },
+        ],
+      },
+    };
+    expect(parseReposFromQueryResponse(resp)).toEqual(["hugin"]);
+  });
+
+  it("ignores namespaces that don't match the pattern", () => {
+    const resp = {
+      result: {
+        content: [
+          {
+            text: JSON.stringify({
+              results: [
+                { namespace: "security/repos/hugin", key: "audit" },
+                { namespace: "security/scan-metadata", key: "last-run" },
+                { namespace: "projects/hugin", key: "status" },
+                // deeper path should not match
+                { namespace: "security/repos/hugin/sub", key: "x" },
+              ],
+            }),
+          },
+        ],
+      },
+    };
+    expect(parseReposFromQueryResponse(resp)).toEqual(["hugin"]);
+  });
+
+  it("handles malformed text field gracefully", () => {
+    const resp = {
+      result: { content: [{ text: "not json" }] },
+    };
+    expect(parseReposFromQueryResponse(resp)).toEqual([]);
+  });
+});
+
+// ── parseFixableCount ─────────────────────────────────────────────────────────
+
+describe("parseFixableCount", () => {
+  it("returns 0 for null/empty input", () => {
+    expect(parseFixableCount(null)).toBe(0);
+    expect(parseFixableCount({})).toBe(0);
+  });
+
+  it("returns 0 when found is false", () => {
+    const resp = {
+      result: {
+        content: [
+          {
+            text: JSON.stringify({ found: false, content: "" }),
+          },
+        ],
+      },
+    };
+    expect(parseFixableCount(resp)).toBe(0);
+  });
+
+  it("parses fixable count from JSON content field", () => {
+    const auditContent = JSON.stringify({
+      vulnerabilities: 3,
+      fixable: 2,
+      critical: 1,
+    });
+    const resp = {
+      result: {
+        content: [
+          {
+            text: JSON.stringify({ found: true, content: auditContent }),
+          },
+        ],
+      },
+    };
+    expect(parseFixableCount(resp)).toBe(2);
+  });
+
+  it("parses fixable count from plain text pattern 'fixable: N'", () => {
+    const auditContent = "3 vulnerabilities found\nfixable: 2\n1 needs --force";
+    const resp = {
+      result: {
+        content: [
+          {
+            text: JSON.stringify({ found: true, content: auditContent }),
+          },
+        ],
+      },
+    };
+    expect(parseFixableCount(resp)).toBe(2);
+  });
+
+  it("returns 0 when fixable is 0 in JSON", () => {
+    const auditContent = JSON.stringify({ vulnerabilities: 1, fixable: 0 });
+    const resp = {
+      result: {
+        content: [
+          {
+            text: JSON.stringify({ found: true, content: auditContent }),
+          },
+        ],
+      },
+    };
+    expect(parseFixableCount(resp)).toBe(0);
+  });
+
+  it("returns 0 when no fixable field present", () => {
+    const auditContent = "no vulnerabilities found";
+    const resp = {
+      result: {
+        content: [
+          {
+            text: JSON.stringify({ found: true, content: auditContent }),
+          },
+        ],
+      },
+    };
+    expect(parseFixableCount(resp)).toBe(0);
+  });
+
+  it("handles malformed text field gracefully", () => {
+    const resp = {
+      result: { content: [{ text: "BROKEN JSON {{{" }] },
+    };
+    expect(parseFixableCount(resp)).toBe(0);
+  });
+});
+
+// ── filterEligibleRepos ───────────────────────────────────────────────────────
+
+describe("filterEligibleRepos", () => {
+  it("returns repos with fixable > 0", () => {
+    const repos = ["hugin", "munin-memory", "heimdall"];
+    const counts = new Map([
+      ["hugin", 3],
+      ["munin-memory", 0],
+      ["heimdall", 1],
+    ]);
+    expect(filterEligibleRepos(repos, counts)).toEqual(["hugin", "heimdall"]);
+  });
+
+  it("returns empty array when all counts are 0", () => {
+    const repos = ["hugin", "munin-memory"];
+    const counts = new Map([
+      ["hugin", 0],
+      ["munin-memory", 0],
+    ]);
+    expect(filterEligibleRepos(repos, counts)).toEqual([]);
+  });
+
+  it("treats missing count as 0 (repo not in map)", () => {
+    const repos = ["hugin", "unknown-repo"];
+    const counts = new Map([["hugin", 2]]);
+    expect(filterEligibleRepos(repos, counts)).toEqual(["hugin"]);
+  });
+
+  it("returns empty array for empty repo list", () => {
+    expect(filterEligibleRepos([], new Map())).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #26. Implements `docs/design/autonomous-dependency-bumps.md`.

`scripts/submit-dep-bumps.sh` reads the weekly Grimnir security-scan results from Munin (`security/repos/<repo>`) and, for each repo with **fixable** npm audit findings, submits one Hugin task (`runtime:claude`, `type:dep-bump`) that:
- runs `npm audit fix` (**never** `--force`),
- runs `npm run build` + `npm test` if present — **no PR if they fail** (reports the regression); no-test repos get a `needs-manual-verification` note,
- lets the existing branch-per-task flow (#47) open a PR on `chore/audit-fix-<date>` — **never auto-merge**,
- summarizes advisories closed / packages bumped / remaining major-bump-only items.

**One PR per repo per run**; idempotent via an open `chore/audit-fix-*` PR check (`gh`). Eligibility + audit-count parsing are extracted to `src/dep-bump-eligibility.ts` (pure functions, unit-tested — 17 tests).

Trigger: run manually, or chain after the weekly scan timer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
