### PR TITLE
fix(registry): orin default model 7b → 3b (7b OOMs on 8GB Orin)

### DIFF
--- a/src/runtime-registry.ts
+++ b/src/runtime-registry.ts
@@ -132,7 +132,10 @@ export const RUNTIME_REGISTRY: readonly RuntimeDefinition[] = [
     modelSize: "small",
     capabilities: [],
     ollamaHost: "orin",
-    defaultModel: "qwen2.5-coder:7b",
+    // qwen2.5-coder:7b OOMs on the 8 GB Orin Nano (contiguous CUDA buffer alloc fails;
+    // empirically verified 2026-06-15). qwen2.5-coder:3b is the largest coder model that
+    // fits and runs on GPU (~18 tok/s headless). Do not raise without re-testing on hardware.
+    defaultModel: "qwen2.5-coder:3b",
     provider: "ollama-local",
     egress: "local",
     zdrRequired: false,


### PR DESCRIPTION
## Problem
`qwen2.5-coder:7b` was set as the `ollama-orin` default in #100, but it **cannot run on the 8 GB Orin Nano** — verified on hardware today, the GPU can't allocate the ~4.37 GB contiguous CUDA buffer:
```
cudaMalloc failed: out of memory
alloc_tensor_range: failed to allocate CUDA0 buffer of size 4370558976
```
Any task defaulting to the Orin host would 500.

## Fix
Default → `qwen2.5-coder:3b`, the largest coder model that fits + runs on GPU (~18 tok/s headless).

## Hardware notes (2026-06-15)
- `qwen2.5-coder:3b` — ✅ 100% GPU, ~18 tok/s
- `qwen2.5-coder:7b` — ❌ OOM (4.37 GB CUDA buffer)
- `qwen3:4b` — ❌ OOM (2.49 GB CUDA buffer)

The Orin is empirically a hard ~3B-class cell; 4B+ needs the BosGame/Mac Studio tier.

Build + runtime-registry tests green (30/30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)