### PR TITLE
feat(ollama): wire orin GPU host (#97)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Content format:
 - **Reply-to:** telegram:12345678
 - **Reply-format:** summary
 - **Model:** qwen2.5:7b
-- **Ollama-host:** pi | laptop
+- **Ollama-host:** pi | laptop | orin
 - **Reasoning:** true | false
 - **Fallback:** claude | none
 - **Context-refs:** meta/conventions/status, projects/heimdall/status
@@ -74,7 +74,7 @@ Content format:
 **Task groups:** `Group:` and `Sequence:` enable multi-step task orchestration. Both are forwarded in results and heartbeats.
 
 **Ollama-specific fields:**
-- `Ollama-host:` — prefer a specific host (`pi` for local, `laptop` for remote via Tailscale). Default: auto-select.
+- `Ollama-host:` — prefer a specific host (`pi` for local, `laptop` for remote via Tailscale, `orin` for the Jetson Orin Nano GPU cell via Tailscale). Default: auto-select.
 - `Reasoning:` — `true` to force `think:true` via native `/api/chat`, `false` to force `think:false`. Omit to auto: reasoning-model families (qwen3/3.5, deepseek-r1, magistral) default to `think:false` via `/api/chat`; other models use the OpenAI-compatible endpoint unchanged. `gpt-oss` uses level-based reasoning (`low`/`medium`/`high`) and is not auto-routed — set `Reasoning:` explicitly only once Hugin supports levels.
 - `Fallback:` — `claude` to fall back to Claude on infra failures (host unreachable, 5xx); `none` (default) to fail without fallback. Semantic failure (model responds but poorly) is never retried — that's experiment data.
 - `Context-refs:` — comma-separated Munin references (`namespace/key`) to fetch and inject into the prompt. Hugin enforces Munin classification against the task/runtime trust boundary before injecting them.
@@ -86,7 +86,7 @@ Content format:
 
 **Auto-routing:** Use `Runtime: auto` to let Hugin select the runtime. The router filters by trust tier (sensitivity ceiling), availability (ollama host probes), and capabilities, then ranks by cost (free > subscription), trust (trusted > semi-trusted), and model size. Optional `Capabilities: tools, code, structured-output` narrows candidates. Explicit runtimes remain the default — `auto` is opt-in. Routing decisions are logged and included in structured results.
 
-**Pipeline tasks:** Use `Runtime: pipeline` with a `### Pipeline` section instead of `### Prompt`. Pipeline phases use runtime IDs (`claude-sdk`, `codex-spawn`, `ollama-pi`, `ollama-laptop`, or `auto`) which differ from standalone runtime names. Per-phase `Capabilities:` is supported.
+**Pipeline tasks:** Use `Runtime: pipeline` with a `### Pipeline` section instead of `### Prompt`. Pipeline phases use runtime IDs (`claude-sdk`, `codex-spawn`, `ollama-pi`, `ollama-laptop`, `ollama-orin`, or `auto`) which differ from standalone runtime names. Per-phase `Capabilities:` is supported.
 
 **Artefact delivery (`### Artifacts` manifest, issue #68):** A task may declare an `### Artifacts` section so that **Hugin (not the agent)** owns and verifies delivery of the deliverables. The agent only writes content to the declared local staging paths and must make no delivery claims.
 
@@ -260,6 +260,7 @@ claude mcp add-json hugin '{"command":"node","args":["/Users/magnus/repos/hugin/
 | `HUGIN_ALLOWED_SUBMITTERS` | `Codex,Codex-desktop,ratatoskr,Codex-web,Codex-mobile,claude-code,claude-desktop,claude-web,claude-mobile,hugin` | Comma-separated list of allowed `Submitted by:` values. Includes both current Codex-facing names and legacy `claude-*` names during the transition. Set to `*` to allow all. |
 | `OLLAMA_PI_URL` | `http://127.0.0.1:11434` | Ollama endpoint on Pi (local) |
 | `OLLAMA_LAPTOP_URL` | — | Ollama endpoint on laptop (via Tailscale, empty = disabled) |
+| `OLLAMA_ORIN_URL` | — | Ollama endpoint on Jetson Orin Nano GPU cell (via Tailscale IP 100.127.176.78, empty = disabled) |
 | `OLLAMA_DEFAULT_MODEL` | `qwen2.5:3b` | Default model for ollama tasks without explicit Model field |
 | `HUGIN_ALLOWED_EGRESS_HOSTS` | — | Comma-separated extra hosts to allow for outbound fetch (added to built-in allowlist) |
 | `HUGIN_INJECTION_POLICY` | `warn` | Prompt-injection policy for context-refs: `off` (no scan), `warn` (prepend warning banner), `block` (quarantine high-severity refs, task continues), `fail` (reject task). See `docs/security/prompt-injection-scanner.md`. |

--- a/src/egress-policy.ts
+++ b/src/egress-policy.ts
@@ -48,6 +48,7 @@ export function buildDefaultEgressHosts(input: {
   muninUrl: string;
   ollamaPiUrl?: string;
   ollamaLaptopUrl?: string;
+  ollamaOrinUrl?: string;
   extraHosts?: string[];
 }): string[] {
   const hosts = new Set<string>([
@@ -64,6 +65,7 @@ export function buildDefaultEgressHosts(input: {
     input.muninUrl,
     input.ollamaPiUrl,
     input.ollamaLaptopUrl,
+    input.ollamaOrinUrl,
   ]) {
     const host = hostFromUrl(candidate);
     if (host) hosts.add(host);

--- a/src/index.ts
+++ b/src/index.ts
@@ -253,6 +253,7 @@ const config = {
     .filter(Boolean),
   ollamaPiUrl: process.env.OLLAMA_PI_URL || "http://127.0.0.1:11434",
   ollamaLaptopUrl: process.env.OLLAMA_LAPTOP_URL || "",
+  ollamaOrinUrl: process.env.OLLAMA_ORIN_URL || "",
   ollamaDefaultModel: process.env.OLLAMA_DEFAULT_MODEL || "qwen2.5:3b",
   extraAllowedEgressHosts: (process.env.HUGIN_ALLOWED_EGRESS_HOSTS || "")
     .split(",")
@@ -410,6 +411,7 @@ const egressPolicy = installFetchEgressPolicy(
     muninUrl: config.muninUrl,
     ollamaPiUrl: config.ollamaPiUrl,
     ollamaLaptopUrl: config.ollamaLaptopUrl,
+    ollamaOrinUrl: config.ollamaOrinUrl,
     extraHosts: config.extraAllowedEgressHosts,
   }),
 );
@@ -4615,12 +4617,16 @@ console.log(`Log directory: ${LOG_DIR}`);
 configureHosts({
   piUrl: config.ollamaPiUrl,
   laptopUrl: config.ollamaLaptopUrl,
+  orinUrl: config.ollamaOrinUrl,
 });
 if (config.ollamaPiUrl) {
   console.log(`Ollama Pi: ${config.ollamaPiUrl}`);
 }
 if (config.ollamaLaptopUrl) {
   console.log(`Ollama Laptop: ${config.ollamaLaptopUrl}`);
+}
+if (config.ollamaOrinUrl) {
+  console.log(`Ollama Orin: ${config.ollamaOrinUrl}`);
 }
 console.log(`Ollama default model: ${config.ollamaDefaultModel}`);
 

--- a/src/ollama-hosts.ts
+++ b/src/ollama-hosts.ts
@@ -18,6 +18,7 @@ export interface OllamaHost {
 export interface OllamaHostsConfig {
   piUrl: string;
   laptopUrl: string; // empty string = disabled
+  orinUrl: string; // empty string = disabled
 }
 
 const CONNECT_TIMEOUT_MS = 3_000;
@@ -29,10 +30,13 @@ const hosts = new Map<string, OllamaHost>();
 let hostsConfig: OllamaHostsConfig = {
   piUrl: "http://127.0.0.1:11434",
   laptopUrl: "",
+  orinUrl: "",
 };
 
 export function configureHosts(config: OllamaHostsConfig): void {
   hostsConfig = config;
+  // Reset host entries so removed/disabled hosts do not persist across reconfiguration
+  hosts.clear();
   // Initialize host entries
   hosts.set("pi", {
     name: "pi",
@@ -45,6 +49,15 @@ export function configureHosts(config: OllamaHostsConfig): void {
     hosts.set("laptop", {
       name: "laptop",
       baseUrl: config.laptopUrl,
+      available: false,
+      models: [],
+      lastChecked: 0,
+    });
+  }
+  if (config.orinUrl) {
+    hosts.set("orin", {
+      name: "orin",
+      baseUrl: config.orinUrl,
       available: false,
       models: [],
       lastChecked: 0,
@@ -113,8 +126,8 @@ export async function resolveOllamaHost(
     }
   }
 
-  // Try all hosts in priority order: pi first (always-on), then laptop
-  const order = ["pi", "laptop"];
+  // Try all hosts in priority order: pi first (always-on), then laptop, then orin
+  const order = ["pi", "laptop", "orin"];
   for (const name of order) {
     const host = hosts.get(name);
     if (!host) continue;

--- a/src/pipeline-ir.ts
+++ b/src/pipeline-ir.ts
@@ -27,6 +27,7 @@ export const pipelineRuntimeIdSchema = z.enum([
   "codex-spawn",
   "ollama-pi",
   "ollama-laptop",
+  "ollama-orin",
 ]);
 export type PipelineRuntimeId = z.infer<typeof pipelineRuntimeIdSchema>;
 
@@ -38,7 +39,7 @@ export const pipelinePhaseIRSchema = z.object({
   taskNamespace: z.string().min(1),
   runtime: pipelineRuntimeIdSchema,
   dispatcherRuntime: z.enum(["claude", "codex", "ollama"]),
-  ollamaHost: z.enum(["pi", "laptop"]).optional(),
+  ollamaHost: z.enum(["pi", "laptop", "orin"]).optional(),
   model: z.string().min(1).optional(),
   context: z.string().min(1).optional(),
   dependsOn: z.array(z.string().min(1)),

--- a/src/pipeline-summary.ts
+++ b/src/pipeline-summary.ts
@@ -39,7 +39,7 @@ export const pipelinePhaseExecutionSummarySchema = z.object({
   taskNamespace: z.string().min(1),
   runtime: pipelineRuntimeIdSchema,
   dispatcherRuntime: z.enum(["claude", "codex", "ollama"]),
-  ollamaHost: z.enum(["pi", "laptop"]).optional(),
+  ollamaHost: z.enum(["pi", "laptop", "orin"]).optional(),
   model: z.string().min(1).optional(),
   declaredSensitivity: z.enum(["public", "internal", "private"]).optional(),
   effectiveSensitivity: z.enum(["public", "internal", "private"]).default("internal"),

--- a/src/runtime-registry.ts
+++ b/src/runtime-registry.ts
@@ -48,7 +48,7 @@ export interface RuntimeDefinition {
   costModel: CostModel;
   modelSize: ModelSize;
   capabilities: RuntimeCapability[];
-  ollamaHost?: "pi" | "laptop";
+  ollamaHost?: "pi" | "laptop" | "orin";
   defaultModel?: string;
 
   // Orthogonal policy fields (orchestrator v1, see docs/orchestrator-v1-data-model.md §6)
@@ -118,6 +118,21 @@ export const RUNTIME_REGISTRY: readonly RuntimeDefinition[] = [
     capabilities: [],
     ollamaHost: "laptop",
     defaultModel: "qwen3.5:35b-a3b",
+    provider: "ollama-local",
+    egress: "local",
+    zdrRequired: false,
+    autoEligible: true,
+    family: "one-shot",
+  },
+  {
+    id: "ollama-orin",
+    dispatcherRuntime: "ollama",
+    trustTier: "trusted",
+    costModel: "free",
+    modelSize: "small",
+    capabilities: [],
+    ollamaHost: "orin",
+    defaultModel: "qwen2.5-coder:7b",
     provider: "ollama-local",
     egress: "local",
     zdrRequired: false,

--- a/tests/ollama-hosts.test.ts
+++ b/tests/ollama-hosts.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  configureHosts,
+  resolveOllamaHost,
+  getHostStatus,
+  probeAllHosts,
+} from "../src/ollama-hosts.js";
+
+// Helper: build a minimal /api/tags response
+function tagsResponse(models: string[]) {
+  return new Response(JSON.stringify({ models: models.map((name) => ({ name })) }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  // Reset to a clean slate before each test by reconfiguring with empty URLs
+  configureHosts({ piUrl: "http://127.0.0.1:11434", laptopUrl: "", orinUrl: "" });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("configureHosts — orin", () => {
+  it("does not add orin entry when orinUrl is empty", () => {
+    configureHosts({ piUrl: "http://127.0.0.1:11434", laptopUrl: "", orinUrl: "" });
+    const status = getHostStatus();
+    const names = status.map((h) => h.name);
+    expect(names).not.toContain("orin");
+  });
+
+  it("adds orin entry when orinUrl is set", () => {
+    configureHosts({
+      piUrl: "http://127.0.0.1:11434",
+      laptopUrl: "",
+      orinUrl: "http://100.127.176.78:11434",
+    });
+    const status = getHostStatus();
+    const names = status.map((h) => h.name);
+    expect(names).toContain("orin");
+  });
+
+  it("orin entry has the correct baseUrl", () => {
+    const orinUrl = "http://100.127.176.78:11434";
+    configureHosts({ piUrl: "http://127.0.0.1:11434", laptopUrl: "", orinUrl });
+    const status = getHostStatus();
+    const orin = status.find((h) => h.name === "orin");
+    expect(orin).toBeDefined();
+    expect(orin!.baseUrl).toBe(orinUrl);
+  });
+});
+
+describe("resolveOllamaHost — orin preferred", () => {
+  const orinUrl = "http://100.127.176.78:11434";
+
+  it("resolves to orin host when preferred and available", async () => {
+    configureHosts({
+      piUrl: "http://127.0.0.1:11434",
+      laptopUrl: "",
+      orinUrl,
+    });
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (url: RequestInfo | URL) => {
+      const u = typeof url === "string" ? url : url.toString();
+      if (u.includes("100.127.176.78")) {
+        return tagsResponse(["qwen2.5-coder:7b"]);
+      }
+      return new Response("{}", { status: 503 });
+    });
+
+    const host = await resolveOllamaHost(undefined, "orin");
+    expect(host).not.toBeNull();
+    expect(host!.name).toBe("orin");
+  });
+
+  it("returns null when orin is preferred but unreachable", async () => {
+    configureHosts({
+      piUrl: "http://127.0.0.1:11434",
+      laptopUrl: "",
+      orinUrl,
+    });
+
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("Connection refused"));
+
+    const host = await resolveOllamaHost(undefined, "orin");
+    expect(host).toBeNull();
+  });
+
+  it("falls back through pi when orin not configured", async () => {
+    configureHosts({
+      piUrl: "http://127.0.0.1:11434",
+      laptopUrl: "",
+      orinUrl: "",
+    });
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      tagsResponse(["qwen2.5:3b"]),
+    );
+
+    const host = await resolveOllamaHost(undefined, "orin");
+    // orin not in registry, falls through fallback loop, pi is available
+    expect(host).not.toBeNull();
+    expect(host!.name).toBe("pi");
+  });
+});
+
+describe("resolveOllamaHost — orin in auto-selection order", () => {
+  const orinUrl = "http://100.127.176.78:11434";
+
+  it("auto-selects orin when it has the requested model and pi does not", async () => {
+    configureHosts({
+      piUrl: "http://127.0.0.1:11434",
+      laptopUrl: "",
+      orinUrl,
+    });
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (url: RequestInfo | URL) => {
+      const u = typeof url === "string" ? url : url.toString();
+      if (u.startsWith("http://127.0.0.1")) {
+        return tagsResponse(["qwen2.5:3b"]); // pi has a different model
+      }
+      if (u.includes("100.127.176.78")) {
+        return tagsResponse(["qwen2.5-coder:7b"]);
+      }
+      return new Response("{}", { status: 503 });
+    });
+
+    const host = await resolveOllamaHost("qwen2.5-coder:7b");
+    expect(host).not.toBeNull();
+    expect(host!.name).toBe("orin");
+  });
+});
+
+describe("orin negative caching", () => {
+  const orinUrl = "http://100.127.176.78:11434";
+
+  it("uses negative cache to avoid re-probing a recently-failed orin host", async () => {
+    configureHosts({
+      piUrl: "http://127.0.0.1:11434",
+      laptopUrl: "",
+      orinUrl,
+    });
+
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("Connection refused"));
+
+    // First probe
+    await resolveOllamaHost(undefined, "orin");
+    const callsAfterFirst = fetchMock.mock.calls.filter((c) => {
+      const u = typeof c[0] === "string" ? c[0] : (c[0] as URL).toString();
+      return u.includes("100.127.176.78");
+    }).length;
+
+    // Second probe (should be cached)
+    await resolveOllamaHost(undefined, "orin");
+    const callsAfterSecond = fetchMock.mock.calls.filter((c) => {
+      const u = typeof c[0] === "string" ? c[0] : (c[0] as URL).toString();
+      return u.includes("100.127.176.78");
+    }).length;
+
+    // Should not have probed orin again due to negative cache
+    expect(callsAfterSecond).toBe(callsAfterFirst);
+  });
+});
+
+describe("probeAllHosts — includes orin when configured", () => {
+  const orinUrl = "http://100.127.176.78:11434";
+
+  it("returns orin in probeAllHosts results when configured", async () => {
+    configureHosts({
+      piUrl: "http://127.0.0.1:11434",
+      laptopUrl: "",
+      orinUrl,
+    });
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      tagsResponse(["qwen2.5-coder:7b"]),
+    );
+
+    const allHosts = await probeAllHosts();
+    const names = allHosts.map((h) => h.name);
+    expect(names).toContain("orin");
+  });
+
+  it("does not return orin in probeAllHosts results when not configured", async () => {
+    configureHosts({
+      piUrl: "http://127.0.0.1:11434",
+      laptopUrl: "",
+      orinUrl: "",
+    });
+
+    vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      tagsResponse(["qwen2.5:3b"]),
+    );
+
+    const allHosts = await probeAllHosts();
+    const names = allHosts.map((h) => h.name);
+    expect(names).not.toContain("orin");
+  });
+});

--- a/tests/runtime-registry.test.ts
+++ b/tests/runtime-registry.test.ts
@@ -17,6 +17,7 @@ describe("RUNTIME_REGISTRY", () => {
     expect(ids).toContain("codex-spawn");
     expect(ids).toContain("ollama-pi");
     expect(ids).toContain("ollama-laptop");
+    expect(ids).toContain("ollama-orin");
     expect(ids).toContain("openrouter");
     expect(ids).toContain("pi-harness");
   });
@@ -108,6 +109,23 @@ describe("buildRuntimeCandidates", () => {
     lastChecked: Date.now(),
   };
 
+  const orinOffline: OllamaHost = {
+    name: "orin",
+    baseUrl: "http://100.127.176.78:11434",
+    available: false,
+    models: [],
+    lastChecked: Date.now(),
+    lastError: "Connection refused",
+  };
+
+  const orinOnline: OllamaHost = {
+    name: "orin",
+    baseUrl: "http://100.127.176.78:11434",
+    available: true,
+    models: ["qwen2.5-coder:7b", "qwen2.5:3b"],
+    lastChecked: Date.now(),
+  };
+
   it("marks cloud runtimes as always available", () => {
     const candidates = buildRuntimeCandidates([piOnline, laptopOffline]);
     const claude = candidates.find((c) => c.id === "claude-sdk");
@@ -147,6 +165,26 @@ describe("buildRuntimeCandidates", () => {
     const candidates = buildRuntimeCandidates([piOnline, laptopOffline]);
     expect(candidates.length).toBe(RUNTIME_REGISTRY.length);
   });
+
+  it("marks orin host as unavailable when probe says so", () => {
+    const candidates = buildRuntimeCandidates([piOnline, laptopOffline, orinOffline]);
+    const orin = candidates.find((c) => c.id === "ollama-orin");
+    expect(orin?.available).toBe(false);
+    expect(orin?.models).toEqual([]);
+  });
+
+  it("marks orin host as available and populates models when online", () => {
+    const candidates = buildRuntimeCandidates([piOnline, laptopOffline, orinOnline]);
+    const orin = candidates.find((c) => c.id === "ollama-orin");
+    expect(orin?.available).toBe(true);
+    expect(orin?.models).toEqual(["qwen2.5-coder:7b", "qwen2.5:3b"]);
+  });
+
+  it("handles missing orin host entry gracefully", () => {
+    const candidates = buildRuntimeCandidates([piOnline]); // no orin host
+    const orin = candidates.find((c) => c.id === "ollama-orin");
+    expect(orin?.available).toBe(false);
+  });
 });
 
 describe("orchestrator v1 policy fields", () => {
@@ -173,7 +211,7 @@ describe("orchestrator v1 policy fields", () => {
   });
 
   it("existing one-shot runtimes are auto-eligible by default", () => {
-    for (const id of ["claude-sdk", "codex-spawn", "ollama-pi", "ollama-laptop"]) {
+    for (const id of ["claude-sdk", "codex-spawn", "ollama-pi", "ollama-laptop", "ollama-orin"]) {
       const entry = getRegistryEntryById(id);
       expect(entry?.autoEligible).toBe(true);
       expect(entry?.family).toBe("one-shot");


### PR DESCRIPTION
## Summary

- Adds `orin` as a third ollama host backed by `OLLAMA_ORIN_URL` env var (Jetson Orin Nano at Tailscale IP 100.127.176.78). Empty = disabled, exact same pattern as `laptop`.
- Registers `ollama-orin` in the runtime registry (small/free/trusted, `defaultModel: qwen2.5-coder:7b`), pipeline IR, and pipeline-summary schema so it is available everywhere `ollama-laptop` is.
- Extends egress policy to auto-allowlist the Orin's Tailscale IP when the URL is set.
- 13 new tests (10 in a new `tests/ollama-hosts.test.ts`, 3 extending `tests/runtime-registry.test.ts`); suite is 938/938 green.

## Deploy follow-up (NOT in this PR — human step)

1. Install ollama on the Orin (`curl https://ollama.ai/install.sh | sh` or the JetPack CUDA build).
2. Pull the model: `ollama pull qwen2.5-coder:7b`.
3. Add to Pi's `.env`: `OLLAMA_ORIN_URL=http://100.127.176.78:11434`.
4. Restart hugin: `systemctl --user restart hugin`.
5. Smoke-test: submit a task with `Ollama-host: orin`.

## Test plan

- [x] `npm run build` — clean TypeScript compile
- [x] `npm test` — 938/938 green (66 test files)
- [x] New `tests/ollama-hosts.test.ts` covers: orin disabled when URL empty, enabled when set, correct baseUrl, resolves when preferred+available, returns null when unreachable, negative caching, probeAllHosts inclusion
- [x] `tests/runtime-registry.test.ts` extended: ollama-orin in registry, available/unavailable/missing-host cases for buildRuntimeCandidates

Closes #97 (partial — code plumbing only; hardware setup + OPF eval are follow-up tasks on the Orin unit itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)