### PR TITLE
feat: eval-gated skill-distillation system (#79-#84)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,4 +287,5 @@ claude mcp add-json hugin '{"command":"node","args":["/Users/magnus/repos/hugin/
 | `HUGIN_DELIVERY_RETRY_MAX_ATTEMPTS` | `10` | Deferred-delivery (`defer`) retry budget: max delivery attempts before terminalizing `failed` + `Exit code: 2`. |
 | `HUGIN_DELIVERY_RETRY_MAX_AGE_MS` | `86400000` (24h) | Deferred-delivery retry budget: max age from the first attempt before terminalizing. Whichever of attempts/age trips first wins, so a permanently-unreachable NAS still reaches a terminal state. |
 | `HUGIN_DELIVERY_RETRY_INTERVAL_MS` | `300000` (5min) | Cadence of the deferred-delivery retry reaper (separate timer, armed only under `defer`). |
+| `HUGIN_SKILL_LANE` | `off` | Local-skill lane master switch (issues #79–#84). `on` enables the fail-closed local-skill route pre-step (`src/skill/skill-lane.ts`: classify → retrieve → select an `active` RouteBinding). Until authored slice-one artifacts + a real cell exist, the lane fails closed to the cloud auto-router, so this is a no-op when on. |
 | `ARXIV_STORAGE_PATH` | — | Directory where arxiv-mcp-server caches downloaded papers. Forwarded into the arxiv MCP subprocess environment. |

--- a/src/index.ts
+++ b/src/index.ts
@@ -285,6 +285,12 @@ const config = {
     process.env.HUGIN_DELIVERY_RETRY_INTERVAL_MS,
     300_000, // 5min
   ),
+  // Local-skill lane master switch (issue #84). Default OFF — the lane only ever
+  // runs local when an `active`, drift-free, sensitivity-cleared RouteBinding is
+  // selectable (src/skill/skill-lane.ts), which requires authored slice-one
+  // artifacts + a real cell that do not exist yet. Until then the orchestrator
+  // fails closed to the existing cloud auto-router, so flipping this on is a no-op.
+  skillLaneEnabled: process.env.HUGIN_SKILL_LANE === "on",
 };
 
 const brokerEnv = readBrokerEnv(process.env);

--- a/src/skill/eval-runner.ts
+++ b/src/skill/eval-runner.ts
@@ -1,0 +1,316 @@
+/**
+ * eval-runner.ts — offline eval harness for issue #83 (A6).
+ *
+ * Designed for testability:
+ *   - `runEvalSuite` accepts an injected `runFixture` executor so tests never
+ *     need a real model, cell, or Munin instance.
+ *   - No imports from route-binding-schema, procedure-package-schema,
+ *     retrieval-schema, or any other #79–#82 modules — this module is
+ *     independently compilable and testable.
+ *   - Does not import from Munin client, index.ts, or router.ts.
+ *
+ * Anti-Goodhart rules enforced at runtime (mirrors the schema-level refines):
+ *   1. `assertIndependentOracle` throws if no oracle is independent.
+ *   2. A `judge-model` oracle verdict is advisory: it can never alone decide
+ *      pass or fail.  A definitive verdict requires at least one non-judge
+ *      oracle.
+ */
+
+import type { EvalSuite, Oracle, Fixture, RetrievalFixture } from "./eval-suite-schema.js";
+import type { FailureStage } from "./refs.js";
+import { calibratedMetricsSchema } from "./refs.js";
+import type { CalibratedMetrics } from "./refs.js";
+
+// ---------------------------------------------------------------------------
+// Per-fixture result shape (typed locally — caller assembles full ValidationRun)
+// ---------------------------------------------------------------------------
+
+export interface PerFixtureResult {
+  fixtureId: string;
+  outcome: "pass" | "fail" | "abstain";
+  /** Set on fail: which stage the failure was caught at. */
+  caughtAtStage?: FailureStage;
+  /** The oracle that produced the definitive verdict. */
+  oracleId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Eval-suite aggregate result
+// ---------------------------------------------------------------------------
+
+export interface EvalSuiteRunResult {
+  metrics: CalibratedMetrics;
+  perFixtureResults: PerFixtureResult[];
+}
+
+// ---------------------------------------------------------------------------
+// Runtime anti-Goodhart guard
+// ---------------------------------------------------------------------------
+
+/**
+ * Throw if the suite has no independent oracle.  Mirrors the schema .refine so
+ * callers can enforce this at runtime (e.g. before recording a ValidationRun).
+ */
+export function assertIndependentOracle(suite: EvalSuite): void {
+  if (!suite.oracles.some((o) => o.independent)) {
+    throw new Error(
+      `EvalSuite "${suite.evalSuiteId}": at least one independent oracle required`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Single-fixture grading
+// ---------------------------------------------------------------------------
+
+/**
+ * Grade a single fixture output against the provided oracles.
+ *
+ * Oracle evaluation order:
+ *   1. Non-judge oracles are consulted first and are authoritative.
+ *   2. A `judge-model` oracle is advisory: its verdict is recorded in
+ *      `oracleId` only when there is no authoritative verdict from a
+ *      non-judge oracle.  It can never cause pass/fail alone — if the only
+ *      oracles are judge-model, the outcome is "abstain".
+ *
+ * This function does NOT execute oracles externally.  In the offline eval
+ * harness, oracle execution is the responsibility of `runFixture` (the
+ * injected executor).  `gradeFixture` decides the verdict based on the
+ * output already produced.  The oracle array is used to determine which
+ * oracle's logic should be applied; the actual check is a structural
+ * equality comparison between `output` and `fixture.expected` (suitable
+ * for deterministic test-suite and schema-validator oracle kinds).
+ *
+ * For richer oracle dispatch (running external commands, calling APIs),
+ * replace this function with one that accepts pre-computed per-oracle
+ * verdicts.  The anti-Goodhart contract (judge advisory, independent
+ * required) is enforced regardless.
+ */
+export function gradeFixture(
+  f: Fixture,
+  output: unknown,
+  oracles: Oracle[],
+): PerFixtureResult {
+  const nonJudgeOracles = oracles.filter((o) => o.kind !== "judge-model");
+  const judgeOracles = oracles.filter((o) => o.kind === "judge-model");
+
+  // Determine match: structural equality (JSON round-trip safe for primitives
+  // and plain objects).  Callers with richer oracle kinds should wrap this
+  // function to inject oracle-specific verdicts.
+  const matches = JSON.stringify(output) === JSON.stringify(f.expected);
+
+  // --- Non-judge oracles (authoritative) -----------------------------------
+  if (nonJudgeOracles.length > 0) {
+    // Use the first independent non-judge oracle for the definitive verdict.
+    // If none is independent, fall back to the first non-judge oracle.
+    const authoritative =
+      nonJudgeOracles.find((o) => o.independent) ?? nonJudgeOracles[0];
+
+    if (matches) {
+      return { fixtureId: f.id, outcome: "pass", oracleId: authoritative.id };
+    } else {
+      // Map the oracle kind to the stage where the failure was caught.
+      const caughtAtStage = oracleKindToStage(authoritative.kind);
+      return {
+        fixtureId: f.id,
+        outcome: "fail",
+        caughtAtStage,
+        oracleId: authoritative.id,
+      };
+    }
+  }
+
+  // --- Judge-only case (advisory → abstain) --------------------------------
+  if (judgeOracles.length > 0) {
+    // Judge verdicts are recorded but never decide pass/fail alone.
+    const judge = judgeOracles[0];
+    return {
+      fixtureId: f.id,
+      outcome: "abstain",
+      oracleId: judge.id,
+    };
+  }
+
+  // No oracles at all — abstain.
+  return { fixtureId: f.id, outcome: "abstain", oracleId: "none" };
+}
+
+/**
+ * Map an oracle kind to the FailureStage taxonomy.  Used by gradeFixture to
+ * record where in the pipeline a failure was caught.
+ */
+function oracleKindToStage(kind: Oracle["kind"]): FailureStage {
+  switch (kind) {
+    case "test-suite":
+      return "tests";
+    case "schema-validator":
+      return "schema";
+    case "snapshot-diff":
+      return "tests";
+    case "static-analyzer":
+      return "preflight";
+    case "judge-model":
+      // Should not reach here (judge is advisory), but handle defensively.
+      return "grader";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Full suite runner
+// ---------------------------------------------------------------------------
+
+/**
+ * Run all four fixture kinds in the eval suite, grade each using `gradeFixture`,
+ * and aggregate into `CalibratedMetrics` + `perFixtureResults`.
+ *
+ * @param suite        The parsed and validated EvalSuite.
+ * @param runFixture   Injected executor: given a fixture (Fixture or
+ *                     RetrievalFixture), returns the model/cell output.
+ *                     For retrieval fixtures, the output should be a boolean
+ *                     indicating whether the skill was selected.
+ *                     This injection point is what makes the runner testable
+ *                     without a real model.
+ *
+ * The caller is responsible for assembling the full ValidationRun (issue #79
+ * schema) — this function only produces the metrics + perFixtureResults portion.
+ */
+export async function runEvalSuite(
+  suite: EvalSuite,
+  runFixture: (fixture: Fixture | RetrievalFixture) => Promise<unknown>,
+): Promise<EvalSuiteRunResult> {
+  // Runtime anti-Goodhart guard (mirrors schema .refine).
+  assertIndependentOracle(suite);
+
+  const perFixtureResults: PerFixtureResult[] = [];
+  const durations: number[] = [];
+
+  // Helper: run a Fixture and grade it.
+  async function runAndGrade(f: Fixture): Promise<void> {
+    const start = Date.now();
+    const output = await runFixture(f);
+    durations.push((Date.now() - start) / 1000);
+    perFixtureResults.push(gradeFixture(f, output, suite.oracles));
+  }
+
+  // Helper: run a RetrievalFixture and grade it.
+  async function runAndGradeRetrieval(rf: RetrievalFixture): Promise<void> {
+    const start = Date.now();
+    const output = await runFixture(rf);
+    durations.push((Date.now() - start) / 1000);
+
+    // Retrieval fixture: output is expected to be a boolean (selected / not selected).
+    const selected = Boolean(output);
+    const pass = selected === rf.shouldSelect;
+
+    // Find the appropriate oracle for the verdict.
+    const nonJudgeOracles = suite.oracles.filter((o) => o.kind !== "judge-model");
+    const oracleId =
+      (nonJudgeOracles.find((o) => o.independent) ?? nonJudgeOracles[0])?.id ??
+      "none";
+
+    if (pass) {
+      perFixtureResults.push({ fixtureId: rf.id, outcome: "pass", oracleId });
+    } else {
+      perFixtureResults.push({
+        fixtureId: rf.id,
+        outcome: "fail",
+        caughtAtStage: "retrieval",
+        oracleId,
+      });
+    }
+  }
+
+  // Run all four fixture kinds sequentially (offline harness; no parallelism).
+  for (const f of suite.fixtures.positive) {
+    await runAndGrade(f);
+  }
+  for (const f of suite.fixtures.negative) {
+    await runAndGrade(f);
+  }
+  for (const rf of suite.fixtures.retrieval) {
+    await runAndGradeRetrieval(rf);
+  }
+  for (const f of suite.fixtures.mutation) {
+    await runAndGrade(f);
+  }
+
+  // Aggregate metrics.
+  const total = perFixtureResults.length;
+  const passCount = perFixtureResults.filter((r) => r.outcome === "pass").length;
+  const abstainCount = perFixtureResults.filter((r) => r.outcome === "abstain").length;
+  const failResults = perFixtureResults.filter((r) => r.outcome === "fail");
+
+  // Build failure-kind histogram.  Zod v4 z.record(enumSchema, ...) requires all
+  // enum keys to be present — initialise every FailureKind to 0 first.
+  const failureKindHistogram: Record<string, number> = {
+    "retrieval-miss": 0,
+    "classification-wrong": 0,
+    preflight: 0,
+    parser: 0,
+    schema: 0,
+    tests: 0,
+    timeout: 0,
+    grader: 0,
+    delivery: 0,
+    infra: 0,
+  };
+  for (const r of failResults) {
+    // Map FailureStage → FailureKind (the two enums overlap partially but are
+    // distinct).  FailureStage "retrieval" maps to FailureKind "retrieval-miss".
+    const kind = stageToFailureKind(r.caughtAtStage ?? "grader");
+    failureKindHistogram[kind] = (failureKindHistogram[kind] ?? 0) + 1;
+  }
+
+  // Duration percentiles (over all fixtures).
+  const sortedDurations = [...durations].sort((a, b) => a - b);
+  const p50 = percentile(sortedDurations, 0.5);
+  const p95 = percentile(sortedDurations, 0.95);
+
+  const metrics = calibratedMetricsSchema.parse({
+    passRate: total > 0 ? passCount / total : 0,
+    sampleSize: total,
+    p50DurationSeconds: p50,
+    p95DurationSeconds: p95,
+    failureKindHistogram,
+    abstentionRate: total > 0 ? abstainCount / total : 0,
+  });
+
+  return { metrics, perFixtureResults };
+}
+
+// ---------------------------------------------------------------------------
+// Utility
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a FailureStage value to the closest FailureKind for the metrics
+ * histogram.  The two enums overlap but are distinct: FailureStage records
+ * *where* a failure was caught in the pipeline; FailureKind labels the
+ * category for routing/policy decisions.
+ */
+function stageToFailureKind(stage: FailureStage): string {
+  switch (stage) {
+    case "retrieval":
+      return "retrieval-miss";
+    case "classification":
+      return "classification-wrong";
+    case "preflight":
+      return "preflight";
+    case "parser":
+      return "parser";
+    case "schema":
+      return "schema";
+    case "tests":
+      return "tests";
+    case "timeout":
+      return "timeout";
+    case "grader":
+      return "grader";
+  }
+}
+
+function percentile(sorted: number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const idx = Math.max(0, Math.ceil(sorted.length * p) - 1);
+  return sorted[idx] ?? 0;
+}

--- a/src/skill/eval-suite-schema.ts
+++ b/src/skill/eval-suite-schema.ts
@@ -1,0 +1,122 @@
+/**
+ * eval-suite-schema.ts — EvalSuite, Oracle, Fixture, RetrievalFixture Zod
+ * schemas for issue #83 (A6: eval-suite format with independent oracle +
+ * immutable validation runs).
+ *
+ * Anti-Goodhart rules enforced here:
+ *   1. At least one oracle must have `independent: true` (schema .refine).
+ *   2. `judgeIsAdvisoryOnly` is z.literal(true) — a plain boolean would let
+ *      a false value through at parse time.
+ *   3. All four fixture kinds require .min(1): positive, negative, retrieval,
+ *      mutation.  A missing kind is a parse error, not a runtime warn.
+ */
+
+import { z } from "zod";
+import {
+  sha256HexSchema,
+  failureStageSchema,    // re-exported for callers that only import eval-suite
+} from "./refs.js";
+
+export { failureStageSchema };
+
+// ---------------------------------------------------------------------------
+// Oracle
+// ---------------------------------------------------------------------------
+
+export const oracleSchema = z.object({
+  id: z.string().min(1),
+  kind: z.enum([
+    "test-suite",
+    "schema-validator",
+    "snapshot-diff",
+    "static-analyzer",
+    "judge-model",
+  ]),
+  /**
+   * true  = this oracle was NOT authored by the skill author and is NOT the
+   *         skill's own grader — it provides independent evidence.
+   * false = the oracle is authored by the same party that wrote the skill.
+   *
+   * At least one oracle with independent: true is required by the evalSuiteSchema
+   * .refine so that a frontier-authored skill+grader cannot become a rubber stamp.
+   */
+  independent: z.boolean(),
+  /** Path, command, or module reference that locates the oracle implementation. */
+  ref: z.string().min(1),
+});
+export type Oracle = z.infer<typeof oracleSchema>;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+export const fixtureSchema = z.object({
+  id: z.string().min(1),
+  input: z.unknown(),
+  expected: z.unknown(),
+  /**
+   * List of field paths or aspects the grader is allowed to ignore due to
+   * known non-determinism (e.g. timestamps, UUIDs).  Defaults to [].
+   */
+  allowedNondeterminism: z.array(z.string()).default([]),
+});
+export type Fixture = z.infer<typeof fixtureSchema>;
+
+export const retrievalFixtureSchema = z.object({
+  id: z.string().min(1),
+  input: z.string(),
+  /**
+   * true  = the retrieval step SHOULD select this skill for this input.
+   * false = hard-negative: the retrieval step must NOT select this skill.
+   */
+  shouldSelect: z.boolean(),
+});
+export type RetrievalFixture = z.infer<typeof retrievalFixtureSchema>;
+
+// ---------------------------------------------------------------------------
+// EvalSuite
+// ---------------------------------------------------------------------------
+
+export const evalSuiteSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    evalSuiteId: z.string().min(1),
+    /** SHA-256 content hash of this eval suite (content-addressed). */
+    evalSuiteHash: sha256HexSchema,
+    skillId: z.string().min(1),
+    taskClassId: z.string().min(1),
+    /**
+     * Anti-Goodhart rule 1: at least one oracle must have independent: true.
+     * Enforced via .refine so that a suite authored entirely by the skill
+     * author cannot be used as standalone validation evidence.
+     */
+    oracles: z.array(oracleSchema).refine(
+      (oracles) => oracles.some((o) => o.independent),
+      { message: "at least one independent oracle required" },
+    ),
+    /**
+     * Anti-Goodhart rule 2: LLM-judge results are recorded but never decide
+     * pass/fail alone.  z.literal(true) makes it impossible to parse a suite
+     * where this safety invariant is false.
+     */
+    judgeIsAdvisoryOnly: z.literal(true),
+    fixtures: z.object({
+      /** In-class inputs that must pass. */
+      positive: z.array(fixtureSchema).min(1),
+      /** In-class inputs the skill should fail or abort cleanly on. */
+      negative: z.array(fixtureSchema).min(1),
+      /**
+       * Retrieval fixtures: should/should-not be selected by the retrieval
+       * step.  Hard-negative cases catch overfit retrieval.
+       */
+      retrieval: z.array(retrievalFixtureSchema).min(1),
+      /**
+       * Perturbed inputs that catch overfit graders.  A grader that can't
+       * distinguish a mutation from a clean pass is not testing the skill.
+       */
+      mutation: z.array(fixtureSchema).min(1),
+    }),
+  })
+  .strict();
+
+export type EvalSuite = z.infer<typeof evalSuiteSchema>;

--- a/src/skill/procedure-package-schema.ts
+++ b/src/skill/procedure-package-schema.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+import { egressClassSchema } from "./refs.js";
+
+// Runtime-neutral procedure-package format (A3 / issue #80).
+// Source-of-truth: skills/<id>/package.yaml (validated by this schema).
+// The promoted unit is the *profile* compiled from this package — never the
+// raw package itself. See docs/design/skill-distillation-implementation.md §A3.
+
+export const procedurePackageSchema = z.object({
+  schemaVersion: z.literal(1),
+  skillId: z.string().min(1),
+  title: z.string(),
+  taskClassId: z.string().min(1),
+  inputSchema: z.record(z.string(), z.unknown()),
+  outputSchema: z.record(z.string(), z.unknown()),
+  toolAllowlist: z.array(z.string().min(1)),
+  steps: z
+    .array(
+      z.object({
+        id: z.string(),
+        instruction: z.string(),
+        checkpoint: z.string(),
+      }),
+    )
+    .min(1),
+  examples: z
+    .array(z.object({ input: z.unknown(), output: z.unknown() }))
+    .min(1),
+  antiExamples: z
+    .array(
+      z.object({
+        input: z.unknown(),
+        why: z.string(),
+      }),
+    )
+    .min(1),
+  abortConditions: z.array(z.string()).min(1),
+  contraindications: z.array(z.string()).default([]),
+  egressClass: egressClassSchema,
+  evalSuiteId: z.string().min(1),
+});
+
+export type ProcedurePackage = z.infer<typeof procedurePackageSchema>;

--- a/src/skill/profile-compiler.ts
+++ b/src/skill/profile-compiler.ts
@@ -1,0 +1,203 @@
+import { z } from "zod";
+import { contentHash, sha256HexSchema, egressClassSchema } from "./refs.js";
+import {
+  procedurePackageSchema,
+  type ProcedurePackage,
+} from "./procedure-package-schema.js";
+
+// pi-local-30b compiled profile (A3 / issue #80).
+// Compiled from a ProcedurePackage via compileProfile(); the promoted unit is
+// always the *profile*, never the raw package.
+// See docs/design/skill-distillation-implementation.md §A3.
+
+export const piLocal30bProfileSchema = z.object({
+  schemaVersion: z.literal(1),
+  skillId: z.string(),
+  profileId: z.string(),
+  sourcePackageHash: sha256HexSchema,
+  profileHash: sha256HexSchema,
+  systemPreamble: z.string(),
+  inputSchema: z.record(z.string(), z.unknown()),
+  outputSchema: z.record(z.string(), z.unknown()),
+  toolAllowlist: z.array(z.string()),
+  stepList: z.array(
+    z.object({
+      id: z.string(),
+      prompt: z.string(),
+      checkpointAssertion: z.string(),
+    }),
+  ),
+  examples: z.array(z.unknown()),
+  antiExamples: z.array(z.unknown()),
+  abortConditions: z.array(z.string()),
+  maxContextChars: z.number().int().positive(),
+  expectedArtifacts: z.array(z.string()),
+  perStepGraderHooks: z
+    .array(z.object({ stepId: z.string(), graderRef: z.string() }))
+    .default([]),
+  // Carry the egress class through so callers can enforce policy without
+  // re-reading the package.
+  egressClass: egressClassSchema,
+});
+
+export type PiLocal30bProfile = z.infer<typeof piLocal30bProfileSchema>;
+
+// ---------------------------------------------------------------------------
+// validatePackage — zod parse + structural checks
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse and validate a raw value as a ProcedurePackage.
+ * Throws a ZodError on schema violations, or an Error on structural violations
+ * (e.g. duplicate step ids, empty toolAllowlist).
+ */
+export function validatePackage(raw: unknown): ProcedurePackage {
+  const pkg = procedurePackageSchema.parse(raw);
+
+  // Structural check: step ids must be unique.
+  const stepIds = pkg.steps.map((s) => s.id);
+  const uniqueIds = new Set(stepIds);
+  if (uniqueIds.size !== stepIds.length) {
+    const dups = stepIds.filter((id, i) => stepIds.indexOf(id) !== i);
+    throw new Error(
+      `ProcedurePackage structural error: duplicate step ids: ${[...new Set(dups)].join(", ")}`,
+    );
+  }
+
+  // Structural check: toolAllowlist must be non-empty (a package with an
+  // empty allowlist cannot safely be compiled into a pi-local-30b profile
+  // — the profile would permit no tools at all, making execution impossible).
+  if (pkg.toolAllowlist.length === 0) {
+    throw new Error(
+      "ProcedurePackage structural error: toolAllowlist must be non-empty",
+    );
+  }
+
+  return pkg;
+}
+
+// ---------------------------------------------------------------------------
+// compileProfile — pure, deterministic
+// ---------------------------------------------------------------------------
+
+const DEFAULT_MAX_CONTEXT_CHARS = 32_000;
+
+/**
+ * Compile a validated ProcedurePackage into a pi-local-30b profile.
+ *
+ * PURE + DETERMINISTIC: no Date.now(), no Math.random(), no external I/O.
+ * The same pkg always produces the identical profile (and therefore the
+ * identical profileHash), which is what makes drift detection in A2 reliable.
+ *
+ * profileHash stability contract:
+ *   1. Build the entire profile object WITHOUT the profileHash field.
+ *   2. contentHash() that object → the hash value.
+ *   3. Attach profileHash to the returned object.
+ *   4. The hash covers everything except itself, so it is self-consistent
+ *      and reproducible: profileHash(compileProfile(pkg)) === profile.profileHash.
+ */
+export function compileProfile(
+  pkg: ProcedurePackage,
+  target: "pi-local-30b",
+): PiLocal30bProfile {
+  void target; // only one target today; kept for future additive targets
+
+  const sourcePackageHash = contentHash(pkg);
+
+  // Derive expectedArtifacts from outputSchema keys + any step ids that look
+  // like they produce artifacts (step ids ending in "-output" or "-artifact").
+  // This is a lightweight heuristic; slice-one authored packages should list
+  // explicit outputSchema keys.
+  const expectedArtifacts = deriveExpectedArtifacts(pkg);
+
+  // Build the profile body WITHOUT profileHash.
+  const profileBody: Omit<PiLocal30bProfile, "profileHash"> = {
+    schemaVersion: 1,
+    skillId: pkg.skillId,
+    profileId: `${pkg.skillId}:pi-local-30b`,
+    sourcePackageHash,
+    systemPreamble: buildSystemPreamble(pkg),
+    inputSchema: pkg.inputSchema,
+    outputSchema: pkg.outputSchema,
+    toolAllowlist: pkg.toolAllowlist,
+    stepList: pkg.steps.map((step) => ({
+      id: step.id,
+      prompt: step.instruction,
+      checkpointAssertion: step.checkpoint,
+    })),
+    examples: pkg.examples,
+    antiExamples: pkg.antiExamples,
+    abortConditions: pkg.abortConditions,
+    maxContextChars: DEFAULT_MAX_CONTEXT_CHARS,
+    expectedArtifacts,
+    perStepGraderHooks: [],
+    egressClass: pkg.egressClass,
+  };
+
+  // Hash the body (excludes profileHash) — stable, no external entropy.
+  const hash = contentHash(profileBody);
+
+  return { ...profileBody, profileHash: hash };
+}
+
+// ---------------------------------------------------------------------------
+// profileHash — recompute the content address for verification
+// ---------------------------------------------------------------------------
+
+/**
+ * Recompute the content address of a profile for drift verification.
+ *
+ * Strips the profile's own `profileHash` field before hashing so the result
+ * agrees with what compileProfile() embedded. This lets callers check:
+ *   profileHash(profile) === profile.profileHash
+ * to detect any mutation after compilation.
+ */
+export function profileHash(profile: PiLocal30bProfile): string {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { profileHash: _excluded, ...body } = profile;
+  return contentHash(body);
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers (pure)
+// ---------------------------------------------------------------------------
+
+function buildSystemPreamble(pkg: ProcedurePackage): string {
+  const lines: string[] = [
+    `You are a constrained operator executing the "${pkg.title}" skill (id: ${pkg.skillId}).`,
+    ``,
+    `Your task class is: ${pkg.taskClassId}`,
+    `Egress class: ${pkg.egressClass} (you MUST NOT make network calls beyond what this permits).`,
+    ``,
+    `Allowed tools: ${pkg.toolAllowlist.join(", ")}.`,
+    `You MUST NOT call any tool not in this allowlist.`,
+    ``,
+    `Abort immediately if any of the following conditions are true:`,
+    ...pkg.abortConditions.map((c) => `  - ${c}`),
+    ``,
+    `Do NOT use this skill if any of the following apply (anti-examples exist to guide you):`,
+    ...pkg.antiExamples.map((ae) => `  - ${ae.why}`),
+    ``,
+    `Proceed step by step. After each step, verify the checkpoint before continuing.`,
+    `Do not improvise beyond the defined steps.`,
+  ];
+
+  if (pkg.contraindications.length > 0) {
+    lines.push(``, `Contraindications (do not proceed if any hold):`);
+    pkg.contraindications.forEach((c) => lines.push(`  - ${c}`));
+  }
+
+  return lines.join("\n");
+}
+
+function deriveExpectedArtifacts(pkg: ProcedurePackage): string[] {
+  // Prefer explicit outputSchema keys as the primary artifact list.
+  const schemaKeys = Object.keys(pkg.outputSchema);
+  if (schemaKeys.length > 0) return schemaKeys;
+
+  // Fallback: steps whose id ends with a common artifact suffix.
+  const artifactSuffixes = ["-output", "-artifact", "-result", "-patch", "-file"];
+  return pkg.steps
+    .filter((s) => artifactSuffixes.some((suffix) => s.id.endsWith(suffix)))
+    .map((s) => s.id);
+}

--- a/src/skill/refs.ts
+++ b/src/skill/refs.ts
@@ -1,0 +1,137 @@
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import { sensitivitySchema, type Sensitivity } from "../sensitivity.js";
+
+// Shared foundation for the eval-gated skill-distillation system (issues #79–#84,
+// design: docs/design/skill-distillation-implementation.md). Every artifact type
+// (RouteBinding, TaskClassifier, SkillPackage/Profile, EvalSuite, ValidationRun)
+// references the others by id + content hash, so they MUST agree on:
+//   - a single canonical-JSON hashing scheme (so a profile/binding/run hash is
+//     stable and drift detection works), and
+//   - the shared enums / sub-schemas below.
+// This module is the one place those live; the per-artifact modules import here.
+
+export { sensitivitySchema };
+export type { Sensitivity };
+
+// --- Canonical JSON + content hashing -------------------------------------
+// Deterministic: object keys sorted recursively, no insignificant whitespace,
+// arrays preserved in order. `undefined` members are dropped (JSON semantics).
+// The same input value ALWAYS produces the same string → the same sha256, which
+// is what lets A2 drift-detection compare a stored tuple hash to a recomputed one.
+export function canonicalJSONString(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+function canonicalize(value: unknown): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (Array.isArray(value)) return value.map(canonicalize);
+  const obj = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(obj).sort()) {
+    const v = obj[key];
+    if (v === undefined) continue; // mirror JSON.stringify drop-undefined
+    out[key] = canonicalize(v);
+  }
+  return out;
+}
+
+/** sha256 (hex) over the canonical JSON of `value`. Stable + reproducible. */
+export function contentHash(value: unknown): string {
+  return createHash("sha256").update(canonicalJSONString(value)).digest("hex");
+}
+
+const SHA256_HEX = /^[0-9a-f]{64}$/;
+export const sha256HexSchema = z.string().regex(SHA256_HEX, "expected 64-char sha256 hex");
+
+// --- Shared enums ---------------------------------------------------------
+
+// RouteBinding / classifier lifecycle. `active` is gated on Hugin #77 (now fixed)
+// for any Hugin-integrated evidence; offline-fixture states are not.
+export const lifecycleStateSchema = z.enum([
+  "draft",
+  "candidate",
+  "shadow",
+  "active",
+  "stale",
+  "quarantined",
+  "disabled",
+]);
+export type LifecycleState = z.infer<typeof lifecycleStateSchema>;
+
+// Why a local-lane attempt failed (recorded in calibrated metrics + validation runs).
+export const failureKindSchema = z.enum([
+  "retrieval-miss",
+  "classification-wrong",
+  "preflight",
+  "parser",
+  "schema",
+  "tests",
+  "timeout",
+  "grader",
+  "delivery",
+  "infra",
+]);
+export type FailureKind = z.infer<typeof failureKindSchema>;
+
+// The pipeline STAGE at which a fixture failure surfaced (anti-Goodhart, A6) —
+// turns "local is flaky" into "profile vX fails retrieval-negative Z".
+export const failureStageSchema = z.enum([
+  "retrieval",
+  "classification",
+  "preflight",
+  "parser",
+  "schema",
+  "tests",
+  "timeout",
+  "grader",
+]);
+export type FailureStage = z.infer<typeof failureStageSchema>;
+
+// Trust/egress class of a cell or skill — mirrors the runtime-registry policy axis.
+export const egressClassSchema = z.enum(["local", "subscription", "third-party"]);
+export type EgressClass = z.infer<typeof egressClassSchema>;
+
+// --- Shared sub-schemas ---------------------------------------------------
+
+// Content-addressed references: a RouteBinding never inlines the artifacts it
+// binds — it pins them by (id, version?, hash). Drift = a current hash no longer
+// matching the pinned hash → the binding fail-closes to `stale`.
+export const tupleRefSchema = z.object({
+  taskClassId: z.string().min(1),
+  taskClassVersion: z.number().int().nonnegative(),
+  taskClassHash: sha256HexSchema,
+  skillProfileId: z.string().min(1),
+  skillProfileHash: sha256HexSchema,
+  cellManifestId: z.string().min(1),
+  cellManifestHash: sha256HexSchema,
+  evalSuiteId: z.string().min(1),
+  evalSuiteHash: sha256HexSchema,
+});
+export type TupleRef = z.infer<typeof tupleRefSchema>;
+
+// Calibrated metrics from a binding's active ValidationRun — NOT a boolean and
+// NOT live telemetry. The partial-pass / latency texture is decisive (C-debate).
+export const calibratedMetricsSchema = z.object({
+  passRate: z.number().min(0).max(1),
+  sampleSize: z.number().int().positive(),
+  p50DurationSeconds: z.number().nonnegative(),
+  p95DurationSeconds: z.number().nonnegative(),
+  failureKindHistogram: z.record(failureKindSchema, z.number().int().nonnegative()),
+  abstentionRate: z.number().min(0).max(1),
+});
+export type CalibratedMetrics = z.infer<typeof calibratedMetricsSchema>;
+
+/**
+ * Whether two tuple refs pin the same content (all four artifact hashes match).
+ * The core of fail-closed drift detection: compare a binding's pinned tuple to
+ * the tuple recomputed from current artifact content.
+ */
+export function tupleHashesMatch(a: TupleRef, b: TupleRef): boolean {
+  return (
+    a.taskClassHash === b.taskClassHash &&
+    a.skillProfileHash === b.skillProfileHash &&
+    a.cellManifestHash === b.cellManifestHash &&
+    a.evalSuiteHash === b.evalSuiteHash
+  );
+}

--- a/src/skill/retrieval-schema.ts
+++ b/src/skill/retrieval-schema.ts
@@ -1,0 +1,101 @@
+/**
+ * Munin retrieval row schema for the procedural-retrieval subsystem (A4 / #81).
+ *
+ * One row per skill profile, stored at:
+ *   skills/<skill-id>/retrieval
+ * Tagged: procedural-retrieval, skill:<id>, task-class:<classId>,
+ *         route-state:<bindingState>, sensitivity:<level>
+ *
+ * This schema is SECURITY-LOAD-BEARING:
+ *   - hardNegatives are exclusion rules; a prompt-digest match disqualifies
+ *     the row from selection entirely (not just a score penalty).
+ *   - bindingState mirrors the RouteBinding lifecycle for fast fail-close
+ *     without a second Munin read.
+ *   - evalConfidence feeds the confidence threshold that gates local routing.
+ */
+
+import { z } from "zod";
+import {
+  lifecycleStateSchema,
+  egressClassSchema,
+  sha256HexSchema,
+} from "./refs.js";
+
+export const proceduralRetrievalRowSchema = z.object({
+  schemaVersion: z.literal(1),
+
+  /** Skill identifier — matches the `skills/<skillId>/...` namespace. */
+  skillId: z.string().min(1),
+
+  /** Profile identifier — which compiled profile this row represents. */
+  profileId: z.string().min(1),
+
+  /**
+   * SHA-256 content hash of the compiled profile.
+   * Used for drift detection: if the hash has changed the binding is stale.
+   */
+  profileHash: sha256HexSchema,
+
+  /**
+   * Task class this skill handles.  Primary retrieval key — server-side tag
+   * filter uses `task-class:<taskClassId>` to keep the candidate set small.
+   */
+  taskClassId: z.string().min(1),
+
+  /**
+   * Short phrases that describe when this skill should be triggered.
+   * Used for trigger-phrase scoring when the Munin query score is absent.
+   * At least one entry required.
+   */
+  triggerPhrases: z.array(z.string().min(1)).min(1),
+
+  /** Input field names that must be present before this skill can run. */
+  requiredInputs: z.array(z.string()),
+
+  /** Exact tool names the skill requires to be available. */
+  requiredTools: z.array(z.string()),
+
+  /** Human-readable conditions under which this skill must NOT be used. */
+  contraindications: z.array(z.string()),
+
+  /**
+   * Hard-negative look-alike patterns.
+   * A prompt-digest that matches ANY entry here MUST NOT be selected — the
+   * candidate is dropped entirely before scoring and threshold checks.
+   * At least one entry required (enforces that authors think about near-misses).
+   */
+  hardNegatives: z.array(z.string().min(1)).min(1),
+
+  /**
+   * Egress class: how far the skill may reach outside the local machine.
+   * Must be consistent with the bound cell and binding fallback policy.
+   */
+  egressClass: egressClassSchema,
+
+  /** Expected output artifact types this skill produces. */
+  expectedArtifacts: z.array(z.string()),
+
+  /**
+   * Confidence score from the active ValidationRun (0–1 inclusive).
+   * Below `RetrievalConfig.confidenceThreshold` → abstain.
+   */
+  evalConfidence: z.number().min(0).max(1),
+
+  /** Known failure modes from past ValidationRuns — informational. */
+  knownFailureModes: z.array(z.string()),
+
+  /**
+   * Back-reference to the RouteBinding that produced this row.
+   * Used for `not-selectable` / stale checks and `RouteDecision` recording.
+   */
+  bindingId: z.string().min(1),
+
+  /**
+   * Mirror of the RouteBinding lifecycle state at last write.
+   * Only `"active"` is selectable.  Any other value → not-selectable outcome.
+   * Fail-closed: an unknown/future state is also not selectable.
+   */
+  bindingState: lifecycleStateSchema,
+});
+
+export type ProceduralRetrievalRow = z.infer<typeof proceduralRetrievalRowSchema>;

--- a/src/skill/retrieval.ts
+++ b/src/skill/retrieval.ts
@@ -1,0 +1,216 @@
+/**
+ * Procedural retrieval with a fail-closed abstention contract (A4 / #81).
+ *
+ * Security contract — the default is NEVER run local:
+ *
+ *   1. Munin unreachable (health() false OR any read/query throws)
+ *      → kind: "unavailable", reason: "munin-down"
+ *
+ *   2. A candidate's hardNegatives contains the task promptDigest
+ *      → candidate DROPPED before scoring (not just penalised).
+ *
+ *   3. Top candidate score < confidenceThreshold
+ *      → kind: "abstain", reason: "below-threshold"
+ *
+ *   4. (top1 score) − (top2 score) < topTwoMarginThreshold
+ *      → kind: "abstain", reason: "ambiguous-top-two"
+ *
+ *   5. Selected row's bindingState !== "active"
+ *      → kind: "not-selectable", reason: "stale-or-quarantined"
+ *
+ *   6. Otherwise → kind: "selected"
+ *
+ * Scoring (documented):
+ *   Retrieval rows are scored by the Munin query relevance score when the
+ *   server provides it (non-zero `score` field on `MuninQueryResult`).
+ *   When the score is absent or zero, a deterministic trigger-phrase match
+ *   score is used: (number of triggerPhrases that appear as substrings of
+ *   the lowercased promptDigest) / (total triggerPhrases).  This gives a
+ *   score in [0, 1] with the same semantics as the Munin score; it is
+ *   intentionally simple and deterministic so that tests do not depend on
+ *   Munin's internal ranking.  `evalConfidence` is NOT used as a score
+ *   tiebreaker — it is a per-row quality gate applied later (step 3 above
+ *   compares against it).
+ *
+ * All outcomes (including abstentions) should be recorded in the
+ * RouteDecision by the caller.
+ */
+
+import type { MuninClient, MuninQueryResult } from "../munin-client.js";
+import {
+  proceduralRetrievalRowSchema,
+  type ProceduralRetrievalRow,
+} from "./retrieval-schema.js";
+import type { Sensitivity } from "./refs.js";
+
+// ── Public types ──────────────────────────────────────────────────────────────
+
+export interface RetrievalConfig {
+  /** Minimum score for the top candidate to be selected. Default: abstain. */
+  confidenceThreshold: number;
+  /**
+   * Minimum required gap between the top-1 and top-2 scores.
+   * If top1 − top2 < topTwoMarginThreshold the result is ambiguous.
+   */
+  topTwoMarginThreshold: number;
+}
+
+export type RetrievalOutcome =
+  | { kind: "selected"; row: ProceduralRetrievalRow; score: number }
+  | { kind: "abstain"; reason: "below-threshold" | "ambiguous-top-two" }
+  | { kind: "unavailable"; reason: "munin-down" }
+  | { kind: "not-selectable"; reason: "stale-or-quarantined" };
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Parse a Munin query result into a ProceduralRetrievalRow.
+ * Returns null if the content cannot be parsed or fails schema validation.
+ */
+function parseRow(result: MuninQueryResult): ProceduralRetrievalRow | null {
+  try {
+    const parsed = JSON.parse(result.content_preview);
+    const validation = proceduralRetrievalRowSchema.safeParse(parsed);
+    return validation.success ? validation.data : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compute a deterministic trigger-phrase match score in [0, 1].
+ *
+ * The promptDigest is lowercased and each trigger phrase is checked as a
+ * substring.  score = matched / total.  Returns 0 when triggerPhrases is
+ * empty (which the schema prevents in practice).
+ */
+function triggerPhraseScore(
+  promptDigest: string,
+  triggerPhrases: readonly string[],
+): number {
+  if (triggerPhrases.length === 0) return 0;
+  const lower = promptDigest.toLowerCase();
+  let matched = 0;
+  for (const phrase of triggerPhrases) {
+    if (lower.includes(phrase.toLowerCase())) {
+      matched++;
+    }
+  }
+  return matched / triggerPhrases.length;
+}
+
+/**
+ * Score a candidate row.  Uses the Munin-provided query score when non-zero;
+ * falls back to trigger-phrase matching otherwise.
+ */
+function scoreCandidate(
+  result: MuninQueryResult,
+  row: ProceduralRetrievalRow,
+  promptDigest: string,
+): number {
+  // Munin query results carry a relevance score.  Use it when available.
+  // The score field is not part of the documented MuninQueryResult interface
+  // but Munin may include it as an extra property.
+  const muninScore = (result as MuninQueryResult & { score?: number }).score;
+  if (typeof muninScore === "number" && muninScore > 0) {
+    return muninScore;
+  }
+  return triggerPhraseScore(promptDigest, row.triggerPhrases);
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Retrieve the best procedural skill for `task`, applying the fail-closed
+ * abstention contract.
+ *
+ * @param task         The incoming task's digest + class + sensitivity.
+ * @param munin        Munin client (injected; tests use a fake).
+ * @param cfg          Confidence and margin thresholds.
+ */
+export async function retrieveProcedure(
+  task: {
+    promptDigest: string;
+    taskClassId: string;
+    sensitivity: Sensitivity;
+  },
+  munin: MuninClient,
+  cfg: RetrievalConfig,
+): Promise<RetrievalOutcome> {
+
+  // ── Step 1: Check Munin health ─────────────────────────────────────────────
+  // Fail-closed: any infrastructure issue → munin-down.
+  let healthy: boolean;
+  try {
+    healthy = await munin.health();
+  } catch {
+    return { kind: "unavailable", reason: "munin-down" };
+  }
+  if (!healthy) {
+    return { kind: "unavailable", reason: "munin-down" };
+  }
+
+  // ── Step 2: Query retrieval rows for this task class ───────────────────────
+  // Server-side tag filter keeps the candidate set small.
+  let queryResult: { results: MuninQueryResult[]; total: number };
+  try {
+    queryResult = await munin.query({
+      query: task.promptDigest,
+      namespace: "skills",
+      tags: [`task-class:${task.taskClassId}`, "procedural-retrieval"],
+    });
+  } catch {
+    return { kind: "unavailable", reason: "munin-down" };
+  }
+
+  // ── Step 3: Parse rows and apply hard-negative exclusion ──────────────────
+  // A candidate whose hardNegatives contains the promptDigest is DROPPED
+  // entirely — not penalised in score, completely removed from the set.
+  type ScoredCandidate = { row: ProceduralRetrievalRow; score: number };
+  const candidates: ScoredCandidate[] = [];
+
+  for (const result of queryResult.results) {
+    const row = parseRow(result);
+    if (row === null) continue;
+
+    // Hard-negative exclusion (security-load-bearing).
+    const isHardNegative = row.hardNegatives.some(
+      (neg) => neg === task.promptDigest,
+    );
+    if (isHardNegative) continue;
+
+    const score = scoreCandidate(result, row, task.promptDigest);
+    candidates.push({ row, score });
+  }
+
+  // ── Step 4: No candidates → below-threshold ───────────────────────────────
+  if (candidates.length === 0) {
+    return { kind: "abstain", reason: "below-threshold" };
+  }
+
+  // ── Step 5: Sort descending by score ──────────────────────────────────────
+  candidates.sort((a, b) => b.score - a.score);
+  const top1 = candidates[0]!;
+  const top2 = candidates[1];
+
+  // ── Step 6: Confidence threshold check ────────────────────────────────────
+  if (top1.score < cfg.confidenceThreshold) {
+    return { kind: "abstain", reason: "below-threshold" };
+  }
+
+  // ── Step 7: Top-two margin check ──────────────────────────────────────────
+  if (top2 !== undefined) {
+    const margin = top1.score - top2.score;
+    if (margin < cfg.topTwoMarginThreshold) {
+      return { kind: "abstain", reason: "ambiguous-top-two" };
+    }
+  }
+
+  // ── Step 8: Binding state check (fail-closed) ─────────────────────────────
+  if (top1.row.bindingState !== "active") {
+    return { kind: "not-selectable", reason: "stale-or-quarantined" };
+  }
+
+  // ── Step 9: Selected ──────────────────────────────────────────────────────
+  return { kind: "selected", row: top1.row, score: top1.score };
+}

--- a/src/skill/route-binding-schema.ts
+++ b/src/skill/route-binding-schema.ts
@@ -1,0 +1,144 @@
+import { z } from "zod";
+import {
+  sha256HexSchema,
+  lifecycleStateSchema,
+  failureKindSchema,
+  failureStageSchema,
+  egressClassSchema,
+  tupleRefSchema,
+  calibratedMetricsSchema,
+  sensitivitySchema,
+} from "./refs.js";
+
+// Re-export the shared types that callers of this module commonly need.
+export {
+  lifecycleStateSchema,
+  tupleRefSchema,
+  calibratedMetricsSchema,
+  sensitivitySchema,
+};
+export type { LifecycleState, TupleRef, CalibratedMetrics, Sensitivity } from "./refs.js";
+
+// --- FallbackPolicy -------------------------------------------------------
+// Decided PRE-execution (not post-failure under recovery pressure).
+// Reuses the existing registry policy axes (egress / zdr / provider).
+export const fallbackPolicySchema = z.object({
+  /** Whether a cloud runtime is permitted at all for this class. */
+  cloudAllowed: z.boolean(),
+  /** Whether Hugin may auto-escalate to cloud on local failure without approval. */
+  autoEscalateAllowed: z.boolean(),
+  /** Whether a human must approve before cloud fallback is triggered. */
+  requiresUserApproval: z.boolean(),
+  /** Mirrors RuntimeDefinition.zdrRequired — zero-data-residency constraint. */
+  zdrRequired: z.boolean(),
+  /** Mirrors the runtime-registry Egress axis. */
+  egressClass: egressClassSchema,
+  /**
+   * Soft cap on spend per task for cloud fallback.
+   * Absent = no cap. Router may still apply registry-level limits.
+   */
+  maxCloudCostUsd: z.number().nonnegative().optional(),
+  /** Ordered list of runtime IDs to try for cloud fallback. */
+  fallbackProviderSet: z.array(z.string().min(1)).default([]),
+  /** Failure kinds that should trigger a cloud fallback (others → fail hard). */
+  fallbackOnFailureKinds: z.array(failureKindSchema).default([]),
+});
+export type FallbackPolicy = z.infer<typeof fallbackPolicySchema>;
+
+// --- RouteBinding ---------------------------------------------------------
+// The *only* selectable object in the skill-distillation system.
+// Immutable rows + mutable active pointer (state tag + activeValidationRunHash).
+// All referenced artifacts are pinned by content hash — drift auto-demotes to stale.
+export const routeBindingSchema = z.object({
+  schemaVersion: z.literal(1),
+  bindingId: z.string().min(1),
+  /** Monotonically increasing version counter within a bindingId. */
+  version: z.number().int().nonnegative(),
+  /** Current lifecycle position. Only `active` bindings are selectable. */
+  state: lifecycleStateSchema,
+  /** Content-addressed references to all four artifacts this binding pins. */
+  tuple: tupleRefSchema,
+  /** Pre-execution routing policy. Never modified post-failure. */
+  fallbackPolicy: fallbackPolicySchema,
+  /**
+   * Calibrated metrics from the binding's active ValidationRun.
+   * Absent until the binding reaches >= shadow state (requires at least one run).
+   */
+  metrics: calibratedMetricsSchema.optional(),
+  /**
+   * sha256 of the ValidationRun that promoted this binding to its current state.
+   * Used as an immutable provenance link; must match a write-once run record.
+   */
+  activeValidationRunHash: sha256HexSchema.optional(),
+  /**
+   * min(cell trust ceiling, classifier confidence floor, eval suite quality floor).
+   * Router checks this against the task's effective sensitivity; binding is
+   * not selectable if the task exceeds this ceiling.
+   */
+  effectiveSensitivityCeiling: sensitivitySchema,
+  createdAt: z.string(),
+  updatedAt: z.string(),
+  notes: z.string().optional(),
+});
+export type RouteBinding = z.infer<typeof routeBindingSchema>;
+
+// --- ValidationRun --------------------------------------------------------
+// Write-once, content-addressed evidence record.
+// runHash = sha256 over the full reproducibility envelope below.
+export const validationRunSchema = z.object({
+  schemaVersion: z.literal(1),
+  /** sha256 over the canonical JSON of everything below this field. */
+  runHash: sha256HexSchema,
+  bindingId: z.string().min(1),
+  /** Artifact hashes pinned at run time — must match the binding's tuple. */
+  tuple: tupleRefSchema,
+
+  // --- Full reproducibility envelope (critique C05) -----------------------
+  /** sha256 of the grader code / grader artifact used. */
+  graderHash: z.string(),
+  /** sha256 of the prompt template used for each fixture. */
+  promptHash: z.string(),
+  harnessName: z.string(),
+  harnessVersion: z.string(),
+  wrapperName: z.string(),
+  wrapperVersion: z.string(),
+  /** Exact model identifier string (e.g. "qwen3-coder-30b-instruct"). */
+  modelId: z.string(),
+  /** sha256 or OCI digest of the GGUF / ONNX / safetensors file. */
+  modelFileHash: z.string(),
+  /** e.g. "Q4_K_M", "fp16", "int8" */
+  quantization: z.string(),
+  contextCap: z.number().int().positive(),
+  /** e.g. "native-thinking", "forced-think-false", "openai-compat" */
+  thinkingFormat: z.string(),
+  toolCallParserResult: z.enum(["pass", "fail", "skipped"]),
+  os: z.string(),
+  /** e.g. "pi5-8gb", "laptop-m3" */
+  hardwareClass: z.string(),
+  memoryCapMb: z.number().int(),
+  /** sha256 over the tool environment manifest (MCP versions, tool allowlist). */
+  toolEnvManifestHash: z.string(),
+  executionTimeoutMs: z.number().int(),
+  stepBudget: z.number().int(),
+
+  // --- Results ------------------------------------------------------------
+  /** Aggregate metrics across all fixtures in this run. */
+  metrics: calibratedMetricsSchema,
+  perFixtureResults: z.array(
+    z.object({
+      fixtureId: z.string(),
+      outcome: z.enum(["pass", "fail", "abstain"]),
+      /** Which pipeline stage surfaced this failure (absent for passes). */
+      caughtAtStage: failureStageSchema.optional(),
+      /** Which oracle rendered the verdict. */
+      oracleId: z.string(),
+    }),
+  ),
+  ranAt: z.string(),
+  /**
+   * Always true — ValidationRuns are write-once; this literal prevents
+   * accidental mutation and is checked at deserialization.
+   */
+  immutable: z.literal(true),
+});
+export type ValidationRun = z.infer<typeof validationRunSchema>;

--- a/src/skill/route-binding-store.ts
+++ b/src/skill/route-binding-store.ts
@@ -1,0 +1,293 @@
+/**
+ * route-binding-store.ts
+ *
+ * Pure + effectful operations over RouteBinding records:
+ *   - transition()           — pure lifecycle enforcement
+ *   - isSelectable()         — fail-closed selectability predicate
+ *   - loadActiveBinding()    — Munin query + parse
+ *   - recordValidationRun()  — write-once ValidationRun guard
+ *   - demoteOnDrift()        — stale demotion with CAS write
+ *
+ * All effectful functions accept a MuninClient to keep them testable without
+ * a live Munin server. The pure functions depend on nothing outside this module
+ * and refs.ts.
+ */
+
+import type { MuninClient } from "../munin-client.js";
+import {
+  tupleHashesMatch,
+  type TupleRef,
+  type LifecycleState,
+  type Sensitivity,
+} from "./refs.js";
+import {
+  routeBindingSchema,
+  validationRunSchema,
+  type RouteBinding,
+  type ValidationRun,
+} from "./route-binding-schema.js";
+
+// ---------------------------------------------------------------------------
+// Sensitivity ordering — needed for `isSelectable` ceiling check.
+// Re-use compareSensitivity from sensitivity.ts via an inline ordering that
+// mirrors the canonical lattice (public < internal < private).
+// ---------------------------------------------------------------------------
+const SENSITIVITY_ORDER: Record<Sensitivity, number> = {
+  public: 0,
+  internal: 1,
+  private: 2,
+};
+
+function sensitivityGte(ceiling: Sensitivity, task: Sensitivity): boolean {
+  return SENSITIVITY_ORDER[ceiling] >= SENSITIVITY_ORDER[task];
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle graph
+// ---------------------------------------------------------------------------
+// Allowed directed edges in the lifecycle DAG.
+// Re-promotion from stale/quarantined is conditional (requires new runHash) —
+// enforced separately in transition().
+const ALLOWED_TRANSITIONS: Map<LifecycleState, ReadonlySet<LifecycleState>> =
+  new Map([
+    ["draft",       new Set<LifecycleState>(["candidate", "disabled"])],
+    ["candidate",   new Set<LifecycleState>(["shadow", "disabled"])],
+    ["shadow",      new Set<LifecycleState>(["active", "quarantined", "disabled"])],
+    ["active",      new Set<LifecycleState>(["stale", "quarantined", "disabled"])],
+    ["stale",       new Set<LifecycleState>(["candidate", "shadow", "active", "disabled"])],
+    ["quarantined", new Set<LifecycleState>(["candidate", "shadow", "active", "disabled"])],
+    ["disabled",    new Set<LifecycleState>()],     // terminal — no further transitions
+  ]);
+
+// States that require a NEW ValidationRun hash to re-promote.
+const REQUIRES_NEW_RUN_ON_REPROMOTION: ReadonlySet<LifecycleState> = new Set([
+  "stale",
+  "quarantined",
+]);
+
+// States that count as "promotion" (moving toward active).
+const PROMOTION_TARGETS: ReadonlySet<LifecycleState> = new Set([
+  "candidate",
+  "shadow",
+  "active",
+]);
+
+// ---------------------------------------------------------------------------
+// Pure: transition()
+// ---------------------------------------------------------------------------
+/**
+ * Produce an updated RouteBinding with `state = to` (and `updatedAt` stamped
+ * to now). Throws if the transition is not in the allowed lifecycle graph, or
+ * if re-promotion from stale/quarantined is attempted without a new `runHash`
+ * in `evidence` that differs from the binding's current `activeValidationRunHash`.
+ *
+ * The caller is responsible for persisting the returned binding to Munin.
+ */
+export function transition(
+  b: RouteBinding,
+  to: LifecycleState,
+  evidence?: { runHash: string },
+): RouteBinding {
+  const allowed = ALLOWED_TRANSITIONS.get(b.state);
+  if (!allowed || !allowed.has(to)) {
+    throw new Error(
+      `Illegal lifecycle transition: ${b.state} → ${to} for binding ${b.bindingId}`,
+    );
+  }
+
+  // Re-promotion from stale or quarantined requires a new immutable ValidationRun.
+  if (
+    REQUIRES_NEW_RUN_ON_REPROMOTION.has(b.state) &&
+    PROMOTION_TARGETS.has(to)
+  ) {
+    if (!evidence?.runHash) {
+      throw new Error(
+        `Re-promotion from "${b.state}" to "${to}" requires a new ValidationRun ` +
+          `(evidence.runHash missing) for binding ${b.bindingId}`,
+      );
+    }
+    if (evidence.runHash === b.activeValidationRunHash) {
+      throw new Error(
+        `Re-promotion from "${b.state}" to "${to}" requires a NEW ValidationRun ` +
+          `hash distinct from the current one (${evidence.runHash}) ` +
+          `for binding ${b.bindingId}`,
+      );
+    }
+  }
+
+  return {
+    ...b,
+    state: to,
+    activeValidationRunHash: evidence?.runHash ?? b.activeValidationRunHash,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pure: isSelectable()
+// ---------------------------------------------------------------------------
+/**
+ * Fail-closed selectability check. Returns `{ ok: true }` only when:
+ *   1. The binding is in `active` state.
+ *   2. The binding's pinned tuple hashes match `currentHashes` (no drift).
+ *   3. The binding's `effectiveSensitivityCeiling >= taskSens`.
+ *
+ * Each failure produces a distinct `reason` string so the caller can log and
+ * act appropriately (e.g. trigger demoteOnDrift for hash-drift).
+ */
+export function isSelectable(
+  b: RouteBinding,
+  currentHashes: TupleRef,
+  taskSens: Sensitivity,
+): { ok: boolean; reason?: string } {
+  if (b.state !== "active") {
+    return { ok: false, reason: "not-active" };
+  }
+  if (!tupleHashesMatch(b.tuple, currentHashes)) {
+    return { ok: false, reason: "hash-drift" };
+  }
+  if (!sensitivityGte(b.effectiveSensitivityCeiling, taskSens)) {
+    return { ok: false, reason: "sensitivity-ceiling" };
+  }
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// Effectful: loadActiveBinding()
+// ---------------------------------------------------------------------------
+/**
+ * Query Munin's `routes/` namespace for an active binding whose `taskClassId`
+ * matches. Returns the first valid `RouteBinding` found, or `null` if none.
+ *
+ * Uses Munin tag filtering (`route-state:active`, `task-class:<id>`) to keep
+ * the candidate set small. Silently skips entries that fail Zod parse (stale
+ * Munin data should not crash the router).
+ */
+export async function loadActiveBinding(
+  taskClassId: string,
+  munin: MuninClient,
+): Promise<RouteBinding | null> {
+  const { results } = await munin.query({
+    query: taskClassId,
+    namespace: "routes",
+    tags: ["route-state:active", `task-class:${taskClassId}`],
+    limit: 10,
+  });
+
+  for (const result of results) {
+    // Each binding is stored at routes/<bindingId>/binding under key "binding".
+    // Skip validation-run records and any other keys in the namespace.
+    if (!result.key || result.key !== "binding") continue;
+
+    const [ns, key] = [result.namespace, result.key] as [string, string];
+    const entry = await munin.read(ns, key);
+    if (!entry) continue;
+
+    const parsed = routeBindingSchema.safeParse(
+      safeParseJSON(entry.content),
+    );
+    if (!parsed.success) {
+      // Log the validation error but don't crash — stale schema rows should
+      // not take down the router's normal path.
+      console.warn(
+        `[route-binding-store] Skipping unparseable binding at ${ns}/${key}:`,
+        parsed.error.message,
+      );
+      continue;
+    }
+
+    const binding = parsed.data;
+    if (binding.state !== "active") continue;
+    if (binding.tuple.taskClassId !== taskClassId) continue;
+
+    return binding;
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Effectful: recordValidationRun()
+// ---------------------------------------------------------------------------
+/**
+ * Write-once: persist a ValidationRun to Munin at
+ * `routes/<bindingId>/validation-run/<runHash>`.
+ *
+ * Reads the target key first. If an entry already exists, throws — ValidationRuns
+ * are immutable by design and must never be overwritten. This ensures the
+ * content-addressed provenance chain cannot be silently corrupted.
+ */
+export async function recordValidationRun(
+  run: ValidationRun,
+  munin: MuninClient,
+): Promise<void> {
+  const ns = `routes/${run.bindingId}`;
+  const key = `validation-run/${run.runHash}`;
+
+  const existing = await munin.read(ns, key);
+  if (existing) {
+    throw new Error(
+      `ValidationRun ${run.runHash} already exists for binding ${run.bindingId} — ` +
+        `ValidationRuns are immutable and must never be overwritten.`,
+    );
+  }
+
+  await munin.write(
+    ns,
+    key,
+    JSON.stringify(run),
+    [
+      "validation-run",
+      `binding-id:${run.bindingId}`,
+      `run-hash:${run.runHash}`,
+      `task-class:${run.tuple.taskClassId}`,
+    ],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Effectful: demoteOnDrift()
+// ---------------------------------------------------------------------------
+/**
+ * Transition a binding to `stale` (hash-drift fail-close) and persist it to
+ * Munin using CAS semantics (expected_updated_at = binding.updatedAt) to
+ * prevent concurrent overwrites.
+ *
+ * Returns the updated (stale) binding so the caller can log / fall through
+ * to cloud routing.
+ */
+export async function demoteOnDrift(
+  b: RouteBinding,
+  munin: MuninClient,
+): Promise<RouteBinding> {
+  const demoted = transition(b, "stale");
+
+  const ns = `routes/${b.bindingId}`;
+  const key = "binding";
+
+  await munin.write(
+    ns,
+    key,
+    JSON.stringify(demoted),
+    [
+      "route-state:stale",
+      `task-class:${demoted.tuple.taskClassId}`,
+      `binding-id:${demoted.bindingId}`,
+    ],
+    // CAS: only write if the entry hasn't changed since we last read it.
+    b.updatedAt,
+  );
+
+  return demoted;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function safeParseJSON(content: string): unknown {
+  try {
+    return JSON.parse(content);
+  } catch {
+    return undefined;
+  }
+}

--- a/src/skill/skill-lane.ts
+++ b/src/skill/skill-lane.ts
@@ -1,0 +1,191 @@
+import type { MuninClient } from "../munin-client.js";
+import type { Sensitivity, TupleRef } from "./refs.js";
+import type { SkillRoute } from "../task-result-schema.js";
+import {
+  classifyTask as defaultClassifyTask,
+  loadActiveClassifiers as defaultLoadActiveClassifiers,
+} from "./task-classifier.js";
+import type { TaskClassifier, ClassifyResult } from "./task-classifier-schema.js";
+import {
+  retrieveProcedure as defaultRetrieveProcedure,
+  type RetrievalConfig,
+  type RetrievalOutcome,
+} from "./retrieval.js";
+import {
+  loadActiveBinding as defaultLoadActiveBinding,
+  isSelectable,
+} from "./route-binding-store.js";
+import type { RouteBinding } from "./route-binding-schema.js";
+
+// Slice-one local-skill lane orchestrator (issue #84). Composes the five
+// artifact modules into ONE fail-closed selection pre-step:
+//
+//   classify (A5) → retrieve (A4) → load active binding (A2) → selectability (A2)
+//
+// It is a composable PRE-STEP for the dispatcher, deliberately kept OUT of the
+// pure `routeTask` (router.ts stays sync/Munin-free). Every path is fail-closed:
+// anything short of a fully selectable, drift-free, sensitivity-cleared `active`
+// binding returns `fallthrough` → the caller uses the existing cloud auto-router.
+// Every outcome (including abstentions) yields a `skillRoute` audit record for
+// `result-structured`.
+//
+// NOTE on scope: this is the *selection* contract. Actually EXECUTING a selected
+// profile on a local cell (and grading/delivering the result) needs an authored
+// slice-one procedure package + a real Pi cell/model, which do not exist yet — so
+// `recomputeTupleHashes` defaults to returning `null` (cannot verify no-drift ⇒
+// fail-closed ⇒ always fall through). The lane is therefore a safe no-op in
+// production until slice-one content is authored; tests inject the dependencies
+// to exercise the selected path. Wiring `selectSkillRoute` into the dispatcher's
+// execute path is the remaining #84 step, gated on a real cell.
+
+export interface SkillLaneConfig {
+  /** Master switch (HUGIN_SKILL_LANE). Off ⇒ immediate fall-through. */
+  enabled: boolean;
+  retrieval: RetrievalConfig;
+}
+
+export interface SkillLaneDeps {
+  loadActiveClassifiers: (munin: MuninClient) => Promise<TaskClassifier[]>;
+  classifyTask: (prompt: string, classifiers: TaskClassifier[]) => ClassifyResult;
+  retrieveProcedure: (
+    task: { promptDigest: string; taskClassId: string; sensitivity: Sensitivity },
+    munin: MuninClient,
+    cfg: RetrievalConfig,
+  ) => Promise<RetrievalOutcome>;
+  loadActiveBinding: (
+    taskClassId: string,
+    munin: MuninClient,
+  ) => Promise<RouteBinding | null>;
+  /**
+   * Recompute the CURRENT content hashes of a binding's referenced artifacts so
+   * `isSelectable` can fail-close on drift. Returns `null` when the artifacts
+   * cannot be loaded/verified — which is treated as not-selectable (fail-closed).
+   * Default returns `null` (no authored artifacts yet).
+   */
+  recomputeTupleHashes: (binding: RouteBinding) => Promise<TupleRef | null>;
+}
+
+export interface SkillLaneTask {
+  prompt: string;
+  /** A stable digest of the prompt used for retrieval / hard-negative matching. */
+  promptDigest: string;
+  /** Independently-computed effective sensitivity (NEVER derived from the class). */
+  sensitivity: Sensitivity;
+}
+
+export type SkillLaneOutcome =
+  | { kind: "selected"; binding: RouteBinding; skillRoute: SkillRoute }
+  | { kind: "fallthrough"; skillRoute: SkillRoute };
+
+const DEFAULT_DEPS: SkillLaneDeps = {
+  loadActiveClassifiers: defaultLoadActiveClassifiers,
+  classifyTask: defaultClassifyTask,
+  retrieveProcedure: defaultRetrieveProcedure,
+  loadActiveBinding: defaultLoadActiveBinding,
+  recomputeTupleHashes: async () => null,
+};
+
+function fallthrough(reason: string, extra?: Partial<SkillRoute>): SkillLaneOutcome {
+  return {
+    kind: "fallthrough",
+    skillRoute: { abstained: true, abstainReason: reason, ...extra },
+  };
+}
+
+/**
+ * Decide whether the local-skill lane handles this task. Fail-closed: returns
+ * `selected` ONLY for a fully verified, drift-free, sensitivity-cleared `active`
+ * binding; every other condition (lane off, Munin error, classifier abstain,
+ * retrieval abstain/unavailable/not-selectable, no binding, drift, ceiling) is a
+ * `fallthrough` to the cloud auto-router, with the reason recorded.
+ */
+export async function selectSkillRoute(
+  task: SkillLaneTask,
+  munin: MuninClient,
+  cfg: SkillLaneConfig,
+  deps: Partial<SkillLaneDeps> = {},
+): Promise<SkillLaneOutcome> {
+  const d: SkillLaneDeps = { ...DEFAULT_DEPS, ...deps };
+
+  if (!cfg.enabled) return fallthrough("lane-disabled");
+
+  // 1. Classify (deterministic-first). Munin errors fail closed.
+  let classifiers: TaskClassifier[];
+  try {
+    classifiers = await d.loadActiveClassifiers(munin);
+  } catch {
+    return fallthrough("munin-error");
+  }
+  if (classifiers.length === 0) return fallthrough("no-classifiers");
+
+  const cls = d.classifyTask(task.prompt, classifiers);
+  if (cls.kind === "abstain") {
+    return fallthrough(`classify:${cls.reason}`);
+  }
+  const classId = cls.classId;
+  const classConfidence = cls.confidence;
+
+  // 2. Retrieve (own fail-closed contract). Munin errors fail closed.
+  let retrieval: RetrievalOutcome;
+  try {
+    retrieval = await d.retrieveProcedure(
+      { promptDigest: task.promptDigest, taskClassId: classId, sensitivity: task.sensitivity },
+      munin,
+      cfg.retrieval,
+    );
+  } catch {
+    return fallthrough("munin-error", { classId, classConfidence });
+  }
+  if (retrieval.kind !== "selected") {
+    return fallthrough(`retrieve:${retrieval.reason}`, { classId, classConfidence });
+  }
+
+  // 3. Load the active binding for the class.
+  let binding: RouteBinding | null;
+  try {
+    binding = await d.loadActiveBinding(classId, munin);
+  } catch {
+    return fallthrough("munin-error", { classId, classConfidence });
+  }
+  if (!binding) return fallthrough("no-active-binding", { classId, classConfidence });
+
+  // 4. Selectability — fail-closed on drift / state / sensitivity ceiling. The
+  //    current artifact hashes must be recomputable; if not, we cannot prove the
+  //    binding hasn't drifted, so we do NOT run local.
+  let currentHashes: TupleRef | null;
+  try {
+    currentHashes = await d.recomputeTupleHashes(binding);
+  } catch {
+    currentHashes = null;
+  }
+  if (!currentHashes) {
+    return fallthrough("cannot-verify-drift", {
+      classId,
+      classConfidence,
+      bindingId: binding.bindingId,
+      bindingVersion: binding.version,
+    });
+  }
+
+  const sel = isSelectable(binding, currentHashes, task.sensitivity);
+  if (!sel.ok) {
+    return fallthrough(`binding:${sel.reason}`, {
+      classId,
+      classConfidence,
+      bindingId: binding.bindingId,
+      bindingVersion: binding.version,
+    });
+  }
+
+  return {
+    kind: "selected",
+    binding,
+    skillRoute: {
+      abstained: false,
+      classId,
+      classConfidence,
+      bindingId: binding.bindingId,
+      bindingVersion: binding.version,
+    },
+  };
+}

--- a/src/skill/task-classifier-schema.ts
+++ b/src/skill/task-classifier-schema.ts
@@ -1,0 +1,120 @@
+import { z } from "zod";
+import { sha256HexSchema, sensitivitySchema } from "./refs.js";
+import type { Sensitivity } from "./refs.js";
+
+// Re-export Sensitivity so callers don't need two imports.
+export type { Sensitivity };
+
+/**
+ * A single classification rule.
+ *
+ * `match` is treated as a **case-insensitive substring** against the prompt
+ * text. This is deterministic, auditable, and requires no external dependencies.
+ * Regex support is intentionally deferred (substring rules are sufficient for
+ * slice-one and easier to author/review in YAML). The choice is documented here
+ * so future authors know the contract: if you need regex, extend `kind` to
+ * "regex" alongside "substring".
+ */
+export const ruleSchema = z.object({
+  match: z.string().min(1),
+  weight: z.number(),
+});
+export type Rule = z.infer<typeof ruleSchema>;
+
+/**
+ * The scoring predicate for a `TaskClassifier`.
+ *
+ * Design rationale — deterministic-first:
+ * - `rule` predicates are fully deterministic (substring match, weighted sum).
+ * - `llm-advisory+rule-floor` means an LLM judge may be consulted but the
+ *   final decision still depends on at least one rule floor passing. The LLM
+ *   is never the sole decision-maker (mirrors the A6 oracle rule in the eval
+ *   suite: judge is advisory only).
+ */
+export const predicateSchema = z.object({
+  kind: z.enum(["rule", "llm-advisory+rule-floor"]),
+  rules: z.array(ruleSchema),
+  /**
+   * Minimum confidence (0..1) required to emit a `classified` result.
+   * Below this → abstain with reason "below-threshold".
+   */
+  confidenceThreshold: z.number().min(0).max(1),
+  /**
+   * Minimum gap between top-1 and top-2 confidence scores required to
+   * avoid "ambiguous-top-two" abstain. A task that fits two classes equally
+   * well should never be silently assigned to either.
+   */
+  topTwoMargin: z.number().min(0).max(1),
+});
+export type Predicate = z.infer<typeof predicateSchema>;
+
+/**
+ * A `TaskClassifier` describes a single task class (e.g. "coding-task",
+ * "documentation-task") and the predicate used to decide whether an incoming
+ * task prompt belongs to it.
+ *
+ * Classifier artifacts are versioned, content-addressed, and stored in git at
+ * `skills/_classifier/<classId>.yaml`. The runtime active pointer lives in
+ * Munin at `routes/_classifier/<classId>/active`.
+ *
+ * SECURITY NOTE: `sensitivityCeiling` constrains, never raises. The router
+ * ANDs this value with the cell trust ceiling and the task's independently-
+ * computed effective sensitivity. See `effectiveSensitivityCeiling` in
+ * `task-classifier.ts` for the enforcement point.
+ */
+export const taskClassifierSchema = z.object({
+  schemaVersion: z.literal(1),
+  classId: z.string().min(1),
+  version: z.number().int().nonnegative(),
+  /**
+   * Content hash (sha256 hex, 64 chars) of the classifier body. Stored in the
+   * Munin active pointer so the router can detect drift without re-fetching the
+   * full object. Computed by `classifierHash()` in `task-classifier.ts`.
+   */
+  classifierHash: sha256HexSchema,
+  predicate: predicateSchema,
+  /**
+   * Hard-negative examples: prompts that superficially look like they belong to
+   * this class but must NOT be classified to it. Any matching hard-negative
+   * zeroes the classifier's score for that prompt.
+   *
+   * At least one is required — a classifier with no hard negatives has not
+   * thought about its own failure modes.
+   */
+  hardNegatives: z.array(
+    z.object({ input: z.string(), why: z.string() })
+  ).min(1),
+  /**
+   * Free-text contraindications: phrases whose presence in the prompt disqualify
+   * the classifier (e.g. "read-only analysis", "do not write code").
+   * Unlike hardNegatives, contraindications are simple substrings with no `why`.
+   */
+  contraindications: z.array(z.string()),
+  /** Positive examples — at least one prompt that MUST classify to this class. */
+  shouldClassify: z.array(z.object({ input: z.string() })).min(1),
+  /** Negative examples — at least one prompt that must NOT classify to this class. */
+  shouldNotClassify: z.array(z.object({ input: z.string() })).min(1),
+  /**
+   * Maximum sensitivity level this class may carry to the local cell.
+   * The router takes min(this, cellTrustCeiling, taskEffectiveSensitivity).
+   * A classifier can only restrict what the bound cell receives — it can never
+   * widen the sensitivity lattice.
+   */
+  sensitivityCeiling: sensitivitySchema,
+});
+export type TaskClassifier = z.infer<typeof taskClassifierSchema>;
+
+/**
+ * The result of `classifyTask`.
+ *
+ * `classified` — a confident, unambiguous match to exactly one class.
+ * `abstain`    — no class was selected; reason tells the router why:
+ *   - `below-threshold`: top score is below the winning classifier's threshold.
+ *   - `ambiguous-top-two`: top-2 scores are within `topTwoMargin` of each other.
+ *
+ * Abstain is **fail-closed**: no class → no local route → fall through to the
+ * existing cloud auto-router.
+ */
+export type ClassifyResult =
+  | { kind: "classified"; classId: string; confidence: number }
+  | { kind: "abstain"; reason: "below-threshold" | "ambiguous-top-two" };

--- a/src/skill/task-classifier.ts
+++ b/src/skill/task-classifier.ts
@@ -1,0 +1,262 @@
+/**
+ * TaskClassifier runtime logic — pure, deterministic-first.
+ *
+ * This module implements the A5 / #82 task-classification contract from the
+ * skill-distillation design spec. Classification is SECURITY-LOAD-BEARING:
+ * the class assigned to a task is the key into routing, sensitivity policy,
+ * and local-cell dispatch. See the "Security interaction (must hold)" section
+ * of docs/design/skill-distillation-implementation.md for the invariants.
+ */
+
+import { taskClassifierSchema, type TaskClassifier, type ClassifyResult } from "./task-classifier-schema.js";
+import { contentHash } from "./refs.js";
+import type { Sensitivity } from "./refs.js";
+import type { MuninClient } from "../munin-client.js";
+
+// Sensitivity ordering for min() computation.
+const SENSITIVITY_ORDER: Record<Sensitivity, number> = {
+  public: 0,
+  internal: 1,
+  private: 2,
+};
+
+const ORDER_TO_SENSITIVITY: Sensitivity[] = ["public", "internal", "private"];
+
+function sensitivityMin(a: Sensitivity, b: Sensitivity): Sensitivity {
+  return ORDER_TO_SENSITIVITY[Math.min(SENSITIVITY_ORDER[a], SENSITIVITY_ORDER[b])];
+}
+
+// ---------------------------------------------------------------------------
+// Scoring helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Evaluate whether a hard-negative or contraindication matches the prompt.
+ * Uses the same case-insensitive substring strategy as the rule engine so
+ * the exclusion contract is symmetric with the scoring contract.
+ */
+function anySubstringMatch(prompt: string, patterns: string[]): boolean {
+  const lower = prompt.toLowerCase();
+  return patterns.some((p) => lower.includes(p.toLowerCase()));
+}
+
+/**
+ * Score a single classifier against a prompt.
+ *
+ * Algorithm (deterministic-first):
+ * 1. Check hard negatives: if any `hardNegative.input` is a case-insensitive
+ *    substring of the prompt → score is 0 (classifier is excluded).
+ * 2. Check contraindications: if any contraindication phrase is a case-insensitive
+ *    substring of the prompt → score is 0.
+ * 3. Sum weights of rules whose `match` is a case-insensitive substring of the
+ *    prompt. Normalize to 0..1 by dividing by the sum of all rule weights.
+ *    If total weight is 0 (no rules at all) → score is 0.
+ *
+ * Match strategy: **case-insensitive substring** (not regex). Documented in
+ * task-classifier-schema.ts. Deterministic, auditable, no external deps.
+ */
+function scoreClassifier(prompt: string, classifier: TaskClassifier): number {
+  // Hard-negative exclusion (takes priority over any rule match)
+  const hardNegativeInputs = classifier.hardNegatives.map((hn) => hn.input);
+  if (anySubstringMatch(prompt, hardNegativeInputs)) {
+    return 0;
+  }
+
+  // Contraindication exclusion
+  if (classifier.contraindications.length > 0 &&
+      anySubstringMatch(prompt, classifier.contraindications)) {
+    return 0;
+  }
+
+  // Rule scoring: sum matching weights, normalize by total weight
+  const totalWeight = classifier.predicate.rules.reduce((sum, r) => sum + r.weight, 0);
+  if (totalWeight === 0) return 0;
+
+  const lowerPrompt = prompt.toLowerCase();
+  const matchedWeight = classifier.predicate.rules.reduce((sum, r) => {
+    return lowerPrompt.includes(r.match.toLowerCase()) ? sum + r.weight : sum;
+  }, 0);
+
+  return matchedWeight / totalWeight;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify a prompt against a set of classifiers. Pure and deterministic.
+ *
+ * Fail-closed: any ambiguity or insufficient confidence returns an `abstain`
+ * result. The caller (the router) must treat `abstain` as "no local route" and
+ * fall through to the existing cloud auto-router.
+ *
+ * Decision procedure:
+ * 1. Score every classifier (0..1).
+ * 2. Sort descending by score; pick top-1 and top-2.
+ * 3. If top-1 score < top-1 classifier's `confidenceThreshold` → abstain
+ *    with reason "below-threshold".
+ * 4. If top-1 and top-2 both exist and (top1 − top2) < top-1's `topTwoMargin`
+ *    → abstain with reason "ambiguous-top-two".
+ * 5. Otherwise emit `classified` with top-1's classId and confidence.
+ */
+export function classifyTask(
+  prompt: string,
+  classifiers: TaskClassifier[],
+): ClassifyResult {
+  if (classifiers.length === 0) {
+    return { kind: "abstain", reason: "below-threshold" };
+  }
+
+  // Score all classifiers
+  const scores = classifiers.map((c) => ({
+    classId: c.classId,
+    confidence: scoreClassifier(prompt, c),
+    threshold: c.predicate.confidenceThreshold,
+    margin: c.predicate.topTwoMargin,
+  }));
+
+  // Sort descending by confidence
+  scores.sort((a, b) => b.confidence - a.confidence);
+
+  const top = scores[0];
+  const second = scores[1];
+
+  // Below-threshold check
+  if (top.confidence < top.threshold) {
+    return { kind: "abstain", reason: "below-threshold" };
+  }
+
+  // Ambiguous-top-two check (only when a second candidate exists with score > 0)
+  if (second !== undefined && second.confidence > 0) {
+    const gap = top.confidence - second.confidence;
+    if (gap < top.margin) {
+      return { kind: "abstain", reason: "ambiguous-top-two" };
+    }
+  }
+
+  return { kind: "classified", classId: top.classId, confidence: top.confidence };
+}
+
+/**
+ * Compute the content hash (sha256 hex) for a classifier object.
+ * Uses canonical JSON (key-sorted, no whitespace) so the hash is stable
+ * regardless of property insertion order in the caller's object literal.
+ *
+ * This value is stored in the Munin active pointer; the router checks it on
+ * every poll cycle to detect drift between the live classifier and the cached
+ * version. Any change to the classifier body produces a different hash →
+ * the router fail-closes the binding to `stale`.
+ */
+export function classifierHash(c: TaskClassifier): string {
+  return contentHash(c);
+}
+
+/**
+ * Compute the effective sensitivity ceiling for a local-cell route attempt.
+ *
+ * SECURITY INVARIANT: This function can only CONSTRAIN, never raise.
+ * It returns `min(classifierCeiling, cellTrustCeiling, taskEffectiveSensitivity)`
+ * on the public < internal < private lattice.
+ *
+ * Why this matters:
+ * - The classifier selects *which procedure* the task follows. It does NOT get
+ *   to override the sensitivity lattice.
+ * - A misclassification (e.g. classifier incorrectly lowers apparent sensitivity)
+ *   is caught by this function: the task's independently-computed
+ *   `taskEffectiveSensitivity` (from `sensitivity.ts`) is always in the AND.
+ * - Cloud cells that are `internal`-trust cannot receive `private` tasks even if
+ *   the classifier declares its ceiling as `private`.
+ *
+ * The three inputs are kept as separate parameters (not a single array) to make
+ * their origin explicit at the call site — callers cannot accidentally omit the
+ * task-level sensitivity by passing a short array.
+ */
+export function effectiveSensitivityCeiling(
+  classifierCeiling: Sensitivity,
+  cellTrustCeiling: Sensitivity,
+  taskEffectiveSensitivity: Sensitivity,
+): Sensitivity {
+  return sensitivityMin(
+    sensitivityMin(classifierCeiling, cellTrustCeiling),
+    taskEffectiveSensitivity,
+  );
+}
+
+/**
+ * Load active classifiers from Munin.
+ *
+ * Reads all entries in the `routes/_classifier/` namespace tagged `active`,
+ * fetches full content for each via `readBatch`, parses as a `TaskClassifier`,
+ * and returns the valid ones. Invalid entries (schema parse failure) are skipped
+ * with a warning — a single malformed classifier must not block all routing.
+ *
+ * Munin `query` returns only `content_preview`; full content requires a
+ * separate `readBatch` call using the (namespace, key) pairs.
+ *
+ * Munin key convention: `routes/_classifier/<classId>/active`
+ */
+export async function loadActiveClassifiers(
+  munin: MuninClient,
+): Promise<TaskClassifier[]> {
+  let queryResults;
+  try {
+    const resp = await munin.query({
+      query: "",
+      namespace: "routes/_classifier",
+      tags: ["active"],
+    });
+    queryResults = resp.results;
+  } catch (err) {
+    // Munin unreachable: fail-closed (no classifiers → no local route)
+    console.warn("[task-classifier] loadActiveClassifiers: Munin query failed:", err);
+    return [];
+  }
+
+  if (queryResults.length === 0) return [];
+
+  // Fetch full content for each result (query only returns content_preview).
+  const keyed = queryResults.filter((r) => r.key !== null);
+  let fullEntries;
+  try {
+    fullEntries = await munin.readBatch(
+      keyed.map((r) => ({ namespace: r.namespace, key: r.key as string })),
+    );
+  } catch (err) {
+    console.warn("[task-classifier] loadActiveClassifiers: Munin readBatch failed:", err);
+    return [];
+  }
+
+  const classifiers: TaskClassifier[] = [];
+  for (const entry of fullEntries) {
+    if (!entry.found) {
+      console.warn(
+        `[task-classifier] Classifier entry not found: ${entry.namespace}/${entry.key}`,
+      );
+      continue;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(entry.content);
+    } catch {
+      console.warn(
+        `[task-classifier] Skipping unparseable entry ${entry.namespace}/${entry.key}`,
+      );
+      continue;
+    }
+
+    const result = taskClassifierSchema.safeParse(parsed);
+    if (!result.success) {
+      console.warn(
+        `[task-classifier] Skipping invalid classifier at ${entry.namespace}/${entry.key}:`,
+        result.error.issues.map((i) => i.message).join("; "),
+      );
+      continue;
+    }
+
+    classifiers.push(result.data);
+  }
+
+  return classifiers;
+}

--- a/src/task-result-schema.ts
+++ b/src/task-result-schema.ts
@@ -70,6 +70,21 @@ export const routingEliminationSchema = z.object({
   reason: z.string().min(1),
 });
 
+// Skill-lane routing decision (issue #84 / #79–#83). Recorded for EVERY task the
+// local-skill lane considers — including abstentions — so a route decision is
+// auditable. Additive + optional, same non-breaking rationale as artifactDelivery
+// below: old Zod readers strip it. The classifier/retrieval/binding selection
+// lives in src/skill/*; this is just the audit record carried in the result.
+export const skillRouteSchema = z.object({
+  bindingId: z.string().min(1).optional(),
+  bindingVersion: z.number().int().nonnegative().optional(),
+  classId: z.string().min(1).optional(),
+  classConfidence: z.number().min(0).max(1).optional(),
+  abstained: z.boolean().default(false),
+  abstainReason: z.string().min(1).optional(),
+});
+export type SkillRoute = z.infer<typeof skillRouteSchema>;
+
 export const taskExecutionRuntimeMetadataSchema = z.object({
   requestedModel: z.string().min(1).optional(),
   effectiveModel: z.string().min(1).optional(),
@@ -80,6 +95,7 @@ export const taskExecutionRuntimeMetadataSchema = z.object({
   autoRouted: z.boolean().optional(),
   routingReason: z.string().min(1).optional(),
   eliminatedRuntimes: z.array(routingEliminationSchema).optional(),
+  skillRoute: skillRouteSchema.optional(),
 });
 export type TaskExecutionRuntimeMetadata = z.infer<
   typeof taskExecutionRuntimeMetadataSchema

--- a/tests/eval-runner.test.ts
+++ b/tests/eval-runner.test.ts
@@ -1,0 +1,405 @@
+import { describe, expect, it } from "vitest";
+import {
+  gradeFixture,
+  runEvalSuite,
+  assertIndependentOracle,
+  type PerFixtureResult,
+} from "../src/skill/eval-runner.js";
+import type { Oracle, Fixture, RetrievalFixture, EvalSuite } from "../src/skill/eval-suite-schema.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const independentTestOracle: Oracle = {
+  id: "o-test",
+  kind: "test-suite",
+  independent: true,
+  ref: "tests/grader.sh",
+};
+
+const independentSchemaOracle: Oracle = {
+  id: "o-schema",
+  kind: "schema-validator",
+  independent: true,
+  ref: "schema.json",
+};
+
+const dependentOracle: Oracle = {
+  id: "o-dep",
+  kind: "snapshot-diff",
+  independent: false,
+  ref: "snapshots/",
+};
+
+const judgeOracle: Oracle = {
+  id: "o-judge",
+  kind: "judge-model",
+  independent: false,
+  ref: "judge:gpt-4o",
+};
+
+const judgeIndependentOracle: Oracle = {
+  id: "o-judge-ind",
+  kind: "judge-model",
+  independent: true,
+  ref: "judge:external",
+};
+
+function fixture(id: string, input: unknown, expected: unknown): Fixture {
+  return { id, input, expected, allowedNondeterminism: [] };
+}
+
+function minimalSuite(
+  overrides: Partial<EvalSuite> = {},
+): EvalSuite {
+  return {
+    schemaVersion: 1,
+    evalSuiteId: "suite-runner-test",
+    evalSuiteHash: "a".repeat(64),
+    skillId: "skill-test",
+    taskClassId: "tc-test",
+    oracles: [independentTestOracle],
+    judgeIsAdvisoryOnly: true as const,
+    fixtures: {
+      positive: [fixture("pos-1", "in", "out")],
+      negative: [fixture("neg-1", "bad", null)],
+      retrieval: [{ id: "ret-1", input: "query", shouldSelect: true }],
+      mutation: [fixture("mut-1", "mutated", "different")],
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// assertIndependentOracle
+// ---------------------------------------------------------------------------
+
+describe("assertIndependentOracle", () => {
+  it("does not throw when a suite has an independent oracle", () => {
+    const suite = minimalSuite();
+    expect(() => assertIndependentOracle(suite)).not.toThrow();
+  });
+
+  it("throws when no oracle is independent", () => {
+    const suite = minimalSuite({ oracles: [dependentOracle] });
+    expect(() => assertIndependentOracle(suite)).toThrow(
+      "at least one independent oracle required",
+    );
+  });
+
+  it("throws for an empty oracle array", () => {
+    const suite = minimalSuite({ oracles: [] });
+    expect(() => assertIndependentOracle(suite)).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gradeFixture — basic pass/fail
+// ---------------------------------------------------------------------------
+
+describe("gradeFixture — basic verdicts", () => {
+  it("returns pass when output matches expected", () => {
+    const f = fixture("f1", "input", "expected-output");
+    const result = gradeFixture(f, "expected-output", [independentTestOracle]);
+    expect(result.outcome).toBe("pass");
+    expect(result.fixtureId).toBe("f1");
+    expect(result.oracleId).toBe("o-test");
+  });
+
+  it("returns fail when output does not match expected", () => {
+    const f = fixture("f1", "input", "expected-output");
+    const result = gradeFixture(f, "wrong-output", [independentTestOracle]);
+    expect(result.outcome).toBe("fail");
+    expect(result.fixtureId).toBe("f1");
+  });
+
+  it("returns abstain when no oracles are provided", () => {
+    const f = fixture("f1", "input", "out");
+    const result = gradeFixture(f, "out", []);
+    expect(result.outcome).toBe("abstain");
+    expect(result.oracleId).toBe("none");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gradeFixture — failure stage recording
+// ---------------------------------------------------------------------------
+
+describe("gradeFixture — caughtAtStage recording", () => {
+  it("records 'tests' stage for test-suite oracle failure", () => {
+    const f = fixture("f1", "in", "out");
+    const result = gradeFixture(f, "wrong", [independentTestOracle]);
+    expect(result.outcome).toBe("fail");
+    expect(result.caughtAtStage).toBe("tests");
+  });
+
+  it("records 'schema' stage for schema-validator oracle failure", () => {
+    const f = fixture("f1", "in", "out");
+    const result = gradeFixture(f, "wrong", [independentSchemaOracle]);
+    expect(result.outcome).toBe("fail");
+    expect(result.caughtAtStage).toBe("schema");
+  });
+
+  it("records 'preflight' stage for static-analyzer oracle failure", () => {
+    const staticOracle: Oracle = {
+      id: "o-static",
+      kind: "static-analyzer",
+      independent: true,
+      ref: "linter",
+    };
+    const f = fixture("f1", "in", "out");
+    const result = gradeFixture(f, "wrong", [staticOracle]);
+    expect(result.outcome).toBe("fail");
+    expect(result.caughtAtStage).toBe("preflight");
+  });
+
+  it("records 'tests' stage for snapshot-diff oracle failure", () => {
+    const f = fixture("f1", "in", "out");
+    const result = gradeFixture(f, "wrong", [dependentOracle]);
+    expect(result.outcome).toBe("fail");
+    expect(result.caughtAtStage).toBe("tests");
+  });
+
+  it("does not set caughtAtStage on pass", () => {
+    const f = fixture("f1", "in", "out");
+    const result = gradeFixture(f, "out", [independentTestOracle]);
+    expect(result.outcome).toBe("pass");
+    expect(result.caughtAtStage).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gradeFixture — judge-model is advisory only
+// ---------------------------------------------------------------------------
+
+describe("gradeFixture — judge-model advisory rule", () => {
+  it("abstains when the only oracle is a judge-model (cannot decide alone)", () => {
+    const f = fixture("f1", "in", "out");
+    const result = gradeFixture(f, "wrong", [judgeOracle]);
+    // Judge alone can never decide pass or fail.
+    expect(result.outcome).toBe("abstain");
+    expect(result.oracleId).toBe("o-judge");
+  });
+
+  it("abstains even on a match when only judge oracles are present", () => {
+    const f = fixture("f1", "in", "out");
+    const result = gradeFixture(f, "out", [judgeOracle]);
+    expect(result.outcome).toBe("abstain");
+  });
+
+  it("uses non-judge oracle for verdict when both types are present", () => {
+    const f = fixture("f1", "in", "out");
+    const result = gradeFixture(f, "wrong", [judgeOracle, independentTestOracle]);
+    // The non-judge oracle is authoritative.
+    expect(result.outcome).toBe("fail");
+    expect(result.oracleId).toBe("o-test");
+  });
+
+  it("non-judge independent oracle is preferred over non-independent oracle", () => {
+    const f = fixture("f1", "in", "out");
+    // dependentOracle is non-independent, independentTestOracle is independent.
+    const result = gradeFixture(f, "wrong", [dependentOracle, independentTestOracle]);
+    expect(result.oracleId).toBe("o-test");
+    expect(result.outcome).toBe("fail");
+  });
+
+  it("records the judge oracle id in abstain result", () => {
+    const f = fixture("f1", "in", "out");
+    const result = gradeFixture(f, "out", [judgeOracle]);
+    expect(result.oracleId).toBe("o-judge");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runEvalSuite — injected executor, no real model
+// ---------------------------------------------------------------------------
+
+describe("runEvalSuite — injected executor", () => {
+  it("produces metrics and perFixtureResults for a passing suite", async () => {
+    const suite = minimalSuite();
+    // Injected executor: always returns the expected output for Fixture,
+    // and true for RetrievalFixture.
+    const runFixture = async (f: Fixture | RetrievalFixture) => {
+      if ("shouldSelect" in f) {
+        // RetrievalFixture: return boolean matching shouldSelect.
+        return f.shouldSelect;
+      }
+      return (f as Fixture).expected;
+    };
+
+    const result = await runEvalSuite(suite, runFixture);
+
+    expect(result.metrics.sampleSize).toBe(4); // pos + neg + ret + mut = 4
+    expect(result.metrics.passRate).toBe(1);
+    expect(result.perFixtureResults.length).toBe(4);
+    for (const r of result.perFixtureResults) {
+      expect(r.outcome).toBe("pass");
+    }
+  });
+
+  it("produces a failing result for a fixture that returns wrong output", async () => {
+    const suite = minimalSuite();
+    const runFixture = async (f: Fixture | RetrievalFixture) => {
+      // Always return "wrong" for Fixture, mismatch shouldSelect for retrieval.
+      if ("shouldSelect" in f) return !f.shouldSelect;
+      return "wrong";
+    };
+
+    const result = await runEvalSuite(suite, runFixture);
+
+    expect(result.metrics.passRate).toBe(0);
+    for (const r of result.perFixtureResults) {
+      expect(r.outcome).toBe("fail");
+    }
+  });
+
+  it("records caughtAtStage on failing fixtures", async () => {
+    const suite = minimalSuite();
+    const runFixture = async (f: Fixture | RetrievalFixture) => {
+      if ("shouldSelect" in f) return f.shouldSelect; // retrieval passes
+      return "wrong";
+    };
+
+    const result = await runEvalSuite(suite, runFixture);
+
+    const failingResults = result.perFixtureResults.filter(
+      (r) => r.outcome === "fail",
+    );
+    for (const r of failingResults) {
+      expect(r.caughtAtStage).toBeDefined();
+    }
+  });
+
+  it("records retrieval failure stage as 'retrieval'", async () => {
+    const suite = minimalSuite();
+    const runFixture = async (f: Fixture | RetrievalFixture) => {
+      if ("shouldSelect" in f) return !f.shouldSelect; // retrieval fails
+      return (f as Fixture).expected; // other fixtures pass
+    };
+
+    const result = await runEvalSuite(suite, runFixture);
+
+    const retrievalResult = result.perFixtureResults.find(
+      (r) => r.fixtureId === "ret-1",
+    );
+    expect(retrievalResult?.outcome).toBe("fail");
+    expect(retrievalResult?.caughtAtStage).toBe("retrieval");
+  });
+
+  it("throws if the suite has no independent oracle", async () => {
+    const suite = minimalSuite({ oracles: [dependentOracle] });
+    const runFixture = async () => "out";
+    await expect(runEvalSuite(suite, runFixture)).rejects.toThrow(
+      "at least one independent oracle required",
+    );
+  });
+
+  it("computes metrics from mixed pass/fail results", async () => {
+    // Suite with 2 positive, 1 negative, 1 retrieval, 1 mutation = 5 fixtures.
+    const suite = minimalSuite({
+      fixtures: {
+        positive: [
+          fixture("pos-1", "in", "out"),
+          fixture("pos-2", "in2", "out2"),
+        ],
+        negative: [fixture("neg-1", "bad", null)],
+        retrieval: [{ id: "ret-1", input: "q", shouldSelect: true }],
+        mutation: [fixture("mut-1", "mutated", "different")],
+      },
+    });
+
+    // Pass pos-1, fail pos-2, pass neg-1, pass ret-1, fail mut-1.
+    const runFixture = async (f: Fixture | RetrievalFixture) => {
+      if ("shouldSelect" in f) return f.shouldSelect;
+      const fx = f as Fixture;
+      if (fx.id === "pos-2" || fx.id === "mut-1") return "wrong";
+      return fx.expected;
+    };
+
+    const result = await runEvalSuite(suite, runFixture);
+
+    expect(result.metrics.sampleSize).toBe(5);
+    // 3 pass (pos-1, neg-1, ret-1), 2 fail (pos-2, mut-1)
+    expect(result.metrics.passRate).toBeCloseTo(3 / 5);
+    expect(result.perFixtureResults.length).toBe(5);
+  });
+
+  it("records abstentionRate when judge-only oracles are present", async () => {
+    // Suite with only a judge oracle — all fixtures will abstain.
+    const suite = minimalSuite({
+      oracles: [judgeIndependentOracle], // independent judge to pass assertIndependentOracle
+    });
+
+    const runFixture = async (f: Fixture | RetrievalFixture) => {
+      if ("shouldSelect" in f) return (f as RetrievalFixture).shouldSelect;
+      return (f as Fixture).expected;
+    };
+
+    const result = await runEvalSuite(suite, runFixture);
+
+    // All fixtures go through gradeFixture with only a judge oracle.
+    // The non-retrieval fixtures will abstain (judge-only); retrieval fixtures
+    // use the judge oracle id but the logic directly passes/fails them.
+    // Retrieval fixtures don't go through gradeFixture, they go through
+    // runAndGradeRetrieval which directly evaluates boolean match.
+    expect(result.metrics.sampleSize).toBe(4);
+    // Retrieval passes (shouldSelect matches), non-retrieval fixtures abstain.
+    const abstainCount = result.perFixtureResults.filter(
+      (r) => r.outcome === "abstain",
+    ).length;
+    expect(abstainCount).toBeGreaterThan(0);
+    expect(result.metrics.abstentionRate).toBeGreaterThan(0);
+  });
+
+  it("runs all four fixture kinds", async () => {
+    const suite = minimalSuite();
+    const visitedIds: string[] = [];
+
+    const runFixture = async (f: Fixture | RetrievalFixture) => {
+      visitedIds.push(f.id);
+      if ("shouldSelect" in f) return f.shouldSelect;
+      return (f as Fixture).expected;
+    };
+
+    await runEvalSuite(suite, runFixture);
+
+    expect(visitedIds).toContain("pos-1");
+    expect(visitedIds).toContain("neg-1");
+    expect(visitedIds).toContain("ret-1");
+    expect(visitedIds).toContain("mut-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// refs.ts — contentHash and sha256HexSchema
+// ---------------------------------------------------------------------------
+
+describe("refs.ts — contentHash and sha256HexSchema", () => {
+  it("contentHash produces a 64-char hex string", async () => {
+    const { contentHash } = await import("../src/skill/refs.js");
+    const h = contentHash("hello world");
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("contentHash is deterministic for identical input", async () => {
+    const { contentHash } = await import("../src/skill/refs.js");
+    expect(contentHash("test")).toBe(contentHash("test"));
+  });
+
+  it("contentHash differs for different inputs", async () => {
+    const { contentHash } = await import("../src/skill/refs.js");
+    expect(contentHash("a")).not.toBe(contentHash("b"));
+  });
+
+  it("sha256HexSchema accepts a valid hash", async () => {
+    const { sha256HexSchema } = await import("../src/skill/refs.js");
+    expect(() => sha256HexSchema.parse("a".repeat(64))).not.toThrow();
+  });
+
+  it("sha256HexSchema rejects invalid hash", async () => {
+    const { sha256HexSchema } = await import("../src/skill/refs.js");
+    expect(() => sha256HexSchema.parse("short")).toThrow();
+    expect(() => sha256HexSchema.parse("Z".repeat(64))).toThrow(); // uppercase not allowed
+  });
+});

--- a/tests/eval-suite-schema.test.ts
+++ b/tests/eval-suite-schema.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import {
+  evalSuiteSchema,
+  oracleSchema,
+  fixtureSchema,
+  retrievalFixtureSchema,
+  type EvalSuite,
+  type Oracle,
+} from "../src/skill/eval-suite-schema.js";
+
+// ---------------------------------------------------------------------------
+// Minimal valid building blocks
+// ---------------------------------------------------------------------------
+
+const independentOracle: Oracle = {
+  id: "o-independent",
+  kind: "test-suite",
+  independent: true,
+  ref: "tests/skill-grader.sh",
+};
+
+const dependentOracle: Oracle = {
+  id: "o-dependent",
+  kind: "schema-validator",
+  independent: false,
+  ref: "schemas/output.json",
+};
+
+const judgeOracle: Oracle = {
+  id: "o-judge",
+  kind: "judge-model",
+  independent: false,
+  ref: "judge:gpt-4o",
+};
+
+const positiveFixture = { id: "pos-1", input: "hello", expected: "world" };
+const negativeFixture = { id: "neg-1", input: "bad input", expected: null };
+const retrievalFixture = { id: "ret-1", input: "normalize imports", shouldSelect: true };
+const mutationFixture = { id: "mut-1", input: "mutated", expected: "different" };
+
+function minimalSuite(overrides: Partial<EvalSuite> = {}): unknown {
+  return {
+    schemaVersion: 1,
+    evalSuiteId: "suite-test-001",
+    evalSuiteHash: "a".repeat(64),
+    skillId: "skill-import-norm",
+    taskClassId: "tc-import-norm",
+    oracles: [independentOracle],
+    judgeIsAdvisoryOnly: true as const,
+    fixtures: {
+      positive: [positiveFixture],
+      negative: [negativeFixture],
+      retrieval: [retrievalFixture],
+      mutation: [mutationFixture],
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Oracle schema
+// ---------------------------------------------------------------------------
+
+describe("oracleSchema", () => {
+  it("accepts all valid oracle kinds", () => {
+    const kinds: Oracle["kind"][] = [
+      "test-suite",
+      "schema-validator",
+      "snapshot-diff",
+      "static-analyzer",
+      "judge-model",
+    ];
+    for (const kind of kinds) {
+      expect(() =>
+        oracleSchema.parse({ id: "o1", kind, independent: true, ref: "x" }),
+      ).not.toThrow();
+    }
+  });
+
+  it("rejects unknown kind", () => {
+    expect(() =>
+      oracleSchema.parse({ id: "o1", kind: "linter", independent: true, ref: "x" }),
+    ).toThrow();
+  });
+
+  it("independent flag is a plain boolean", () => {
+    const result = oracleSchema.parse({
+      id: "o1",
+      kind: "test-suite",
+      independent: false,
+      ref: "x",
+    });
+    expect(result.independent).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fixtureSchema
+// ---------------------------------------------------------------------------
+
+describe("fixtureSchema", () => {
+  it("defaults allowedNondeterminism to []", () => {
+    const f = fixtureSchema.parse({ id: "f1", input: "x", expected: "y" });
+    expect(f.allowedNondeterminism).toEqual([]);
+  });
+
+  it("accepts explicit allowedNondeterminism", () => {
+    const f = fixtureSchema.parse({
+      id: "f1",
+      input: "x",
+      expected: "y",
+      allowedNondeterminism: ["timestamp", "uuid"],
+    });
+    expect(f.allowedNondeterminism).toEqual(["timestamp", "uuid"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// retrievalFixtureSchema
+// ---------------------------------------------------------------------------
+
+describe("retrievalFixtureSchema", () => {
+  it("accepts shouldSelect true and false", () => {
+    const pos = retrievalFixtureSchema.parse({ id: "r1", input: "query", shouldSelect: true });
+    const neg = retrievalFixtureSchema.parse({ id: "r2", input: "query", shouldSelect: false });
+    expect(pos.shouldSelect).toBe(true);
+    expect(neg.shouldSelect).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evalSuiteSchema — independent oracle refine
+// ---------------------------------------------------------------------------
+
+describe("evalSuiteSchema — independent oracle rule", () => {
+  it("accepts a suite with at least one independent oracle", () => {
+    const suite = minimalSuite();
+    expect(() => evalSuiteSchema.parse(suite)).not.toThrow();
+  });
+
+  it("rejects a suite with only non-independent oracles", () => {
+    const suite = minimalSuite({ oracles: [dependentOracle] });
+    expect(() => evalSuiteSchema.parse(suite)).toThrow(
+      "at least one independent oracle required",
+    );
+  });
+
+  it("rejects a suite with only judge-model oracles (judge is also non-independent by convention)", () => {
+    // judge-model oracles are never independent in the anti-Goodhart model.
+    const suite = minimalSuite({ oracles: [judgeOracle] });
+    expect(() => evalSuiteSchema.parse(suite)).toThrow(
+      "at least one independent oracle required",
+    );
+  });
+
+  it("accepts a suite with a mix where one oracle is independent", () => {
+    const suite = minimalSuite({ oracles: [dependentOracle, independentOracle, judgeOracle] });
+    expect(() => evalSuiteSchema.parse(suite)).not.toThrow();
+  });
+
+  it("rejects an empty oracle array", () => {
+    const suite = minimalSuite({ oracles: [] });
+    expect(() => evalSuiteSchema.parse(suite)).toThrow(
+      "at least one independent oracle required",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evalSuiteSchema — judgeIsAdvisoryOnly must be literal true
+// ---------------------------------------------------------------------------
+
+describe("evalSuiteSchema — judgeIsAdvisoryOnly invariant", () => {
+  it("accepts judgeIsAdvisoryOnly: true", () => {
+    const suite = minimalSuite();
+    const parsed = evalSuiteSchema.parse(suite);
+    expect(parsed.judgeIsAdvisoryOnly).toBe(true);
+  });
+
+  it("rejects judgeIsAdvisoryOnly: false (z.literal(true) enforcement)", () => {
+    // z.literal(true) means false is not a valid value.
+    const suite = minimalSuite({ judgeIsAdvisoryOnly: false as unknown as true });
+    expect(() => evalSuiteSchema.parse(suite)).toThrow();
+  });
+
+  it("rejects missing judgeIsAdvisoryOnly", () => {
+    const raw = minimalSuite() as Record<string, unknown>;
+    delete raw["judgeIsAdvisoryOnly"];
+    expect(() => evalSuiteSchema.parse(raw)).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evalSuiteSchema — four fixture kinds each require min(1)
+// ---------------------------------------------------------------------------
+
+describe("evalSuiteSchema — fixture kinds all required min(1)", () => {
+  const fixtureKinds = ["positive", "negative", "retrieval", "mutation"] as const;
+
+  for (const kind of fixtureKinds) {
+    it(`rejects suite with empty ${kind} fixtures`, () => {
+      const base = minimalSuite() as Record<string, unknown>;
+      base["fixtures"] = {
+        ...(base["fixtures"] as object),
+        [kind]: [],
+      };
+      expect(() => evalSuiteSchema.parse(base)).toThrow();
+    });
+
+    it(`rejects suite with missing ${kind} fixtures`, () => {
+      const base = minimalSuite() as Record<string, unknown>;
+      const fixtures = { ...(base["fixtures"] as Record<string, unknown>) };
+      delete fixtures[kind];
+      base["fixtures"] = fixtures;
+      expect(() => evalSuiteSchema.parse(base)).toThrow();
+    });
+  }
+
+  it("accepts a suite with exactly one fixture of each kind", () => {
+    const suite = minimalSuite();
+    const parsed = evalSuiteSchema.parse(suite);
+    expect(parsed.fixtures.positive.length).toBe(1);
+    expect(parsed.fixtures.negative.length).toBe(1);
+    expect(parsed.fixtures.retrieval.length).toBe(1);
+    expect(parsed.fixtures.mutation.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evalSuiteHash must be a 64-char hex string
+// ---------------------------------------------------------------------------
+
+describe("evalSuiteSchema — evalSuiteHash validation", () => {
+  it("rejects a non-hex hash", () => {
+    const suite = minimalSuite({ evalSuiteHash: "not-a-hash" });
+    expect(() => evalSuiteSchema.parse(suite)).toThrow();
+  });
+
+  it("rejects a too-short hash", () => {
+    const suite = minimalSuite({ evalSuiteHash: "abc123" });
+    expect(() => evalSuiteSchema.parse(suite)).toThrow();
+  });
+
+  it("accepts a valid 64-char hex hash", () => {
+    const suite = minimalSuite({ evalSuiteHash: "f".repeat(64) });
+    expect(() => evalSuiteSchema.parse(suite)).not.toThrow();
+  });
+});

--- a/tests/profile-compiler.test.ts
+++ b/tests/profile-compiler.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect } from "vitest";
+import {
+  validatePackage,
+  compileProfile,
+  profileHash,
+  type PiLocal30bProfile,
+} from "../src/skill/profile-compiler.js";
+import type { ProcedurePackage } from "../src/skill/procedure-package-schema.js";
+import { contentHash } from "../src/skill/refs.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const MINIMAL_PACKAGE: ProcedurePackage = {
+  schemaVersion: 1,
+  skillId: "test-normalize-imports",
+  title: "Normalize TypeScript imports",
+  taskClassId: "ts-import-normalization",
+  inputSchema: { file: { type: "string" } },
+  outputSchema: { patch: { type: "string" } },
+  toolAllowlist: ["read_file", "write_file"],
+  steps: [
+    {
+      id: "read-source",
+      instruction: "Read the target TypeScript file.",
+      checkpoint: "File content is loaded into context.",
+    },
+    {
+      id: "apply-patch",
+      instruction: "Normalize import order and write the patched file.",
+      checkpoint: "File written; no syntax errors introduced.",
+    },
+  ],
+  examples: [
+    {
+      input: { file: "src/index.ts" },
+      output: { patch: "--- a/src/index.ts\n+++ b/src/index.ts\n..." },
+    },
+  ],
+  antiExamples: [
+    {
+      input: { file: "package.json" },
+      why: "This skill is for TypeScript files only; JSON files must not be modified.",
+    },
+  ],
+  abortConditions: [
+    "The file contains syntax errors before modification.",
+    "The file is larger than 500 lines.",
+  ],
+  contraindications: [],
+  egressClass: "local",
+  evalSuiteId: "eval-ts-import-normalization-v1",
+};
+
+// ---------------------------------------------------------------------------
+// validatePackage
+// ---------------------------------------------------------------------------
+
+describe("validatePackage", () => {
+  it("accepts a valid minimal package", () => {
+    const pkg = validatePackage(MINIMAL_PACKAGE);
+    expect(pkg.skillId).toBe("test-normalize-imports");
+  });
+
+  it("rejects a package with zero steps (schema min(1))", () => {
+    expect(() =>
+      validatePackage({ ...MINIMAL_PACKAGE, steps: [] }),
+    ).toThrow();
+  });
+
+  it("rejects a package with zero antiExamples (schema min(1))", () => {
+    expect(() =>
+      validatePackage({ ...MINIMAL_PACKAGE, antiExamples: [] }),
+    ).toThrow();
+  });
+
+  it("rejects a package with zero examples (schema min(1))", () => {
+    expect(() =>
+      validatePackage({ ...MINIMAL_PACKAGE, examples: [] }),
+    ).toThrow();
+  });
+
+  it("rejects a package with zero abortConditions (schema min(1))", () => {
+    expect(() =>
+      validatePackage({ ...MINIMAL_PACKAGE, abortConditions: [] }),
+    ).toThrow();
+  });
+
+  it("rejects a package with duplicate step ids (structural check)", () => {
+    expect(() =>
+      validatePackage({
+        ...MINIMAL_PACKAGE,
+        steps: [
+          { id: "step-a", instruction: "A", checkpoint: "A done" },
+          { id: "step-a", instruction: "B", checkpoint: "B done" },
+        ],
+      }),
+    ).toThrow(/duplicate step ids/);
+  });
+
+  it("rejects a package with an empty toolAllowlist (structural check)", () => {
+    expect(() =>
+      validatePackage({ ...MINIMAL_PACKAGE, toolAllowlist: [] }),
+    ).toThrow(/toolAllowlist must be non-empty/);
+  });
+
+  it("applies default [] for contraindications", () => {
+    const raw = { ...MINIMAL_PACKAGE };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (raw as any).contraindications;
+    const pkg = validatePackage(raw);
+    expect(pkg.contraindications).toEqual([]);
+  });
+
+  it("rejects missing required fields", () => {
+    expect(() => validatePackage({ schemaVersion: 1 })).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// compileProfile — determinism + correctness
+// ---------------------------------------------------------------------------
+
+describe("compileProfile — determinism", () => {
+  it("same package → identical profile across repeated calls", () => {
+    const p1 = compileProfile(MINIMAL_PACKAGE, "pi-local-30b");
+    const p2 = compileProfile(MINIMAL_PACKAGE, "pi-local-30b");
+    expect(p1).toEqual(p2);
+  });
+
+  it("same package → identical profileHash across repeated calls", () => {
+    const h1 = compileProfile(MINIMAL_PACKAGE, "pi-local-30b").profileHash;
+    const h2 = compileProfile(MINIMAL_PACKAGE, "pi-local-30b").profileHash;
+    expect(h1).toBe(h2);
+  });
+
+  it("different package content → different profileHash", () => {
+    const altered = validatePackage({
+      ...MINIMAL_PACKAGE,
+      title: "A different title that changes the hash",
+    });
+    const h1 = compileProfile(MINIMAL_PACKAGE, "pi-local-30b").profileHash;
+    const h2 = compileProfile(altered, "pi-local-30b").profileHash;
+    expect(h1).not.toBe(h2);
+  });
+
+  it("changing only one step instruction changes the hash", () => {
+    const altered = validatePackage({
+      ...MINIMAL_PACKAGE,
+      steps: [
+        { ...MINIMAL_PACKAGE.steps[0], instruction: "Modified instruction" },
+        MINIMAL_PACKAGE.steps[1],
+      ],
+    });
+    const h1 = compileProfile(MINIMAL_PACKAGE, "pi-local-30b").profileHash;
+    const h2 = compileProfile(altered, "pi-local-30b").profileHash;
+    expect(h1).not.toBe(h2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// profileHash — self-consistency invariant
+// ---------------------------------------------------------------------------
+
+describe("profileHash", () => {
+  it("profileHash(compileProfile(pkg)) equals profile.profileHash", () => {
+    const profile = compileProfile(MINIMAL_PACKAGE, "pi-local-30b");
+    expect(profileHash(profile)).toBe(profile.profileHash);
+  });
+
+  it("profileHash is a 64-char sha256 hex string", () => {
+    const profile = compileProfile(MINIMAL_PACKAGE, "pi-local-30b");
+    expect(profile.profileHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("mutating the profile after compilation changes the recomputed hash", () => {
+    const profile = compileProfile(MINIMAL_PACKAGE, "pi-local-30b");
+    const mutated: PiLocal30bProfile = {
+      ...profile,
+      systemPreamble: "Mutated preamble — drift detected",
+    };
+    // The embedded profileHash still matches the original; the recomputed one does not.
+    expect(profileHash(mutated)).not.toBe(profile.profileHash);
+    // But the embedded field is unchanged (we didn't update it).
+    expect(mutated.profileHash).toBe(profile.profileHash);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// compileProfile — content correctness
+// ---------------------------------------------------------------------------
+
+describe("compileProfile — output structure", () => {
+  it("carries input/output schemas from the package", () => {
+    const profile = compileProfile(MINIMAL_PACKAGE, "pi-local-30b");
+    expect(profile.inputSchema).toEqual(MINIMAL_PACKAGE.inputSchema);
+    expect(profile.outputSchema).toEqual(MINIMAL_PACKAGE.outputSchema);
+  });
+
+  it("carries toolAllowlist from the package", () => {
+    const profile = compileProfile(MINIMAL_PACKAGE, "pi-local-30b");
+    expect(profile.toolAllowlist).toEqual(MINIMAL_PACKAGE.toolAllowlist);
+  });
+
+  it("maps steps to stepList with {id, prompt, checkpointAssertion}", () => {
+    const profile = compileProfile(MINIMAL_PACKAGE, "pi-local-30b");
+    expect(profile.stepList).toHaveLength(2);
+    expect(profile.stepList[0]).toMatchObject({
+      id: "read-source",
+      prompt: MINIMAL_PACKAGE.steps[0].instruction,
+      checkpointAssertion: MINIMAL_PACKAGE.steps[0].checkpoint,
+    });
+  });
+
+  it("carries examples and antiExamples", () => {
+    const profile = compileProfile(MINIMAL_PACKAGE, "pi-local-30b");
+    expect(profile.examples).toEqual(MINIMAL_PACKAGE.examples);
+    expect(profile.antiExamples).toEqual(MINIMAL_PACKAGE.antiExamples);
+  });
+
+  it("carries abortConditions", () => {
+    const profile = compileProfile(MINIMAL_PACKAGE, "pi-local-30b");
+    expect(profile.abortConditions).toEqual(MINIMAL_PACKAGE.abortConditions);
+  });
+
+  it("sets a positive integer maxContextChars default", () => {
+    const profile = compileProfile(MINIMAL_PACKAGE, "pi-local-30b");
+    expect(profile.maxContextChars).toBeGreaterThan(0);
+    expect(Number.isInteger(profile.maxContextChars)).toBe(true);
+  });
+
+  it("defaults perStepGraderHooks to []", () => {
+    const profile = compileProfile(MINIMAL_PACKAGE, "pi-local-30b");
+    expect(profile.perStepGraderHooks).toEqual([]);
+  });
+
+  it("sets sourcePackageHash to contentHash of the package", () => {
+    const profile = compileProfile(MINIMAL_PACKAGE, "pi-local-30b");
+    expect(profile.sourcePackageHash).toBe(contentHash(MINIMAL_PACKAGE));
+  });
+
+  it("derives expectedArtifacts from outputSchema keys when present", () => {
+    const profile = compileProfile(MINIMAL_PACKAGE, "pi-local-30b");
+    // outputSchema has key "patch"
+    expect(profile.expectedArtifacts).toContain("patch");
+  });
+
+  it("carries egressClass from the package", () => {
+    const profile = compileProfile(MINIMAL_PACKAGE, "pi-local-30b");
+    expect(profile.egressClass).toBe("local");
+  });
+
+  it("builds a non-empty systemPreamble mentioning the skill title and allowlist", () => {
+    const profile = compileProfile(MINIMAL_PACKAGE, "pi-local-30b");
+    expect(profile.systemPreamble).toContain(MINIMAL_PACKAGE.title);
+    expect(profile.systemPreamble).toContain("read_file");
+  });
+
+  it("sets profileId to '<skillId>:pi-local-30b'", () => {
+    const profile = compileProfile(MINIMAL_PACKAGE, "pi-local-30b");
+    expect(profile.profileId).toBe("test-normalize-imports:pi-local-30b");
+  });
+});

--- a/tests/route-binding-store.test.ts
+++ b/tests/route-binding-store.test.ts
@@ -1,0 +1,563 @@
+/**
+ * Tests for route-binding-store.ts
+ * Uses an in-memory fake MuninClient — no network.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import type { MuninEntry, MuninQueryResult } from "../src/munin-client.js";
+import {
+  transition,
+  isSelectable,
+  loadActiveBinding,
+  recordValidationRun,
+  demoteOnDrift,
+} from "../src/skill/route-binding-store.js";
+import type { RouteBinding, ValidationRun } from "../src/skill/route-binding-schema.js";
+import { routeBindingSchema, validationRunSchema } from "../src/skill/route-binding-schema.js";
+import type { TupleRef } from "../src/skill/refs.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+/** Pad a string to 64 chars — produces valid sha256-hex-shaped hashes for tests. */
+const H = (n: string) => n.repeat(64).slice(0, 64);
+
+function makeTuple(overrides: Partial<TupleRef> = {}): TupleRef {
+  return {
+    taskClassId: "invoice-normalizer",
+    taskClassVersion: 1,
+    taskClassHash: H("a"),
+    skillProfileId: "pi-local-30b-v1",
+    skillProfileHash: H("b"),
+    cellManifestId: "ollama-qwen3-coder-cell-v1",
+    cellManifestHash: H("c"),
+    evalSuiteId: "invoice-eval-v1",
+    evalSuiteHash: H("d"),
+    ...overrides,
+  };
+}
+
+function makeBinding(overrides: Partial<RouteBinding> = {}): RouteBinding {
+  const now = new Date().toISOString();
+  return {
+    schemaVersion: 1,
+    bindingId: "binding-001",
+    version: 1,
+    state: "draft",
+    tuple: makeTuple(),
+    fallbackPolicy: {
+      cloudAllowed: true,
+      autoEscalateAllowed: true,
+      requiresUserApproval: false,
+      zdrRequired: false,
+      egressClass: "local",
+      fallbackProviderSet: ["claude-sdk"],
+      fallbackOnFailureKinds: ["infra", "timeout"],
+    },
+    effectiveSensitivityCeiling: "internal",
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
+
+function makeValidationRun(overrides: Partial<ValidationRun> = {}): ValidationRun {
+  return {
+    schemaVersion: 1,
+    runHash: H("e"),
+    bindingId: "binding-001",
+    tuple: makeTuple(),
+    graderHash: H("f"),
+    promptHash: H("g"),
+    harnessName: "hugin-eval-harness",
+    harnessVersion: "1.0.0",
+    wrapperName: "ollama-wrapper",
+    wrapperVersion: "0.3.0",
+    modelId: "qwen3-coder-30b-instruct",
+    modelFileHash: H("h"),
+    quantization: "Q4_K_M",
+    contextCap: 8192,
+    thinkingFormat: "forced-think-false",
+    toolCallParserResult: "pass",
+    os: "linux",
+    hardwareClass: "pi5-8gb",
+    memoryCapMb: 8192,
+    toolEnvManifestHash: H("i"),
+    executionTimeoutMs: 120000,
+    stepBudget: 10,
+    metrics: {
+      passRate: 0.889,
+      sampleSize: 27,
+      p50DurationSeconds: 45,
+      p95DurationSeconds: 90,
+      // All failureKind enum values must be present — Zod v4 z.record(enum, val)
+      // requires every key from the enum to be in the object.
+      failureKindHistogram: {
+        "retrieval-miss": 0,
+        "classification-wrong": 0,
+        "preflight": 0,
+        "parser": 0,
+        "schema": 0,
+        "tests": 0,
+        "timeout": 1,
+        "grader": 0,
+        "delivery": 0,
+        "infra": 2,
+      },
+      abstentionRate: 0.05,
+    },
+    perFixtureResults: [
+      { fixtureId: "f1", outcome: "pass", oracleId: "test-suite-oracle" },
+    ],
+    ranAt: new Date().toISOString(),
+    immutable: true,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fake MuninClient
+// ---------------------------------------------------------------------------
+/** In-memory store keyed by "namespace/key" */
+type Store = Map<string, MuninEntry>;
+
+function makeFakeMunin(initial?: Store) {
+  const store: Store = initial ?? new Map();
+
+  return {
+    // Track writes for assertions
+    writes: [] as Array<{ namespace: string; key: string; content: string; expectedUpdatedAt?: string }>,
+
+    async read(namespace: string, key: string): Promise<(MuninEntry & { found: true }) | null> {
+      const entry = store.get(`${namespace}/${key}`);
+      if (!entry) return null;
+      return { ...entry, found: true };
+    },
+
+    async write(
+      namespace: string,
+      key: string,
+      content: string,
+      tags?: string[],
+      expectedUpdatedAt?: string,
+    ): Promise<Record<string, unknown>> {
+      // Simulate CAS rejection when expected_updated_at doesn't match.
+      const existing = store.get(`${namespace}/${key}`);
+      if (expectedUpdatedAt !== undefined) {
+        if (existing && existing.updated_at !== expectedUpdatedAt) {
+          throw new Error(
+            `Munin write rejected for ${namespace}/${key}: cas-conflict — updated_at mismatch`,
+          );
+        }
+      }
+      const now = new Date().toISOString();
+      const entry: MuninEntry = {
+        id: `${namespace}/${key}`,
+        namespace,
+        key,
+        content,
+        tags: tags ?? [],
+        created_at: existing?.created_at ?? now,
+        updated_at: now,
+      };
+      store.set(`${namespace}/${key}`, entry);
+      this.writes.push({ namespace, key, content, expectedUpdatedAt });
+      return { ok: true };
+    },
+
+    async query(opts: {
+      query: string;
+      namespace?: string;
+      tags?: string[];
+      limit?: number;
+    }): Promise<{ results: MuninQueryResult[]; total: number }> {
+      const results: MuninQueryResult[] = [];
+      for (const [, entry] of store.entries()) {
+        // Namespace filter: prefix match (real Munin matches sub-namespaces too).
+        if (opts.namespace && !entry.namespace.startsWith(opts.namespace)) continue;
+        if (opts.tags && opts.tags.length > 0) {
+          const hasAllTags = opts.tags.every((t) => entry.tags.includes(t));
+          if (!hasAllTags) continue;
+        }
+        results.push({
+          id: entry.id,
+          namespace: entry.namespace,
+          key: entry.key,
+          entry_type: "state",
+          content_preview: entry.content.slice(0, 100),
+          tags: entry.tags,
+          created_at: entry.created_at,
+          updated_at: entry.updated_at,
+        });
+      }
+      return { results: results.slice(0, opts.limit ?? 100), total: results.length };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests: schema round-trip
+// ---------------------------------------------------------------------------
+describe("route-binding-schema round-trip", () => {
+  it("parses a valid RouteBinding", () => {
+    const b = makeBinding();
+    const result = routeBindingSchema.safeParse(b);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a binding with a bad hash (short hash)", () => {
+    const b = { ...makeBinding(), tuple: makeTuple({ taskClassHash: "short" }) };
+    const result = routeBindingSchema.safeParse(b);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a binding with an invalid state", () => {
+    const b = { ...makeBinding(), state: "promoted" };
+    const result = routeBindingSchema.safeParse(b);
+    expect(result.success).toBe(false);
+  });
+
+  it("parses a valid ValidationRun", () => {
+    const run = makeValidationRun();
+    const result = validationRunSchema.safeParse(run);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects a ValidationRun with immutable !== true", () => {
+    const run = { ...makeValidationRun(), immutable: false as true };
+    const result = validationRunSchema.safeParse(run);
+    expect(result.success).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: transition() — lifecycle enforcement
+// ---------------------------------------------------------------------------
+describe("transition() — legal transitions", () => {
+  it("draft → candidate", () => {
+    const b = makeBinding({ state: "draft" });
+    const next = transition(b, "candidate");
+    expect(next.state).toBe("candidate");
+  });
+
+  it("candidate → shadow", () => {
+    const b = makeBinding({ state: "candidate" });
+    const next = transition(b, "shadow");
+    expect(next.state).toBe("shadow");
+  });
+
+  it("shadow → active (with evidence)", () => {
+    const b = makeBinding({ state: "shadow" });
+    const next = transition(b, "active", { runHash: H("e") });
+    expect(next.state).toBe("active");
+    expect(next.activeValidationRunHash).toBe(H("e"));
+  });
+
+  it("active → stale", () => {
+    const b = makeBinding({ state: "active" });
+    const next = transition(b, "stale");
+    expect(next.state).toBe("stale");
+  });
+
+  it("active → quarantined", () => {
+    const b = makeBinding({ state: "active" });
+    const next = transition(b, "quarantined");
+    expect(next.state).toBe("quarantined");
+  });
+
+  it("stale → active (re-promotion with new run hash)", () => {
+    const b = makeBinding({ state: "stale", activeValidationRunHash: H("e") });
+    const next = transition(b, "active", { runHash: H("f") });
+    expect(next.state).toBe("active");
+    expect(next.activeValidationRunHash).toBe(H("f"));
+  });
+
+  it("quarantined → candidate (re-promotion with new run hash)", () => {
+    const b = makeBinding({ state: "quarantined", activeValidationRunHash: H("e") });
+    const next = transition(b, "candidate", { runHash: H("f") });
+    expect(next.state).toBe("candidate");
+  });
+
+  it("any state → disabled (manual kill)", () => {
+    for (const state of ["draft", "candidate", "shadow", "active", "stale", "quarantined"] as const) {
+      const b = makeBinding({ state });
+      expect(transition(b, "disabled").state).toBe("disabled");
+    }
+  });
+
+  it("transition() updates updatedAt", () => {
+    const b = makeBinding({ state: "draft", updatedAt: "2026-01-01T00:00:00Z" });
+    const next = transition(b, "candidate");
+    expect(next.updatedAt).not.toBe("2026-01-01T00:00:00Z");
+  });
+
+  it("transition() is pure — does not mutate the input binding", () => {
+    const b = makeBinding({ state: "draft" });
+    const stateBefore = b.state;
+    transition(b, "candidate");
+    expect(b.state).toBe(stateBefore);
+  });
+});
+
+describe("transition() — illegal transitions", () => {
+  it("draft → active (skips steps)", () => {
+    const b = makeBinding({ state: "draft" });
+    expect(() => transition(b, "active")).toThrow();
+  });
+
+  it("draft → shadow (skips candidate)", () => {
+    const b = makeBinding({ state: "draft" });
+    expect(() => transition(b, "shadow")).toThrow();
+  });
+
+  it("candidate → active (skips shadow)", () => {
+    const b = makeBinding({ state: "candidate" });
+    expect(() => transition(b, "active")).toThrow();
+  });
+
+  it("disabled → any state (terminal)", () => {
+    const b = makeBinding({ state: "disabled" });
+    expect(() => transition(b, "draft")).toThrow();
+    expect(() => transition(b, "active")).toThrow();
+  });
+
+  it("stale → active without evidence throws", () => {
+    const b = makeBinding({ state: "stale" });
+    expect(() => transition(b, "active")).toThrow(/requires a new ValidationRun/);
+  });
+
+  it("quarantined → shadow without evidence throws", () => {
+    const b = makeBinding({ state: "quarantined" });
+    expect(() => transition(b, "shadow")).toThrow(/requires a new ValidationRun/);
+  });
+
+  it("stale → active with same runHash throws", () => {
+    const b = makeBinding({ state: "stale", activeValidationRunHash: H("e") });
+    expect(() => transition(b, "active", { runHash: H("e") })).toThrow(/new.*ValidationRun hash|NEW.*ValidationRun/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: isSelectable()
+// ---------------------------------------------------------------------------
+describe("isSelectable() — fail-closed predicate", () => {
+  const currentHashes = makeTuple();
+
+  it("returns ok for active binding with matching hashes and adequate ceiling", () => {
+    const b = makeBinding({ state: "active", effectiveSensitivityCeiling: "internal" });
+    expect(isSelectable(b, currentHashes, "public")).toEqual({ ok: true });
+    expect(isSelectable(b, currentHashes, "internal")).toEqual({ ok: true });
+  });
+
+  it("not-active: reason for draft binding", () => {
+    const b = makeBinding({ state: "draft" });
+    const result = isSelectable(b, currentHashes, "public");
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("not-active");
+  });
+
+  it("not-active: reason for shadow binding", () => {
+    const b = makeBinding({ state: "shadow" });
+    const result = isSelectable(b, currentHashes, "public");
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("not-active");
+  });
+
+  it("not-active: reason for stale binding", () => {
+    const b = makeBinding({ state: "stale" });
+    const result = isSelectable(b, currentHashes, "public");
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("not-active");
+  });
+
+  it("hash-drift: detects mutated skillProfileHash", () => {
+    const b = makeBinding({ state: "active" });
+    const driftedHashes = makeTuple({ skillProfileHash: H("z") });
+    const result = isSelectable(b, driftedHashes, "public");
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("hash-drift");
+  });
+
+  it("hash-drift: detects mutated cellManifestHash", () => {
+    const b = makeBinding({ state: "active" });
+    const driftedHashes = makeTuple({ cellManifestHash: H("z") });
+    const result = isSelectable(b, driftedHashes, "public");
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("hash-drift");
+  });
+
+  it("hash-drift: detects mutated evalSuiteHash", () => {
+    const b = makeBinding({ state: "active" });
+    const driftedHashes = makeTuple({ evalSuiteHash: H("z") });
+    const result = isSelectable(b, driftedHashes, "public");
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("hash-drift");
+  });
+
+  it("sensitivity-ceiling: internal ceiling rejects private task", () => {
+    const b = makeBinding({ state: "active", effectiveSensitivityCeiling: "internal" });
+    const result = isSelectable(b, currentHashes, "private");
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("sensitivity-ceiling");
+  });
+
+  it("sensitivity-ceiling: public ceiling rejects internal task", () => {
+    const b = makeBinding({ state: "active", effectiveSensitivityCeiling: "public" });
+    const result = isSelectable(b, currentHashes, "internal");
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("sensitivity-ceiling");
+  });
+
+  it("private ceiling allows private task", () => {
+    const b = makeBinding({ state: "active", effectiveSensitivityCeiling: "private" });
+    expect(isSelectable(b, currentHashes, "private")).toEqual({ ok: true });
+    expect(isSelectable(b, currentHashes, "internal")).toEqual({ ok: true });
+    expect(isSelectable(b, currentHashes, "public")).toEqual({ ok: true });
+  });
+
+  it("priority: not-active checked before hash-drift", () => {
+    // A stale binding with drifted hashes should report not-active, not hash-drift
+    const b = makeBinding({ state: "stale" });
+    const driftedHashes = makeTuple({ skillProfileHash: H("z") });
+    const result = isSelectable(b, driftedHashes, "public");
+    expect(result.reason).toBe("not-active");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: loadActiveBinding()
+// ---------------------------------------------------------------------------
+describe("loadActiveBinding()", () => {
+  it("returns null when no binding exists", async () => {
+    const munin = makeFakeMunin();
+    const result = await loadActiveBinding("invoice-normalizer", munin as never);
+    expect(result).toBeNull();
+  });
+
+  it("returns the active binding when one exists", async () => {
+    const binding = makeBinding({ state: "active" });
+    const store: Store = new Map();
+    const now = new Date().toISOString();
+    store.set("routes/binding-001/binding", {
+      id: "routes/binding-001/binding",
+      namespace: "routes/binding-001",
+      key: "binding",
+      content: JSON.stringify(binding),
+      tags: ["route-state:active", "task-class:invoice-normalizer"],
+      created_at: now,
+      updated_at: now,
+    });
+
+    const munin = makeFakeMunin(store);
+    // Make query match the stored entry
+    const result = await loadActiveBinding("invoice-normalizer", munin as never);
+    expect(result).not.toBeNull();
+    expect(result?.bindingId).toBe("binding-001");
+    expect(result?.state).toBe("active");
+  });
+
+  it("skips non-binding keys (e.g. validation-run)", async () => {
+    const run = makeValidationRun();
+    const store: Store = new Map();
+    const now = new Date().toISOString();
+    store.set("routes/binding-001/validation-run/abc", {
+      id: "routes/binding-001/validation-run/abc",
+      namespace: "routes/binding-001",
+      key: "validation-run/abc",
+      content: JSON.stringify(run),
+      tags: ["route-state:active", "task-class:invoice-normalizer"],
+      created_at: now,
+      updated_at: now,
+    });
+
+    const munin = makeFakeMunin(store);
+    const result = await loadActiveBinding("invoice-normalizer", munin as never);
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: recordValidationRun()
+// ---------------------------------------------------------------------------
+describe("recordValidationRun()", () => {
+  it("writes the run to Munin on first call", async () => {
+    const munin = makeFakeMunin();
+    const run = makeValidationRun();
+    await recordValidationRun(run, munin as never);
+    expect(munin.writes).toHaveLength(1);
+    expect(munin.writes[0]?.key).toBe(`validation-run/${run.runHash}`);
+    expect(munin.writes[0]?.namespace).toBe(`routes/${run.bindingId}`);
+  });
+
+  it("rejects a duplicate runHash (write-once constraint)", async () => {
+    const munin = makeFakeMunin();
+    const run = makeValidationRun();
+    // First write succeeds
+    await recordValidationRun(run, munin as never);
+    // Second write must throw
+    await expect(recordValidationRun(run, munin as never)).rejects.toThrow(
+      /immutable.*never be overwritten|already exists/i,
+    );
+  });
+
+  it("includes required tags in the write", async () => {
+    const munin = makeFakeMunin();
+    const run = makeValidationRun();
+    await recordValidationRun(run, munin as never);
+    const tags = munin.writes[0]!.content; // content is what we care about
+    // Check tags were passed (via the write call args)
+    const lastWrite = munin.writes[munin.writes.length - 1]!;
+    expect(lastWrite.namespace).toContain(run.bindingId);
+  });
+
+  it("two runs with different runHashes for same binding both succeed", async () => {
+    const munin = makeFakeMunin();
+    const run1 = makeValidationRun({ runHash: H("e") });
+    const run2 = makeValidationRun({ runHash: H("f") });
+    await expect(recordValidationRun(run1, munin as never)).resolves.toBeUndefined();
+    await expect(recordValidationRun(run2, munin as never)).resolves.toBeUndefined();
+    expect(munin.writes).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: demoteOnDrift()
+// ---------------------------------------------------------------------------
+describe("demoteOnDrift()", () => {
+  it("returns a stale binding", async () => {
+    const munin = makeFakeMunin();
+    const b = makeBinding({ state: "active", updatedAt: "2026-05-01T00:00:00Z" });
+    const demoted = await demoteOnDrift(b, munin as never);
+    expect(demoted.state).toBe("stale");
+  });
+
+  it("writes to routes/<bindingId>/binding with CAS token", async () => {
+    const munin = makeFakeMunin();
+    const updatedAt = "2026-05-01T00:00:00Z";
+    const b = makeBinding({ state: "active", updatedAt });
+    await demoteOnDrift(b, munin as never);
+    expect(munin.writes).toHaveLength(1);
+    const w = munin.writes[0]!;
+    expect(w.namespace).toBe(`routes/${b.bindingId}`);
+    expect(w.key).toBe("binding");
+    expect(w.expectedUpdatedAt).toBe(updatedAt);
+  });
+
+  it("written content is parseable as RouteBinding with state=stale", async () => {
+    const munin = makeFakeMunin();
+    const b = makeBinding({ state: "active", updatedAt: "2026-05-01T00:00:00Z" });
+    await demoteOnDrift(b, munin as never);
+    const written = JSON.parse(munin.writes[0]!.content);
+    const parsed = routeBindingSchema.safeParse(written);
+    expect(parsed.success).toBe(true);
+    expect(parsed.data?.state).toBe("stale");
+  });
+
+  it("demoteOnDrift on a non-active binding still transitions to stale (from allowed states)", async () => {
+    const munin = makeFakeMunin();
+    // stale → stale is NOT in the allowed graph, but active → stale is.
+    // Only active bindings should be drift-demoted in practice; test that.
+    const b = makeBinding({ state: "active" });
+    const demoted = await demoteOnDrift(b, munin as never);
+    expect(demoted.state).toBe("stale");
+  });
+});

--- a/tests/skill-refs.test.ts
+++ b/tests/skill-refs.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import {
+  canonicalJSONString,
+  contentHash,
+  tupleHashesMatch,
+  lifecycleStateSchema,
+  tupleRefSchema,
+  type TupleRef,
+} from "../src/skill/refs.js";
+
+const H = (n: string) => n.repeat(64).slice(0, 64);
+
+describe("skill/refs canonical hashing", () => {
+  it("is key-order independent (canonical)", () => {
+    const a = { b: 1, a: 2, c: { y: 1, x: 2 } };
+    const b = { c: { x: 2, y: 1 }, a: 2, b: 1 };
+    expect(canonicalJSONString(a)).toBe(canonicalJSONString(b));
+    expect(contentHash(a)).toBe(contentHash(b));
+  });
+
+  it("preserves array order (arrays are not sorted)", () => {
+    expect(contentHash([1, 2, 3])).not.toBe(contentHash([3, 2, 1]));
+  });
+
+  it("drops undefined members like JSON.stringify", () => {
+    expect(canonicalJSONString({ a: 1, b: undefined })).toBe('{"a":1}');
+  });
+
+  it("produces a 64-char sha256 hex and is stable across calls", () => {
+    const h1 = contentHash({ skillId: "x", v: 1 });
+    const h2 = contentHash({ v: 1, skillId: "x" });
+    expect(h1).toMatch(/^[0-9a-f]{64}$/);
+    expect(h1).toBe(h2);
+  });
+
+  it("different content → different hash", () => {
+    expect(contentHash({ a: 1 })).not.toBe(contentHash({ a: 2 }));
+  });
+});
+
+describe("skill/refs shared schemas", () => {
+  it("lifecycle enum covers the full state machine", () => {
+    for (const s of [
+      "draft",
+      "candidate",
+      "shadow",
+      "active",
+      "stale",
+      "quarantined",
+      "disabled",
+    ]) {
+      expect(lifecycleStateSchema.safeParse(s).success).toBe(true);
+    }
+    expect(lifecycleStateSchema.safeParse("promoted").success).toBe(false);
+  });
+
+  it("tupleRef requires 64-char hex hashes", () => {
+    const good: TupleRef = {
+      taskClassId: "c",
+      taskClassVersion: 1,
+      taskClassHash: H("a"),
+      skillProfileId: "p",
+      skillProfileHash: H("b"),
+      cellManifestId: "m",
+      cellManifestHash: H("c"),
+      evalSuiteId: "e",
+      evalSuiteHash: H("d"),
+    };
+    expect(tupleRefSchema.safeParse(good).success).toBe(true);
+    expect(
+      tupleRefSchema.safeParse({ ...good, taskClassHash: "short" }).success,
+    ).toBe(false);
+  });
+
+  it("tupleHashesMatch detects drift on any artifact hash", () => {
+    const base: TupleRef = {
+      taskClassId: "c",
+      taskClassVersion: 1,
+      taskClassHash: H("a"),
+      skillProfileId: "p",
+      skillProfileHash: H("b"),
+      cellManifestId: "m",
+      cellManifestHash: H("c"),
+      evalSuiteId: "e",
+      evalSuiteHash: H("d"),
+    };
+    expect(tupleHashesMatch(base, { ...base })).toBe(true);
+    expect(tupleHashesMatch(base, { ...base, skillProfileHash: H("f") })).toBe(false);
+  });
+});

--- a/tests/skill/retrieval.test.ts
+++ b/tests/skill/retrieval.test.ts
@@ -1,0 +1,317 @@
+/**
+ * Tests for src/skill/retrieval.ts — fail-closed abstention contract.
+ *
+ * All Munin interactions use a fake client; no network calls.
+ *
+ * Covered branches:
+ *   1. munin-down — health() returns false
+ *   2. munin-down — health() throws
+ *   3. munin-down — query() throws (after health passes)
+ *   4. below-threshold — no candidates after hard-negative filtering
+ *   5. below-threshold — top score < confidenceThreshold
+ *   6. ambiguous-top-two — top1 − top2 < topTwoMarginThreshold
+ *   7. hard-negative excluded — a row that would otherwise win is dropped
+ *      because its hardNegatives contains the promptDigest; a different
+ *      row without a hard-negative match is returned instead
+ *   8. not-selectable — bindingState is "stale" (not "active")
+ *   9. selected — clean happy path
+ *  10. schema round-trip — ProceduralRetrievalRowSchema parse + serialise
+ */
+
+import { describe, it, expect } from "vitest";
+import { retrieveProcedure } from "../../src/skill/retrieval.js";
+import type { RetrievalConfig } from "../../src/skill/retrieval.js";
+import {
+  proceduralRetrievalRowSchema,
+  type ProceduralRetrievalRow,
+} from "../../src/skill/retrieval-schema.js";
+import type { MuninQueryResult } from "../../src/munin-client.js";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const PROFILE_HASH = "a".repeat(64);
+const BINDING_ID = "binding-001";
+const TASK_CLASS_ID = "fix-imports";
+
+/** A minimal valid ProceduralRetrievalRow. */
+const BASE_ROW: ProceduralRetrievalRow = {
+  schemaVersion: 1,
+  skillId: "import-normaliser",
+  profileId: "pi-local-30b-v1",
+  profileHash: PROFILE_HASH,
+  taskClassId: TASK_CLASS_ID,
+  triggerPhrases: ["normalise imports", "fix imports", "sort imports"],
+  requiredInputs: ["filePath"],
+  requiredTools: ["Bash"],
+  contraindications: [],
+  hardNegatives: ["unrelated-digest-xyz"],
+  egressClass: "local",
+  expectedArtifacts: ["patch"],
+  evalConfidence: 0.9,
+  knownFailureModes: [],
+  bindingId: BINDING_ID,
+  bindingState: "active",
+};
+
+const DEFAULT_CFG: RetrievalConfig = {
+  confidenceThreshold: 0.5,
+  topTwoMarginThreshold: 0.1,
+};
+
+const TASK = {
+  promptDigest: "normalise imports in src/index.ts",
+  taskClassId: TASK_CLASS_ID,
+  sensitivity: "internal" as const,
+};
+
+/** Build a MuninQueryResult whose content_preview is the serialised row. */
+function makeQueryResult(
+  row: ProceduralRetrievalRow,
+  muninScore?: number,
+): MuninQueryResult & { score?: number } {
+  return {
+    id: `skills/${row.skillId}`,
+    namespace: "skills",
+    key: `${row.skillId}/retrieval`,
+    entry_type: "memory",
+    content_preview: JSON.stringify(row),
+    tags: [
+      "procedural-retrieval",
+      `skill:${row.skillId}`,
+      `task-class:${row.taskClassId}`,
+      `route-state:${row.bindingState}`,
+    ],
+    created_at: "2026-05-29T10:00:00Z",
+    updated_at: "2026-05-29T10:00:00Z",
+    ...(muninScore !== undefined ? { score: muninScore } : {}),
+  };
+}
+
+/** Build a fake MuninClient. */
+function makeMunin(opts: {
+  healthy?: boolean;
+  healthThrows?: boolean;
+  queryThrows?: boolean;
+  results?: MuninQueryResult[];
+}) {
+  return {
+    async health(): Promise<boolean> {
+      if (opts.healthThrows) throw new Error("connection refused");
+      return opts.healthy ?? true;
+    },
+    async query(_args: unknown): Promise<{ results: MuninQueryResult[]; total: number }> {
+      if (opts.queryThrows) throw new Error("query failed");
+      return { results: opts.results ?? [], total: opts.results?.length ?? 0 };
+    },
+  } as unknown as import("../../src/munin-client.js").MuninClient;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("retrieveProcedure", () => {
+  // ── 1. munin-down: health returns false ─────────────────────────────────────
+  it("returns munin-down when health() returns false", async () => {
+    const outcome = await retrieveProcedure(
+      TASK,
+      makeMunin({ healthy: false }),
+      DEFAULT_CFG,
+    );
+    expect(outcome).toEqual({ kind: "unavailable", reason: "munin-down" });
+  });
+
+  // ── 2. munin-down: health() throws ──────────────────────────────────────────
+  it("returns munin-down when health() throws", async () => {
+    const outcome = await retrieveProcedure(
+      TASK,
+      makeMunin({ healthThrows: true }),
+      DEFAULT_CFG,
+    );
+    expect(outcome).toEqual({ kind: "unavailable", reason: "munin-down" });
+  });
+
+  // ── 3. munin-down: query() throws ───────────────────────────────────────────
+  it("returns munin-down when query() throws after health passes", async () => {
+    const outcome = await retrieveProcedure(
+      TASK,
+      makeMunin({ healthy: true, queryThrows: true }),
+      DEFAULT_CFG,
+    );
+    expect(outcome).toEqual({ kind: "unavailable", reason: "munin-down" });
+  });
+
+  // ── 4. below-threshold: empty candidate set ──────────────────────────────────
+  it("returns below-threshold when Munin returns no results", async () => {
+    const outcome = await retrieveProcedure(
+      TASK,
+      makeMunin({ results: [] }),
+      DEFAULT_CFG,
+    );
+    expect(outcome).toEqual({ kind: "abstain", reason: "below-threshold" });
+  });
+
+  // ── 5. below-threshold: score < confidenceThreshold ─────────────────────────
+  it("returns below-threshold when top score is below confidenceThreshold", async () => {
+    // Use a promptDigest that does not match any triggerPhrases → score = 0
+    const task = { ...TASK, promptDigest: "completely unrelated task description" };
+    const outcome = await retrieveProcedure(
+      task,
+      makeMunin({ results: [makeQueryResult(BASE_ROW)] }),
+      { confidenceThreshold: 0.5, topTwoMarginThreshold: 0.1 },
+    );
+    expect(outcome).toEqual({ kind: "abstain", reason: "below-threshold" });
+  });
+
+  // ── 6. ambiguous-top-two ─────────────────────────────────────────────────────
+  it("returns ambiguous-top-two when top1 and top2 are within margin", async () => {
+    // Give both rows explicit scores that are close together.
+    const result1 = makeQueryResult(BASE_ROW, 0.8);
+    const row2: ProceduralRetrievalRow = {
+      ...BASE_ROW,
+      skillId: "import-normaliser-v2",
+      profileId: "pi-local-30b-v2",
+      profileHash: "b".repeat(64),
+    };
+    const result2 = makeQueryResult(row2, 0.75); // gap = 0.05 < threshold 0.1
+
+    const outcome = await retrieveProcedure(
+      TASK,
+      makeMunin({ results: [result1, result2] }),
+      { confidenceThreshold: 0.5, topTwoMarginThreshold: 0.1 },
+    );
+    expect(outcome).toEqual({ kind: "abstain", reason: "ambiguous-top-two" });
+  });
+
+  // ── 7. hard-negative excluded ────────────────────────────────────────────────
+  it("excludes the row that matches a hardNegative; the other row wins", async () => {
+    // row1 has the incoming promptDigest in its hardNegatives → must be dropped.
+    const row1: ProceduralRetrievalRow = {
+      ...BASE_ROW,
+      skillId: "import-normaliser-lookalike",
+      hardNegatives: [TASK.promptDigest], // exact match → excluded
+    };
+    // row2 is the legitimate match (does NOT have the digest in hardNegatives).
+    const row2: ProceduralRetrievalRow = {
+      ...BASE_ROW,
+      skillId: "import-normaliser",
+    };
+
+    // Give row1 a higher Munin score so it would win without hard-negative exclusion.
+    const result1 = makeQueryResult(row1, 0.95);
+    const result2 = makeQueryResult(row2, 0.8);
+
+    const outcome = await retrieveProcedure(
+      TASK,
+      makeMunin({ results: [result1, result2] }),
+      { confidenceThreshold: 0.5, topTwoMarginThreshold: 0.1 },
+    );
+
+    // row1 must be excluded; row2 is the only remaining candidate.
+    expect(outcome.kind).toBe("selected");
+    if (outcome.kind === "selected") {
+      expect(outcome.row.skillId).toBe("import-normaliser");
+    }
+  });
+
+  // ── 8. not-selectable: stale bindingState ────────────────────────────────────
+  it("returns not-selectable when bindingState is stale", async () => {
+    const staleRow: ProceduralRetrievalRow = {
+      ...BASE_ROW,
+      bindingState: "stale",
+    };
+    const outcome = await retrieveProcedure(
+      TASK,
+      makeMunin({ results: [makeQueryResult(staleRow, 0.9)] }),
+      DEFAULT_CFG,
+    );
+    expect(outcome).toEqual({ kind: "not-selectable", reason: "stale-or-quarantined" });
+  });
+
+  // Confirm other non-active states also trigger not-selectable.
+  it("returns not-selectable when bindingState is quarantined", async () => {
+    const quarantinedRow: ProceduralRetrievalRow = {
+      ...BASE_ROW,
+      bindingState: "quarantined",
+    };
+    const outcome = await retrieveProcedure(
+      TASK,
+      makeMunin({ results: [makeQueryResult(quarantinedRow, 0.9)] }),
+      DEFAULT_CFG,
+    );
+    expect(outcome).toEqual({ kind: "not-selectable", reason: "stale-or-quarantined" });
+  });
+
+  // ── 9. selected: clean happy path ────────────────────────────────────────────
+  it("returns selected with row and score on the happy path", async () => {
+    const outcome = await retrieveProcedure(
+      TASK,
+      makeMunin({ results: [makeQueryResult(BASE_ROW, 0.9)] }),
+      DEFAULT_CFG,
+    );
+    expect(outcome.kind).toBe("selected");
+    if (outcome.kind === "selected") {
+      expect(outcome.row.skillId).toBe("import-normaliser");
+      expect(outcome.score).toBeCloseTo(0.9);
+    }
+  });
+
+  // ── trigger-phrase fallback scoring (no Munin score) ─────────────────────────
+  it("falls back to trigger-phrase score when Munin score is absent", async () => {
+    // TASK.promptDigest = "normalise imports in src/index.ts"
+    // BASE_ROW.triggerPhrases = ["normalise imports", "fix imports", "sort imports"]
+    // "normalise imports" matches → score = 1/3 ≈ 0.333
+    const outcome = await retrieveProcedure(
+      TASK,
+      // No muninScore passed — content_preview only
+      makeMunin({ results: [makeQueryResult(BASE_ROW)] }),
+      { confidenceThreshold: 0.3, topTwoMarginThreshold: 0.0 },
+    );
+    // 1/3 ≈ 0.333 > 0.3 → selected
+    expect(outcome.kind).toBe("selected");
+  });
+});
+
+// ── Schema round-trip ─────────────────────────────────────────────────────────
+describe("proceduralRetrievalRowSchema round-trip", () => {
+  it("parses a valid row and re-serialises to the same shape", () => {
+    const parsed = proceduralRetrievalRowSchema.parse(BASE_ROW);
+    expect(parsed).toEqual(BASE_ROW);
+  });
+
+  it("rejects a row with empty triggerPhrases", () => {
+    const bad = { ...BASE_ROW, triggerPhrases: [] };
+    const result = proceduralRetrievalRowSchema.safeParse(bad);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a row with empty hardNegatives", () => {
+    const bad = { ...BASE_ROW, hardNegatives: [] };
+    const result = proceduralRetrievalRowSchema.safeParse(bad);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an invalid profileHash (not 64 hex chars)", () => {
+    const bad = { ...BASE_ROW, profileHash: "tooshort" };
+    const result = proceduralRetrievalRowSchema.safeParse(bad);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an evalConfidence outside [0, 1]", () => {
+    const bad = { ...BASE_ROW, evalConfidence: 1.5 };
+    const result = proceduralRetrievalRowSchema.safeParse(bad);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an unknown bindingState", () => {
+    const bad = { ...BASE_ROW, bindingState: "promoted" };
+    const result = proceduralRetrievalRowSchema.safeParse(bad);
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts all valid lifecycleState values", () => {
+    for (const state of ["draft", "candidate", "shadow", "active", "stale", "quarantined", "disabled"] as const) {
+      const row = { ...BASE_ROW, bindingState: state };
+      const result = proceduralRetrievalRowSchema.safeParse(row);
+      expect(result.success).toBe(true);
+    }
+  });
+});

--- a/tests/skill/skill-lane.test.ts
+++ b/tests/skill/skill-lane.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from "vitest";
+import {
+  selectSkillRoute,
+  type SkillLaneConfig,
+  type SkillLaneDeps,
+} from "../../src/skill/skill-lane.js";
+import type { MuninClient } from "../../src/munin-client.js";
+import type { RouteBinding } from "../../src/skill/route-binding-schema.js";
+import type { TupleRef } from "../../src/skill/refs.js";
+
+const H = (c: string) => c.repeat(64).slice(0, 64);
+
+const TUPLE: TupleRef = {
+  taskClassId: "fmt",
+  taskClassVersion: 1,
+  taskClassHash: H("a"),
+  skillProfileId: "p",
+  skillProfileHash: H("b"),
+  cellManifestId: "m",
+  cellManifestHash: H("c"),
+  evalSuiteId: "e",
+  evalSuiteHash: H("d"),
+};
+
+const BINDING: RouteBinding = {
+  schemaVersion: 1,
+  bindingId: "fmt-binding",
+  version: 3,
+  state: "active",
+  tuple: TUPLE,
+  fallbackPolicy: {
+    cloudAllowed: true,
+    autoEscalateAllowed: true,
+    requiresUserApproval: false,
+    zdrRequired: false,
+    egressClass: "local",
+    fallbackProviderSet: [],
+    fallbackOnFailureKinds: [],
+  },
+  effectiveSensitivityCeiling: "private",
+  createdAt: "t0",
+  updatedAt: "t1",
+};
+
+const munin = {} as MuninClient;
+const cfg: SkillLaneConfig = {
+  enabled: true,
+  retrieval: { confidenceThreshold: 0.5, topTwoMarginThreshold: 0.1 },
+};
+
+// Dependency stubs for the happy path; each test overrides what it needs.
+function happyDeps(): Partial<SkillLaneDeps> {
+  return {
+    loadActiveClassifiers: async () => [{} as never],
+    classifyTask: () => ({ kind: "classified", classId: "fmt", confidence: 0.9 }),
+    retrieveProcedure: async () => ({
+      kind: "selected",
+      row: {} as never,
+      score: 0.9,
+    }),
+    loadActiveBinding: async () => BINDING,
+    recomputeTupleHashes: async () => TUPLE, // matches → no drift
+  };
+}
+
+describe("selectSkillRoute (#84 fail-closed orchestrator)", () => {
+  it("selects when classify+retrieve+binding+selectability all pass", async () => {
+    const r = await selectSkillRoute(
+      { prompt: "p", promptDigest: "d", sensitivity: "internal" },
+      munin,
+      cfg,
+      happyDeps(),
+    );
+    expect(r.kind).toBe("selected");
+    expect(r.skillRoute.abstained).toBe(false);
+    expect(r.skillRoute.bindingId).toBe("fmt-binding");
+    expect(r.skillRoute.classId).toBe("fmt");
+  });
+
+  it("falls through when the lane is disabled", async () => {
+    const r = await selectSkillRoute(
+      { prompt: "p", promptDigest: "d", sensitivity: "internal" },
+      munin,
+      { ...cfg, enabled: false },
+      happyDeps(),
+    );
+    expect(r.kind).toBe("fallthrough");
+    expect(r.skillRoute.abstainReason).toBe("lane-disabled");
+  });
+
+  it("fails closed on a Munin error loading classifiers", async () => {
+    const r = await selectSkillRoute(
+      { prompt: "p", promptDigest: "d", sensitivity: "internal" },
+      munin,
+      cfg,
+      { ...happyDeps(), loadActiveClassifiers: async () => { throw new Error("down"); } },
+    );
+    expect(r.kind).toBe("fallthrough");
+    expect(r.skillRoute.abstainReason).toBe("munin-error");
+  });
+
+  it("falls through when no classifiers are active", async () => {
+    const r = await selectSkillRoute(
+      { prompt: "p", promptDigest: "d", sensitivity: "internal" },
+      munin,
+      cfg,
+      { ...happyDeps(), loadActiveClassifiers: async () => [] },
+    );
+    expect(r.skillRoute.abstainReason).toBe("no-classifiers");
+  });
+
+  it("falls through on classifier abstain", async () => {
+    const r = await selectSkillRoute(
+      { prompt: "p", promptDigest: "d", sensitivity: "internal" },
+      munin,
+      cfg,
+      { ...happyDeps(), classifyTask: () => ({ kind: "abstain", reason: "ambiguous-top-two" }) },
+    );
+    expect(r.skillRoute.abstainReason).toBe("classify:ambiguous-top-two");
+  });
+
+  it("falls through on retrieval abstain (records class)", async () => {
+    const r = await selectSkillRoute(
+      { prompt: "p", promptDigest: "d", sensitivity: "internal" },
+      munin,
+      cfg,
+      { ...happyDeps(), retrieveProcedure: async () => ({ kind: "abstain", reason: "below-threshold" }) },
+    );
+    expect(r.skillRoute.abstainReason).toBe("retrieve:below-threshold");
+    expect(r.skillRoute.classId).toBe("fmt");
+  });
+
+  it("fails closed when Munin is unavailable during retrieval", async () => {
+    const r = await selectSkillRoute(
+      { prompt: "p", promptDigest: "d", sensitivity: "internal" },
+      munin,
+      cfg,
+      { ...happyDeps(), retrieveProcedure: async () => ({ kind: "unavailable", reason: "munin-down" }) },
+    );
+    expect(r.skillRoute.abstainReason).toBe("retrieve:munin-down");
+  });
+
+  it("falls through when no active binding exists", async () => {
+    const r = await selectSkillRoute(
+      { prompt: "p", promptDigest: "d", sensitivity: "internal" },
+      munin,
+      cfg,
+      { ...happyDeps(), loadActiveBinding: async () => null },
+    );
+    expect(r.skillRoute.abstainReason).toBe("no-active-binding");
+  });
+
+  it("fails closed when drift cannot be verified (default recompute returns null)", async () => {
+    const deps = happyDeps();
+    delete deps.recomputeTupleHashes; // use default → null
+    const r = await selectSkillRoute(
+      { prompt: "p", promptDigest: "d", sensitivity: "internal" },
+      munin,
+      cfg,
+      deps,
+    );
+    expect(r.kind).toBe("fallthrough");
+    expect(r.skillRoute.abstainReason).toBe("cannot-verify-drift");
+    expect(r.skillRoute.bindingId).toBe("fmt-binding");
+  });
+
+  it("fails closed on hash drift", async () => {
+    const drifted: TupleRef = { ...TUPLE, skillProfileHash: H("f") };
+    const r = await selectSkillRoute(
+      { prompt: "p", promptDigest: "d", sensitivity: "internal" },
+      munin,
+      cfg,
+      { ...happyDeps(), recomputeTupleHashes: async () => drifted },
+    );
+    expect(r.skillRoute.abstainReason).toBe("binding:hash-drift");
+  });
+
+  it("fails closed when the binding's sensitivity ceiling is below the task's", async () => {
+    const r = await selectSkillRoute(
+      { prompt: "p", promptDigest: "d", sensitivity: "private" },
+      munin,
+      cfg,
+      { ...happyDeps(), loadActiveBinding: async () => ({ ...BINDING, effectiveSensitivityCeiling: "internal" }) },
+    );
+    expect(r.skillRoute.abstainReason).toBe("binding:sensitivity-ceiling");
+  });
+});

--- a/tests/skill/task-classifier.test.ts
+++ b/tests/skill/task-classifier.test.ts
@@ -1,0 +1,468 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  classifyTask,
+  classifierHash,
+  effectiveSensitivityCeiling,
+  loadActiveClassifiers,
+} from "../../src/skill/task-classifier.js";
+import type { TaskClassifier } from "../../src/skill/task-classifier-schema.js";
+import type { MuninClient } from "../../src/munin-client.js";
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const H = (c: string) => c.repeat(64).slice(0, 64);
+
+// These classifiers use weights that sum to 1.0 per classifier so that
+// a single rule match produces confidence == that rule's weight directly.
+// Threshold is set below the weight of any single rule that should match,
+// so the shouldClassify prompts clear it.
+const coderClassifier: TaskClassifier = {
+  schemaVersion: 1,
+  classId: "coding-task",
+  version: 1,
+  classifierHash: H("a"),
+  predicate: {
+    kind: "rule",
+    // Weights sum to 1.0; any single rule match produces its weight as confidence.
+    rules: [
+      { match: "write a function", weight: 0.5 },
+      { match: "implement",        weight: 0.4 },
+      { match: "fix the bug",      weight: 0.1 },
+    ],
+    confidenceThreshold: 0.35, // below min single-rule weight (0.4), so any strong match passes
+    topTwoMargin: 0.1,
+  },
+  hardNegatives: [
+    { input: "explain the difference between X and Y", why: "educational, not coding" },
+  ],
+  contraindications: ["do not write code", "read-only analysis"],
+  shouldClassify: [
+    { input: "please implement a sorting function in TypeScript" },
+    { input: "write a function that parses JSON" },
+  ],
+  shouldNotClassify: [
+    { input: "explain the difference between TCP and UDP" },
+    { input: "summarize this document" },
+  ],
+  sensitivityCeiling: "internal",
+};
+
+const docsClassifier: TaskClassifier = {
+  schemaVersion: 1,
+  classId: "documentation-task",
+  version: 1,
+  classifierHash: H("b"),
+  predicate: {
+    kind: "rule",
+    // Weights sum to 1.0.
+    rules: [
+      { match: "write documentation", weight: 0.5 },
+      { match: "document the api",    weight: 0.4 },
+      { match: "summarize",           weight: 0.1 },
+    ],
+    confidenceThreshold: 0.35,
+    topTwoMargin: 0.1,
+  },
+  hardNegatives: [
+    { input: "write code", why: "implementation, not documentation" },
+  ],
+  contraindications: [],
+  shouldClassify: [
+    { input: "write documentation for the auth module" },
+    { input: "document the api endpoints" },
+  ],
+  shouldNotClassify: [
+    { input: "implement a login function" },
+  ],
+  sensitivityCeiling: "public",
+};
+
+// ---------------------------------------------------------------------------
+// classifyTask: shouldClassify inputs
+// ---------------------------------------------------------------------------
+
+describe("classifyTask — shouldClassify inputs classify to the right class", () => {
+  it("classifies a prompt matching coderClassifier.shouldClassify[0]", () => {
+    const result = classifyTask(
+      "please implement a sorting function in TypeScript",
+      [coderClassifier],
+    );
+    expect(result.kind).toBe("classified");
+    if (result.kind === "classified") {
+      expect(result.classId).toBe("coding-task");
+      expect(result.confidence).toBeGreaterThanOrEqual(0);
+      expect(result.confidence).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("classifies a prompt matching coderClassifier.shouldClassify[1]", () => {
+    const result = classifyTask(
+      "write a function that parses JSON",
+      [coderClassifier],
+    );
+    expect(result.kind).toBe("classified");
+    if (result.kind === "classified") {
+      expect(result.classId).toBe("coding-task");
+    }
+  });
+
+  it("classifies a docs prompt to docsClassifier", () => {
+    const result = classifyTask(
+      "write documentation for the auth module",
+      [docsClassifier],
+    );
+    expect(result.kind).toBe("classified");
+    if (result.kind === "classified") {
+      expect(result.classId).toBe("documentation-task");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyTask: shouldNotClassify inputs
+// ---------------------------------------------------------------------------
+
+describe("classifyTask — shouldNotClassify inputs abstain or pick different class", () => {
+  it("abstains or picks wrong class for coderClassifier.shouldNotClassify[0]", () => {
+    const result = classifyTask(
+      "explain the difference between TCP and UDP",
+      [coderClassifier],
+    );
+    // Either abstains or does not classify to coding-task
+    if (result.kind === "classified") {
+      expect(result.classId).not.toBe("coding-task");
+    } else {
+      expect(result.kind).toBe("abstain");
+    }
+  });
+
+  it("abstains or picks wrong class for coderClassifier.shouldNotClassify[1]", () => {
+    const result = classifyTask("summarize this document", [coderClassifier]);
+    if (result.kind === "classified") {
+      expect(result.classId).not.toBe("coding-task");
+    } else {
+      expect(result.kind).toBe("abstain");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyTask: hard-negative / contraindication exclusion
+// ---------------------------------------------------------------------------
+
+describe("classifyTask — hard-negative and contraindication exclusion", () => {
+  it("hard-negative input scores 0 (cannot classify to that class)", () => {
+    // The coderClassifier hard-negative pattern appears in this prompt
+    const result = classifyTask(
+      "explain the difference between X and Y",
+      [coderClassifier],
+    );
+    // Must NOT classify to coding-task
+    if (result.kind === "classified") {
+      expect(result.classId).not.toBe("coding-task");
+    }
+    // If only one classifier, should abstain since hard-negative zeroed it out
+    const singleResult = classifyTask(
+      "explain the difference between X and Y",
+      [coderClassifier],
+    );
+    expect(singleResult.kind).toBe("abstain");
+  });
+
+  it("contraindication in prompt zeroes out that classifier", () => {
+    // "do not write code" is a contraindication for coderClassifier
+    const result = classifyTask(
+      "implement a function (do not write code, just describe it)",
+      [coderClassifier],
+    );
+    // Should NOT classify to coding-task because contraindication matched
+    if (result.kind === "classified") {
+      expect(result.classId).not.toBe("coding-task");
+    }
+  });
+
+  it("hard-negative on docsClassifier prevents docs classification", () => {
+    // "write code" is a hard-negative for docsClassifier
+    const result = classifyTask(
+      "write code for the auth module",
+      [docsClassifier],
+    );
+    // docsClassifier should score 0 due to hard-negative
+    if (result.kind === "classified") {
+      expect(result.classId).not.toBe("documentation-task");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyTask: below-threshold abstain
+// ---------------------------------------------------------------------------
+
+describe("classifyTask — below-threshold abstain", () => {
+  it("abstains with below-threshold when no rules match", () => {
+    const result = classifyTask(
+      "what is the weather like today",
+      [coderClassifier],
+    );
+    expect(result.kind).toBe("abstain");
+    if (result.kind === "abstain") {
+      expect(result.reason).toBe("below-threshold");
+    }
+  });
+
+  it("abstains below-threshold for a classifier with high threshold and partial match", () => {
+    // Classifier has 4 rules summing to 1.0; only the weakest (weight=0.1) matches.
+    // Score = 0.1/1.0 = 0.1 < threshold 0.4 → abstain below-threshold.
+    const strictClassifier: TaskClassifier = {
+      ...coderClassifier,
+      classId: "strict-class",
+      classifierHash: H("c"),
+      predicate: {
+        kind: "rule",
+        rules: [
+          { match: "strongly specific phrase xyz", weight: 0.4 },
+          { match: "another specific phrase abc", weight: 0.3 },
+          { match: "yet another phrase def",      weight: 0.2 },
+          { match: "function",                    weight: 0.1 },
+        ],
+        confidenceThreshold: 0.4, // requires a strong rule to match; only "function" hits
+        topTwoMargin: 0.0,
+      },
+    };
+    // "define a function" only matches "function" (weight 0.1) → 0.1/1.0 = 0.1 < 0.4
+    const result = classifyTask("define a function", [strictClassifier]);
+    expect(result.kind).toBe("abstain");
+    if (result.kind === "abstain") {
+      expect(result.reason).toBe("below-threshold");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyTask: ambiguous-top-two abstain
+// ---------------------------------------------------------------------------
+
+describe("classifyTask — ambiguous-top-two abstain", () => {
+  it("abstains ambiguous-top-two when two classifiers score very close", () => {
+    // Build two classifiers that both match the same prompt with identical weight
+    const classifierA: TaskClassifier = {
+      ...coderClassifier,
+      classId: "class-a",
+      classifierHash: H("d"),
+      predicate: {
+        kind: "rule",
+        rules: [{ match: "analyze the system", weight: 1.0 }],
+        confidenceThreshold: 0.1,
+        topTwoMargin: 0.2, // requires 0.2 margin; tied inputs will abstain
+      },
+    };
+    const classifierB: TaskClassifier = {
+      ...coderClassifier,
+      classId: "class-b",
+      classifierHash: H("e"),
+      predicate: {
+        kind: "rule",
+        rules: [{ match: "analyze the system", weight: 1.0 }],
+        confidenceThreshold: 0.1,
+        topTwoMargin: 0.2,
+      },
+    };
+    const result = classifyTask("analyze the system performance", [classifierA, classifierB]);
+    // Both match "analyze the system" equally → ambiguous-top-two
+    expect(result.kind).toBe("abstain");
+    if (result.kind === "abstain") {
+      expect(result.reason).toBe("ambiguous-top-two");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// effectiveSensitivityCeiling — SECURITY TESTS
+// ---------------------------------------------------------------------------
+
+describe("effectiveSensitivityCeiling — security invariant: can only constrain, never raise", () => {
+  it("returns min of classifier ceiling, cell trust ceiling, task sensitivity", () => {
+    // classifier=private, cell=internal, task=public → public (most restrictive)
+    expect(effectiveSensitivityCeiling("private", "internal", "public")).toBe("public");
+  });
+
+  it("classifier ceiling=private, task=internal → internal (cannot raise beyond task)", () => {
+    // classifier says private is OK, but task is only internal
+    expect(effectiveSensitivityCeiling("private", "private", "internal")).toBe("internal");
+  });
+
+  it("cell=public is the binding floor — returns public regardless of others", () => {
+    expect(effectiveSensitivityCeiling("private", "public", "private")).toBe("public");
+    expect(effectiveSensitivityCeiling("internal", "public", "internal")).toBe("public");
+  });
+
+  it("task=public → result is always public regardless of classifier/cell", () => {
+    expect(effectiveSensitivityCeiling("private", "private", "public")).toBe("public");
+    expect(effectiveSensitivityCeiling("internal", "internal", "public")).toBe("public");
+  });
+
+  it("all three equal → returns that value", () => {
+    expect(effectiveSensitivityCeiling("internal", "internal", "internal")).toBe("internal");
+    expect(effectiveSensitivityCeiling("private", "private", "private")).toBe("private");
+    expect(effectiveSensitivityCeiling("public", "public", "public")).toBe("public");
+  });
+
+  it("result never EXCEEDS any single input (exhaustive over all triples)", () => {
+    const levels = ["public", "internal", "private"] as const;
+    const ORDER = { public: 0, internal: 1, private: 2 };
+    for (const classifierCeil of levels) {
+      for (const cellTrust of levels) {
+        for (const taskSens of levels) {
+          const result = effectiveSensitivityCeiling(classifierCeil, cellTrust, taskSens);
+          // The result must be <= ALL three inputs on the lattice
+          expect(ORDER[result]).toBeLessThanOrEqual(ORDER[classifierCeil]);
+          expect(ORDER[result]).toBeLessThanOrEqual(ORDER[cellTrust]);
+          expect(ORDER[result]).toBeLessThanOrEqual(ORDER[taskSens]);
+        }
+      }
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifierHash — stable
+// ---------------------------------------------------------------------------
+
+describe("classifierHash — stable across calls", () => {
+  it("produces a 64-char hex hash", () => {
+    const h = classifierHash(coderClassifier);
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("is stable (same input → same hash)", () => {
+    expect(classifierHash(coderClassifier)).toBe(classifierHash(coderClassifier));
+  });
+
+  it("different classifiers produce different hashes", () => {
+    expect(classifierHash(coderClassifier)).not.toBe(classifierHash(docsClassifier));
+  });
+
+  it("is key-order independent (canonical JSON)", () => {
+    // Create a copy with differently-ordered keys to verify canonical hashing
+    const reordered: TaskClassifier = {
+      version: coderClassifier.version,
+      classId: coderClassifier.classId,
+      schemaVersion: coderClassifier.schemaVersion,
+      classifierHash: coderClassifier.classifierHash,
+      predicate: coderClassifier.predicate,
+      hardNegatives: coderClassifier.hardNegatives,
+      contraindications: coderClassifier.contraindications,
+      shouldClassify: coderClassifier.shouldClassify,
+      shouldNotClassify: coderClassifier.shouldNotClassify,
+      sensitivityCeiling: coderClassifier.sensitivityCeiling,
+    };
+    expect(classifierHash(coderClassifier)).toBe(classifierHash(reordered));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadActiveClassifiers — reads from Munin
+// ---------------------------------------------------------------------------
+
+describe("loadActiveClassifiers — Munin integration", () => {
+  it("returns empty array when Munin has no active classifiers", async () => {
+    const fakeMunin = {
+      query: vi.fn().mockResolvedValue({ results: [], total: 0 }),
+    } as unknown as MuninClient;
+
+    const result = await loadActiveClassifiers(fakeMunin);
+    expect(result).toEqual([]);
+  });
+
+  it("reads and validates classifier entries from Munin", async () => {
+    const validClassifier: TaskClassifier = {
+      schemaVersion: 1,
+      classId: "test-class",
+      version: 1,
+      classifierHash: H("f"),
+      predicate: {
+        kind: "rule",
+        rules: [{ match: "test prompt", weight: 1.0 }],
+        confidenceThreshold: 0.5,
+        topTwoMargin: 0.1,
+      },
+      hardNegatives: [{ input: "ignore this", why: "test" }],
+      contraindications: [],
+      shouldClassify: [{ input: "run the test" }],
+      shouldNotClassify: [{ input: "summarize" }],
+      sensitivityCeiling: "internal",
+    };
+
+    const fakeMunin = {
+      query: vi.fn().mockResolvedValue({
+        results: [
+          {
+            namespace: "routes/_classifier",
+            key: "test-class/active",
+            content_preview: "",
+            tags: ["active"],
+            id: "1",
+            entry_type: "state",
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+        total: 1,
+      }),
+      // loadActiveClassifiers uses readBatch (not read) to fetch full content
+      readBatch: vi.fn().mockResolvedValue([
+        {
+          found: true,
+          namespace: "routes/_classifier",
+          key: "test-class/active",
+          content: JSON.stringify(validClassifier),
+          tags: ["active"],
+          id: "1",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+      ]),
+    } as unknown as MuninClient;
+
+    const result = await loadActiveClassifiers(fakeMunin);
+    expect(result).toHaveLength(1);
+    expect(result[0].classId).toBe("test-class");
+  });
+
+  it("skips invalid entries silently (does not throw)", async () => {
+    const fakeMunin = {
+      query: vi.fn().mockResolvedValue({
+        results: [
+          {
+            namespace: "routes/_classifier",
+            key: "bad-class/active",
+            content_preview: "",
+            tags: ["active"],
+            id: "2",
+            entry_type: "state",
+            created_at: "2026-01-01T00:00:00Z",
+            updated_at: "2026-01-01T00:00:00Z",
+          },
+        ],
+        total: 1,
+      }),
+      readBatch: vi.fn().mockResolvedValue([
+        {
+          found: true,
+          namespace: "routes/_classifier",
+          key: "bad-class/active",
+          content: JSON.stringify({ invalid: "data" }),
+          tags: ["active"],
+          id: "2",
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+      ]),
+    } as unknown as MuninClient;
+
+    const result = await loadActiveClassifiers(fakeMunin);
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
Implements the eval-gated skill-distillation system per `docs/design/skill-distillation-implementation.md` (merged in #89). **Closes #79, #80, #81, #82, #83**; substantially implements **#84** (selection orchestrator + contract — see "remaining" below).

Built as a shared foundation + 5 artifact modules (5 parallel sub-agents, integrated onto one canonical `refs.ts`) + a fail-closed orchestrator.

## What's here (`src/skill/`)
- **`refs.ts`** — canonical-JSON content hashing (deterministic sha256) + shared schemas (lifecycle, failureKind/stage, egressClass, tupleRef, calibratedMetrics, drift helper). The hash agreement that makes drift detection work.
- **#79** `route-binding-schema.ts` + `route-binding-store.ts` — RouteBinding + ValidationRun; pure `transition()` (full lifecycle, re-promotion needs a fresh runHash), `isSelectable()` (active + no-drift + sensitivity-ceiling), write-once `recordValidationRun()`, `demoteOnDrift()`.
- **#80** `procedure-package-schema.ts` + `profile-compiler.ts` — portable package + deterministic `pi-local-30b` profile compiler; self-excluding `profileHash`.
- **#81** `retrieval-schema.ts` + `retrieval.ts` — procedural-retrieval row + fail-closed abstention (munin-down / below-threshold / ambiguous-top-two / not-selectable; hard-negatives excluded).
- **#82** `task-classifier-schema.ts` + `task-classifier.ts` — first-class classifier; `effectiveSensitivityCeiling` proven over all 27 sensitivity triples to only **constrain**, never raise (security invariant).
- **#83** `eval-suite-schema.ts` + `eval-runner.ts` — anti-Goodhart suite (≥1 independent oracle enforced at schema + runtime; judge advisory-only) + offline runner with injected executor + per-fixture failure-stage recording.
- **#84** `skill-lane.ts` — fail-closed orchestrator composing classify → retrieve → select binding → selectability; emits the additive `skillRoute` audit (added to `task-result-schema.ts`). `HUGIN_SKILL_LANE` flag (default off).

## Testing
- `tsc --noEmit` clean; **877 tests green** (~205 new skill tests across all modules + the orchestrator).

## Remaining (#84 follow-ups — need infrastructure that doesn't exist yet)
- Wire `selectSkillRoute` into the dispatcher's execute path (safe no-op until artifacts exist).
- Author the slice-one content (one procedure package + cell manifest + eval fixtures) and a real local cell (ollama Qwen3-Coder-30B).
- Live local execution + grading + the `→active` promotion (gated on #77, now fixed, + a Hugin-integrated kill/restart acceptance test). Until then the lane fails closed to the cloud auto-router.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
