### PR TITLE
feat(homeserver): M5 gateway executor (dual-path, mock-tested)

### DIFF
--- a/src/homeserver-executor.ts
+++ b/src/homeserver-executor.ts
@@ -31,11 +31,12 @@ export interface HomeserverTaskConfig {
   gatewayBaseUrl: string; // e.g. http://127.0.0.1:8080
   apiKey: string; // Bearer token (may be "" on a keyless loopback gateway)
   path: HomeserverPath;
-  /** Required for "chat" (the model to serve). Optional for "delegate" (the gateway/ledger picks). */
+  /** Required for "chat" (the model to serve). Ignored on "delegate" (the gateway/ledger selects). */
   model?: string;
   /** Forwarded to /delegate as the ledger bucket. */
   taskType?: string;
-  /** Forwarded to /delegate to escalate the call to a frontier model when local is non-viable. */
+  /** Reserved for forward-compat: the gateway /delegate HTTP endpoint does not yet accept a
+   *  frontier model, so this is currently NOT sent. Re-wire once the gateway exposes escalation. */
   frontierModelId?: string;
   timeoutMs: number;
   maxOutputChars: number;
@@ -83,15 +84,27 @@ export interface HomeserverGatewayConfig {
  *   HOMESERVER_GATEWAY_URL      — e.g. http://127.0.0.1:8080 (required to enable)
  *   HOMESERVER_GATEWAY_API_KEY  — Bearer token (optional on a keyless loopback gateway)
  */
+/** localhost / 127.0.0.1 / ::1 — the only hosts where a keyless gateway is safe. */
+function isLoopbackUrl(url: string): boolean {
+  try {
+    const h = new URL(url).hostname.replace(/^\[|\]$/g, "");
+    return h === "localhost" || h === "127.0.0.1" || h === "::1";
+  } catch {
+    return false;
+  }
+}
+
 export function loadHomeserverGatewayConfig(
   env: NodeJS.ProcessEnv = process.env,
 ): HomeserverGatewayConfig | null {
-  const baseUrl = env.HOMESERVER_GATEWAY_URL?.trim();
-  if (!baseUrl) return null;
-  return {
-    baseUrl: baseUrl.replace(/\/$/, ""),
-    apiKey: env.HOMESERVER_GATEWAY_API_KEY?.trim() ?? "",
-  };
+  const raw = env.HOMESERVER_GATEWAY_URL?.trim();
+  if (!raw) return null;
+  const baseUrl = raw.replace(/\/$/, "");
+  const apiKey = env.HOMESERVER_GATEWAY_API_KEY?.trim() ?? "";
+  // A keyless gateway is only safe on loopback. Refuse to send unauthenticated
+  // requests to a remote/LAN/public gateway — treat it as not-configured.
+  if (!apiKey && !isLoopbackUrl(baseUrl)) return null;
+  return { baseUrl, apiKey };
 }
 
 // --- Constants ---
@@ -106,8 +119,12 @@ const SYSTEM_PROMPT =
 function parseRetryAfter(res: Response): number | null {
   const raw = res.headers.get("retry-after");
   if (!raw) return null;
+  // Retry-After is either delta-seconds or an HTTP-date (RFC 9110).
   const n = Number(raw);
-  return Number.isFinite(n) && n >= 0 ? Math.round(n) : null;
+  if (Number.isFinite(n)) return n >= 0 ? Math.round(n) : null;
+  const dateMs = Date.parse(raw);
+  if (!Number.isNaN(dateMs)) return Math.max(0, Math.round((dateMs - Date.now()) / 1000));
+  return null;
 }
 
 function buildUserMessage(task: HomeserverTaskConfig): string {
@@ -130,7 +147,11 @@ export async function executeHomeserverTask(
   const userMessage = buildUserMessage(task);
   const promptChars = SYSTEM_PROMPT.length + userMessage.length;
 
+  fs.mkdirSync(logDir, { recursive: true });
   const logStream = fs.createWriteStream(logFile, { encoding: "utf-8" });
+  // Best-effort log: never let a late stream error (ENOENT/EACCES after the dir is
+  // removed, a full disk, etc.) surface as an unhandled exception that crashes the worker.
+  logStream.on("error", () => {});
   logStream.write(
     [
       "=== Hugin Task Log (homeserver/M5) ===",
@@ -217,10 +238,11 @@ export async function executeHomeserverTask(
     const body: Record<string, unknown> =
       task.path === "delegate"
         ? {
+            // The gateway /delegate HTTP handler only accepts prompt + taskType
+            // (+ systemPrompt/maxTokens). It does NOT accept modelId or frontierModelId
+            // today, so we don't send them — see gateway-api-contract.md.
             prompt: userMessage,
             ...(task.taskType ? { taskType: task.taskType } : {}),
-            ...(task.model ? { modelId: task.model } : {}),
-            ...(task.frontierModelId ? { frontierModelId: task.frontierModelId } : {}),
           }
         : {
             model: task.model,
@@ -237,7 +259,9 @@ export async function executeHomeserverTask(
       body: JSON.stringify(body),
       signal: abortController.signal,
     });
-    clearTimeout(timer);
+    // NOTE: the abort timer stays armed until the body is fully consumed (see the
+    // finally below) — a gateway that flushes headers then stalls the body must not
+    // be able to wedge Hugin's single worker on res.json()/res.text().
 
     // Backpressure: the gateway is telling us to back off, not that the task failed.
     if (res.status === 429 || res.status === 503) {
@@ -286,7 +310,9 @@ export async function executeHomeserverTask(
         result.totalTokens = (result.promptTokens ?? 0) + (result.completionTokens ?? 0);
       }
       if (typeof outcome.metrics?.latencyMs === "number") result.inferenceMs = outcome.metrics.latencyMs;
-      result.exitCode = 0;
+      // A well-formed 200 DelegationOutcome can still report failure; don't mask fail/error
+      // as a successful Hugin execution (that would suppress retry/escalation downstream).
+      result.exitCode = outcome.outcome === "fail" || outcome.outcome === "error" ? 1 : 0;
       return finish();
     }
 
@@ -350,7 +376,6 @@ export async function executeHomeserverTask(
     }
     return finish();
   } catch (err) {
-    clearTimeout(timer);
     if (err instanceof Error && err.name === "AbortError") {
       result.exitCode = "TIMEOUT";
       appendOutput(`\n[Gateway request aborted after ${Math.round((Date.now() - startMs) / 1000)}s]\n`);
@@ -359,5 +384,8 @@ export async function executeHomeserverTask(
       appendOutput(`\n[Gateway error: ${err instanceof Error ? err.message : String(err)}]\n`);
     }
     return finish();
+  } finally {
+    // Clear the task timeout only after the response body has been fully consumed.
+    clearTimeout(timer);
   }
 }

--- a/src/homeserver-executor.ts
+++ b/src/homeserver-executor.ts
@@ -1,0 +1,363 @@
+/**
+ * Home-server (BosGame M5) executor for Hugin tasks.
+ *
+ * Speaks the home-server gateway contract documented in
+ * `docs/gateway-api-contract.md` of the home-server-inference-evaluation repo.
+ * Dual-path:
+ *   - "chat":     POST /v1/chat/completions  (OpenAI-compatible, streaming SSE) — raw inference
+ *   - "delegate": POST /delegate             (ledger-gated one-shot; returns DelegationOutcome)
+ *
+ * Bearer auth via the gateway API key. Honors gateway backpressure so Hugin's
+ * macro-router can route elsewhere instead of failing the task:
+ *   - 429 → backpressure="quota"      (RPM/TPM/daily budget)
+ *   - 503 → backpressure="admission"  (owner preempted the serial GPU) + Retry-After
+ *
+ * SCOPE: this module is intentionally standalone and is NOT yet spliced into the
+ * dispatcher's runtime union / executor-selection switch. That live-wiring is the
+ * M5 boot-day step — it needs the real box to validate end-to-end. Everything here
+ * is unit-tested against a mocked gateway so the splice is a fill-in-the-blanks job.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+// --- Types ---
+
+export type HomeserverPath = "chat" | "delegate";
+
+export interface HomeserverTaskConfig {
+  prompt: string;
+  gatewayBaseUrl: string; // e.g. http://127.0.0.1:8080
+  apiKey: string; // Bearer token (may be "" on a keyless loopback gateway)
+  path: HomeserverPath;
+  /** Required for "chat" (the model to serve). Optional for "delegate" (the gateway/ledger picks). */
+  model?: string;
+  /** Forwarded to /delegate as the ledger bucket. */
+  taskType?: string;
+  /** Forwarded to /delegate to escalate the call to a frontier model when local is non-viable. */
+  frontierModelId?: string;
+  timeoutMs: number;
+  maxOutputChars: number;
+  injectedContext?: string;
+}
+
+export type Backpressure = "none" | "quota" | "admission";
+
+export interface HomeserverExecutorResult {
+  exitCode: number | "TIMEOUT";
+  output: string;
+  logFile: string;
+  resultText: string | null;
+  promptTokens: number | null;
+  completionTokens: number | null;
+  totalTokens: number | null;
+  inferenceMs: number | null;
+  promptChars: number;
+  outputChars: number;
+  /** Gateway asked us to back off; the macro-router should route elsewhere or retry later. */
+  backpressure: Backpressure;
+  retryAfterS: number | null;
+  // --- /delegate-path metadata (null on the chat path) ---
+  delegated: boolean | null;
+  outcome: string | null; // pass | partial | fail | error | unverified
+  score: number | null;
+  decisionReason: string | null;
+  ledgerId: string | null;
+  escalated: boolean | null;
+}
+
+export interface HomeserverExecutorOptions {
+  abortController?: AbortController;
+}
+
+export interface HomeserverGatewayConfig {
+  baseUrl: string;
+  apiKey: string;
+}
+
+/**
+ * Resolve the gateway endpoint from the environment. Returns null when
+ * HOMESERVER_GATEWAY_URL is unset, so callers can cleanly fall back to other
+ * runtimes when no M5 is configured.
+ *   HOMESERVER_GATEWAY_URL      — e.g. http://127.0.0.1:8080 (required to enable)
+ *   HOMESERVER_GATEWAY_API_KEY  — Bearer token (optional on a keyless loopback gateway)
+ */
+export function loadHomeserverGatewayConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): HomeserverGatewayConfig | null {
+  const baseUrl = env.HOMESERVER_GATEWAY_URL?.trim();
+  if (!baseUrl) return null;
+  return {
+    baseUrl: baseUrl.replace(/\/$/, ""),
+    apiKey: env.HOMESERVER_GATEWAY_API_KEY?.trim() ?? "",
+  };
+}
+
+// --- Constants ---
+
+const MIN_STREAM_TIMEOUT_MS = 5_000;
+
+const SYSTEM_PROMPT =
+  "You are a task worker in the Grimnir system. Complete the task below using only the provided context. Be concise and direct.";
+
+// --- Helpers ---
+
+function parseRetryAfter(res: Response): number | null {
+  const raw = res.headers.get("retry-after");
+  if (!raw) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? Math.round(n) : null;
+}
+
+function buildUserMessage(task: HomeserverTaskConfig): string {
+  const parts: string[] = [];
+  if (task.injectedContext) parts.push("## Context\n" + task.injectedContext);
+  parts.push("## Task\n" + task.prompt);
+  return parts.join("\n\n---\n\n");
+}
+
+// --- Executor ---
+
+export async function executeHomeserverTask(
+  task: HomeserverTaskConfig,
+  taskId: string,
+  logDir: string,
+  options?: HomeserverExecutorOptions,
+): Promise<HomeserverExecutorResult> {
+  const logFile = path.join(logDir, `${taskId}.log`);
+  const startedAt = new Date().toISOString();
+  const userMessage = buildUserMessage(task);
+  const promptChars = SYSTEM_PROMPT.length + userMessage.length;
+
+  const logStream = fs.createWriteStream(logFile, { encoding: "utf-8" });
+  logStream.write(
+    [
+      "=== Hugin Task Log (homeserver/M5) ===",
+      `Task: ${taskId}`,
+      `Runtime: homeserver`,
+      `Path: ${task.path}`,
+      `Model: ${task.model ?? "(gateway-selected)"}`,
+      `Gateway: ${task.gatewayBaseUrl}`,
+      `Timeout: ${task.timeoutMs}ms`,
+      `Context injected: ${task.injectedContext ? `${task.injectedContext.length} chars` : "none"}`,
+      `Started: ${startedAt}`,
+      "===\n",
+    ].join("\n"),
+  );
+
+  let output = "";
+  const appendOutput = (text: string) => {
+    output += text;
+    if (output.length > task.maxOutputChars * 2) {
+      output = output.slice(-task.maxOutputChars);
+    }
+    logStream.write(text);
+  };
+
+  const startMs = Date.now();
+  const result: HomeserverExecutorResult = {
+    exitCode: 1,
+    output: "",
+    logFile,
+    resultText: null,
+    promptTokens: null,
+    completionTokens: null,
+    totalTokens: null,
+    inferenceMs: null,
+    promptChars,
+    outputChars: 0,
+    backpressure: "none",
+    retryAfterS: null,
+    delegated: null,
+    outcome: null,
+    score: null,
+    decisionReason: null,
+    ledgerId: null,
+    escalated: null,
+  };
+
+  const finish = async (): Promise<HomeserverExecutorResult> => {
+    result.output = output.slice(-task.maxOutputChars);
+    result.outputChars = output.length;
+    if (result.inferenceMs === null) result.inferenceMs = Date.now() - startMs;
+    const footer = [
+      "\n===",
+      `Exit code: ${result.exitCode}`,
+      `Backpressure: ${result.backpressure}${result.retryAfterS !== null ? ` (retry ${result.retryAfterS}s)` : ""}`,
+      `Duration: ${Math.round((Date.now() - startMs) / 1000)}s`,
+      `Prompt tokens: ${result.promptTokens ?? "unknown"}`,
+      `Completion tokens: ${result.completionTokens ?? "unknown"}`,
+      `Output chars: ${output.length}`,
+      `Completed: ${new Date().toISOString()}`,
+      "===\n",
+    ].join("\n");
+    logStream.write(footer);
+    await new Promise<void>((resolve) => logStream.end(() => resolve()));
+    return result;
+  };
+
+  // Wire an abort controller + timeout, honoring an externally-supplied signal.
+  const abortController = new AbortController();
+  if (options?.abortController) {
+    if (options.abortController.signal.aborted) abortController.abort();
+    else options.abortController.signal.addEventListener("abort", () => abortController.abort());
+  }
+  const timer = setTimeout(() => abortController.abort(), task.timeoutMs);
+
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (task.apiKey) headers.Authorization = `Bearer ${task.apiKey}`;
+
+  try {
+    const url =
+      task.path === "delegate"
+        ? `${task.gatewayBaseUrl}/delegate`
+        : `${task.gatewayBaseUrl}/v1/chat/completions`;
+
+    const body: Record<string, unknown> =
+      task.path === "delegate"
+        ? {
+            prompt: userMessage,
+            ...(task.taskType ? { taskType: task.taskType } : {}),
+            ...(task.model ? { modelId: task.model } : {}),
+            ...(task.frontierModelId ? { frontierModelId: task.frontierModelId } : {}),
+          }
+        : {
+            model: task.model,
+            messages: [
+              { role: "system", content: SYSTEM_PROMPT },
+              { role: "user", content: userMessage },
+            ],
+            stream: true,
+          };
+
+    const res = await fetch(url, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+      signal: abortController.signal,
+    });
+    clearTimeout(timer);
+
+    // Backpressure: the gateway is telling us to back off, not that the task failed.
+    if (res.status === 429 || res.status === 503) {
+      result.backpressure = res.status === 429 ? "quota" : "admission";
+      result.retryAfterS = parseRetryAfter(res);
+      result.exitCode = 1;
+      const detail = await res.text().catch(() => "");
+      appendOutput(
+        `[Gateway ${res.status} ${result.backpressure}${result.retryAfterS !== null ? `, retry ${result.retryAfterS}s` : ""}] ${detail}\n`,
+      );
+      return finish();
+    }
+
+    if (!res.ok) {
+      const errText = await res.text().catch(() => "");
+      appendOutput(`[Gateway HTTP ${res.status}] ${errText}\n`);
+      result.exitCode = res.status; // surface 401/403/400 as the exit code
+      return finish();
+    }
+
+    if (task.path === "delegate") {
+      // Non-streaming JSON: DelegationOutcome.
+      const outcome = (await res.json()) as {
+        delegated?: boolean;
+        escalate?: boolean;
+        outcome?: string;
+        score?: number | null;
+        output?: string;
+        decisionReason?: string;
+        ledgerId?: string;
+        metrics?: { promptTokens?: number; completionTokens?: number; latencyMs?: number };
+        frontierOutput?: string;
+      };
+      const text = outcome.output ?? outcome.frontierOutput ?? "";
+      appendOutput(text);
+      result.resultText = text.trim() || null;
+      result.delegated = outcome.delegated ?? null;
+      result.escalated = outcome.escalate ?? null;
+      result.outcome = outcome.outcome ?? null;
+      result.score = outcome.score ?? null;
+      result.decisionReason = outcome.decisionReason ?? null;
+      result.ledgerId = outcome.ledgerId ?? null;
+      result.promptTokens = outcome.metrics?.promptTokens ?? null;
+      result.completionTokens = outcome.metrics?.completionTokens ?? null;
+      if (result.promptTokens !== null || result.completionTokens !== null) {
+        result.totalTokens = (result.promptTokens ?? 0) + (result.completionTokens ?? 0);
+      }
+      if (typeof outcome.metrics?.latencyMs === "number") result.inferenceMs = outcome.metrics.latencyMs;
+      result.exitCode = 0;
+      return finish();
+    }
+
+    // Chat path: stream the OpenAI-compatible SSE body.
+    if (!res.body) {
+      appendOutput("[Gateway error: no response body]\n");
+      return finish();
+    }
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let timedOut = false;
+
+    const rawRemainingMs = task.timeoutMs - (Date.now() - startMs);
+    const remainingMs = Math.max(MIN_STREAM_TIMEOUT_MS, rawRemainingMs);
+    const streamTimer = setTimeout(() => {
+      timedOut = true;
+      reader.cancel().catch(() => {});
+    }, remainingMs);
+
+    const processLine = (line: string): void => {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith("data: ")) return;
+      const data = trimmed.slice(6).trim();
+      if (data === "[DONE]") return;
+      try {
+        const chunk = JSON.parse(data);
+        const delta = chunk.choices?.[0]?.delta?.content;
+        if (delta) appendOutput(delta);
+        if (chunk.usage) {
+          result.promptTokens = chunk.usage.prompt_tokens ?? null;
+          result.completionTokens = chunk.usage.completion_tokens ?? null;
+          result.totalTokens = chunk.usage.total_tokens ?? null;
+        }
+      } catch {
+        // skip malformed chunks
+      }
+    };
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+        for (const line of lines) processLine(line);
+      }
+      buffer += decoder.decode();
+      if (buffer) processLine(buffer);
+    } finally {
+      clearTimeout(streamTimer);
+    }
+
+    if (timedOut) {
+      result.exitCode = "TIMEOUT";
+      appendOutput("\n[Gateway streaming timed out]\n");
+    } else {
+      result.exitCode = 0;
+      result.resultText = output.trim() || null;
+    }
+    return finish();
+  } catch (err) {
+    clearTimeout(timer);
+    if (err instanceof Error && err.name === "AbortError") {
+      result.exitCode = "TIMEOUT";
+      appendOutput(`\n[Gateway request aborted after ${Math.round((Date.now() - startMs) / 1000)}s]\n`);
+    } else {
+      result.exitCode = 1;
+      appendOutput(`\n[Gateway error: ${err instanceof Error ? err.message : String(err)}]\n`);
+    }
+    return finish();
+  }
+}

--- a/tests/homeserver-executor.test.ts
+++ b/tests/homeserver-executor.test.ts
@@ -36,6 +36,18 @@ function jsonResponse(obj: unknown, status = 200, headers: Record<string, string
   });
 }
 
+/** A streaming SSE response whose bytes are split exactly at the given chunk boundaries. */
+function streamResponse(chunks: string[]): Response {
+  const enc = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(enc.encode(c));
+      controller.close();
+    },
+  });
+  return new Response(stream, { status: 200, headers: { "Content-Type": "text/event-stream" } });
+}
+
 let tmpLogDir: string;
 
 beforeEach(() => {
@@ -65,6 +77,25 @@ describe("loadHomeserverGatewayConfig", () => {
       HOMESERVER_GATEWAY_URL: "http://127.0.0.1:8080",
     } as NodeJS.ProcessEnv);
     expect(cfg).toEqual({ baseUrl: "http://127.0.0.1:8080", apiKey: "" });
+  });
+
+  it("allows a keyless gateway on loopback (localhost / 127.0.0.1 / ::1)", () => {
+    for (const url of ["http://localhost:8080", "http://127.0.0.1:8080", "http://[::1]:8080"]) {
+      expect(loadHomeserverGatewayConfig({ HOMESERVER_GATEWAY_URL: url } as NodeJS.ProcessEnv))
+        .toEqual({ baseUrl: url, apiKey: "" });
+    }
+  });
+
+  it("REFUSES a keyless gateway on a non-loopback host (returns null)", () => {
+    expect(loadHomeserverGatewayConfig({ HOMESERVER_GATEWAY_URL: "http://10.0.0.5:8080" } as NodeJS.ProcessEnv)).toBeNull();
+    expect(loadHomeserverGatewayConfig({ HOMESERVER_GATEWAY_URL: "http://m5.lan:8080" } as NodeJS.ProcessEnv)).toBeNull();
+  });
+
+  it("allows a non-loopback gateway when a key is provided", () => {
+    expect(loadHomeserverGatewayConfig({
+      HOMESERVER_GATEWAY_URL: "http://10.0.0.5:8080",
+      HOMESERVER_GATEWAY_API_KEY: "k",
+    } as NodeJS.ProcessEnv)).toEqual({ baseUrl: "http://10.0.0.5:8080", apiKey: "k" });
   });
 });
 
@@ -154,9 +185,33 @@ describe("executeHomeserverTask — delegate path", () => {
     expect(url).toBe("http://m5.test:8080/delegate");
     const body = JSON.parse((init as RequestInit).body as string);
     expect(body.taskType).toBe("extract");
-    expect(body.modelId).toBe("qwen3-coder");
-    expect(body.frontierModelId).toBe("anthropic/claude-opus-4-5");
     expect(typeof body.prompt).toBe("string");
+    // The gateway /delegate handler ignores these fields, so the executor must not send them.
+    expect(body.modelId).toBeUndefined();
+    expect(body.frontierModelId).toBeUndefined();
+  });
+
+  it("maps outcome 'fail'/'error' to a non-zero exit code, but 'unverified' to 0", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({ delegated: true, outcome: "fail", score: 0, output: "nope" }),
+    );
+    const failR = await executeHomeserverTask(makeTaskConfig({ path: "delegate" }), "delegate-fail", tmpLogDir);
+    expect(failR.exitCode).toBe(1);
+    expect(failR.outcome).toBe("fail");
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({ delegated: true, outcome: "error", output: "" }),
+    );
+    const errR = await executeHomeserverTask(makeTaskConfig({ path: "delegate" }), "delegate-error", tmpLogDir);
+    expect(errR.exitCode).toBe(1);
+
+    // 'unverified' is the gateway's normal success-without-grading case — must stay exit 0.
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({ delegated: true, outcome: "unverified", output: "ran ok" }),
+    );
+    const unvR = await executeHomeserverTask(makeTaskConfig({ path: "delegate" }), "delegate-unverified", tmpLogDir);
+    expect(unvR.exitCode).toBe(0);
+    expect(unvR.resultText).toBe("ran ok");
   });
 });
 
@@ -195,5 +250,43 @@ describe("executeHomeserverTask — backpressure & errors", () => {
     expect(result.exitCode).toBe(401);
     expect(result.backpressure).toBe("none");
     expect(result.output).toContain("401");
+  });
+
+  it("parses an HTTP-date Retry-After on 503 (not just delta-seconds)", async () => {
+    const future = new Date(Date.now() + 30_000).toUTCString();
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("busy", { status: 503, headers: { "Retry-After": future } }),
+    );
+    const r = await executeHomeserverTask(makeTaskConfig(), "bp-503-date", tmpLogDir);
+    expect(r.backpressure).toBe("admission");
+    expect(r.retryAfterS).not.toBeNull();
+    expect(r.retryAfterS!).toBeGreaterThanOrEqual(0);
+    expect(r.retryAfterS!).toBeLessThanOrEqual(31);
+  });
+});
+
+describe("executeHomeserverTask — streaming edge cases", () => {
+  it("reassembles SSE frames split across byte chunks and parses a final chunk with no trailing newline", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      streamResponse([
+        'data: {"choices":[{"delta":{"content":"hel', // frame split mid-JSON
+        'lo"}}]}\n\n',
+        // final usage frame, deliberately NOT newline-terminated
+        'data: {"choices":[{"delta":{}}],"usage":{"prompt_tokens":3,"completion_tokens":1,"total_tokens":4}}',
+      ]),
+    );
+    const r = await executeHomeserverTask(makeTaskConfig(), "chat-split", tmpLogDir);
+    expect(r.exitCode).toBe(0);
+    expect(r.resultText).toBe("hello");
+    expect(r.totalTokens).toBe(4);
+  });
+
+  it("returns cleanly (no crash) when a 200 chat response has no body", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response(null, { status: 200, headers: { "Content-Type": "text/event-stream" } }),
+    );
+    const r = await executeHomeserverTask(makeTaskConfig(), "chat-nobody", tmpLogDir);
+    expect(r.resultText).toBeNull();
+    expect(r.output).toContain("no response body");
   });
 });

--- a/tests/homeserver-executor.test.ts
+++ b/tests/homeserver-executor.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import {
+  executeHomeserverTask,
+  loadHomeserverGatewayConfig,
+  type HomeserverTaskConfig,
+} from "../src/homeserver-executor.js";
+
+function makeTaskConfig(overrides?: Partial<HomeserverTaskConfig>): HomeserverTaskConfig {
+  return {
+    prompt: "Extract the year from: born 1998.",
+    gatewayBaseUrl: "http://m5.test:8080",
+    apiKey: "owner-key",
+    path: "chat",
+    model: "qwen3-coder",
+    timeoutMs: 30_000,
+    maxOutputChars: 5_000,
+    ...overrides,
+  };
+}
+
+function sseResponse(lines: string[]): Response {
+  return new Response(lines.join(""), {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+function jsonResponse(obj: unknown, status = 200, headers: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(obj), {
+    status,
+    headers: { "Content-Type": "application/json", ...headers },
+  });
+}
+
+let tmpLogDir: string;
+
+beforeEach(() => {
+  tmpLogDir = fs.mkdtempSync(path.join(os.tmpdir(), "hugin-homeserver-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpLogDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+describe("loadHomeserverGatewayConfig", () => {
+  it("returns null when HOMESERVER_GATEWAY_URL is unset", () => {
+    expect(loadHomeserverGatewayConfig({} as NodeJS.ProcessEnv)).toBeNull();
+  });
+
+  it("parses base URL (stripping trailing slash) and api key", () => {
+    const cfg = loadHomeserverGatewayConfig({
+      HOMESERVER_GATEWAY_URL: "http://127.0.0.1:8080/",
+      HOMESERVER_GATEWAY_API_KEY: "k1",
+    } as NodeJS.ProcessEnv);
+    expect(cfg).toEqual({ baseUrl: "http://127.0.0.1:8080", apiKey: "k1" });
+  });
+
+  it("treats a missing api key as empty (keyless loopback gateway)", () => {
+    const cfg = loadHomeserverGatewayConfig({
+      HOMESERVER_GATEWAY_URL: "http://127.0.0.1:8080",
+    } as NodeJS.ProcessEnv);
+    expect(cfg).toEqual({ baseUrl: "http://127.0.0.1:8080", apiKey: "" });
+  });
+});
+
+describe("executeHomeserverTask — chat path", () => {
+  it("streams /v1/chat/completions with Bearer auth and captures usage", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      sseResponse([
+        `data: ${JSON.stringify({ choices: [{ delta: { content: "19" } }] })}\n\n`,
+        `data: ${JSON.stringify({ choices: [{ delta: { content: "98" } }] })}\n\n`,
+        `data: ${JSON.stringify({
+          choices: [{ delta: {} }],
+          usage: { prompt_tokens: 12, completion_tokens: 2, total_tokens: 14 },
+        })}\n\n`,
+        "data: [DONE]\n\n",
+      ]),
+    );
+
+    const result = await executeHomeserverTask(makeTaskConfig(), "chat-ok", tmpLogDir);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.resultText).toBe("1998");
+    expect(result.promptTokens).toBe(12);
+    expect(result.completionTokens).toBe(2);
+    expect(result.totalTokens).toBe(14);
+    expect(result.backpressure).toBe("none");
+    expect(result.delegated).toBeNull(); // chat path carries no delegate metadata
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("http://m5.test:8080/v1/chat/completions");
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer owner-key");
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.stream).toBe(true);
+    expect(body.model).toBe("qwen3-coder");
+  });
+
+  it("omits the Authorization header on a keyless gateway", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(sseResponse(["data: [DONE]\n\n"]));
+
+    await executeHomeserverTask(makeTaskConfig({ apiKey: "" }), "chat-keyless", tmpLogDir);
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers.Authorization).toBeUndefined();
+  });
+});
+
+describe("executeHomeserverTask — delegate path", () => {
+  it("POSTs /delegate and maps the DelegationOutcome", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({
+        delegated: true,
+        escalate: false,
+        taskType: "extract",
+        modelId: "qwen3-coder",
+        decisionReason: "viable (4/5 pass)",
+        outcome: "pass",
+        score: 1,
+        output: "1998",
+        ledgerId: "ledger-123",
+        metrics: { promptTokens: 45, completionTokens: 3, latencyMs: 820 },
+      }),
+    );
+
+    const result = await executeHomeserverTask(
+      makeTaskConfig({ path: "delegate", taskType: "extract", frontierModelId: "anthropic/claude-opus-4-5" }),
+      "delegate-ok",
+      tmpLogDir,
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.resultText).toBe("1998");
+    expect(result.delegated).toBe(true);
+    expect(result.escalated).toBe(false);
+    expect(result.outcome).toBe("pass");
+    expect(result.score).toBe(1);
+    expect(result.ledgerId).toBe("ledger-123");
+    expect(result.decisionReason).toBe("viable (4/5 pass)");
+    expect(result.promptTokens).toBe(45);
+    expect(result.completionTokens).toBe(3);
+    expect(result.totalTokens).toBe(48);
+    expect(result.inferenceMs).toBe(820);
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe("http://m5.test:8080/delegate");
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.taskType).toBe("extract");
+    expect(body.modelId).toBe("qwen3-coder");
+    expect(body.frontierModelId).toBe("anthropic/claude-opus-4-5");
+    expect(typeof body.prompt).toBe("string");
+  });
+});
+
+describe("executeHomeserverTask — backpressure & errors", () => {
+  it("flags 503 as admission backpressure and parses Retry-After", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("owner preempted the GPU", { status: 503, headers: { "Retry-After": "5" } }),
+    );
+
+    const result = await executeHomeserverTask(makeTaskConfig(), "bp-503", tmpLogDir);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.backpressure).toBe("admission");
+    expect(result.retryAfterS).toBe(5);
+    expect(result.resultText).toBeNull();
+  });
+
+  it("flags 429 as quota backpressure", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({ error: { message: "rpm exceeded" } }, 429),
+    );
+
+    const result = await executeHomeserverTask(makeTaskConfig(), "bp-429", tmpLogDir);
+
+    expect(result.backpressure).toBe("quota");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("surfaces 401 as the exit code without backpressure", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({ error: { message: "invalid api key" } }, 401),
+    );
+
+    const result = await executeHomeserverTask(makeTaskConfig(), "auth-401", tmpLogDir);
+
+    expect(result.exitCode).toBe(401);
+    expect(result.backpressure).toBe("none");
+    expect(result.output).toContain("401");
+  });
+});


### PR DESCRIPTION
Pre-M5 wiring prep (T3). Adds a standalone executor that speaks the home-server gateway contract (`gateway-api-contract.md` in `home-server-inference-evaluation`), so the BosGame M5 boot-day work is fill-in-the-blanks rather than design.

**`src/homeserver-executor.ts`** — dual-path:
- `chat` → streams `POST /v1/chat/completions` (OpenAI-compat SSE), raw inference
- `delegate` → `POST /delegate`, ledger-gated one-shot, maps `DelegationOutcome` (delegated/outcome/score/ledgerId/escalated/metrics)
- Bearer auth via `HOMESERVER_GATEWAY_URL` / `HOMESERVER_GATEWAY_API_KEY` (`loadHomeserverGatewayConfig`; keyless loopback supported)
- Backpressure-aware: `429`→`quota`, `503`→`admission` (+ `Retry-After`), so the macro-router can route elsewhere instead of failing the task
- Mirrors `ollama-executor.ts` (ring-buffer capture, abort/timeout, awaited log flush)

**`tests/homeserver-executor.test.ts`** — 9 tests, mocked `fetch`: chat streaming + Bearer header, keyless (no auth header), delegate-outcome mapping, 503/429 backpressure + Retry-After, 401, and the config loader. ✅ green, typechecks clean.

**Deliberately out of scope (M5-gated):** splicing this into the dispatcher's `DispatcherRuntime` union and executor-selection switch in `index.ts`. That needs the live box to validate end-to-end, so it's the documented boot-day step rather than blind wiring now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)