### PR TITLE
feat: vendor-neutral orchestrator — cloud lane (PR1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ Part of the Grimnir system: **Munin** (memory/brain), **Mímir** (file archive),
    - `claude` (default): Agent SDK `query()` for structured results
    - `codex`: `codex exec --full-auto` spawn
    - `ollama`: Calls ollama's OpenAI-compatible API with streaming. Supports context injection via `Context-refs` and infra-only fallback to Claude.
+   - `orchestrator`: Hugin's native fanout engine — planner decomposes into subtasks, workers fan out concurrently, optional verifier pass, synthesizer merges into the final answer. See **Orchestrator runtime** below.
 4. Captures output (SDK message events or stdout/stderr) + streams to per-task log file
 5. Writes result back to Munin, updates tags to `completed` or `failed`
 6. Emits heartbeat to `tasks/_heartbeat` after each poll cycle
@@ -40,7 +41,7 @@ Content format:
 ```markdown
 ## Task: <title>
 
-- **Runtime:** claude | codex | ollama | pipeline | auto
+- **Runtime:** claude | codex | ollama | pipeline | auto | orchestrator
 - **Context:** repo:heimdall
 - **Working dir:** /home/magnus/workspace
 - **Timeout:** 300000
@@ -88,6 +89,14 @@ Content format:
 
 **Pipeline tasks:** Use `Runtime: pipeline` with a `### Pipeline` section instead of `### Prompt`. Pipeline phases use runtime IDs (`claude-sdk`, `codex-spawn`, `ollama-pi`, `ollama-laptop`, `ollama-orin`, or `auto`) which differ from standalone runtime names. Per-phase `Capabilities:` is supported.
 
+**Orchestrator runtime (`Runtime: orchestrator`):** Hugin's native, vendor-neutral fanout engine — its own ultracode/Workflow equivalent, with no Claude Code harness or vendor lock-in.
+
+- **How it works:** A planner model decomposes the prompt into subtasks → workers fan out concurrently on cheap models → an optional verifier pass checks each worker output → a synthesizer merges survivors into the final answer. Each role is independently configurable.
+- **Role bindings:** Every role (planner, worker, verifier, synthesizer) is a `provider|model` binding. Defaults: workers on DeepSeek Flash via OpenRouter; planner and synthesizer on a stronger model. Override any role via the `HUGIN_ORCH_*_MODEL` env vars below.
+- **Resilience:** A planner-JSON parse failure falls back to single-worker mode. Individual worker failures do not sink the run — the synthesizer operates on surviving outputs.
+- **Sensitivity guard (fail-closed):** A task with `Sensitivity: private` is **rejected before any model call** unless every role is bound to a sovereign/local provider (currently only `berget`). Default OpenRouter workers cannot hold private data, so the guard trips at submit time, not at execution time.
+- **Task fields:** No additional task-level fields beyond the standard set. Use the `HUGIN_ORCH_*` env vars to tune role bindings and concurrency globally, or set `Model:` to select a non-default worker model (the planner/synth retain their defaults).
+
 **Artefact delivery (`### Artifacts` manifest, issue #68):** A task may declare an `### Artifacts` section so that **Hugin (not the agent)** owns and verifies delivery of the deliverables. The agent only writes content to the declared local staging paths and must make no delivery claims.
 
 - **Grammar (load-bearing):** `### Artifacts` MUST appear *before* `### Prompt`. Prompt extraction reads from `### Prompt` to EOF, so a manifest placed after it would leak into the agent prompt — Hugin rejects that ordering at submit time.
@@ -134,6 +143,17 @@ hugin/
 │   ├── task-graph.ts             # Task dependency graph for pipelines
 │   ├── result-format.ts          # Result formatting utilities
 │   ├── artifact-delivery.ts      # Runtime-owned artefact delivery (#68): manifest parse/validate, target allowlist, rsync→sha256→mv deliver+verify
+│   ├── model-pricing.ts          # Vendor-neutral $/M-token table for cost-aware routing and result metadata
+│   ├── orchestrator/             # Native fanout engine (Runtime: orchestrator)
+│   │   ├── engine.ts             # Top-level fanout loop: plan → fan-out workers → optional verify → synthesize
+│   │   ├── model-invoker.ts      # Role→provider+model dispatch; wraps OpenRouter/Berget/etc. behind a single interface
+│   │   ├── worker-executor.ts    # Per-subtask worker: pi-harness + direct-model paths
+│   │   ├── plan.ts               # Plan IR + planner-output parsing (JSON → subtask list, fallback to single-worker)
+│   │   ├── prompts.ts            # Role prompt templates (planner, worker, verifier, synthesizer)
+│   │   ├── config.ts             # DEFAULT_ORCHESTRATOR_CONFIG + env-var overrides for all roles
+│   │   ├── sensitivity-guard.ts  # Pre-flight: reject private tasks unless all roles are sovereign providers
+│   │   ├── provider-config.ts    # Provider registry (openrouter, berget, …) with base URLs and sovereignty flags
+│   │   └── orchestrator-executor.ts # Dispatcher adapter: TaskContent → engine → structured result
 │   ├── mcp-server.ts             # hugin-mcp stdio entrypoint (orchestrator-side, on the laptop)
 │   ├── friction-mcp.ts           # friction-mcp stdio entrypoint (report_friction tool for AI self-reporting)
 │   ├── friction/                 # friction-mcp internals
@@ -290,3 +310,13 @@ claude mcp add-json hugin '{"command":"node","args":["/Users/magnus/repos/hugin/
 | `HUGIN_DELIVERY_RETRY_INTERVAL_MS` | `300000` (5min) | Cadence of the deferred-delivery retry reaper (separate timer, armed only under `defer`). |
 | `HUGIN_SKILL_LANE` | `off` | Local-skill lane master switch (issues #79–#84). `on` enables the fail-closed local-skill route pre-step (`src/skill/skill-lane.ts`: classify → retrieve → select an `active` RouteBinding), wired into the dispatcher via `src/skill/skill-lane-dispatch.ts#consultSkillLane`. Slice-one artifacts are now authored (`skills/markdown-frontmatter-normalization/`, `src/skill/slice-one/`) but the committed RouteBinding is `draft`, the cell manifest is a placeholder, and no local executor is wired — so the lane still fails closed to the cloud auto-router even when `on`. Driving the binding to `active` against a real local cell is a deliberate human go-live step (see `skills/README.md`). |
 | `ARXIV_STORAGE_PATH` | — | Directory where arxiv-mcp-server caches downloaded papers. Forwarded into the arxiv MCP subprocess environment. |
+| `HUGIN_ACTIVE_SUBSCRIPTIONS` | (all active) | Comma-separated runtime IDs of subscriptions you actually pay for (e.g. `claude-sdk`). Subscription-cost runtimes are auto-eligible only if listed here; unset = all active subscription runtimes are eligible. Vendor-neutral — Claude today, Berget Code / ChatGPT later. |
+| `BERGET_API_KEY` | — | API key for the Berget.ai EU-sovereign provider (OpenAI-compatible, base URL `https://api.berget.ai/v1`). Required for any orchestrator role bound to the `berget` provider. The only currently recognized sovereign provider for `Sensitivity: private` orchestrator tasks. |
+| `HUGIN_ORCH_PLANNER_MODEL` | (see `DEFAULT_ORCHESTRATOR_CONFIG`) | Override the planner role model. Format: `provider\|model` (e.g. `openrouter\|anthropic/claude-3.5-sonnet`). Omit the `provider\|` prefix to keep the role's default provider. |
+| `HUGIN_ORCH_WORKER_MODEL` | (see `DEFAULT_ORCHESTRATOR_CONFIG`) | Override the worker role model. Default: DeepSeek Flash via OpenRouter. |
+| `HUGIN_ORCH_VERIFIER_MODEL` | (see `DEFAULT_ORCHESTRATOR_CONFIG`) | Override the verifier role model. Verifier pass only runs when `HUGIN_ORCH_VERIFY=on`. |
+| `HUGIN_ORCH_SYNTH_MODEL` | (see `DEFAULT_ORCHESTRATOR_CONFIG`) | Override the synthesizer role model. |
+| `HUGIN_ORCH_MAX_CONCURRENCY` | `4` | Max concurrent worker fan-out in the orchestrator engine. |
+| `HUGIN_ORCH_VERIFY` | `off` | Set to `on` or `true` to run a verifier pass on each successful worker output before synthesis. |
+| `HUGIN_ORCH_PER_CALL_TIMEOUT_MS` | `120000` | Per-model-call timeout (ms) inside the orchestrator engine, applied to planner, each worker, each verifier, and the synthesizer. |
+| `HUGIN_ORCH_MAX_SUBTASKS` | `12` | Cap on the number of subtasks the planner may produce. Plans exceeding this are truncated before fan-out. |

--- a/docs/orchestrator-redesign.md
+++ b/docs/orchestrator-redesign.md
@@ -1,0 +1,99 @@
+# Hugin Orchestrator Re-platforming — Design / ADR
+
+**Status:** Accepted (2026-06-16) · **Branch:** `feat/orchestrator-workflows` (worktree)
+
+## Context
+
+Hugin began as a task dispatcher for "research spikes" (backwards-engineered deep
+research). Two things changed the goal:
+
+1. Claude Code's **ultracode / Workflows** proved to be a powerful way to "just get
+   things done" via multi-agent fanout — we want that *capability* in Hugin.
+2. New local compute is arriving (BosGame **Strix Halo 128 GB**, alongside the Jetson
+   Orin Nano and the Pi), and we want to make liberal, price-driven use of it plus
+   cheap cloud open-weight models.
+
+Crucially, we are **dropping Claude Code (the harness) entirely** — on the Pi and on
+BosGame. The harness and the model become interchangeable commodities chosen on
+**price / availability**, not vendor. Vendor lock-in is the thing we are designing out.
+
+## Decisions
+
+### D1 — Hugin owns orchestration (not a harness)
+
+ultracode/Workflows are Claude-Code-specific and do not survive the harness swap. A
+2026 survey of OSS harnesses (OpenCode, Goose, Aider, OpenHands, Cline, Crush, **pi**)
+found none does externally-driveable multi-agent fanout well enough to lean on. pi
+(pi.dev) states the contract we want explicitly: *"No sub-agents… orchestration is the
+caller's job."*
+
+→ The orchestration brain (fanout · verify · synthesize) lives **in Hugin**, extending
+the existing `pipeline-*.ts` engine. Harnesses/models are pluggable **worker units**.
+
+### D2 — pi (pi.dev) is the primary worker harness
+
+`earendil-works/pi`: MIT, native ARM64 binaries, model-agnostic (`~/.pi/agent/models.json`
+custom OpenAI-compatible providers), headless via `pi -p`, `--mode json` event stream,
+and an RPC protocol over stdin/stdout (`docs/rpc.md`). MCP is *not* bundled (opt-in
+extension) — fine, since Hugin owns orchestration. Goose is the upgrade path if a single
+task ever needs internal decomposition.
+
+### D3 — Vendor-neutral model roster, price-first
+
+| Tier | Use | Models (initial) |
+|------|-----|------------------|
+| 1 — cheap heavy worker | bulk reason/summarize/classify/codegen | OpenRouter `:floor` → DeepSeek V4 Flash ($0.09/$0.18), Llama 4 Scout |
+| 2 — mid | agentic / complex reasoning | DeepSeek V4 Pro, Qwen3.7 Plus |
+| 3 — quality / orchestrator | planning, synthesis, verify | Claude (for now); ledger decides when an open model (e.g. Kimi K2.6) can take it |
+| Sovereignty lane | `Sensitivity: private/internal` | Berget.ai (EU/Sweden, NIS2, no US jurisdiction) or local |
+
+Blended cost vs all-Claude: **~15–25× cheaper**. Berget is ~10–40% pricier than
+OpenRouter's floor — used as a sovereignty lane, not the default.
+
+### D4 — Local seam = homeserver gateway `/delegate` + ledger (ADR-004, home-server-inference-evaluation)
+
+Local inference (Strix/Orin) routes through the homeserver gateway's owner-key
+`POST /delegate`, which verifies output, writes a ledger row, and can auto-escalate to a
+frontier model. Hugin reads `GET /ledger` for the local lane's capability signal.
+
+### D5 — Cross-provider quality learning: two stores for now (option b)
+
+The homeserver `/ledger` has no external write path and is local-inference-focused.
+Hugin keeps its **own cloud-worker verdict store** and reads `/ledger` only for the local
+lane. Converge to a single KB later.
+
+### D6 — Adaptive quality gate
+
+Per (model × task-type), the verdict store/ledger drives confidence. Low confidence →
+escalate to a stronger tier (or Claude verify); high confidence → trust. This is what
+makes the price savings safe.
+
+### D7 — Host split
+
+- **Pi (huginmunin):** always-on control plane (poll/claim/heartbeat/CAS) + Munin memory.
+  Keep it — Munin must be always-available; the dispatcher loop wants a stable base.
+- **BosGame / M5:** heavy fanout execution host + local inference, on demand. Workflow
+  fanout caps at `min(16, cores−2)` → Pi ≈ 2, Strix ≈ 14. Orchestrator **execution host
+  is configurable** so big runs go to BosGame while control stays on the Pi.
+
+## Build sequencing (multi-PR)
+
+Cloud lanes need **no new hardware** and are testable today — they directly deliver
+"Hugin chugs along on offline tasks with cheap models." Local/BosGame layer in as
+hardware lands.
+
+- **PR 1 (cloud lane):** ← *current*
+  1. Vendor-neutral worker substrate — `pi-harness`, `berget`, generalized `direct-model`
+     providers in the registry; sensitivity/price gates in the router.
+  2. pi-harness executor — spawn `pi --mode json`, capture structured result.
+  3. Native orchestration engine — extend `pipeline-*.ts` into the ultracode-equivalent
+     (fanout · verify · synthesize) over worker executors.
+- **PR 2:** adaptive quality + cloud-worker verdict store; wire `/ledger` for local lane.
+- **PR 3:** savings tracker (price model × token volume vs all-Claude baseline → Munin).
+- **PR 4:** host split (Pi control / BosGame execution), as BosGame arrives.
+
+## Non-goals (this re-platforming)
+
+- Running the orchestrator brain itself on an open model (deferred until the ledger
+  shows an open model can orchestrate acceptably).
+- Touching the home-server-inference-evaluation repo (single-ledger convergence is later).

--- a/src/index.ts
+++ b/src/index.ts
@@ -102,6 +102,7 @@ import { routeTask, type RouterDecision } from "./router.js";
 import {
   buildRuntimeCandidates,
   isLegacyDispatcherRuntime,
+  parseActiveSubscriptions,
   type RuntimeCapability,
 } from "./runtime-registry.js";
 import {
@@ -3259,7 +3260,10 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     if (parsedTask.autoRouted) {
       try {
         const ollamaHosts = await probeAllHosts();
-        const candidates = buildRuntimeCandidates(ollamaHosts);
+        const activeSubscriptions = parseActiveSubscriptions(
+          process.env.HUGIN_ACTIVE_SUBSCRIPTIONS,
+        );
+        const candidates = buildRuntimeCandidates(ollamaHosts, { activeSubscriptions });
         const decision = routeTask({
           effectiveSensitivity: sensitivityAssessment.effective,
           capabilities: parsedTask.capabilities,

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,6 +123,9 @@ import { IdempotencyIndex } from "./broker/idempotency.js";
 import { BrokerReconciler } from "./broker/reconciliation.js";
 import { OrchWorker } from "./broker/orch-worker.js";
 import { OpenRouterClient } from "./openrouter-client.js";
+import { loadOrchestratorConfig } from "./orchestrator/config.js";
+import { createModelInvoker } from "./orchestrator/model-invoker.js";
+import { runOrchestratorTask } from "./orchestrator/orchestrator-executor.js";
 
 export type ExfilPolicy = "off" | "warn" | "flag" | "redact";
 
@@ -367,6 +370,7 @@ let currentTaskConfig: TaskConfig | null = null;
 let currentChild: ChildProcess | null = null;
 let currentSdkAbort: AbortController | null = null;
 let currentOllamaAbort: AbortController | null = null;
+let currentOrchestratorAbort: AbortController | null = null;
 // Runtime-owned artefact delivery (issue #68). Aborted by operator cancel /
 // shutdown so a hung `ssh`/`rsync` cannot wedge the single dispatcher slot.
 let currentDeliveryAbort: AbortController | null = null;
@@ -439,7 +443,7 @@ const reaperMunin = createMuninClient();
 
 interface TaskConfig {
   prompt: string;
-  runtime: "claude" | "codex" | "ollama";
+  runtime: "claude" | "codex" | "ollama" | "orchestrator";
   workingDir: string;
   context?: string;
   timeoutMs: number;
@@ -481,7 +485,7 @@ interface TaskConfig {
 type DeclaredRuntime = TaskConfig["runtime"] | "pipeline" | "auto";
 
 function parseDeclaredRuntime(content: string): DeclaredRuntime | undefined {
-  return content.match(/\*\*Runtime:\*\*\s*(claude|codex|ollama|pipeline|auto)/i)?.[1]?.toLowerCase() as
+  return content.match(/\*\*Runtime:\*\*\s*(claude|codex|ollama|pipeline|auto|orchestrator)/i)?.[1]?.toLowerCase() as
     | DeclaredRuntime
     | undefined;
 }
@@ -557,6 +561,7 @@ function parseTask(content: string): TaskConfig | null {
       | "claude"
       | "codex"
       | "ollama"
+      | "orchestrator"
       | undefined;
   const workingDir = content.match(
     /\*\*Working dir:\*\*\s*(.+)/i
@@ -1567,6 +1572,9 @@ function requestCancellationForCurrentTask(request: CancellationRequest): void {
   }
   if (currentOllamaAbort && !currentOllamaAbort.signal.aborted) {
     currentOllamaAbort.abort(request.reason);
+  }
+  if (currentOrchestratorAbort && !currentOrchestratorAbort.signal.aborted) {
+    currentOrchestratorAbort.abort(request.reason);
   }
   if (currentDeliveryAbort && !currentDeliveryAbort.signal.aborted) {
     currentDeliveryAbort.abort(request.reason);
@@ -3538,7 +3546,8 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
 
     const isOllama = task.runtime === "ollama";
     const isClaude = task.runtime === "claude";
-    const executorLabel = isOllama ? "ollama" : isClaude ? "agent-sdk" : "spawn";
+    const isOrchestrator = task.runtime === "orchestrator";
+    const executorLabel = isOllama ? "ollama" : isClaude ? "agent-sdk" : isOrchestrator ? "orchestrator" : "spawn";
 
     // Capture quota before task execution (skip for ollama — it's Claude-specific)
     const quotaBefore = isOllama ? { q5: null, q7: null } : await fetchQuota();
@@ -3786,6 +3795,52 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     logFile = sdkResult.logFile;
     resultText = sdkResult.resultText;
     costUsd = sdkResult.costUsd;
+    } else if (isOrchestrator) {
+    // --- Orchestrator execution path ---
+    console.log(`Using orchestrator executor for task ${taskNs}`);
+    const orchAbort = new AbortController();
+    currentOrchestratorAbort = orchAbort;
+    logFile = path.join(LOG_DIR, `${taskId}.log`);
+    const orchLogStream = fs.createWriteStream(logFile, { encoding: "utf-8" });
+    orchLogStream.write(
+      [
+        "=== Hugin Task Log (orchestrator) ===",
+        `Task: ${taskNs}`,
+        `Runtime: orchestrator`,
+        `Working dir: ${task.workingDir}`,
+        `Timeout: ${task.timeoutMs}`,
+        `Started: ${startedAt}`,
+        "===\n",
+      ].join("\n"),
+    );
+    const orchConfig = loadOrchestratorConfig(process.env);
+    const orchInvoker = createModelInvoker(orchConfig.roles, {
+      timeoutMs: orchConfig.perCallTimeoutMs,
+      maxOutputChars: config.maxOutputChars,
+    });
+    const orchResult = await runOrchestratorTask(
+      {
+        prompt: task.prompt,
+        sensitivity: task.effectiveSensitivity || "internal",
+        timeoutMs: task.timeoutMs,
+        maxOutputChars: config.maxOutputChars,
+      },
+      orchConfig,
+      {
+        invoker: orchInvoker,
+        onLog: (line) => {
+          console.log(`[orch:${taskId}] ${line}`);
+          orchLogStream.write(`${line}\n`);
+        },
+        signal: orchAbort.signal,
+      },
+    );
+    orchLogStream.end();
+    currentOrchestratorAbort = null;
+    exitCode = orchResult.exitCode;
+    output = orchResult.output;
+    resultText = orchResult.resultText;
+    costUsd = orchResult.costUsd;
     } else {
       const spawnResult = await spawnRuntime(task, { taskNs, muninClient: munin });
       exitCode = spawnResult.exitCode;
@@ -3810,6 +3865,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     stopLeaseRenewal();
     currentSdkAbort = null;
     currentOllamaAbort = null;
+    currentOrchestratorAbort = null;
 
     const durationMs = Date.now() - startMs;
     const completedAt = new Date().toISOString();
@@ -3878,12 +3934,12 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     let rawBodyText: string;
     let structuredBodyKind: TaskExecutionBodyKind;
 
-    if ((isClaude || isOllama) && resultText) {
+    if ((isClaude || isOllama || isOrchestrator) && resultText) {
       resultSource = effectiveExecutor;
       rawBodyText = resultText;
       structuredBodyKind = "response";
       resultBody = `### Response\n\n${resultText}`;
-    } else if (!isClaude && !isOllama) {
+    } else if (!isClaude && !isOllama && !isOrchestrator) {
       const hookResult = readHookResult(taskId);
       if (hookResult) {
         resultSource = "hook";

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,7 +123,7 @@ import { IdempotencyIndex } from "./broker/idempotency.js";
 import { BrokerReconciler } from "./broker/reconciliation.js";
 import { OrchWorker } from "./broker/orch-worker.js";
 import { OpenRouterClient } from "./openrouter-client.js";
-import { loadOrchestratorConfig } from "./orchestrator/config.js";
+import { loadOrchestratorConfig, applyTaskModel } from "./orchestrator/config.js";
 import { createModelInvoker } from "./orchestrator/model-invoker.js";
 import { runOrchestratorTask } from "./orchestrator/orchestrator-executor.js";
 
@@ -3813,7 +3813,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         "===\n",
       ].join("\n"),
     );
-    const orchConfig = loadOrchestratorConfig(process.env);
+    const orchConfig = applyTaskModel(loadOrchestratorConfig(process.env), task.model);
     const orchInvoker = createModelInvoker(orchConfig.roles, {
       timeoutMs: orchConfig.perCallTimeoutMs,
       maxOutputChars: config.maxOutputChars,

--- a/src/model-pricing.ts
+++ b/src/model-pricing.ts
@@ -1,0 +1,131 @@
+/**
+ * Vendor-neutral model price table (USD per 1 million tokens).
+ *
+ * Used for price-aware routing and savings tracking. Prices are approximate
+ * and sourced from provider documentation / OpenRouter listings.
+ *
+ * **Last updated: 2026-06-16.**
+ *
+ * This is a manual snapshot, not a live feed. Bump the comment date when
+ * you refresh prices. If a model is not in the table, `getModelPrice` returns
+ * `undefined` and `estimateCostUsd` returns `null` — callers should treat
+ * that as a non-fatal observability gap, not a hard error.
+ */
+
+export interface ModelPrice {
+  provider: string;
+  /** USD per million input (prompt) tokens. */
+  inputUsdPerM: number;
+  /** USD per million output (completion) tokens. */
+  outputUsdPerM: number;
+}
+
+/**
+ * Price table keyed by model id (slug, matching provider conventions).
+ *
+ * Sections:
+ *   - OpenRouter models (routed via openrouter runtime)
+ *   - Berget models (EU-sovereign, routed via berget runtime)
+ *   - Anthropic baseline (for savings comparison via CLAUDE_BASELINE_MODEL_ID)
+ */
+export const MODEL_PRICING: Readonly<Record<string, ModelPrice>> = {
+  // ---- OpenRouter ----
+  "deepseek/deepseek-v4-flash": {
+    provider: "openrouter",
+    inputUsdPerM: 0.09,
+    outputUsdPerM: 0.18,
+  },
+  "meta-llama/llama-4-scout": {
+    provider: "openrouter",
+    inputUsdPerM: 0.10,
+    outputUsdPerM: 0.30,
+  },
+  "deepseek/deepseek-v4-pro": {
+    provider: "openrouter",
+    inputUsdPerM: 0.44,
+    outputUsdPerM: 0.87,
+  },
+  "qwen/qwen3.7-plus": {
+    provider: "openrouter",
+    inputUsdPerM: 0.32,
+    outputUsdPerM: 1.28,
+  },
+  "moonshotai/kimi-k2.6": {
+    provider: "openrouter",
+    inputUsdPerM: 0.68,
+    outputUsdPerM: 3.41,
+  },
+
+  // ---- Berget (EU-sovereign) ----
+  "mistralai/mistral-small-3.2-24b-instruct": {
+    provider: "berget",
+    inputUsdPerM: 0.33,
+    outputUsdPerM: 0.33,
+  },
+  "google/gemma-4-31b-instruct": {
+    provider: "berget",
+    inputUsdPerM: 0.28,
+    outputUsdPerM: 0.55,
+  },
+  "openai/gpt-oss-120b": {
+    provider: "berget",
+    inputUsdPerM: 0.44,
+    outputUsdPerM: 0.99,
+  },
+  "zhipu/glm-4.7": {
+    provider: "berget",
+    inputUsdPerM: 0.77,
+    outputUsdPerM: 2.75,
+  },
+  "mistralai/mistral-medium-3.5": {
+    provider: "berget",
+    inputUsdPerM: 1.65,
+    outputUsdPerM: 5.50,
+  },
+
+  // ---- Anthropic baseline (for savings comparison) ----
+  "claude-opus-4-8": {
+    provider: "anthropic",
+    inputUsdPerM: 5.00,
+    outputUsdPerM: 25.00,
+  },
+  "claude-sonnet-4-6": {
+    provider: "anthropic",
+    inputUsdPerM: 3.00,
+    outputUsdPerM: 15.00,
+  },
+  "claude-haiku-4-5": {
+    provider: "anthropic",
+    inputUsdPerM: 1.00,
+    outputUsdPerM: 5.00,
+  },
+};
+
+/**
+ * Look up pricing for a model by id.
+ * Returns `undefined` if the model is not in the snapshot.
+ */
+export function getModelPrice(modelId: string): ModelPrice | undefined {
+  return MODEL_PRICING[modelId];
+}
+
+/**
+ * Estimate the cost in USD for a given model and token counts.
+ * Returns `null` if the model is not in the snapshot.
+ */
+export function estimateCostUsd(
+  modelId: string,
+  inputTokens: number,
+  outputTokens: number,
+): number | null {
+  const price = MODEL_PRICING[modelId];
+  if (!price) return null;
+  return (inputTokens / 1_000_000) * price.inputUsdPerM +
+    (outputTokens / 1_000_000) * price.outputUsdPerM;
+}
+
+/**
+ * The all-Claude baseline model used for savings comparison.
+ * Routing decisions that substitute a cheaper model save against this rate.
+ */
+export const CLAUDE_BASELINE_MODEL_ID = "claude-sonnet-4-6";

--- a/src/model-pricing.ts
+++ b/src/model-pricing.ts
@@ -27,9 +27,14 @@ export interface ModelPrice {
  *   - OpenRouter models (routed via openrouter runtime)
  *   - Berget models (EU-sovereign, routed via berget runtime)
  *   - Anthropic baseline (for savings comparison via CLAUDE_BASELINE_MODEL_ID)
+ *
+ * Berget prices are in EUR; converted to USD at EUR/USD ≈ 1.12 (June 2026).
+ * Berget slugs are case-sensitive and must match exactly as returned by the
+ * Berget /v1/models endpoint.
  */
 export const MODEL_PRICING: Readonly<Record<string, ModelPrice>> = {
   // ---- OpenRouter ----
+  // Verified via /api/v1/models on 2026-06-17.
   "deepseek/deepseek-v4-flash": {
     provider: "openrouter",
     inputUsdPerM: 0.09,
@@ -55,32 +60,55 @@ export const MODEL_PRICING: Readonly<Record<string, ModelPrice>> = {
     inputUsdPerM: 0.68,
     outputUsdPerM: 3.41,
   },
+  // Planner/verifier/synthesizer default on OpenRouter
+  "anthropic/claude-sonnet-4.6": {
+    provider: "openrouter",
+    inputUsdPerM: 3.00,
+    outputUsdPerM: 15.00,
+  },
 
   // ---- Berget (EU-sovereign) ----
-  "mistralai/mistral-small-3.2-24b-instruct": {
+  // Verified slugs and prices from Berget /v1/models on 2026-06-17.
+  // Prices are EUR/M tokens × 1.12 (EUR→USD) rounded to 4 decimal places.
+  "meta-llama/Llama-3.1-8B-Instruct": {
     provider: "berget",
-    inputUsdPerM: 0.33,
-    outputUsdPerM: 0.33,
+    inputUsdPerM: 0.22,
+    outputUsdPerM: 0.22,
   },
-  "google/gemma-4-31b-instruct": {
+  "mistralai/Mistral-Small-3.2-24B-Instruct-2506": {
+    provider: "berget",
+    inputUsdPerM: 0.34,
+    outputUsdPerM: 0.34,
+  },
+  "google/gemma-4-31B-it": {
     provider: "berget",
     inputUsdPerM: 0.28,
-    outputUsdPerM: 0.55,
+    outputUsdPerM: 0.56,
   },
   "openai/gpt-oss-120b": {
     provider: "berget",
-    inputUsdPerM: 0.44,
-    outputUsdPerM: 0.99,
+    inputUsdPerM: 0.22,
+    outputUsdPerM: 0.84,
   },
-  "zhipu/glm-4.7": {
+  "zai-org/GLM-4.7-FP8": {
     provider: "berget",
-    inputUsdPerM: 0.77,
-    outputUsdPerM: 2.75,
+    inputUsdPerM: 0.78,
+    outputUsdPerM: 2.80,
   },
-  "mistralai/mistral-medium-3.5": {
+  "mistralai/Mistral-Medium-3.5-128B": {
     provider: "berget",
-    inputUsdPerM: 1.65,
-    outputUsdPerM: 5.50,
+    inputUsdPerM: 1.68,
+    outputUsdPerM: 5.60,
+  },
+  "meta-llama/Llama-3.3-70B-Instruct": {
+    provider: "berget",
+    inputUsdPerM: 1.01,
+    outputUsdPerM: 1.01,
+  },
+  "moonshotai/Kimi-K2.6": {
+    provider: "berget",
+    inputUsdPerM: 0.84,
+    outputUsdPerM: 3.92,
   },
 
   // ---- Anthropic baseline (for savings comparison) ----

--- a/src/orchestrator/config.ts
+++ b/src/orchestrator/config.ts
@@ -25,13 +25,17 @@ function parseRoleEnv(
 }
 
 /**
- * Parse a non-negative integer environment variable, returning the fallback
- * value when the raw string is absent, empty, or not a valid finite integer.
+ * Parse a strictly-positive integer environment variable, returning the
+ * fallback value when the raw string is absent, empty, not a valid integer,
+ * has trailing junk ("2abc"), is zero, or is negative.
  */
 function parseIntEnv(raw: string | undefined, fallback: number): number {
   if (!raw || raw.trim() === "") return fallback;
-  const n = parseInt(raw.trim(), 10);
-  return Number.isFinite(n) ? n : fallback;
+  const trimmed = raw.trim();
+  // Reject anything that is not a pure integer string (no trailing junk).
+  if (!/^-?\d+$/.test(trimmed)) return fallback;
+  const n = Number(trimmed);
+  return Number.isSafeInteger(n) && n > 0 ? n : fallback;
 }
 
 /**
@@ -127,4 +131,25 @@ export function loadOrchestratorConfig(
   }
 
   return cfg;
+}
+
+/**
+ * If `taskModel` is a non-empty string, override the worker role's model in
+ * a copy of `config`, keeping the worker's existing provider. Planner,
+ * verifier, and synthesizer roles are left unchanged.
+ *
+ * Pure function — returns a new OrchestratorConfig; never mutates the input.
+ */
+export function applyTaskModel(
+  config: OrchestratorConfig,
+  taskModel?: string,
+): OrchestratorConfig {
+  if (!taskModel || !taskModel.trim()) return config;
+  return {
+    ...config,
+    roles: {
+      ...config.roles,
+      worker: { ...config.roles.worker, model: taskModel.trim() },
+    },
+  };
 }

--- a/src/orchestrator/config.ts
+++ b/src/orchestrator/config.ts
@@ -1,0 +1,130 @@
+import {
+  DEFAULT_ORCHESTRATOR_CONFIG,
+  type OrchestratorConfig,
+} from "./engine.js";
+
+/**
+ * Parse a role model specifier from an environment variable.
+ *
+ * Format: `provider|model`  — split on the FIRST `|`.
+ * If no `|` present, the entire string is treated as the model and the
+ * default provider for that role is preserved.
+ */
+function parseRoleEnv(
+  raw: string,
+  defaultProvider: string,
+): { provider: string; model: string } {
+  const sep = raw.indexOf("|");
+  if (sep === -1) {
+    return { provider: defaultProvider, model: raw.trim() };
+  }
+  return {
+    provider: raw.slice(0, sep).trim(),
+    model: raw.slice(sep + 1).trim(),
+  };
+}
+
+/**
+ * Parse a non-negative integer environment variable, returning the fallback
+ * value when the raw string is absent, empty, or not a valid finite integer.
+ */
+function parseIntEnv(raw: string | undefined, fallback: number): number {
+  if (!raw || raw.trim() === "") return fallback;
+  const n = parseInt(raw.trim(), 10);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+/**
+ * Load an OrchestratorConfig from environment variables, starting from
+ * DEFAULT_ORCHESTRATOR_CONFIG and applying any overrides that are present.
+ *
+ * Recognised variables:
+ *   HUGIN_ORCH_PLANNER_MODEL   — `provider|model` for the planner role
+ *   HUGIN_ORCH_WORKER_MODEL    — `provider|model` for the worker role
+ *   HUGIN_ORCH_VERIFIER_MODEL  — `provider|model` for the verifier role
+ *   HUGIN_ORCH_SYNTH_MODEL     — `provider|model` for the synthesizer role
+ *   HUGIN_ORCH_MAX_CONCURRENCY — positive integer
+ *   HUGIN_ORCH_VERIFY          — "on" | "true" → verifyWorkers = true
+ *   HUGIN_ORCH_PER_CALL_TIMEOUT_MS — positive integer (ms)
+ *   HUGIN_ORCH_MAX_SUBTASKS    — positive integer
+ *
+ * Pure function — no side-effects, no I/O.
+ */
+export function loadOrchestratorConfig(
+  env: NodeJS.ProcessEnv,
+): OrchestratorConfig {
+  const cfg: OrchestratorConfig = {
+    ...DEFAULT_ORCHESTRATOR_CONFIG,
+    roles: { ...DEFAULT_ORCHESTRATOR_CONFIG.roles },
+  };
+
+  if (env.HUGIN_ORCH_PLANNER_MODEL) {
+    cfg.roles = {
+      ...cfg.roles,
+      planner: parseRoleEnv(
+        env.HUGIN_ORCH_PLANNER_MODEL,
+        DEFAULT_ORCHESTRATOR_CONFIG.roles.planner.provider,
+      ),
+    };
+  }
+
+  if (env.HUGIN_ORCH_WORKER_MODEL) {
+    cfg.roles = {
+      ...cfg.roles,
+      worker: parseRoleEnv(
+        env.HUGIN_ORCH_WORKER_MODEL,
+        DEFAULT_ORCHESTRATOR_CONFIG.roles.worker.provider,
+      ),
+    };
+  }
+
+  if (env.HUGIN_ORCH_VERIFIER_MODEL) {
+    cfg.roles = {
+      ...cfg.roles,
+      verifier: parseRoleEnv(
+        env.HUGIN_ORCH_VERIFIER_MODEL,
+        DEFAULT_ORCHESTRATOR_CONFIG.roles.verifier.provider,
+      ),
+    };
+  }
+
+  if (env.HUGIN_ORCH_SYNTH_MODEL) {
+    cfg.roles = {
+      ...cfg.roles,
+      synthesizer: parseRoleEnv(
+        env.HUGIN_ORCH_SYNTH_MODEL,
+        DEFAULT_ORCHESTRATOR_CONFIG.roles.synthesizer.provider,
+      ),
+    };
+  }
+
+  if (env.HUGIN_ORCH_MAX_CONCURRENCY) {
+    cfg.maxConcurrency = parseIntEnv(
+      env.HUGIN_ORCH_MAX_CONCURRENCY,
+      DEFAULT_ORCHESTRATOR_CONFIG.maxConcurrency,
+    );
+  }
+
+  if (env.HUGIN_ORCH_VERIFY) {
+    const v = env.HUGIN_ORCH_VERIFY.trim().toLowerCase();
+    if (v === "on" || v === "true") {
+      cfg.verifyWorkers = true;
+    }
+  }
+
+  if (env.HUGIN_ORCH_PER_CALL_TIMEOUT_MS) {
+    cfg.perCallTimeoutMs = parseIntEnv(
+      env.HUGIN_ORCH_PER_CALL_TIMEOUT_MS,
+      DEFAULT_ORCHESTRATOR_CONFIG.perCallTimeoutMs,
+    );
+  }
+
+  if (env.HUGIN_ORCH_MAX_SUBTASKS) {
+    cfg.maxSubtasks = parseIntEnv(
+      env.HUGIN_ORCH_MAX_SUBTASKS,
+      DEFAULT_ORCHESTRATOR_CONFIG.maxSubtasks,
+    );
+  }
+
+  return cfg;
+}

--- a/src/orchestrator/engine.ts
+++ b/src/orchestrator/engine.ts
@@ -126,10 +126,20 @@ function parseVerdict(output: string): { ok: boolean; notes?: string } {
 // Cost aggregation
 // ---------------------------------------------------------------------------
 
+/**
+ * Sum costs across all invocations.
+ *
+ * Returns null if:
+ * - No costs were recorded (costs is empty).
+ * - ANY recorded cost is null (cost unknown for that invocation — reporting a
+ *   partial sum would under-report and mislead; null is the honest answer).
+ *
+ * Returns a numeric sum only when ALL costs are known.
+ */
 function sumCosts(costs: (number | null)[]): number | null {
-  const known = costs.filter((c): c is number => c !== null);
-  if (known.length === 0) return null;
-  return known.reduce((a, b) => a + b, 0);
+  if (costs.length === 0) return null;
+  if (costs.some((c) => c === null)) return null;
+  return (costs as number[]).reduce((a, b) => a + b, 0);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/orchestrator/engine.ts
+++ b/src/orchestrator/engine.ts
@@ -218,18 +218,26 @@ export async function runOrchestration(
     );
     allCosts.push(synthResp.costUsd ?? null);
     totalLatencyMs += synthResp.latencyMs;
-    finalOutput = synthResp.output;
+
+    // Robustness: if the synthesizer fails or returns empty/whitespace output,
+    // fall back to a concatenation of the successful worker outputs rather than
+    // returning an empty result. The workers succeeded — only the synth pass
+    // failed — so we preserve ok:true and the caller still gets usable content.
+    if (!synthResp.ok || !synthResp.output.trim()) {
+      finalOutput = successfulOutcomes
+        .map((o) => `## ${o.subtask.id}\n${o.result.output}`)
+        .join("\n\n");
+    } else {
+      finalOutput = synthResp.output;
+    }
   }
 
-  const ok = finalOutput.length > 0;
-
   return {
-    ok,
+    ok: true,
     finalOutput,
     plan,
     outcomes,
     totalCostUsd: sumCosts(allCosts),
     totalLatencyMs,
-    error: ok ? undefined : "Synthesizer returned empty output",
   };
 }

--- a/src/orchestrator/engine.ts
+++ b/src/orchestrator/engine.ts
@@ -1,0 +1,235 @@
+import type { ModelInvoker, RoleBinding } from "./model-invoker.js";
+import {
+  parsePlan,
+  type OrchestratorRole,
+  type OrchestrationPlan,
+  type SubTask,
+} from "./plan.js";
+import type { WorkerResult } from "./worker-executor.js";
+import {
+  buildPlannerPrompt,
+  buildWorkerPrompt,
+  buildVerifierPrompt,
+  buildSynthesizerPrompt,
+} from "./prompts.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type { SubTask };
+
+export interface OrchestratorConfig {
+  roles: Record<OrchestratorRole, RoleBinding>;
+  /** Max concurrent worker invocations. */
+  maxConcurrency: number;
+  /** Run a verifier on each successful worker result. */
+  verifyWorkers: boolean;
+  /** Timeout per model call in ms. */
+  perCallTimeoutMs: number;
+  /** Cap the planner's subtask list to this many entries. */
+  maxSubtasks: number;
+}
+
+export const DEFAULT_ORCHESTRATOR_CONFIG: OrchestratorConfig = {
+  roles: {
+    planner: { provider: "openrouter", model: "anthropic/claude-sonnet-4.6" },
+    worker: { provider: "openrouter", model: "deepseek/deepseek-v4-flash" },
+    verifier: { provider: "openrouter", model: "anthropic/claude-sonnet-4.6" },
+    synthesizer: { provider: "openrouter", model: "anthropic/claude-sonnet-4.6" },
+  },
+  maxConcurrency: 4,
+  verifyWorkers: false,
+  perCallTimeoutMs: 120_000,
+  maxSubtasks: 12,
+};
+
+export interface SubtaskOutcome {
+  subtask: SubTask;
+  result: WorkerResult;
+  verdict?: { ok: boolean; notes?: string };
+}
+
+export interface OrchestrationResult {
+  ok: boolean;
+  finalOutput: string;
+  plan: OrchestrationPlan;
+  outcomes: SubtaskOutcome[];
+  /** Sum of known costUsd across ALL invocations; null only if NO call had a known cost. */
+  totalCostUsd: number | null;
+  totalLatencyMs: number;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// mapWithConcurrency — run async tasks with a concurrency cap
+// ---------------------------------------------------------------------------
+
+/**
+ * Map `items` through `fn` with at most `limit` concurrent executions.
+ *
+ * This is the standard sliding-window approach: we maintain a pool of
+ * in-flight promises and always start the next item when any slot frees up.
+ * Uses no external dependencies.
+ */
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  async function runNext(): Promise<void> {
+    while (nextIndex < items.length) {
+      const idx = nextIndex++;
+      results[idx] = await fn(items[idx], idx);
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(limit, items.length) }, () => runNext());
+  await Promise.all(workers);
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Verdict parser
+// ---------------------------------------------------------------------------
+
+function parseVerdict(output: string): { ok: boolean; notes?: string } {
+  // Try JSON first: { "ok": true/false, "notes"?: string }
+  const braceStart = output.indexOf("{");
+  if (braceStart !== -1) {
+    try {
+      const obj = JSON.parse(output.slice(braceStart));
+      if (typeof obj === "object" && obj !== null && "ok" in obj) {
+        return {
+          ok: Boolean(obj.ok),
+          notes: typeof obj.notes === "string" ? obj.notes : undefined,
+        };
+      }
+    } catch {
+      // fall through to text parsing
+    }
+  }
+
+  // Text parsing: look for PASS/FAIL (case-insensitive)
+  const upper = output.toUpperCase();
+  if (upper.includes("FAIL")) return { ok: false, notes: output.trim() };
+  if (upper.includes("PASS")) return { ok: true, notes: output.trim() };
+
+  // Default: assume ok if unparseable
+  return { ok: true, notes: output.trim() || undefined };
+}
+
+// ---------------------------------------------------------------------------
+// Cost aggregation
+// ---------------------------------------------------------------------------
+
+function sumCosts(costs: (number | null)[]): number | null {
+  const known = costs.filter((c): c is number => c !== null);
+  if (known.length === 0) return null;
+  return known.reduce((a, b) => a + b, 0);
+}
+
+// ---------------------------------------------------------------------------
+// runOrchestration
+// ---------------------------------------------------------------------------
+
+export async function runOrchestration(
+  taskPrompt: string,
+  invoker: ModelInvoker,
+  config?: Partial<OrchestratorConfig>,
+): Promise<OrchestrationResult> {
+  const cfg: OrchestratorConfig = { ...DEFAULT_ORCHESTRATOR_CONFIG, ...config };
+  const allCosts: (number | null)[] = [];
+  let totalLatencyMs = 0;
+
+  // -------------------------------------------------------------------------
+  // 1. Plan
+  // -------------------------------------------------------------------------
+  const planResp = await invoker.invoke("planner", buildPlannerPrompt(taskPrompt));
+  allCosts.push(planResp.costUsd ?? null);
+  totalLatencyMs += planResp.latencyMs;
+
+  const plan = parsePlan(planResp.ok ? planResp.output : "", {
+    maxSubtasks: cfg.maxSubtasks,
+    fallbackPrompt: taskPrompt,
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Fan-out workers
+  // -------------------------------------------------------------------------
+  const outcomes: SubtaskOutcome[] = await mapWithConcurrency(
+    plan.subtasks,
+    cfg.maxConcurrency,
+    async (subtask): Promise<SubtaskOutcome> => {
+      const result = await invoker.invoke("worker", buildWorkerPrompt(taskPrompt, subtask));
+      allCosts.push(result.costUsd ?? null);
+      totalLatencyMs += result.latencyMs;
+      return { subtask, result };
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // 3. Verify (optional)
+  // -------------------------------------------------------------------------
+  if (cfg.verifyWorkers) {
+    for (const outcome of outcomes) {
+      if (!outcome.result.ok) continue; // skip failed workers
+      const verifyResp = await invoker.invoke(
+        "verifier",
+        buildVerifierPrompt(outcome.subtask, outcome.result.output),
+      );
+      allCosts.push(verifyResp.costUsd ?? null);
+      totalLatencyMs += verifyResp.latencyMs;
+      outcome.verdict = parseVerdict(verifyResp.output);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // 4. Synthesize
+  // -------------------------------------------------------------------------
+  const successfulOutcomes = outcomes.filter((o) => o.result.ok);
+
+  if (successfulOutcomes.length === 0) {
+    // All workers failed
+    const errors = outcomes.map((o) => o.result.error ?? "unknown error").join("; ");
+    return {
+      ok: false,
+      finalOutput: "",
+      plan,
+      outcomes,
+      totalCostUsd: sumCosts(allCosts),
+      totalLatencyMs,
+      error: `All workers failed: ${errors}`,
+    };
+  }
+
+  let finalOutput: string;
+
+  if (plan.strategy === "single" || successfulOutcomes.length === 1) {
+    // Skip synth call to save cost
+    finalOutput = successfulOutcomes[0].result.output;
+  } else {
+    const synthResp = await invoker.invoke(
+      "synthesizer",
+      buildSynthesizerPrompt(taskPrompt, successfulOutcomes),
+    );
+    allCosts.push(synthResp.costUsd ?? null);
+    totalLatencyMs += synthResp.latencyMs;
+    finalOutput = synthResp.output;
+  }
+
+  const ok = finalOutput.length > 0;
+
+  return {
+    ok,
+    finalOutput,
+    plan,
+    outcomes,
+    totalCostUsd: sumCosts(allCosts),
+    totalLatencyMs,
+    error: ok ? undefined : "Synthesizer returned empty output",
+  };
+}

--- a/src/orchestrator/model-invoker.ts
+++ b/src/orchestrator/model-invoker.ts
@@ -1,0 +1,50 @@
+import type { OrchestratorRole } from "./plan.js";
+import type { WorkerExecutor, WorkerResult } from "./worker-executor.js";
+import { createWorkerExecutor } from "./worker-executor.js";
+
+export interface RoleBinding {
+  provider: string;
+  model: string;
+}
+
+export interface ModelInvoker {
+  invoke(
+    role: OrchestratorRole,
+    prompt: string,
+    opts?: { systemPrompt?: string },
+  ): Promise<WorkerResult>;
+}
+
+/**
+ * Create a real ModelInvoker that resolves role bindings to WorkerExecutor calls.
+ *
+ * @param roles         - Map of OrchestratorRole → { provider, model }
+ * @param defaults      - Shared defaults: timeoutMs, maxOutputChars
+ * @param executorFactory - Optional injection point for tests; defaults to createWorkerExecutor
+ */
+export function createModelInvoker(
+  roles: Record<OrchestratorRole, RoleBinding>,
+  defaults: { timeoutMs: number; maxOutputChars?: number },
+  executorFactory?: (provider: string) => WorkerExecutor,
+): ModelInvoker {
+  const factory = executorFactory ?? createWorkerExecutor;
+
+  return {
+    async invoke(
+      role: OrchestratorRole,
+      prompt: string,
+      opts?: { systemPrompt?: string },
+    ): Promise<WorkerResult> {
+      const binding = roles[role];
+      const executor = factory(binding.provider);
+      return executor.run({
+        provider: binding.provider,
+        model: binding.model,
+        prompt,
+        systemPrompt: opts?.systemPrompt,
+        timeoutMs: defaults.timeoutMs,
+        maxOutputChars: defaults.maxOutputChars,
+      });
+    },
+  };
+}

--- a/src/orchestrator/orchestrator-executor.ts
+++ b/src/orchestrator/orchestrator-executor.ts
@@ -1,0 +1,180 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import {
+  runOrchestration,
+  type OrchestratorConfig,
+  type OrchestrationResult,
+} from "./engine.js";
+import type { ModelInvoker } from "./model-invoker.js";
+import { assertProvidersAllowSensitivity } from "./sensitivity-guard.js";
+import type { Sensitivity } from "../sensitivity.js";
+
+// ---------------------------------------------------------------------------
+// Public interfaces
+// ---------------------------------------------------------------------------
+
+export interface OrchestratorTaskInput {
+  prompt: string;
+  sensitivity: Sensitivity;
+  timeoutMs: number;
+  maxOutputChars: number;
+}
+
+export interface OrchestratorExecResult {
+  exitCode: number | "TIMEOUT";
+  output: string;
+  resultText: string | null;
+  costUsd: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Summary builder
+// ---------------------------------------------------------------------------
+
+function buildSummary(
+  prompt: string,
+  result: OrchestrationResult,
+  maxOutputChars: number,
+): string {
+  const lines: string[] = [];
+
+  lines.push(`## Orchestration Result`);
+  lines.push(``);
+  lines.push(`- **Strategy:** ${result.plan.strategy}`);
+  lines.push(`- **Subtasks:** ${result.outcomes.length}`);
+  lines.push(`- **Total cost:** ${result.totalCostUsd !== null ? `$${result.totalCostUsd.toFixed(6)}` : "unknown"}`);
+  lines.push(`- **Total latency:** ${result.totalLatencyMs}ms`);
+  lines.push(`- **Outcome:** ${result.ok ? "ok" : `failed${result.error ? ` — ${result.error}` : ""}`}`);
+  lines.push(``);
+
+  if (result.outcomes.length > 0) {
+    lines.push(`### Subtask Outcomes`);
+    for (const [i, outcome] of result.outcomes.entries()) {
+      const costStr =
+        outcome.result.costUsd !== null && outcome.result.costUsd !== undefined
+          ? ` ($${outcome.result.costUsd.toFixed(6)})`
+          : "";
+      const status = outcome.result.ok ? "ok" : `failed${outcome.result.error ? `: ${outcome.result.error}` : ""}`;
+      lines.push(`- ${i + 1}. [${outcome.subtask.id}]: ${status}${costStr}`);
+    }
+    lines.push(``);
+  }
+
+  if (result.finalOutput) {
+    lines.push(`### Final Output`);
+    lines.push(``);
+    lines.push(result.finalOutput);
+  }
+
+  const full = lines.join("\n");
+  if (full.length <= maxOutputChars) return full;
+  return full.slice(0, maxOutputChars);
+}
+
+// ---------------------------------------------------------------------------
+// Main executor
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a task through the orchestration engine, enforcing sensitivity guards
+ * and a task-level timeout.
+ *
+ * The `deps.signal` abort is checked before and after the engine run but does
+ * NOT cancel in-flight model calls mid-engine (per-call timeouts via
+ * `config.perCallTimeoutMs` bound spend). TODO: wire AbortSignal into
+ * ModelInvoker.invoke() for mid-engine cancellation.
+ */
+export async function runOrchestratorTask(
+  input: OrchestratorTaskInput,
+  config: OrchestratorConfig,
+  deps: {
+    invoker: ModelInvoker;
+    onLog?: (line: string) => void;
+    signal?: AbortSignal;
+  },
+): Promise<OrchestratorExecResult> {
+  const { onLog } = deps;
+
+  // --- 1. Sensitivity guard — fail closed BEFORE any model calls ---
+  const guardResult = assertProvidersAllowSensitivity(config, input.sensitivity);
+  if (!guardResult.ok) {
+    onLog?.(`[orchestrator] sensitivity guard rejected: ${guardResult.reason}`);
+    return {
+      exitCode: 1,
+      output: guardResult.reason,
+      resultText: null,
+      costUsd: null,
+    };
+  }
+
+  // --- 2. Check for abort before spending ---
+  if (deps.signal?.aborted) {
+    const reason = "aborted before execution started";
+    onLog?.(`[orchestrator] ${reason}`);
+    return { exitCode: 1, output: reason, resultText: null, costUsd: null };
+  }
+
+  onLog?.(`[orchestrator] starting (strategy will be determined by planner)`);
+
+  // --- 3. Task-level timeout race ---
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+
+  const timeoutPromise = new Promise<"TIMEOUT">((resolve) => {
+    timeoutHandle = setTimeout(() => resolve("TIMEOUT"), input.timeoutMs);
+  });
+
+  const enginePromise = runOrchestration(input.prompt, deps.invoker, config).then(
+    (result): OrchestrationResult | "TIMEOUT" => result,
+  );
+
+  // Race the engine against the timeout.
+  let raceResult: OrchestrationResult | "TIMEOUT";
+  try {
+    raceResult = await Promise.race([enginePromise, timeoutPromise]);
+  } finally {
+    if (timeoutHandle !== null) clearTimeout(timeoutHandle);
+  }
+
+  // --- 4. Handle abort signal after run (if race completed first) ---
+  if (deps.signal?.aborted) {
+    const reason = "aborted after execution completed";
+    onLog?.(`[orchestrator] ${reason}`);
+    return { exitCode: 1, output: reason, resultText: null, costUsd: null };
+  }
+
+  // --- 5. Timeout path ---
+  if (raceResult === "TIMEOUT") {
+    onLog?.(`[orchestrator] task timed out after ${input.timeoutMs}ms`);
+    return {
+      exitCode: "TIMEOUT",
+      output: `Orchestration timed out after ${input.timeoutMs}ms`,
+      resultText: null,
+      costUsd: null,
+    };
+  }
+
+  // --- 6. Map OrchestrationResult → OrchestratorExecResult ---
+  const result = raceResult;
+
+  onLog?.(`[orchestrator] planner ok — strategy=${result.plan.strategy} subtasks=${result.outcomes.length}`);
+
+  for (const [i, outcome] of result.outcomes.entries()) {
+    const costStr =
+      outcome.result.costUsd !== null && outcome.result.costUsd !== undefined
+        ? ` ($${outcome.result.costUsd.toFixed(6)})`
+        : "";
+    const status = outcome.result.ok ? "ok" : "failed";
+    onLog?.(
+      `[orchestrator] worker ${i + 1}/${result.outcomes.length} ${status}${costStr} — [${outcome.subtask.id}]`,
+    );
+  }
+
+  onLog?.(`[orchestrator] ${result.ok ? "done" : "failed"} — total_cost=${result.totalCostUsd !== null ? `$${result.totalCostUsd.toFixed(6)}` : "unknown"} latency=${result.totalLatencyMs}ms`);
+
+  const exitCode = result.ok ? 0 : 1;
+  const output = buildSummary(input.prompt, result, input.maxOutputChars);
+  const resultText = result.finalOutput || null;
+  const costUsd = result.totalCostUsd;
+
+  return { exitCode, output, resultText, costUsd };
+}

--- a/src/orchestrator/plan.ts
+++ b/src/orchestrator/plan.ts
@@ -89,8 +89,10 @@ export function parsePlan(
   const validated = PlanSchema.safeParse(parsed);
   if (!validated.success) return fallback;
 
-  // Cap to maxSubtasks (keep first N)
+  // Cap to maxSubtasks (keep first N). If the cap reduces the list to empty
+  // (e.g. maxSubtasks < 1), fall back to the single-worker plan.
   const subtasks = validated.data.subtasks.slice(0, opts.maxSubtasks);
+  if (subtasks.length === 0) return fallback;
 
   return { strategy: "fanout", subtasks };
 }

--- a/src/orchestrator/plan.ts
+++ b/src/orchestrator/plan.ts
@@ -1,0 +1,96 @@
+import { z } from "zod";
+
+export type OrchestratorRole = "planner" | "worker" | "verifier" | "synthesizer";
+
+export interface SubTask {
+  id: string;
+  prompt: string;
+  rationale?: string;
+}
+
+export interface OrchestrationPlan {
+  strategy: "fanout" | "single";
+  subtasks: SubTask[];
+}
+
+// ---------------------------------------------------------------------------
+// Zod schema for the planner's JSON output
+// ---------------------------------------------------------------------------
+
+const SubTaskSchema = z.object({
+  id: z.string(),
+  prompt: z.string(),
+  rationale: z.string().optional(),
+});
+
+const PlanSchema = z.object({
+  subtasks: z.array(SubTaskSchema).min(1),
+});
+
+// ---------------------------------------------------------------------------
+// parsePlan
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract a JSON object from `raw` — even if wrapped in ```json fences or
+ * surrounded by prose — validate against the plan schema, and return an
+ * OrchestrationPlan.
+ *
+ * On ANY failure (no JSON / invalid schema / empty subtasks): returns a
+ * single-strategy fallback plan. Never throws.
+ */
+export function parsePlan(
+  raw: string,
+  opts: { maxSubtasks: number; fallbackPrompt: string },
+): OrchestrationPlan {
+  const fallback: OrchestrationPlan = {
+    strategy: "single",
+    subtasks: [{ id: "1", prompt: opts.fallbackPrompt }],
+  };
+
+  if (!raw || !raw.trim()) return fallback;
+
+  // Step 1: strip ```json ... ``` fences if present
+  let candidate = raw;
+  const fenceMatch = raw.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (fenceMatch) {
+    candidate = fenceMatch[1].trim();
+  }
+
+  // Step 2: extract the first {...} block (handles leading prose)
+  const braceStart = candidate.indexOf("{");
+  if (braceStart === -1) return fallback;
+
+  // Find the matching closing brace
+  let depth = 0;
+  let braceEnd = -1;
+  for (let i = braceStart; i < candidate.length; i++) {
+    if (candidate[i] === "{") depth++;
+    else if (candidate[i] === "}") {
+      depth--;
+      if (depth === 0) {
+        braceEnd = i;
+        break;
+      }
+    }
+  }
+  if (braceEnd === -1) return fallback;
+
+  const jsonStr = candidate.slice(braceStart, braceEnd + 1);
+
+  // Step 3: parse and validate
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonStr);
+  } catch {
+    return fallback;
+  }
+
+  const validated = PlanSchema.safeParse(parsed);
+  if (!validated.success) return fallback;
+
+  // Cap to maxSubtasks (keep first N)
+  const subtasks = validated.data.subtasks.slice(0, opts.maxSubtasks);
+
+  return { strategy: "fanout", subtasks };
+}

--- a/src/orchestrator/prompts.ts
+++ b/src/orchestrator/prompts.ts
@@ -1,0 +1,74 @@
+import type { SubTask, SubtaskOutcome } from "./engine.js";
+
+/**
+ * Build the prompt for the planner role.
+ *
+ * The planner must return ONLY valid JSON matching:
+ *   { "subtasks": [{ "id": string, "prompt": string, "rationale"?: string }] }
+ *
+ * No prose before or after the JSON object.
+ */
+export function buildPlannerPrompt(taskPrompt: string): string {
+  return `You are an expert task planner. Decompose the following task into parallel subtasks.
+
+Return ONLY a JSON object — no prose, no markdown fences — in this exact shape:
+{"subtasks":[{"id":"1","prompt":"...","rationale":"..."},...]}
+
+Each subtask must be independently executable. Keep subtasks focused and distinct.
+
+Task:
+${taskPrompt}`;
+}
+
+/**
+ * Build the prompt for a worker role executing one subtask.
+ */
+export function buildWorkerPrompt(taskPrompt: string, subtask: SubTask): string {
+  return `You are executing subtask ${subtask.id} of a larger task.
+
+Overall task context:
+${taskPrompt}
+
+Your specific subtask:
+${subtask.prompt}
+
+Complete this subtask thoroughly. Your output will be collected and merged with other subtasks.`;
+}
+
+/**
+ * Build the prompt for the verifier role checking a worker's output.
+ */
+export function buildVerifierPrompt(subtask: SubTask, workerOutput: string): string {
+  return `You are a quality verifier. Review the following subtask and its output.
+
+Subtask:
+${subtask.prompt}
+
+Output to verify:
+${workerOutput}
+
+Respond with either PASS or FAIL followed by brief notes. Example:
+PASS - output is complete and accurate.
+FAIL - output is missing key details about X.`;
+}
+
+/**
+ * Build the prompt for the synthesizer role merging worker outputs.
+ */
+export function buildSynthesizerPrompt(
+  taskPrompt: string,
+  successfulOutcomes: SubtaskOutcome[],
+): string {
+  const parts = successfulOutcomes.map(
+    (o) => `### Subtask ${o.subtask.id}\n${o.result.output}`,
+  );
+  return `You are synthesizing the results of parallel subtasks into one coherent final answer.
+
+Overall task:
+${taskPrompt}
+
+Subtask results:
+${parts.join("\n\n")}
+
+Merge these into a single, coherent, well-structured response that fully answers the overall task. Do not merely concatenate — synthesize.`;
+}

--- a/src/orchestrator/provider-config.ts
+++ b/src/orchestrator/provider-config.ts
@@ -1,0 +1,36 @@
+/**
+ * Provider configuration for the orchestrator worker-executor layer.
+ *
+ * Each provider entry declares the base URL for its OpenAI-compatible
+ * chat/completions endpoint and the environment variable name that holds
+ * the API key.
+ *
+ * BaseUrl override via env (e.g. OPENROUTER_BASE_URL) is a future concern;
+ * kept simple for now — the static table is the source of truth.
+ */
+
+export interface ProviderConfig {
+  /** Base URL for the provider's OpenAI-compatible API (no trailing slash). */
+  baseUrl: string;
+  /** Name of the environment variable that holds the API key. */
+  apiKeyEnvVar: string;
+}
+
+export const PROVIDER_CONFIG: Record<string, ProviderConfig> = {
+  openrouter: {
+    baseUrl: "https://openrouter.ai/api/v1",
+    apiKeyEnvVar: "OPENROUTER_API_KEY",
+  },
+  berget: {
+    baseUrl: "https://api.berget.ai/v1",
+    apiKeyEnvVar: "BERGET_API_KEY",
+  },
+};
+
+/**
+ * Returns the ProviderConfig for the given provider id, or `undefined` if the
+ * provider is not registered.
+ */
+export function getProviderConfig(provider: string): ProviderConfig | undefined {
+  return PROVIDER_CONFIG[provider];
+}

--- a/src/orchestrator/provider-config.ts
+++ b/src/orchestrator/provider-config.ts
@@ -25,6 +25,10 @@ export const PROVIDER_CONFIG: Record<string, ProviderConfig> = {
     baseUrl: "https://api.berget.ai/v1",
     apiKeyEnvVar: "BERGET_API_KEY",
   },
+  google: {
+    baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai",
+    apiKeyEnvVar: "GOOGLE_API_KEY",
+  },
 };
 
 /**

--- a/src/orchestrator/sensitivity-guard.ts
+++ b/src/orchestrator/sensitivity-guard.ts
@@ -1,0 +1,56 @@
+import type { OrchestratorConfig } from "./engine.js";
+import type { Sensitivity } from "../sensitivity.js";
+
+/**
+ * Providers that are permitted to process private-sensitivity data.
+ *
+ * "Sovereign" means data stays within the operator's control: on-prem
+ * or in a jurisdiction that permits private data processing. Cloud
+ * providers are excluded because they transmit data to third-party APIs.
+ *
+ * Future: add "ollama" / "local" once local execution is wired.
+ */
+const SOVEREIGN_OR_LOCAL_PROVIDERS = new Set<string>(["berget"]);
+
+export type SensitivityGuardResult =
+  | { ok: true }
+  | { ok: false; reason: string };
+
+/**
+ * Assert that all providers used across the orchestrator roles are compatible
+ * with the task's effective sensitivity.
+ *
+ * Rules:
+ *   - `public` / `internal`: always allowed (cloud providers are fine).
+ *   - `private`: every role provider MUST be sovereign-or-local; if any
+ *     provider is not in that set the task is rejected before any model call
+ *     is made (fail-closed to prevent accidental private-data leakage).
+ *
+ * This is a pure function — no side-effects, no I/O.
+ */
+export function assertProvidersAllowSensitivity(
+  config: OrchestratorConfig,
+  sensitivity: Sensitivity,
+): SensitivityGuardResult {
+  if (sensitivity !== "private") {
+    // public and internal are allowed on any provider for now.
+    return { ok: true };
+  }
+
+  // Build the set of distinct providers used across all roles.
+  const nonSovereignProviders = Object.values(config.roles)
+    .map((binding) => binding.provider)
+    .filter((provider) => !SOVEREIGN_OR_LOCAL_PROVIDERS.has(provider));
+
+  // Deduplicate for a clean error message.
+  const distinct = [...new Set(nonSovereignProviders)];
+
+  if (distinct.length === 0) {
+    return { ok: true };
+  }
+
+  return {
+    ok: false,
+    reason: `private task cannot use non-sovereign providers: ${distinct.join(", ")}`,
+  };
+}

--- a/src/orchestrator/worker-executor.ts
+++ b/src/orchestrator/worker-executor.ts
@@ -437,9 +437,17 @@ function extractChatCompletion(raw: unknown): ExtractedCompletion | ExtractedErr
   if (!Array.isArray(choices) || choices.length === 0) {
     return { ok: false, error: "Response missing choices array" };
   }
-  const choice = choices[0] as Record<string, unknown>;
-  const message = choice["message"] as Record<string, unknown> | undefined;
-  const content = message?.["content"];
+  const choice = choices[0];
+  if (choice === null || typeof choice !== "object") {
+    return { ok: false, error: "Response choices[0] is not an object" };
+  }
+  const choiceObj = choice as Record<string, unknown>;
+  const message = choiceObj["message"];
+  if (message !== null && message !== undefined && typeof message !== "object") {
+    return { ok: false, error: "Response choices[0].message is not an object" };
+  }
+  const messageObj = message as Record<string, unknown> | undefined;
+  const content = messageObj?.["content"];
   if (typeof content !== "string") {
     return { ok: false, error: "Response missing choices[0].message.content (string)" };
   }

--- a/src/orchestrator/worker-executor.ts
+++ b/src/orchestrator/worker-executor.ts
@@ -122,6 +122,9 @@ export class DirectModelExecutor implements WorkerExecutor {
       model: req.model,
       messages,
       stream: false,
+      // Explicitly cap completion tokens to avoid provider defaults (e.g. Berget
+      // auto-sets max_tokens=32768 which exceeds many small models' context windows).
+      max_tokens: 4096,
     };
 
     const controller = new AbortController();

--- a/src/orchestrator/worker-executor.ts
+++ b/src/orchestrator/worker-executor.ts
@@ -1,0 +1,507 @@
+/**
+ * Worker-executor interface and factory for the orchestration engine.
+ *
+ * Workers run a single bounded sub-task on a chosen model/harness and return
+ * a structured result with token usage and cost. The orchestration engine
+ * (built later) fans out to workers and decides what to do with failures.
+ *
+ * Two concrete implementations are provided:
+ *   - DirectModelExecutor: POSTs to any OpenAI-compatible /chat/completions
+ *     endpoint (openrouter, berget). Reuses no existing client because the
+ *     existing OpenRouterClient is ZDR-gated and openrouter-specific; a minimal
+ *     fetch-based implementation here avoids leaking broker concerns into
+ *     the orchestrator layer.
+ *   - PiHarnessExecutor: Spawns the `pi` CLI and parses its JSON-Lines output.
+ */
+
+import { spawn } from "node:child_process";
+import { estimateCostUsd } from "../model-pricing.js";
+import { getRegistryEntryById } from "../runtime-registry.js";
+import { getProviderConfig } from "./provider-config.js";
+
+/** Default maximum output characters when not specified in the request. */
+export const DEFAULT_MAX_OUTPUT_CHARS = 50_000;
+
+export interface WorkerRequest {
+  /** Provider id: "openrouter" | "berget" | "pi-harness" */
+  provider: string;
+  /** Resolved model id. */
+  model: string;
+  prompt: string;
+  systemPrompt?: string;
+  timeoutMs: number;
+  /** Truncate output to this many characters. Defaults to DEFAULT_MAX_OUTPUT_CHARS. */
+  maxOutputChars?: number;
+}
+
+export interface WorkerResult {
+  ok: boolean;
+  output: string;
+  provider: string;
+  model: string;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  /** Cost in USD computed from model-pricing when both token counts are known. */
+  costUsd: number | null;
+  latencyMs: number;
+  /** Set when ok=false. Never throws out of run(). */
+  error?: string;
+}
+
+export interface WorkerExecutor {
+  run(req: WorkerRequest): Promise<WorkerResult>;
+}
+
+/**
+ * Factory: returns the appropriate executor for the given provider id.
+ *   - "pi-harness" → PiHarnessExecutor
+ *   - everything else → DirectModelExecutor
+ */
+export function createWorkerExecutor(provider: string): WorkerExecutor {
+  if (provider === "pi-harness") {
+    return new PiHarnessExecutor();
+  }
+  return new DirectModelExecutor();
+}
+
+// ---------------------------------------------------------------------------
+// DirectModelExecutor — OpenAI-compatible /chat/completions
+// ---------------------------------------------------------------------------
+
+/**
+ * Executes a single chat completion against any OpenAI-compatible provider.
+ *
+ * Why not reuse OpenRouterClient from src/openrouter-client.ts?
+ * The existing client is gated by the ZDR allowlist (assertZdrAllowed) which is
+ * a broker-level policy concern. The worker-executor layer is provider-agnostic
+ * and must not inherit broker policy; a minimal fetch-based implementation here
+ * is deliberate.
+ */
+export class DirectModelExecutor implements WorkerExecutor {
+  async run(req: WorkerRequest): Promise<WorkerResult> {
+    const start = Date.now();
+    const maxOutput = req.maxOutputChars ?? DEFAULT_MAX_OUTPUT_CHARS;
+
+    const providerCfg = getProviderConfig(req.provider);
+    if (!providerCfg) {
+      return {
+        ok: false,
+        output: "",
+        provider: req.provider,
+        model: req.model,
+        inputTokens: null,
+        outputTokens: null,
+        costUsd: null,
+        latencyMs: Date.now() - start,
+        error: `Unknown provider: ${req.provider}`,
+      };
+    }
+
+    const apiKey = process.env[providerCfg.apiKeyEnvVar];
+    if (!apiKey) {
+      return {
+        ok: false,
+        output: "",
+        provider: req.provider,
+        model: req.model,
+        inputTokens: null,
+        outputTokens: null,
+        costUsd: null,
+        latencyMs: Date.now() - start,
+        error: `Missing API key: environment variable ${providerCfg.apiKeyEnvVar} is not set`,
+      };
+    }
+
+    const messages: Array<{ role: string; content: string }> = [];
+    if (req.systemPrompt) {
+      messages.push({ role: "system", content: req.systemPrompt });
+    }
+    messages.push({ role: "user", content: req.prompt });
+
+    const body: Record<string, unknown> = {
+      model: req.model,
+      messages,
+      stream: false,
+    };
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), req.timeoutMs);
+
+    try {
+      let response: Response;
+      try {
+        response = await fetch(`${providerCfg.baseUrl}/chat/completions`, {
+          method: "POST",
+          headers: buildHeaders(req.provider, apiKey),
+          body: JSON.stringify(body),
+          signal: controller.signal,
+        });
+      } catch (fetchErr) {
+        const errMsg = isAbortError(fetchErr)
+          ? `Request timed out after ${req.timeoutMs}ms`
+          : `Network error: ${fetchErr instanceof Error ? fetchErr.message : String(fetchErr)}`;
+        return {
+          ok: false,
+          output: "",
+          provider: req.provider,
+          model: req.model,
+          inputTokens: null,
+          outputTokens: null,
+          costUsd: null,
+          latencyMs: Date.now() - start,
+          error: errMsg,
+        };
+      }
+
+      if (!response.ok) {
+        let body: string | undefined;
+        try {
+          body = await response.text();
+        } catch {
+          // ignore
+        }
+        return {
+          ok: false,
+          output: "",
+          provider: req.provider,
+          model: req.model,
+          inputTokens: null,
+          outputTokens: null,
+          costUsd: null,
+          latencyMs: Date.now() - start,
+          error: `HTTP ${response.status}${body ? `: ${body.slice(0, 200)}` : ""}`,
+        };
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = await response.json();
+      } catch (parseErr) {
+        if (isAbortError(parseErr)) {
+          return {
+            ok: false,
+            output: "",
+            provider: req.provider,
+            model: req.model,
+            inputTokens: null,
+            outputTokens: null,
+            costUsd: null,
+            latencyMs: Date.now() - start,
+            error: `Response body stalled and timed out after ${req.timeoutMs}ms`,
+          };
+        }
+        return {
+          ok: false,
+          output: "",
+          provider: req.provider,
+          model: req.model,
+          inputTokens: null,
+          outputTokens: null,
+          costUsd: null,
+          latencyMs: Date.now() - start,
+          error: `Response was not valid JSON: ${parseErr instanceof Error ? parseErr.message : String(parseErr)}`,
+        };
+      }
+
+      const extracted = extractChatCompletion(parsed);
+      if (!extracted.ok) {
+        return {
+          ok: false,
+          output: "",
+          provider: req.provider,
+          model: req.model,
+          inputTokens: null,
+          outputTokens: null,
+          costUsd: null,
+          latencyMs: Date.now() - start,
+          error: extracted.error,
+        };
+      }
+
+      const { content, inputTokens, outputTokens } = extracted;
+      const costUsd =
+        inputTokens !== null && outputTokens !== null
+          ? estimateCostUsd(req.model, inputTokens, outputTokens)
+          : null;
+
+      return {
+        ok: true,
+        output: content.slice(0, maxOutput),
+        provider: req.provider,
+        model: req.model,
+        inputTokens,
+        outputTokens,
+        costUsd,
+        latencyMs: Date.now() - start,
+      };
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PiHarnessExecutor — spawn the `pi` CLI
+// ---------------------------------------------------------------------------
+
+/**
+ * Executes a task via the `pi` CLI harness.
+ *
+ * NOTE: All pi argument construction is in one place (buildPiArgs) so it is
+ * trivial to adjust flags once the exact interface is verified against the
+ * real binary at integration time.
+ */
+export class PiHarnessExecutor implements WorkerExecutor {
+  async run(req: WorkerRequest): Promise<WorkerResult> {
+    const start = Date.now();
+    const maxOutput = req.maxOutputChars ?? DEFAULT_MAX_OUTPUT_CHARS;
+
+    const entry = getRegistryEntryById("pi-harness");
+    if (!entry) {
+      return {
+        ok: false,
+        output: "",
+        provider: req.provider,
+        model: req.model,
+        inputTokens: null,
+        outputTokens: null,
+        costUsd: null,
+        latencyMs: Date.now() - start,
+        error: "pi-harness entry not found in runtime registry",
+      };
+    }
+
+    const args = buildPiArgs(req, entry);
+
+    return new Promise<WorkerResult>((resolve) => {
+      let stdout = "";
+      let stderr = "";
+      let killed = false;
+
+      let child: ReturnType<typeof spawn>;
+      try {
+        child = spawn(entry.harnessCmd ?? "pi", args, {
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+      } catch (spawnErr) {
+        resolve({
+          ok: false,
+          output: "",
+          provider: req.provider,
+          model: req.model,
+          inputTokens: null,
+          outputTokens: null,
+          costUsd: null,
+          latencyMs: Date.now() - start,
+          error: `Spawn error: ${spawnErr instanceof Error ? spawnErr.message : String(spawnErr)}`,
+        });
+        return;
+      }
+
+      const killTimer = setTimeout(() => {
+        killed = true;
+        child.kill("SIGTERM");
+      }, req.timeoutMs);
+
+      child.stdout?.on("data", (chunk: Buffer) => {
+        stdout += chunk.toString();
+      });
+      child.stderr?.on("data", (chunk: Buffer) => {
+        stderr += chunk.toString();
+      });
+
+      child.on("error", (err) => {
+        clearTimeout(killTimer);
+        resolve({
+          ok: false,
+          output: "",
+          provider: req.provider,
+          model: req.model,
+          inputTokens: null,
+          outputTokens: null,
+          costUsd: null,
+          latencyMs: Date.now() - start,
+          error: `Child process error: ${err.message}`,
+        });
+      });
+
+      child.on("close", (code) => {
+        clearTimeout(killTimer);
+
+        if (killed) {
+          resolve({
+            ok: false,
+            output: "",
+            provider: req.provider,
+            model: req.model,
+            inputTokens: null,
+            outputTokens: null,
+            costUsd: null,
+            latencyMs: Date.now() - start,
+            error: `Process timed out after ${req.timeoutMs}ms`,
+          });
+          return;
+        }
+
+        if (code !== 0) {
+          resolve({
+            ok: false,
+            output: "",
+            provider: req.provider,
+            model: req.model,
+            inputTokens: null,
+            outputTokens: null,
+            costUsd: null,
+            latencyMs: Date.now() - start,
+            error: `Process exited with code ${code}${stderr ? `: ${stderr.slice(0, 500)}` : ""}`,
+          });
+          return;
+        }
+
+        const parsed = parsePiJsonLines(stdout);
+
+        const costUsd =
+          parsed.inputTokens !== null && parsed.outputTokens !== null
+            ? estimateCostUsd(req.model, parsed.inputTokens, parsed.outputTokens)
+            : null;
+
+        resolve({
+          ok: true,
+          output: parsed.output.slice(0, maxOutput),
+          provider: req.provider,
+          model: req.model,
+          inputTokens: parsed.inputTokens,
+          outputTokens: parsed.outputTokens,
+          costUsd,
+          latencyMs: Date.now() - start,
+        });
+      });
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the argument list for the `pi` CLI harness.
+ *
+ * NOTE: exact pi flags will be verified against the real binary at integration
+ * time — keep ALL pi argument construction in this one function so it is
+ * trivial to adjust later.
+ */
+function buildPiArgs(
+  req: WorkerRequest,
+  registryEntry: ReturnType<typeof getRegistryEntryById> & {},
+): string[] {
+  const flags: string[] = [...(registryEntry.harnessFlags ?? [])];
+  flags.push("--mode", "json");
+  flags.push("--model", req.model);
+  flags.push("-p", req.prompt);
+  return flags;
+}
+
+function buildHeaders(provider: string, apiKey: string): Record<string, string> {
+  const h: Record<string, string> = {
+    authorization: `Bearer ${apiKey}`,
+    "content-type": "application/json",
+  };
+  if (provider === "openrouter") {
+    h["http-referer"] = process.env.OPENROUTER_REFERER ?? "https://hugin.local";
+    h["x-title"] = process.env.OPENROUTER_APP_TITLE ?? "hugin-orch";
+  }
+  return h;
+}
+
+interface ExtractedCompletion {
+  ok: true;
+  content: string;
+  inputTokens: number | null;
+  outputTokens: number | null;
+}
+interface ExtractedError {
+  ok: false;
+  error: string;
+}
+
+function extractChatCompletion(raw: unknown): ExtractedCompletion | ExtractedError {
+  if (!raw || typeof raw !== "object") {
+    return { ok: false, error: "Response was not an object" };
+  }
+  const r = raw as Record<string, unknown>;
+  const choices = r["choices"];
+  if (!Array.isArray(choices) || choices.length === 0) {
+    return { ok: false, error: "Response missing choices array" };
+  }
+  const choice = choices[0] as Record<string, unknown>;
+  const message = choice["message"] as Record<string, unknown> | undefined;
+  const content = message?.["content"];
+  if (typeof content !== "string") {
+    return { ok: false, error: "Response missing choices[0].message.content (string)" };
+  }
+
+  const usage = r["usage"] as Record<string, unknown> | undefined;
+  const inputTokens =
+    typeof usage?.["prompt_tokens"] === "number" ? usage["prompt_tokens"] : null;
+  const outputTokens =
+    typeof usage?.["completion_tokens"] === "number" ? usage["completion_tokens"] : null;
+
+  return { ok: true, content, inputTokens, outputTokens };
+}
+
+interface PiParsedOutput {
+  output: string;
+  inputTokens: number | null;
+  outputTokens: number | null;
+}
+
+/**
+ * Parse JSON Lines output from `pi --mode json`.
+ *
+ * The pi CLI emits one JSON object per line. We scan for lines with
+ * `type: "assistant"` or `type: "result"` to extract the final text and
+ * usage tokens. The last assistant/result line wins if there are multiple.
+ */
+function parsePiJsonLines(raw: string): PiParsedOutput {
+  let output = "";
+  let inputTokens: number | null = null;
+  let outputTokens: number | null = null;
+
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let obj: unknown;
+    try {
+      obj = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    if (!obj || typeof obj !== "object") continue;
+    const o = obj as Record<string, unknown>;
+
+    if (o["type"] === "assistant" || o["type"] === "result") {
+      if (typeof o["content"] === "string") {
+        output = o["content"];
+      } else if (typeof o["text"] === "string") {
+        output = o["text"];
+      }
+    }
+
+    // Token usage may appear on any line (e.g. a separate "usage" event)
+    const usage = o["usage"] as Record<string, unknown> | undefined;
+    if (usage) {
+      if (typeof usage["input_tokens"] === "number") inputTokens = usage["input_tokens"];
+      if (typeof usage["output_tokens"] === "number") outputTokens = usage["output_tokens"];
+      if (typeof usage["prompt_tokens"] === "number") inputTokens = usage["prompt_tokens"];
+      if (typeof usage["completion_tokens"] === "number")
+        outputTokens = usage["completion_tokens"];
+    }
+  }
+
+  return { output, inputTokens, outputTokens };
+}
+
+function isAbortError(err: unknown): boolean {
+  return (err as Error & { name?: string })?.name === "AbortError";
+}

--- a/src/orchestrator/worker-executor.ts
+++ b/src/orchestrator/worker-executor.ts
@@ -459,9 +459,15 @@ interface PiParsedOutput {
 /**
  * Parse JSON Lines output from `pi --mode json`.
  *
- * The pi CLI emits one JSON object per line. We scan for lines with
- * `type: "assistant"` or `type: "result"` to extract the final text and
- * usage tokens. The last assistant/result line wins if there are multiple.
+ * The pi CLI (version 3 schema) emits events of the form:
+ *   { "type": "message_start"|"message_end"|"turn_end", "message": { "role": "assistant", "content": [...], "usage": { "input": N, "output": N } } }
+ *
+ * Content is an array of content blocks; we concatenate all text blocks from
+ * the final assistant message. Usage is at message.usage.input / message.usage.output.
+ *
+ * Legacy / hypothetical shapes (type "assistant"/"result", flat content/text,
+ * flat usage with input_tokens/prompt_tokens) are also handled for forward
+ * compatibility with harness variants.
  */
 function parsePiJsonLines(raw: string): PiParsedOutput {
   let output = "";
@@ -480,6 +486,41 @@ function parsePiJsonLines(raw: string): PiParsedOutput {
     if (!obj || typeof obj !== "object") continue;
     const o = obj as Record<string, unknown>;
 
+    // --- Pi v3 event schema: message_start / message_end / turn_end ---
+    const msgTypes = ["message_start", "message_end", "turn_end"];
+    if (msgTypes.includes(o["type"] as string)) {
+      const msg = o["message"] as Record<string, unknown> | undefined;
+      if (msg && msg["role"] === "assistant") {
+        // Extract text from content array: [{ type: "text", text: "..." }, ...]
+        const contentArr = msg["content"];
+        if (Array.isArray(contentArr) && contentArr.length > 0) {
+          const texts = contentArr
+            .filter(
+              (b): b is Record<string, unknown> =>
+                b !== null && typeof b === "object" && (b as Record<string, unknown>)["type"] === "text",
+            )
+            .map((b) => (typeof b["text"] === "string" ? b["text"] : ""));
+          const joined = texts.join("");
+          if (joined.length > 0) {
+            output = joined;
+          }
+        }
+
+        // Usage: message.usage.input / message.usage.output
+        const msgUsage = msg["usage"] as Record<string, unknown> | undefined;
+        if (msgUsage) {
+          if (typeof msgUsage["input"] === "number") inputTokens = msgUsage["input"];
+          if (typeof msgUsage["output"] === "number") outputTokens = msgUsage["output"];
+          // Also check OpenAI-style field names used by some pi backends
+          if (typeof msgUsage["input_tokens"] === "number") inputTokens = msgUsage["input_tokens"];
+          if (typeof msgUsage["output_tokens"] === "number") outputTokens = msgUsage["output_tokens"];
+          if (typeof msgUsage["prompt_tokens"] === "number") inputTokens = msgUsage["prompt_tokens"];
+          if (typeof msgUsage["completion_tokens"] === "number") outputTokens = msgUsage["completion_tokens"];
+        }
+      }
+    }
+
+    // --- Legacy / flat event schema: type "assistant" or "result" ---
     if (o["type"] === "assistant" || o["type"] === "result") {
       if (typeof o["content"] === "string") {
         output = o["content"];
@@ -488,7 +529,7 @@ function parsePiJsonLines(raw: string): PiParsedOutput {
       }
     }
 
-    // Token usage may appear on any line (e.g. a separate "usage" event)
+    // --- Top-level usage (legacy, separate "usage" event) ---
     const usage = o["usage"] as Record<string, unknown> | undefined;
     if (usage) {
       if (typeof usage["input_tokens"] === "number") inputTokens = usage["input_tokens"];

--- a/src/router.ts
+++ b/src/router.ts
@@ -2,6 +2,7 @@ import type { Sensitivity } from "./sensitivity.js";
 import { compareSensitivity } from "./sensitivity.js";
 import { getRuntimeMaxSensitivity } from "./runtime-registry.js";
 import type { RuntimeCandidate, RuntimeCapability } from "./runtime-registry.js";
+import { getModelPrice } from "./model-pricing.js";
 
 export interface RouterInput {
   effectiveSensitivity: Sensitivity;
@@ -32,6 +33,19 @@ const SIZE_RANK: Record<string, number> = {
   medium: 1,
   small: 2,
 };
+
+/**
+ * Blended (input+output)/2 price in USD per million tokens for the candidate's
+ * default model. Returns `Number.POSITIVE_INFINITY` when the model is unknown
+ * or no defaultModel is set — unpriced candidates sink to the bottom within
+ * their cost tier.
+ */
+function representativePriceUsdPerM(candidate: RuntimeCandidate): number {
+  if (!candidate.defaultModel) return Number.POSITIVE_INFINITY;
+  const price = getModelPrice(candidate.defaultModel);
+  if (!price) return Number.POSITIVE_INFINITY;
+  return (price.inputUsdPerM + price.outputUsdPerM) / 2;
+}
 
 export function routeTask(input: RouterInput): RouterDecision {
   const { effectiveSensitivity, capabilities, preferredModel, availableRuntimes } = input;
@@ -118,9 +132,13 @@ export function routeTask(input: RouterInput): RouterDecision {
     const trustDiff = (TRUST_RANK[a.trustTier] ?? 1) - (TRUST_RANK[b.trustTier] ?? 1);
     if (trustDiff !== 0) return trustDiff;
 
-    // Size: larger > smaller (tiebreaker)
+    // Size: larger > smaller
     const sizeDiff = (SIZE_RANK[a.modelSize] ?? 2) - (SIZE_RANK[b.modelSize] ?? 2);
-    return sizeDiff;
+    if (sizeDiff !== 0) return sizeDiff;
+
+    // Price: cheaper defaultModel wins (within same tier/trust/size).
+    // Unpriced candidates (no defaultModel or unknown price) rank last.
+    return representativePriceUsdPerM(a) - representativePriceUsdPerM(b);
   });
 
   const selected = candidates[0];
@@ -140,7 +158,17 @@ function buildReason(
   if (modelAffinityMatch && selected === modelAffinityMatch) {
     parts.push(`model affinity match`);
   } else {
-    parts.push(`cost:${selected.costModel}, trust:${selected.trustTier}, size:${selected.modelSize}`);
+    const base = `cost:${selected.costModel}, trust:${selected.trustTier}, size:${selected.modelSize}`;
+    if (selected.costModel === "per-token" && selected.defaultModel) {
+      const price = representativePriceUsdPerM(selected);
+      if (price !== Number.POSITIVE_INFINITY) {
+        parts.push(`${base}, price:$${price.toFixed(3)}/M`);
+      } else {
+        parts.push(base);
+      }
+    } else {
+      parts.push(base);
+    }
   }
 
   if (eliminated.length > 0) {

--- a/src/runtime-registry.ts
+++ b/src/runtime-registry.ts
@@ -206,10 +206,37 @@ export function getRegistryEntryById(id: string): RuntimeDefinition | undefined 
   return RUNTIME_REGISTRY.find((r) => r.id === id);
 }
 
+/**
+ * Parse the HUGIN_ACTIVE_SUBSCRIPTIONS env var into a Set of runtime ids.
+ *
+ * - `undefined` / empty / whitespace → `undefined` (meaning "all subscriptions
+ *   active", backwards-compatible default).
+ * - Otherwise → a Set of trimmed, non-empty, comma-separated runtime ids.
+ */
+export function parseActiveSubscriptions(
+  env: string | undefined,
+): ReadonlySet<string> | undefined {
+  if (!env || !env.trim()) return undefined;
+  const ids = env
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  if (ids.length === 0) return undefined;
+  return new Set(ids);
+}
+
+export interface BuildRuntimeCandidatesOpts {
+  /** When provided, subscription-cost runtimes are only available if their id
+   *  is in this set. `undefined` = all subscriptions are active (default). */
+  activeSubscriptions?: ReadonlySet<string>;
+}
+
 export function buildRuntimeCandidates(
   ollamaHosts: OllamaHost[],
+  opts?: BuildRuntimeCandidatesOpts,
 ): RuntimeCandidate[] {
   const hostMap = new Map(ollamaHosts.map((h) => [h.name, h]));
+  const { activeSubscriptions } = opts ?? {};
 
   return RUNTIME_REGISTRY.map((def): RuntimeCandidate => {
     if (def.ollamaHost) {
@@ -220,12 +247,21 @@ export function buildRuntimeCandidates(
         models: host?.models ?? [],
       };
     }
-    // Cloud runtimes (claude, codex, openrouter, pi-harness) are assumed always
-    // available at the registry level. Per-call availability (e.g. OpenRouter
-    // rate limits, harness binary missing) is enforced by the executor.
+
+    // For subscription-cost runtimes, honour the active-subscriptions filter
+    // when provided. Non-subscription and unset behave as before.
+    const available =
+      def.costModel === "subscription" && activeSubscriptions !== undefined
+        ? activeSubscriptions.has(def.id)
+        : true;
+
+    // Cloud runtimes (claude, codex, openrouter, pi-harness, berget) are assumed
+    // always available at the registry level unless filtered out above. Per-call
+    // availability (e.g. OpenRouter rate limits, harness binary missing) is
+    // enforced by the executor.
     return {
       ...def,
-      available: true,
+      available,
       models: [],
     };
   });

--- a/src/runtime-registry.ts
+++ b/src/runtime-registry.ts
@@ -13,7 +13,8 @@ export type LegacyDispatcherRuntime = "claude" | "codex" | "ollama";
 export type DispatcherRuntime =
   | LegacyDispatcherRuntime
   | "openrouter"
-  | "pi-harness";
+  | "pi-harness"
+  | "berget";
 
 const LEGACY_DISPATCHER_RUNTIMES: ReadonlySet<DispatcherRuntime> = new Set([
   "claude",
@@ -36,7 +37,8 @@ export type Provider =
   | "openai-spawn"
   | "ollama-local"
   | "openrouter"
-  | "pi-harness";
+  | "pi-harness"
+  | "berget";
 export type Egress = "subscription" | "local" | "third-party";
 export type RuntimeFamily = "one-shot" | "harness";
 export type ReasoningLevel = "low" | "medium" | "high";
@@ -171,6 +173,24 @@ export const RUNTIME_REGISTRY: readonly RuntimeDefinition[] = [
     harnessCmd: "pi",
     harnessFlags: ["--no-session", "--provider", "openrouter"],
   },
+  {
+    id: "berget",
+    dispatcherRuntime: "berget",
+    // Berget.ai is a Swedish company providing EU-sovereign GPU compute with
+    // GDPR-by-design architecture, NIS2 compliance, and no US jurisdiction.
+    // This makes it the sovereignty lane eligible to carry `private` data,
+    // unlike semi-trusted third-party runtimes that are capped at `internal`.
+    trustTier: "trusted",
+    costModel: "per-token",
+    modelSize: "large",
+    capabilities: ["code"],
+    provider: "berget",
+    egress: "third-party",
+    zdrRequired: false, // EU-native, no US nexus
+    autoEligible: false, // explicit-only for now, consistent with openrouter/pi-harness
+    family: "one-shot",
+    defaultModel: "mistralai/mistral-small-3.2-24b-instruct",
+  },
 ];
 
 const TRUST_TIER_MAX_SENSITIVITY: Record<TrustTier, Sensitivity> = {
@@ -215,7 +235,7 @@ export function buildRuntimeCandidates(
 // Stable aliases (orchestrator v1, see docs/orchestrator-v1-data-model.md §2)
 // ---------------------------------------------------------------------------
 
-export type Alias = "tiny" | "medium" | "large-reasoning" | "pi-large-coder";
+export type Alias = "tiny" | "medium" | "large-reasoning" | "pi-large-coder" | "berget-sovereign";
 
 export interface AliasResolution {
   alias: Alias;
@@ -273,6 +293,14 @@ export const ALIAS_MAP_V1: AliasMap = {
       host: "pi",
       notes:
         "Validated 2026-04-26: 5/6 strict, 6/6 lenient on aider eval. pi --no-session calling OR for the model.",
+    },
+    "berget-sovereign": {
+      alias: "berget-sovereign",
+      family: "one-shot",
+      model: "mistralai/mistral-small-3.2-24b-instruct",
+      runtimeId: "berget",
+      notes:
+        "EU-sovereignty lane for private/internal tasks. Berget.ai: Swedish co, GDPR-by-design, NIS2, no US jurisdiction.",
     },
   },
 };

--- a/src/runtime-registry.ts
+++ b/src/runtime-registry.ts
@@ -12,6 +12,7 @@ export type LegacyDispatcherRuntime = "claude" | "codex" | "ollama";
 // never dispatched in-process.
 export type DispatcherRuntime =
   | LegacyDispatcherRuntime
+  | "orchestrator"
   | "openrouter"
   | "pi-harness"
   | "berget";

--- a/src/runtime-registry.ts
+++ b/src/runtime-registry.ts
@@ -108,7 +108,10 @@ export const RUNTIME_REGISTRY: readonly RuntimeDefinition[] = [
     provider: "ollama-local",
     egress: "local",
     zdrRequired: false,
-    autoEligible: true,
+    // The Pi is the always-on control plane; its qwen2.5:3b is too limited
+    // to be a general auto-routed worker. Explicit-only: use Runtime: ollama
+    // + Ollama-host: pi to target it deliberately.
+    autoEligible: false,
     family: "one-shot",
   },
   {

--- a/src/runtime-registry.ts
+++ b/src/runtime-registry.ts
@@ -193,7 +193,7 @@ export const RUNTIME_REGISTRY: readonly RuntimeDefinition[] = [
     zdrRequired: false, // EU-native, no US nexus
     autoEligible: false, // explicit-only for now, consistent with openrouter/pi-harness
     family: "one-shot",
-    defaultModel: "mistralai/mistral-small-3.2-24b-instruct",
+    defaultModel: "mistralai/Mistral-Small-3.2-24B-Instruct-2506",
   },
 ];
 
@@ -275,7 +275,7 @@ export function buildRuntimeCandidates(
 // Stable aliases (orchestrator v1, see docs/orchestrator-v1-data-model.md §2)
 // ---------------------------------------------------------------------------
 
-export type Alias = "tiny" | "medium" | "large-reasoning" | "pi-large-coder" | "berget-sovereign";
+export type Alias = "tiny" | "medium" | "large-reasoning" | "pi-large-coder";
 
 export interface AliasResolution {
   alias: Alias;
@@ -333,14 +333,6 @@ export const ALIAS_MAP_V1: AliasMap = {
       host: "pi",
       notes:
         "Validated 2026-04-26: 5/6 strict, 6/6 lenient on aider eval. pi --no-session calling OR for the model.",
-    },
-    "berget-sovereign": {
-      alias: "berget-sovereign",
-      family: "one-shot",
-      model: "mistralai/mistral-small-3.2-24b-instruct",
-      runtimeId: "berget",
-      notes:
-        "EU-sovereignty lane for private/internal tasks. Berget.ai: Swedish co, GDPR-by-design, NIS2, no US jurisdiction.",
     },
   },
 };

--- a/src/task-result-schema.ts
+++ b/src/task-result-schema.ts
@@ -25,11 +25,13 @@ export type TaskExecutionBodyKind = z.infer<typeof taskExecutionBodyKindSchema>;
 // sees the legacy executor runtimes (claude/codex/ollama). Orchestrator-only
 // runtimes (openrouter, pi-harness) flow through a separate broker path and
 // produce DelegationResult, never StructuredTaskResult.
+// "orchestrator" is the in-process multi-model fanout runtime (Phase 3b).
 export const dispatcherRuntimeSchema = z.enum([
   "claude",
   "codex",
   "ollama",
   "auto",
+  "orchestrator",
 ]);
 export type DispatcherRuntime = z.infer<typeof dispatcherRuntimeSchema>;
 

--- a/tests/model-pricing.test.ts
+++ b/tests/model-pricing.test.ts
@@ -20,11 +20,12 @@ describe("getModelPrice", () => {
   });
 
   it("returns the berget mistral-small entry", () => {
-    const price = getModelPrice("mistralai/mistral-small-3.2-24b-instruct");
+    // Real slug from Berget /v1/models (case-sensitive); price is EUR 0.30/M → USD ~0.34/M.
+    const price = getModelPrice("mistralai/Mistral-Small-3.2-24B-Instruct-2506");
     expect(price).toBeDefined();
     expect(price!.provider).toBe("berget");
-    expect(price!.inputUsdPerM).toBe(0.33);
-    expect(price!.outputUsdPerM).toBe(0.33);
+    expect(price!.inputUsdPerM).toBe(0.34);
+    expect(price!.outputUsdPerM).toBe(0.34);
   });
 });
 

--- a/tests/model-pricing.test.ts
+++ b/tests/model-pricing.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import {
+  MODEL_PRICING,
+  CLAUDE_BASELINE_MODEL_ID,
+  getModelPrice,
+  estimateCostUsd,
+} from "../src/model-pricing.js";
+
+describe("getModelPrice", () => {
+  it("returns entry for a known model", () => {
+    const price = getModelPrice("deepseek/deepseek-v4-flash");
+    expect(price).toBeDefined();
+    expect(price!.provider).toBe("openrouter");
+    expect(price!.inputUsdPerM).toBe(0.09);
+    expect(price!.outputUsdPerM).toBe(0.18);
+  });
+
+  it("returns undefined for an unknown model", () => {
+    expect(getModelPrice("nonexistent/model-xyz")).toBeUndefined();
+  });
+
+  it("returns the berget mistral-small entry", () => {
+    const price = getModelPrice("mistralai/mistral-small-3.2-24b-instruct");
+    expect(price).toBeDefined();
+    expect(price!.provider).toBe("berget");
+    expect(price!.inputUsdPerM).toBe(0.33);
+    expect(price!.outputUsdPerM).toBe(0.33);
+  });
+});
+
+describe("estimateCostUsd", () => {
+  it("computes cost correctly for a known model", () => {
+    // deepseek-v4-flash: 0.09/0.18 per 1M tokens
+    // input: 1_000_000 tokens → $0.09; output: 500_000 tokens → $0.09
+    // total = 0.18
+    const cost = estimateCostUsd("deepseek/deepseek-v4-flash", 1_000_000, 500_000);
+    expect(cost).not.toBeNull();
+    expect(cost!).toBeCloseTo(0.18, 10);
+  });
+
+  it("returns null for an unknown model", () => {
+    expect(estimateCostUsd("unknown/model", 100, 100)).toBeNull();
+  });
+
+  it("returns 0 for zero tokens", () => {
+    expect(estimateCostUsd("deepseek/deepseek-v4-flash", 0, 0)).toBe(0);
+  });
+});
+
+describe("CLAUDE_BASELINE_MODEL_ID and pricing sanity", () => {
+  it("baseline model exists in MODEL_PRICING", () => {
+    expect(MODEL_PRICING[CLAUDE_BASELINE_MODEL_ID]).toBeDefined();
+  });
+
+  it("Claude sonnet is much pricier than deepseek-v4-flash (input)", () => {
+    const claude = getModelPrice(CLAUDE_BASELINE_MODEL_ID)!;
+    const deepseek = getModelPrice("deepseek/deepseek-v4-flash")!;
+    expect(claude.inputUsdPerM).toBeGreaterThan(deepseek.inputUsdPerM * 10);
+  });
+
+  it("CLAUDE_BASELINE_MODEL_ID is claude-sonnet-4-6", () => {
+    expect(CLAUDE_BASELINE_MODEL_ID).toBe("claude-sonnet-4-6");
+  });
+});

--- a/tests/orchestrator/config.test.ts
+++ b/tests/orchestrator/config.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { loadOrchestratorConfig } from "../../src/orchestrator/config.js";
+import { DEFAULT_ORCHESTRATOR_CONFIG } from "../../src/orchestrator/engine.js";
+
+describe("loadOrchestratorConfig", () => {
+  it("returns defaults when env is empty", () => {
+    const cfg = loadOrchestratorConfig({});
+    expect(cfg).toEqual(DEFAULT_ORCHESTRATOR_CONFIG);
+  });
+
+  it("overrides planner model with provider|model format", () => {
+    const cfg = loadOrchestratorConfig({
+      HUGIN_ORCH_PLANNER_MODEL: "berget|mistral/mistral-7b",
+    });
+    expect(cfg.roles.planner).toEqual({ provider: "berget", model: "mistral/mistral-7b" });
+    // Other roles unchanged
+    expect(cfg.roles.worker).toEqual(DEFAULT_ORCHESTRATOR_CONFIG.roles.worker);
+  });
+
+  it("overrides worker model without provider (keeps default provider)", () => {
+    const cfg = loadOrchestratorConfig({
+      HUGIN_ORCH_WORKER_MODEL: "google/gemma-3-27b-it",
+    });
+    expect(cfg.roles.worker.model).toBe("google/gemma-3-27b-it");
+    expect(cfg.roles.worker.provider).toBe(DEFAULT_ORCHESTRATOR_CONFIG.roles.worker.provider);
+  });
+
+  it("overrides verifier model with provider|model", () => {
+    const cfg = loadOrchestratorConfig({
+      HUGIN_ORCH_VERIFIER_MODEL: "openrouter|anthropic/claude-opus-4",
+    });
+    expect(cfg.roles.verifier).toEqual({ provider: "openrouter", model: "anthropic/claude-opus-4" });
+  });
+
+  it("overrides synthesizer model with provider|model", () => {
+    const cfg = loadOrchestratorConfig({
+      HUGIN_ORCH_SYNTH_MODEL: "berget|meta/llama-3.1-70b",
+    });
+    expect(cfg.roles.synthesizer).toEqual({ provider: "berget", model: "meta/llama-3.1-70b" });
+  });
+
+  it("overrides maxConcurrency", () => {
+    const cfg = loadOrchestratorConfig({ HUGIN_ORCH_MAX_CONCURRENCY: "8" });
+    expect(cfg.maxConcurrency).toBe(8);
+  });
+
+  it("ignores bad int for maxConcurrency (falls back to default)", () => {
+    const cfg = loadOrchestratorConfig({ HUGIN_ORCH_MAX_CONCURRENCY: "not-a-number" });
+    expect(cfg.maxConcurrency).toBe(DEFAULT_ORCHESTRATOR_CONFIG.maxConcurrency);
+  });
+
+  it('enables verifyWorkers when HUGIN_ORCH_VERIFY=on', () => {
+    const cfg = loadOrchestratorConfig({ HUGIN_ORCH_VERIFY: "on" });
+    expect(cfg.verifyWorkers).toBe(true);
+  });
+
+  it('enables verifyWorkers when HUGIN_ORCH_VERIFY=true', () => {
+    const cfg = loadOrchestratorConfig({ HUGIN_ORCH_VERIFY: "true" });
+    expect(cfg.verifyWorkers).toBe(true);
+  });
+
+  it("overrides perCallTimeoutMs", () => {
+    const cfg = loadOrchestratorConfig({ HUGIN_ORCH_PER_CALL_TIMEOUT_MS: "60000" });
+    expect(cfg.perCallTimeoutMs).toBe(60000);
+  });
+
+  it("ignores bad int for perCallTimeoutMs (falls back to default)", () => {
+    const cfg = loadOrchestratorConfig({ HUGIN_ORCH_PER_CALL_TIMEOUT_MS: "" });
+    expect(cfg.perCallTimeoutMs).toBe(DEFAULT_ORCHESTRATOR_CONFIG.perCallTimeoutMs);
+  });
+
+  it("overrides maxSubtasks", () => {
+    const cfg = loadOrchestratorConfig({ HUGIN_ORCH_MAX_SUBTASKS: "6" });
+    expect(cfg.maxSubtasks).toBe(6);
+  });
+
+  it("ignores bad int for maxSubtasks (falls back to default)", () => {
+    const cfg = loadOrchestratorConfig({ HUGIN_ORCH_MAX_SUBTASKS: "abc" });
+    expect(cfg.maxSubtasks).toBe(DEFAULT_ORCHESTRATOR_CONFIG.maxSubtasks);
+  });
+
+  it("applies multiple overrides simultaneously", () => {
+    const cfg = loadOrchestratorConfig({
+      HUGIN_ORCH_PLANNER_MODEL: "berget|llama-3.1-8b",
+      HUGIN_ORCH_MAX_CONCURRENCY: "2",
+      HUGIN_ORCH_VERIFY: "on",
+      HUGIN_ORCH_MAX_SUBTASKS: "4",
+    });
+    expect(cfg.roles.planner).toEqual({ provider: "berget", model: "llama-3.1-8b" });
+    expect(cfg.maxConcurrency).toBe(2);
+    expect(cfg.verifyWorkers).toBe(true);
+    expect(cfg.maxSubtasks).toBe(4);
+  });
+});

--- a/tests/orchestrator/config.test.ts
+++ b/tests/orchestrator/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { loadOrchestratorConfig } from "../../src/orchestrator/config.js";
+import { loadOrchestratorConfig, applyTaskModel } from "../../src/orchestrator/config.js";
 import { DEFAULT_ORCHESTRATOR_CONFIG } from "../../src/orchestrator/engine.js";
 
 describe("loadOrchestratorConfig", () => {
@@ -79,6 +79,31 @@ describe("loadOrchestratorConfig", () => {
     expect(cfg.maxSubtasks).toBe(DEFAULT_ORCHESTRATOR_CONFIG.maxSubtasks);
   });
 
+  it("rejects '0' for maxSubtasks (zero is not positive) → falls back to default", () => {
+    const cfg = loadOrchestratorConfig({ HUGIN_ORCH_MAX_SUBTASKS: "0" });
+    expect(cfg.maxSubtasks).toBe(DEFAULT_ORCHESTRATOR_CONFIG.maxSubtasks);
+  });
+
+  it("rejects '-1' for maxConcurrency (negative) → falls back to default", () => {
+    const cfg = loadOrchestratorConfig({ HUGIN_ORCH_MAX_CONCURRENCY: "-1" });
+    expect(cfg.maxConcurrency).toBe(DEFAULT_ORCHESTRATOR_CONFIG.maxConcurrency);
+  });
+
+  it("rejects '2abc' for perCallTimeoutMs (trailing junk) → falls back to default", () => {
+    const cfg = loadOrchestratorConfig({ HUGIN_ORCH_PER_CALL_TIMEOUT_MS: "2abc" });
+    expect(cfg.perCallTimeoutMs).toBe(DEFAULT_ORCHESTRATOR_CONFIG.perCallTimeoutMs);
+  });
+
+  it("rejects ' ' (whitespace) for maxSubtasks → falls back to default", () => {
+    const cfg = loadOrchestratorConfig({ HUGIN_ORCH_MAX_SUBTASKS: " " });
+    expect(cfg.maxSubtasks).toBe(DEFAULT_ORCHESTRATOR_CONFIG.maxSubtasks);
+  });
+
+  it("accepts '3' for maxSubtasks → 3", () => {
+    const cfg = loadOrchestratorConfig({ HUGIN_ORCH_MAX_SUBTASKS: "3" });
+    expect(cfg.maxSubtasks).toBe(3);
+  });
+
   it("applies multiple overrides simultaneously", () => {
     const cfg = loadOrchestratorConfig({
       HUGIN_ORCH_PLANNER_MODEL: "berget|llama-3.1-8b",
@@ -90,5 +115,49 @@ describe("loadOrchestratorConfig", () => {
     expect(cfg.maxConcurrency).toBe(2);
     expect(cfg.verifyWorkers).toBe(true);
     expect(cfg.maxSubtasks).toBe(4);
+  });
+});
+
+describe("applyTaskModel (Fix #6)", () => {
+  it("overrides worker model when taskModel is set", () => {
+    const cfg = applyTaskModel(DEFAULT_ORCHESTRATOR_CONFIG, "berget|some/model");
+    expect(cfg.roles.worker.model).toBe("berget|some/model");
+    expect(cfg.roles.worker.provider).toBe(DEFAULT_ORCHESTRATOR_CONFIG.roles.worker.provider);
+  });
+
+  it("overrides worker model, preserving the existing worker provider", () => {
+    const base = { ...DEFAULT_ORCHESTRATOR_CONFIG, roles: { ...DEFAULT_ORCHESTRATOR_CONFIG.roles, worker: { provider: "berget", model: "old-model" } } };
+    const cfg = applyTaskModel(base, "new-model");
+    expect(cfg.roles.worker.model).toBe("new-model");
+    expect(cfg.roles.worker.provider).toBe("berget");
+  });
+
+  it("leaves planner/verifier/synthesizer unchanged", () => {
+    const cfg = applyTaskModel(DEFAULT_ORCHESTRATOR_CONFIG, "some/override");
+    expect(cfg.roles.planner).toEqual(DEFAULT_ORCHESTRATOR_CONFIG.roles.planner);
+    expect(cfg.roles.verifier).toEqual(DEFAULT_ORCHESTRATOR_CONFIG.roles.verifier);
+    expect(cfg.roles.synthesizer).toEqual(DEFAULT_ORCHESTRATOR_CONFIG.roles.synthesizer);
+  });
+
+  it("returns the same config object when taskModel is undefined", () => {
+    const result = applyTaskModel(DEFAULT_ORCHESTRATOR_CONFIG, undefined);
+    expect(result).toBe(DEFAULT_ORCHESTRATOR_CONFIG);
+  });
+
+  it("returns the same config object when taskModel is empty string", () => {
+    const result = applyTaskModel(DEFAULT_ORCHESTRATOR_CONFIG, "");
+    expect(result).toBe(DEFAULT_ORCHESTRATOR_CONFIG);
+  });
+
+  it("returns the same config object when taskModel is whitespace-only", () => {
+    const result = applyTaskModel(DEFAULT_ORCHESTRATOR_CONFIG, "   ");
+    expect(result).toBe(DEFAULT_ORCHESTRATOR_CONFIG);
+  });
+
+  it("does not mutate the input config", () => {
+    const original = { ...DEFAULT_ORCHESTRATOR_CONFIG, roles: { ...DEFAULT_ORCHESTRATOR_CONFIG.roles } };
+    const originalWorkerModel = original.roles.worker.model;
+    applyTaskModel(original, "new-model");
+    expect(original.roles.worker.model).toBe(originalWorkerModel);
   });
 });

--- a/tests/orchestrator/engine.test.ts
+++ b/tests/orchestrator/engine.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi } from "vitest";
+import type { ModelInvoker } from "../../src/orchestrator/model-invoker.js";
+import type { OrchestratorRole } from "../../src/orchestrator/plan.js";
+import type { WorkerResult } from "../../src/orchestrator/worker-executor.js";
+import { runOrchestration } from "../../src/orchestrator/engine.js";
+
+function ok(output: string, costUsd: number | null = 0.001): WorkerResult {
+  return {
+    ok: true, output, provider: "openrouter", model: "m",
+    inputTokens: 10, outputTokens: 10, costUsd, latencyMs: 5,
+  };
+}
+function fail(error = "boom"): WorkerResult {
+  return {
+    ok: false, output: "", provider: "openrouter", model: "m",
+    inputTokens: null, outputTokens: null, costUsd: null, latencyMs: 5, error,
+  };
+}
+
+const VALID_PLAN_3 = JSON.stringify({
+  subtasks: [
+    { id: "1", prompt: "Step 1" },
+    { id: "2", prompt: "Step 2" },
+    { id: "3", prompt: "Step 3" },
+  ],
+});
+
+/** Build a mock invoker from a map of role → ordered responses. */
+function buildMockInvoker(
+  responses: Map<OrchestratorRole, WorkerResult[]>,
+  onInvoke?: (role: OrchestratorRole, prompt: string) => void,
+): ModelInvoker {
+  const counters = new Map<OrchestratorRole, number>();
+  return {
+    invoke: vi.fn(async (role: OrchestratorRole, prompt: string) => {
+      onInvoke?.(role, prompt);
+      const queue = responses.get(role) ?? [];
+      const idx = counters.get(role) ?? 0;
+      counters.set(role, idx + 1);
+      return queue[idx] ?? fail(`No response queued for ${role}[${idx}]`);
+    }),
+  };
+}
+
+describe("runOrchestration — happy fanout", () => {
+  it("planner returns 3 subtasks → 3 worker calls → synthesizer merges → ok:true", async () => {
+    const responses = new Map<OrchestratorRole, WorkerResult[]>([
+      ["planner", [ok(VALID_PLAN_3, 0.01)]],
+      ["worker", [ok("W1", 0.002), ok("W2", 0.003), ok("W3", 0.004)]],
+      ["synthesizer", [ok("Final answer", 0.005)]],
+    ]);
+    const invoker = buildMockInvoker(responses);
+
+    const result = await runOrchestration("Do a complex task", invoker, { maxSubtasks: 12 });
+
+    expect(result.ok).toBe(true);
+    expect(result.finalOutput).toBe("Final answer");
+    expect(result.plan.strategy).toBe("fanout");
+    expect(result.outcomes).toHaveLength(3);
+    // totalCostUsd = planner(0.01) + workers(0.002+0.003+0.004) + synth(0.005) = 0.024
+    expect(result.totalCostUsd).toBeCloseTo(0.024, 6);
+  });
+});
+
+describe("runOrchestration — single fallback", () => {
+  it("planner returns garbage → strategy single → 1 worker → finalOutput == worker output, no synth call", async () => {
+    const synthSpy = vi.fn();
+    const responses = new Map<OrchestratorRole, WorkerResult[]>([
+      ["planner", [ok("this is definitely not json")]],
+      ["worker", [ok("Solo worker output", 0.005)]],
+    ]);
+    const invoker = buildMockInvoker(responses, (role) => {
+      if (role === "synthesizer") synthSpy();
+    });
+
+    const result = await runOrchestration("Simple task", invoker);
+
+    expect(result.ok).toBe(true);
+    expect(result.plan.strategy).toBe("single");
+    expect(result.outcomes).toHaveLength(1);
+    expect(result.finalOutput).toBe("Solo worker output");
+    expect(synthSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("runOrchestration — partial failure", () => {
+  it("1 of 3 workers fails → synthesizes from 2 survivors, ok:true, failed outcome retained", async () => {
+    const responses = new Map<OrchestratorRole, WorkerResult[]>([
+      ["planner", [ok(VALID_PLAN_3, 0.01)]],
+      ["worker", [ok("W1", 0.002), fail("worker 2 exploded"), ok("W3", 0.004)]],
+      ["synthesizer", [ok("Merged output", 0.005)]],
+    ]);
+    const invoker = buildMockInvoker(responses);
+
+    const result = await runOrchestration("Partial fail task", invoker);
+
+    expect(result.ok).toBe(true);
+    expect(result.outcomes).toHaveLength(3);
+    const failedOutcome = result.outcomes.find((o) => !o.result.ok);
+    expect(failedOutcome).toBeDefined();
+    expect(failedOutcome!.result.error).toBe("worker 2 exploded");
+    expect(result.finalOutput).toBe("Merged output");
+  });
+});
+
+describe("runOrchestration — all workers fail", () => {
+  it("ok:false, error set, finalOutput empty string", async () => {
+    const responses = new Map<OrchestratorRole, WorkerResult[]>([
+      ["planner", [ok(VALID_PLAN_3, 0.01)]],
+      ["worker", [fail("err1"), fail("err2"), fail("err3")]],
+    ]);
+    const invoker = buildMockInvoker(responses);
+
+    const result = await runOrchestration("Doomed task", invoker);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBeTruthy();
+    expect(result.finalOutput).toBe("");
+    expect(result.outcomes).toHaveLength(3);
+  });
+});
+
+describe("runOrchestration — verify on", () => {
+  it("verifier invoked per successful worker, verdict attached", async () => {
+    const PLAN_2 = JSON.stringify({
+      subtasks: [
+        { id: "1", prompt: "Step 1" },
+        { id: "2", prompt: "Step 2" },
+      ],
+    });
+    const responses = new Map<OrchestratorRole, WorkerResult[]>([
+      ["planner", [ok(PLAN_2, 0.01)]],
+      ["worker", [ok("W1", 0.002), ok("W2", 0.003)]],
+      ["verifier", [ok("PASS looks good", 0.001), ok("PASS", 0.001)]],
+      ["synthesizer", [ok("Final", 0.002)]],
+    ]);
+    const invoker = buildMockInvoker(responses);
+
+    const result = await runOrchestration("Verify task", invoker, { verifyWorkers: true });
+
+    expect(result.ok).toBe(true);
+    expect(result.outcomes.every((o) => o.verdict !== undefined)).toBe(true);
+    expect(result.outcomes[0].verdict!.ok).toBe(true);
+  });
+});
+
+describe("runOrchestration — concurrency cap", () => {
+  it("6 subtasks with maxConcurrency:2 — no more than 2 in-flight simultaneously", async () => {
+    const PLAN_6 = JSON.stringify({
+      subtasks: Array.from({ length: 6 }, (_, i) => ({ id: String(i + 1), prompt: `Step ${i + 1}` })),
+    });
+
+    let inFlight = 0;
+    let maxInFlight = 0;
+
+    const workerResults: WorkerResult[] = Array.from({ length: 6 }, (_, i) =>
+      ok(`W${i + 1}`, 0.001),
+    );
+
+    const responses = new Map<OrchestratorRole, WorkerResult[]>([
+      ["planner", [ok(PLAN_6, 0.01)]],
+      ["worker", workerResults],
+      ["synthesizer", [ok("Final", 0.002)]],
+    ]);
+
+    const counters = new Map<OrchestratorRole, number>();
+    const invoker: ModelInvoker = {
+      invoke: vi.fn(async (role: OrchestratorRole, _prompt: string) => {
+        const queue = responses.get(role) ?? [];
+        const idx = counters.get(role) ?? 0;
+        counters.set(role, idx + 1);
+
+        if (role === "worker") {
+          inFlight++;
+          if (inFlight > maxInFlight) maxInFlight = inFlight;
+          // Simulate async work
+          await new Promise<void>((res) => setImmediate(res));
+          inFlight--;
+        }
+        return queue[idx] ?? fail("no result");
+      }),
+    };
+
+    await runOrchestration("Concurrent task", invoker, { maxConcurrency: 2, maxSubtasks: 6 });
+
+    expect(maxInFlight).toBeLessThanOrEqual(2);
+    expect(maxInFlight).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/tests/orchestrator/engine.test.ts
+++ b/tests/orchestrator/engine.test.ts
@@ -120,6 +120,49 @@ describe("runOrchestration — all workers fail", () => {
   });
 });
 
+describe("runOrchestration — synthesizer fallback", () => {
+  it("synthesizer returns ok:true but empty output → finalOutput is joined worker outputs, ok:true", async () => {
+    const responses = new Map<OrchestratorRole, WorkerResult[]>([
+      ["planner", [ok(VALID_PLAN_3, 0.01)]],
+      ["worker", [ok("W1", 0.002), ok("W2", 0.003), ok("W3", 0.004)]],
+      // synthesizer responds ok:true but with whitespace-only content
+      ["synthesizer", [ok("   ", 0.005)]],
+    ]);
+    const invoker = buildMockInvoker(responses);
+
+    const result = await runOrchestration("Synth empty task", invoker);
+
+    expect(result.ok).toBe(true);
+    // Should contain all three worker outputs labeled by subtask id
+    expect(result.finalOutput).toContain("## 1");
+    expect(result.finalOutput).toContain("W1");
+    expect(result.finalOutput).toContain("## 2");
+    expect(result.finalOutput).toContain("W2");
+    expect(result.finalOutput).toContain("## 3");
+    expect(result.finalOutput).toContain("W3");
+  });
+
+  it("synthesizer returns ok:false → finalOutput is joined worker outputs, ok:true", async () => {
+    const responses = new Map<OrchestratorRole, WorkerResult[]>([
+      ["planner", [ok(VALID_PLAN_3, 0.01)]],
+      ["worker", [ok("Alpha", 0.002), ok("Beta", 0.003), ok("Gamma", 0.004)]],
+      ["synthesizer", [fail("synthesizer model error")]],
+    ]);
+    const invoker = buildMockInvoker(responses);
+
+    const result = await runOrchestration("Synth fail task", invoker);
+
+    expect(result.ok).toBe(true);
+    expect(result.finalOutput).toContain("Alpha");
+    expect(result.finalOutput).toContain("Beta");
+    expect(result.finalOutput).toContain("Gamma");
+    // Each section labeled with the subtask id
+    expect(result.finalOutput).toContain("## 1");
+    expect(result.finalOutput).toContain("## 2");
+    expect(result.finalOutput).toContain("## 3");
+  });
+});
+
 describe("runOrchestration — verify on", () => {
   it("verifier invoked per successful worker, verdict attached", async () => {
     const PLAN_2 = JSON.stringify({

--- a/tests/orchestrator/engine.test.ts
+++ b/tests/orchestrator/engine.test.ts
@@ -187,6 +187,38 @@ describe("runOrchestration — verify on", () => {
   });
 });
 
+describe("runOrchestration — cost aggregation (Fix #9)", () => {
+  it("totalCostUsd is null when any invocation has costUsd:null (mixed priced + unpriced)", async () => {
+    const responses = new Map<OrchestratorRole, WorkerResult[]>([
+      ["planner", [ok(VALID_PLAN_3, 0.01)]],
+      // One worker priced, one unpriced, one priced
+      ["worker", [ok("W1", 0.002), ok("W2", null), ok("W3", 0.004)]],
+      ["synthesizer", [ok("Final", 0.005)]],
+    ]);
+    const invoker = buildMockInvoker(responses);
+
+    const result = await runOrchestration("Cost test task", invoker, { maxSubtasks: 12 });
+
+    expect(result.ok).toBe(true);
+    expect(result.totalCostUsd).toBeNull();
+  });
+
+  it("totalCostUsd is a numeric sum when ALL invocations are priced", async () => {
+    const responses = new Map<OrchestratorRole, WorkerResult[]>([
+      ["planner", [ok(VALID_PLAN_3, 0.01)]],
+      ["worker", [ok("W1", 0.002), ok("W2", 0.003), ok("W3", 0.004)]],
+      ["synthesizer", [ok("Final", 0.005)]],
+    ]);
+    const invoker = buildMockInvoker(responses);
+
+    const result = await runOrchestration("All priced task", invoker, { maxSubtasks: 12 });
+
+    expect(result.ok).toBe(true);
+    // 0.01 + 0.002 + 0.003 + 0.004 + 0.005 = 0.024
+    expect(result.totalCostUsd).toBeCloseTo(0.024, 6);
+  });
+});
+
 describe("runOrchestration — concurrency cap", () => {
   it("6 subtasks with maxConcurrency:2 — no more than 2 in-flight simultaneously", async () => {
     const PLAN_6 = JSON.stringify({

--- a/tests/orchestrator/model-invoker.test.ts
+++ b/tests/orchestrator/model-invoker.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from "vitest";
+import type { WorkerExecutor, WorkerRequest, WorkerResult } from "../../src/orchestrator/worker-executor.js";
+import { createModelInvoker } from "../../src/orchestrator/model-invoker.js";
+import type { OrchestratorRole } from "../../src/orchestrator/plan.js";
+import type { RoleBinding } from "../../src/orchestrator/model-invoker.js";
+
+function makeResult(output: string, costUsd: number | null = 0.001): WorkerResult {
+  return {
+    ok: true,
+    output,
+    provider: "openrouter",
+    model: "test-model",
+    inputTokens: 100,
+    outputTokens: 50,
+    costUsd,
+    latencyMs: 42,
+  };
+}
+
+describe("createModelInvoker", () => {
+  const roles: Record<OrchestratorRole, RoleBinding> = {
+    planner: { provider: "openrouter", model: "planner-model" },
+    worker: { provider: "berget", model: "worker-model" },
+    verifier: { provider: "openrouter", model: "verifier-model" },
+    synthesizer: { provider: "openrouter", model: "synth-model" },
+  };
+
+  it("builds correct WorkerRequest and returns executor result", async () => {
+    const capturedRequests: WorkerRequest[] = [];
+    const mockExecutor: WorkerExecutor = {
+      run: vi.fn(async (req: WorkerRequest) => {
+        capturedRequests.push(req);
+        return makeResult("worker output");
+      }),
+    };
+
+    const invoker = createModelInvoker(
+      roles,
+      { timeoutMs: 30000, maxOutputChars: 10000 },
+      (_provider) => mockExecutor,
+    );
+
+    const result = await invoker.invoke("worker", "do the thing");
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toBe("worker output");
+
+    expect(capturedRequests).toHaveLength(1);
+    const req = capturedRequests[0];
+    expect(req.provider).toBe("berget");
+    expect(req.model).toBe("worker-model");
+    expect(req.prompt).toBe("do the thing");
+    expect(req.timeoutMs).toBe(30000);
+    expect(req.maxOutputChars).toBe(10000);
+  });
+
+  it("passes systemPrompt when provided", async () => {
+    const capturedRequests: WorkerRequest[] = [];
+    const mockExecutor: WorkerExecutor = {
+      run: vi.fn(async (req: WorkerRequest) => {
+        capturedRequests.push(req);
+        return makeResult("out");
+      }),
+    };
+
+    const invoker = createModelInvoker(
+      roles,
+      { timeoutMs: 5000 },
+      () => mockExecutor,
+    );
+
+    await invoker.invoke("planner", "plan something", { systemPrompt: "You are a planner." });
+    expect(capturedRequests[0].systemPrompt).toBe("You are a planner.");
+  });
+
+  it("routes different roles to different providers/models", async () => {
+    const capturedRequests: WorkerRequest[] = [];
+    const mockExecutor: WorkerExecutor = {
+      run: vi.fn(async (req: WorkerRequest) => {
+        capturedRequests.push(req);
+        return makeResult("out");
+      }),
+    };
+
+    const invoker = createModelInvoker(roles, { timeoutMs: 5000 }, () => mockExecutor);
+
+    await invoker.invoke("planner", "plan");
+    await invoker.invoke("synthesizer", "synth");
+
+    expect(capturedRequests[0].model).toBe("planner-model");
+    expect(capturedRequests[0].provider).toBe("openrouter");
+    expect(capturedRequests[1].model).toBe("synth-model");
+  });
+
+  it("returns executor result unchanged (propagates failures)", async () => {
+    const failResult: WorkerResult = {
+      ok: false,
+      output: "",
+      provider: "openrouter",
+      model: "x",
+      inputTokens: null,
+      outputTokens: null,
+      costUsd: null,
+      latencyMs: 10,
+      error: "network error",
+    };
+    const mockExecutor: WorkerExecutor = { run: vi.fn(async () => failResult) };
+
+    const invoker = createModelInvoker(roles, { timeoutMs: 5000 }, () => mockExecutor);
+    const result = await invoker.invoke("worker", "fail me");
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("network error");
+  });
+});

--- a/tests/orchestrator/orchestrator-executor.test.ts
+++ b/tests/orchestrator/orchestrator-executor.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  runOrchestratorTask,
+  type OrchestratorTaskInput,
+} from "../../src/orchestrator/orchestrator-executor.js";
+import {
+  DEFAULT_ORCHESTRATOR_CONFIG,
+  type OrchestratorConfig,
+} from "../../src/orchestrator/engine.js";
+import type { ModelInvoker } from "../../src/orchestrator/model-invoker.js";
+import type { WorkerResult } from "../../src/orchestrator/worker-executor.js";
+
+// ---------------------------------------------------------------------------
+// Mock invoker helpers
+// ---------------------------------------------------------------------------
+
+function makeSuccessResult(output: string, costUsd: number = 0.0001): WorkerResult {
+  return {
+    ok: true,
+    output,
+    costUsd,
+    latencyMs: 10,
+  };
+}
+
+/**
+ * Build a mock ModelInvoker that returns canned responses for each role.
+ * The planner response must be a valid plan JSON that parsePlan can handle;
+ * we produce a simple single-subtask plan so workers get one call.
+ */
+function buildMockInvoker(opts: {
+  plannerOutput?: string;
+  workerOutput?: string;
+  neverResolve?: boolean;
+}): ModelInvoker {
+  const plannerJson = opts.plannerOutput ??
+    JSON.stringify({
+      strategy: "parallel",
+      subtasks: [{ id: "t1", title: "Do the thing", prompt: "Do the thing" }],
+    });
+
+  const invoke = vi.fn(
+    async (role: string): Promise<WorkerResult> => {
+      if (opts.neverResolve) {
+        // Never resolves — used to test timeout
+        return new Promise(() => { /* intentionally never resolves */ });
+      }
+      if (role === "planner") {
+        return makeSuccessResult(plannerJson, 0.0002);
+      }
+      // worker / verifier / synthesizer
+      return makeSuccessResult(opts.workerOutput ?? "Worker output here", 0.0001);
+    },
+  );
+
+  return { invoke };
+}
+
+const defaultInput: OrchestratorTaskInput = {
+  prompt: "Summarize the topic",
+  sensitivity: "internal",
+  timeoutMs: 5000,
+  maxOutputChars: 10000,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("runOrchestratorTask", () => {
+  it("happy path: exitCode 0, resultText set, costUsd summed, onLog called", async () => {
+    const invoker = buildMockInvoker({ workerOutput: "Great result" });
+    const logLines: string[] = [];
+
+    const result = await runOrchestratorTask(
+      defaultInput,
+      DEFAULT_ORCHESTRATOR_CONFIG,
+      { invoker, onLog: (line) => logLines.push(line) },
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.resultText).toBe("Great result");
+    expect(result.costUsd).toBeTypeOf("number");
+    expect(result.costUsd).toBeGreaterThan(0);
+    // onLog should have been called at least once
+    expect(logLines.length).toBeGreaterThan(0);
+    // output should contain the result
+    expect(result.output).toContain("Orchestration Result");
+  });
+
+  it("sensitivity guard blocks private+openrouter — invoker.invoke never called", async () => {
+    const invoker = buildMockInvoker({});
+    const invokeSpy = vi.spyOn(invoker, "invoke");
+
+    // Default config uses openrouter — should be blocked for private
+    const result = await runOrchestratorTask(
+      { ...defaultInput, sensitivity: "private" },
+      DEFAULT_ORCHESTRATOR_CONFIG,
+      { invoker },
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.resultText).toBeNull();
+    expect(result.costUsd).toBeNull();
+    expect(result.output).toContain("private");
+    expect(invokeSpy).not.toHaveBeenCalled();
+  });
+
+  it("timeout path: invoker that never resolves + tiny timeoutMs → exitCode TIMEOUT", async () => {
+    const invoker = buildMockInvoker({ neverResolve: true });
+
+    const result = await runOrchestratorTask(
+      { ...defaultInput, timeoutMs: 50 },
+      DEFAULT_ORCHESTRATOR_CONFIG,
+      { invoker },
+    );
+
+    expect(result.exitCode).toBe("TIMEOUT");
+    expect(result.resultText).toBeNull();
+    expect(result.costUsd).toBeNull();
+    expect(result.output).toContain("timed out");
+  });
+
+  it("aborted signal before execution → exitCode 1, no model calls", async () => {
+    const invoker = buildMockInvoker({});
+    const invokeSpy = vi.spyOn(invoker, "invoke");
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await runOrchestratorTask(
+      defaultInput,
+      DEFAULT_ORCHESTRATOR_CONFIG,
+      { invoker, signal: controller.signal },
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("aborted");
+    expect(invokeSpy).not.toHaveBeenCalled();
+  });
+
+  it("engine failure: all workers fail → exitCode 1", async () => {
+    const failingInvoker: ModelInvoker = {
+      invoke: vi.fn(async (role: string): Promise<WorkerResult> => {
+        if (role === "planner") {
+          return makeSuccessResult(
+            JSON.stringify({
+              strategy: "parallel",
+              subtasks: [{ id: "t1", title: "Task", prompt: "Do it" }],
+            }),
+          );
+        }
+        // Worker fails
+        return {
+          ok: false,
+          output: "",
+          error: "Model error",
+          costUsd: null,
+          latencyMs: 5,
+        };
+      }),
+    };
+
+    const result = await runOrchestratorTask(
+      defaultInput,
+      DEFAULT_ORCHESTRATOR_CONFIG,
+      { invoker: failingInvoker },
+    );
+
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("output is truncated to maxOutputChars", async () => {
+    const invoker = buildMockInvoker({ workerOutput: "X".repeat(5000) });
+
+    const result = await runOrchestratorTask(
+      { ...defaultInput, maxOutputChars: 100 },
+      DEFAULT_ORCHESTRATOR_CONFIG,
+      { invoker },
+    );
+
+    expect(result.output.length).toBeLessThanOrEqual(100);
+  });
+
+  it("private+berget config is allowed (sensitivity guard passes)", async () => {
+    const bergetConfig: OrchestratorConfig = {
+      ...DEFAULT_ORCHESTRATOR_CONFIG,
+      roles: {
+        planner: { provider: "berget", model: "llama" },
+        worker: { provider: "berget", model: "llama" },
+        verifier: { provider: "berget", model: "llama" },
+        synthesizer: { provider: "berget", model: "llama" },
+      },
+    };
+
+    const invoker = buildMockInvoker({ workerOutput: "Secure result" });
+    const result = await runOrchestratorTask(
+      { ...defaultInput, sensitivity: "private" },
+      bergetConfig,
+      { invoker },
+    );
+
+    // Guard should pass; result depends on invoker behavior
+    expect(result.exitCode).toBe(0);
+    expect(result.resultText).toBe("Secure result");
+  });
+});

--- a/tests/orchestrator/plan.test.ts
+++ b/tests/orchestrator/plan.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "vitest";
+import { parsePlan } from "../../src/orchestrator/plan.js";
+
+const FALLBACK_PROMPT = "Do the whole task yourself.";
+
+describe("parsePlan", () => {
+  it("parses valid JSON with subtasks", () => {
+    const raw = JSON.stringify({
+      subtasks: [
+        { id: "1", prompt: "First step", rationale: "reason" },
+        { id: "2", prompt: "Second step" },
+      ],
+    });
+    const plan = parsePlan(raw, { maxSubtasks: 10, fallbackPrompt: FALLBACK_PROMPT });
+    expect(plan.strategy).toBe("fanout");
+    expect(plan.subtasks).toHaveLength(2);
+    expect(plan.subtasks[0].id).toBe("1");
+    expect(plan.subtasks[1].rationale).toBeUndefined();
+  });
+
+  it("parses JSON wrapped in ```json fences", () => {
+    const raw = `\`\`\`json\n${JSON.stringify({ subtasks: [{ id: "1", prompt: "step" }] })}\n\`\`\``;
+    const plan = parsePlan(raw, { maxSubtasks: 10, fallbackPrompt: FALLBACK_PROMPT });
+    expect(plan.strategy).toBe("fanout");
+    expect(plan.subtasks).toHaveLength(1);
+  });
+
+  it("parses JSON with leading prose", () => {
+    const raw = `Here is your plan:\n${JSON.stringify({ subtasks: [{ id: "a", prompt: "Do it" }] })}\nDone.`;
+    const plan = parsePlan(raw, { maxSubtasks: 10, fallbackPrompt: FALLBACK_PROMPT });
+    expect(plan.strategy).toBe("fanout");
+    expect(plan.subtasks[0].prompt).toBe("Do it");
+  });
+
+  it("returns single fallback on garbage input", () => {
+    const plan = parsePlan("this is not json at all!!!", { maxSubtasks: 10, fallbackPrompt: FALLBACK_PROMPT });
+    expect(plan.strategy).toBe("single");
+    expect(plan.subtasks).toHaveLength(1);
+    expect(plan.subtasks[0].id).toBe("1");
+    expect(plan.subtasks[0].prompt).toBe(FALLBACK_PROMPT);
+  });
+
+  it("returns single fallback when subtasks is empty array", () => {
+    const raw = JSON.stringify({ subtasks: [] });
+    const plan = parsePlan(raw, { maxSubtasks: 10, fallbackPrompt: FALLBACK_PROMPT });
+    expect(plan.strategy).toBe("single");
+    expect(plan.subtasks[0].prompt).toBe(FALLBACK_PROMPT);
+  });
+
+  it("caps subtasks to maxSubtasks (keeps first N)", () => {
+    const subtasks = Array.from({ length: 8 }, (_, i) => ({ id: String(i + 1), prompt: `Step ${i + 1}` }));
+    const raw = JSON.stringify({ subtasks });
+    const plan = parsePlan(raw, { maxSubtasks: 3, fallbackPrompt: FALLBACK_PROMPT });
+    expect(plan.strategy).toBe("fanout");
+    expect(plan.subtasks).toHaveLength(3);
+    expect(plan.subtasks[2].id).toBe("3");
+  });
+
+  it("returns single fallback for empty string input", () => {
+    const plan = parsePlan("", { maxSubtasks: 10, fallbackPrompt: FALLBACK_PROMPT });
+    expect(plan.strategy).toBe("single");
+    expect(plan.subtasks[0].prompt).toBe(FALLBACK_PROMPT);
+  });
+});

--- a/tests/orchestrator/plan.test.ts
+++ b/tests/orchestrator/plan.test.ts
@@ -61,4 +61,17 @@ describe("parsePlan", () => {
     expect(plan.strategy).toBe("single");
     expect(plan.subtasks[0].prompt).toBe(FALLBACK_PROMPT);
   });
+
+  it("falls back to single when maxSubtasks:0 empties the subtask list (Fix #5)", () => {
+    const raw = JSON.stringify({
+      subtasks: [
+        { id: "1", prompt: "Step 1" },
+        { id: "2", prompt: "Step 2" },
+      ],
+    });
+    const plan = parsePlan(raw, { maxSubtasks: 0, fallbackPrompt: FALLBACK_PROMPT });
+    expect(plan.strategy).toBe("single");
+    expect(plan.subtasks).toHaveLength(1);
+    expect(plan.subtasks[0].prompt).toBe(FALLBACK_PROMPT);
+  });
 });

--- a/tests/orchestrator/provider-config.test.ts
+++ b/tests/orchestrator/provider-config.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import {
+  PROVIDER_CONFIG,
+  getProviderConfig,
+} from "../../src/orchestrator/provider-config.js";
+
+describe("PROVIDER_CONFIG", () => {
+  it("contains openrouter with correct values", () => {
+    const cfg = PROVIDER_CONFIG["openrouter"];
+    expect(cfg).toBeDefined();
+    expect(cfg.baseUrl).toBe("https://openrouter.ai/api/v1");
+    expect(cfg.apiKeyEnvVar).toBe("OPENROUTER_API_KEY");
+  });
+
+  it("contains berget with correct values", () => {
+    const cfg = PROVIDER_CONFIG["berget"];
+    expect(cfg).toBeDefined();
+    expect(cfg.baseUrl).toBe("https://api.berget.ai/v1");
+    expect(cfg.apiKeyEnvVar).toBe("BERGET_API_KEY");
+  });
+
+  it("baseUrls do not have trailing slashes", () => {
+    for (const [id, cfg] of Object.entries(PROVIDER_CONFIG)) {
+      expect(cfg.baseUrl, `${id} baseUrl`).not.toMatch(/\/$/);
+    }
+  });
+});
+
+describe("getProviderConfig", () => {
+  it("returns config for known provider", () => {
+    const cfg = getProviderConfig("openrouter");
+    expect(cfg).toBeDefined();
+    expect(cfg!.apiKeyEnvVar).toBe("OPENROUTER_API_KEY");
+  });
+
+  it("returns config for berget", () => {
+    const cfg = getProviderConfig("berget");
+    expect(cfg).toBeDefined();
+    expect(cfg!.baseUrl).toBe("https://api.berget.ai/v1");
+  });
+
+  it("returns undefined for unknown provider", () => {
+    expect(getProviderConfig("unknown-provider")).toBeUndefined();
+  });
+
+  it("returns undefined for empty string", () => {
+    expect(getProviderConfig("")).toBeUndefined();
+  });
+});

--- a/tests/orchestrator/sensitivity-guard.test.ts
+++ b/tests/orchestrator/sensitivity-guard.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { assertProvidersAllowSensitivity } from "../../src/orchestrator/sensitivity-guard.js";
+import { DEFAULT_ORCHESTRATOR_CONFIG } from "../../src/orchestrator/engine.js";
+import type { OrchestratorConfig } from "../../src/orchestrator/engine.js";
+
+// Default config uses openrouter for all roles
+const defaultConfig = DEFAULT_ORCHESTRATOR_CONFIG;
+
+// All-berget config
+const bergetConfig: OrchestratorConfig = {
+  ...defaultConfig,
+  roles: {
+    planner: { provider: "berget", model: "llama-3.1-70b" },
+    worker: { provider: "berget", model: "llama-3.1-8b" },
+    verifier: { provider: "berget", model: "llama-3.1-70b" },
+    synthesizer: { provider: "berget", model: "llama-3.1-70b" },
+  },
+};
+
+describe("assertProvidersAllowSensitivity", () => {
+  it("private + default openrouter config → not ok", () => {
+    const result = assertProvidersAllowSensitivity(defaultConfig, "private");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("private");
+      expect(result.reason).toContain("openrouter");
+    }
+  });
+
+  it("private + all-berget config → ok", () => {
+    const result = assertProvidersAllowSensitivity(bergetConfig, "private");
+    expect(result.ok).toBe(true);
+  });
+
+  it("internal + openrouter → ok", () => {
+    const result = assertProvidersAllowSensitivity(defaultConfig, "internal");
+    expect(result.ok).toBe(true);
+  });
+
+  it("public + openrouter → ok", () => {
+    const result = assertProvidersAllowSensitivity(defaultConfig, "public");
+    expect(result.ok).toBe(true);
+  });
+
+  it("private + mixed providers → not ok, lists non-sovereign providers", () => {
+    const mixedConfig: OrchestratorConfig = {
+      ...defaultConfig,
+      roles: {
+        planner: { provider: "berget", model: "llama" },
+        worker: { provider: "openrouter", model: "gpt-4o" },
+        verifier: { provider: "berget", model: "llama" },
+        synthesizer: { provider: "openrouter", model: "claude" },
+      },
+    };
+    const result = assertProvidersAllowSensitivity(mixedConfig, "private");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toContain("openrouter");
+    }
+  });
+
+  it("internal + all-berget config → ok", () => {
+    const result = assertProvidersAllowSensitivity(bergetConfig, "internal");
+    expect(result.ok).toBe(true);
+  });
+});

--- a/tests/orchestrator/worker-executor.test.ts
+++ b/tests/orchestrator/worker-executor.test.ts
@@ -1,0 +1,486 @@
+/**
+ * Tests for the orchestrator worker-executor layer.
+ *
+ * DirectModelExecutor tests mock global fetch.
+ * PiHarnessExecutor tests mock node:child_process spawn using the same
+ * pattern as tests/repo-sync.test.ts.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "node:events";
+
+// ---------------------------------------------------------------------------
+// Mock node:child_process before importing the module
+// ---------------------------------------------------------------------------
+
+interface SpawnBehavior {
+  exitCode: number;
+  stdout?: string;
+  stderr?: string;
+  /** If true, emit an 'error' event instead of 'close'. */
+  spawnError?: string;
+  /** Delay close by this many ms (to test timeouts). */
+  delayMs?: number;
+}
+
+const spawnCalls: Array<{ cmd: string; args: string[] }> = [];
+let spawnBehaviors: SpawnBehavior[] = [];
+let spawnCallIndex = 0;
+
+class MockChildProcess extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  killed = false;
+  kill(_signal?: string) {
+    this.killed = true;
+    // Emit close after kill so the promise resolves
+    setImmediate(() => this.emit("close", null));
+  }
+}
+
+vi.mock("node:child_process", () => ({
+  spawn: (cmd: string, args: string[]) => {
+    spawnCalls.push({ cmd, args });
+    const child = new MockChildProcess();
+    const behavior = spawnBehaviors[spawnCallIndex] ?? { exitCode: 0 };
+    spawnCallIndex++;
+
+    const fire = () => {
+      if (behavior.spawnError) {
+        child.emit("error", new Error(behavior.spawnError));
+        return;
+      }
+      if (behavior.stdout) {
+        child.stdout.emit("data", Buffer.from(behavior.stdout));
+      }
+      if (behavior.stderr) {
+        child.stderr.emit("data", Buffer.from(behavior.stderr));
+      }
+      child.emit("close", behavior.exitCode);
+    };
+
+    if (behavior.delayMs) {
+      setTimeout(fire, behavior.delayMs);
+    } else {
+      setImmediate(fire);
+    }
+
+    return child;
+  },
+}));
+
+// Import AFTER mocking so the mock is in place when the module loads
+const {
+  createWorkerExecutor,
+  DirectModelExecutor,
+  PiHarnessExecutor,
+  DEFAULT_MAX_OUTPUT_CHARS,
+} = await import("../../src/orchestrator/worker-executor.js");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function successResponse(content: string, inputTokens = 10, outputTokens = 20): Response {
+  return new Response(
+    JSON.stringify({
+      model: "some/model",
+      choices: [{ message: { content }, finish_reason: "stop" }],
+      usage: { prompt_tokens: inputTokens, completion_tokens: outputTokens, total_tokens: inputTokens + outputTokens },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+function errorResponse(status: number, body = "bad request"): Response {
+  return new Response(body, { status });
+}
+
+beforeEach(() => {
+  spawnCalls.length = 0;
+  spawnBehaviors = [];
+  spawnCallIndex = 0;
+  vi.unstubAllEnvs();
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+// ---------------------------------------------------------------------------
+// createWorkerExecutor factory
+// ---------------------------------------------------------------------------
+
+describe("createWorkerExecutor", () => {
+  it("returns PiHarnessExecutor for pi-harness", () => {
+    const exec = createWorkerExecutor("pi-harness");
+    expect(exec).toBeInstanceOf(PiHarnessExecutor);
+  });
+
+  it("returns DirectModelExecutor for openrouter", () => {
+    expect(createWorkerExecutor("openrouter")).toBeInstanceOf(DirectModelExecutor);
+  });
+
+  it("returns DirectModelExecutor for berget", () => {
+    expect(createWorkerExecutor("berget")).toBeInstanceOf(DirectModelExecutor);
+  });
+
+  it("returns DirectModelExecutor for unknown provider (handled as error in run)", () => {
+    expect(createWorkerExecutor("unknown-xyz")).toBeInstanceOf(DirectModelExecutor);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DirectModelExecutor
+// ---------------------------------------------------------------------------
+
+describe("DirectModelExecutor — success path", () => {
+  it("returns ok=true with output, token counts, and costUsd computed from pricing", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-key");
+
+    const executor = new DirectModelExecutor();
+    // Inject fetch mock via global
+    const fetchMock = vi.fn().mockResolvedValue(successResponse("hello world", 100, 200));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await executor.run({
+      provider: "openrouter",
+      model: "deepseek/deepseek-v4-flash", // in model-pricing snapshot
+      prompt: "say hello",
+      timeoutMs: 5000,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toBe("hello world");
+    expect(result.provider).toBe("openrouter");
+    expect(result.model).toBe("deepseek/deepseek-v4-flash");
+    expect(result.inputTokens).toBe(100);
+    expect(result.outputTokens).toBe(200);
+    // deepseek-v4-flash: 0.09/M in, 0.18/M out
+    // 100/1e6*0.09 + 200/1e6*0.18 = 0.000009 + 0.000036 = 0.000045
+    expect(result.costUsd).toBeCloseTo(0.000045, 8);
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("sends system prompt when provided", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-key");
+
+    let capturedBody: unknown;
+    vi.stubGlobal("fetch", vi.fn().mockImplementation(async (_url: string, init: RequestInit) => {
+      capturedBody = JSON.parse(init.body as string);
+      return successResponse("ok");
+    }));
+
+    const executor = new DirectModelExecutor();
+    await executor.run({
+      provider: "openrouter",
+      model: "deepseek/deepseek-v4-flash",
+      prompt: "user question",
+      systemPrompt: "be concise",
+      timeoutMs: 5000,
+    });
+
+    const body = capturedBody as { messages: Array<{ role: string; content: string }> };
+    expect(body.messages[0]).toEqual({ role: "system", content: "be concise" });
+    expect(body.messages[1]).toEqual({ role: "user", content: "user question" });
+  });
+
+  it("sends OpenRouter referer and x-title headers", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-key");
+    vi.stubEnv("OPENROUTER_REFERER", "https://my.app");
+    vi.stubEnv("OPENROUTER_APP_TITLE", "my-app");
+
+    let capturedHeaders: Record<string, string> = {};
+    vi.stubGlobal("fetch", vi.fn().mockImplementation(async (_url: string, init: RequestInit) => {
+      capturedHeaders = init.headers as Record<string, string>;
+      return successResponse("ok");
+    }));
+
+    const executor = new DirectModelExecutor();
+    await executor.run({
+      provider: "openrouter",
+      model: "deepseek/deepseek-v4-flash",
+      prompt: "hi",
+      timeoutMs: 5000,
+    });
+
+    expect(capturedHeaders["http-referer"]).toBe("https://my.app");
+    expect(capturedHeaders["x-title"]).toBe("my-app");
+  });
+
+  it("costUsd is null for unknown model not in pricing snapshot", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-key");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(successResponse("answer", 50, 60)));
+
+    const executor = new DirectModelExecutor();
+    const result = await executor.run({
+      provider: "openrouter",
+      model: "unknown/model-not-in-snapshot",
+      prompt: "hi",
+      timeoutMs: 5000,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.costUsd).toBeNull();
+  });
+
+  it("truncates output to maxOutputChars", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-key");
+    const longContent = "x".repeat(200);
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(successResponse(longContent)));
+
+    const executor = new DirectModelExecutor();
+    const result = await executor.run({
+      provider: "openrouter",
+      model: "deepseek/deepseek-v4-flash",
+      prompt: "hi",
+      timeoutMs: 5000,
+      maxOutputChars: 50,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.output.length).toBe(50);
+  });
+});
+
+describe("DirectModelExecutor — HTTP error path", () => {
+  it("returns ok=false with error set and does not throw", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-key");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(errorResponse(500, "internal error")));
+
+    const executor = new DirectModelExecutor();
+    const result = await executor.run({
+      provider: "openrouter",
+      model: "deepseek/deepseek-v4-flash",
+      prompt: "hi",
+      timeoutMs: 5000,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/500/);
+    expect(result.output).toBe("");
+    expect(result.inputTokens).toBeNull();
+    expect(result.outputTokens).toBeNull();
+    expect(result.costUsd).toBeNull();
+  });
+
+  it("returns ok=false on 401", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-key");
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(errorResponse(401, "Unauthorized")));
+
+    const executor = new DirectModelExecutor();
+    const result = await executor.run({
+      provider: "openrouter",
+      model: "deepseek/deepseek-v4-flash",
+      prompt: "hi",
+      timeoutMs: 5000,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/401/);
+  });
+});
+
+describe("DirectModelExecutor — missing API key path", () => {
+  it("returns ok=false with clear error when env var is missing", async () => {
+    // Ensure the env var is not set
+    delete process.env.OPENROUTER_API_KEY;
+
+    const executor = new DirectModelExecutor();
+    const result = await executor.run({
+      provider: "openrouter",
+      model: "deepseek/deepseek-v4-flash",
+      prompt: "hi",
+      timeoutMs: 5000,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/OPENROUTER_API_KEY/);
+    expect(result.output).toBe("");
+  });
+
+  it("returns ok=false for unknown provider without touching network", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    const executor = new DirectModelExecutor();
+    const result = await executor.run({
+      provider: "no-such-provider",
+      model: "some/model",
+      prompt: "hi",
+      timeoutMs: 5000,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/Unknown provider/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("DirectModelExecutor — timeout/abort path", () => {
+  it("returns ok=false with timeout error when fetch is aborted", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-key");
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(Object.assign(new Error("aborted"), { name: "AbortError" })),
+    );
+
+    const executor = new DirectModelExecutor();
+    const result = await executor.run({
+      provider: "openrouter",
+      model: "deepseek/deepseek-v4-flash",
+      prompt: "hi",
+      timeoutMs: 1,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/timed out/i);
+    expect(result.output).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PiHarnessExecutor
+// ---------------------------------------------------------------------------
+
+const PI_JSONL_SUCCESS = [
+  JSON.stringify({ type: "assistant", content: "the answer" }),
+  JSON.stringify({ type: "usage", usage: { input_tokens: 50, output_tokens: 30 } }),
+].join("\n") + "\n";
+
+describe("PiHarnessExecutor — success path", () => {
+  it("parses JSONL output and returns ok=true with content and token counts", async () => {
+    spawnBehaviors = [{ exitCode: 0, stdout: PI_JSONL_SUCCESS }];
+
+    const executor = new PiHarnessExecutor();
+    const result = await executor.run({
+      provider: "pi-harness",
+      model: "qwen/qwen3-coder-next",
+      prompt: "write a function",
+      timeoutMs: 5000,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toBe("the answer");
+    expect(result.inputTokens).toBe(50);
+    expect(result.outputTokens).toBe(30);
+    expect(result.provider).toBe("pi-harness");
+    expect(result.model).toBe("qwen/qwen3-coder-next");
+    // model not in pricing snapshot → null cost
+    expect(result.costUsd).toBeNull();
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("builds args from registry (harnessFlags + mode + model + prompt)", async () => {
+    spawnBehaviors = [{ exitCode: 0, stdout: PI_JSONL_SUCCESS }];
+
+    const executor = new PiHarnessExecutor();
+    await executor.run({
+      provider: "pi-harness",
+      model: "qwen/qwen3-coder-next",
+      prompt: "hello",
+      timeoutMs: 5000,
+    });
+
+    expect(spawnCalls).toHaveLength(1);
+    const { cmd, args } = spawnCalls[0];
+    // harnessCmd from registry
+    expect(cmd).toBe("pi");
+    // harnessFlags present
+    expect(args).toContain("--no-session");
+    expect(args).toContain("--provider");
+    expect(args).toContain("openrouter");
+    // mode and model flags
+    expect(args).toContain("--mode");
+    expect(args).toContain("json");
+    expect(args).toContain("--model");
+    expect(args).toContain("qwen/qwen3-coder-next");
+    // prompt flag
+    expect(args).toContain("-p");
+    expect(args).toContain("hello");
+  });
+
+  it("uses alternate_tokens field if content field absent (text field)", async () => {
+    const jsonl = JSON.stringify({ type: "result", text: "text field result" }) + "\n";
+    spawnBehaviors = [{ exitCode: 0, stdout: jsonl }];
+
+    const executor = new PiHarnessExecutor();
+    const result = await executor.run({
+      provider: "pi-harness",
+      model: "qwen/qwen3-coder-next",
+      prompt: "hi",
+      timeoutMs: 5000,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toBe("text field result");
+  });
+});
+
+describe("PiHarnessExecutor — non-zero exit path", () => {
+  it("returns ok=false with stderr in error, does not throw", async () => {
+    spawnBehaviors = [
+      { exitCode: 1, stdout: "", stderr: "model not found" },
+    ];
+
+    const executor = new PiHarnessExecutor();
+    const result = await executor.run({
+      provider: "pi-harness",
+      model: "qwen/qwen3-coder-next",
+      prompt: "hi",
+      timeoutMs: 5000,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/code 1/);
+    expect(result.error).toMatch(/model not found/);
+    expect(result.output).toBe("");
+  });
+
+  it("returns ok=false on spawn error", async () => {
+    spawnBehaviors = [
+      { exitCode: 1, spawnError: "ENOENT: pi not found" },
+    ];
+
+    const executor = new PiHarnessExecutor();
+    const result = await executor.run({
+      provider: "pi-harness",
+      model: "qwen/qwen3-coder-next",
+      prompt: "hi",
+      timeoutMs: 5000,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/pi not found/);
+  });
+});
+
+describe("PiHarnessExecutor — timeout path", () => {
+  it("kills the child and returns ok=false with timeout error", async () => {
+    // delayMs > timeoutMs so the kill fires first
+    spawnBehaviors = [{ exitCode: 0, stdout: PI_JSONL_SUCCESS, delayMs: 500 }];
+
+    const executor = new PiHarnessExecutor();
+    const result = await executor.run({
+      provider: "pi-harness",
+      model: "qwen/qwen3-coder-next",
+      prompt: "hi",
+      timeoutMs: 10, // very short
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/timed out/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DEFAULT_MAX_OUTPUT_CHARS constant
+// ---------------------------------------------------------------------------
+
+describe("DEFAULT_MAX_OUTPUT_CHARS", () => {
+  it("is 50_000", () => {
+    expect(DEFAULT_MAX_OUTPUT_CHARS).toBe(50_000);
+  });
+});

--- a/tests/orchestrator/worker-executor.test.ts
+++ b/tests/orchestrator/worker-executor.test.ts
@@ -318,6 +318,50 @@ describe("DirectModelExecutor — missing API key path", () => {
   });
 });
 
+describe("DirectModelExecutor — malformed response bodies (Fix #3)", () => {
+  it("{choices:[null]} returns ok=false and does NOT throw", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-key");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ choices: [null] }), { status: 200, headers: { "content-type": "application/json" } }),
+      ),
+    );
+    const executor = new DirectModelExecutor();
+    const result = await executor.run({ provider: "openrouter", model: "deepseek/deepseek-v4-flash", prompt: "hi", timeoutMs: 5000 });
+    expect(result.ok).toBe(false);
+    expect(result.output).toBe("");
+  });
+
+  it("{choices:[{}]} returns ok=false and does NOT throw", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-key");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ choices: [{}] }), { status: 200, headers: { "content-type": "application/json" } }),
+      ),
+    );
+    const executor = new DirectModelExecutor();
+    const result = await executor.run({ provider: "openrouter", model: "deepseek/deepseek-v4-flash", prompt: "hi", timeoutMs: 5000 });
+    expect(result.ok).toBe(false);
+    expect(result.output).toBe("");
+  });
+
+  it("{choices:[{message:{content:123}}]} returns ok=false and does NOT throw", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-key");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ choices: [{ message: { content: 123 } }] }), { status: 200, headers: { "content-type": "application/json" } }),
+      ),
+    );
+    const executor = new DirectModelExecutor();
+    const result = await executor.run({ provider: "openrouter", model: "deepseek/deepseek-v4-flash", prompt: "hi", timeoutMs: 5000 });
+    expect(result.ok).toBe(false);
+    expect(result.output).toBe("");
+  });
+});
+
 describe("DirectModelExecutor — timeout/abort path", () => {
   it("returns ok=false with timeout error when fetch is aborted", async () => {
     vi.stubEnv("OPENROUTER_API_KEY", "test-key");

--- a/tests/orchestrator/worker-executor.test.ts
+++ b/tests/orchestrator/worker-executor.test.ts
@@ -476,6 +476,43 @@ describe("PiHarnessExecutor — timeout path", () => {
 });
 
 // ---------------------------------------------------------------------------
+// PiHarnessExecutor — pi v3 event schema (smoke-test format lock)
+// ---------------------------------------------------------------------------
+
+// Real pi --mode json output uses a v3 event schema: message_start + message_end
+// events carry the assistant content and usage inside a `message` envelope.
+const PI_V3_JSONL = [
+  JSON.stringify({ type: "message_start", message: { role: "assistant", content: [] } }),
+  JSON.stringify({
+    type: "message_end",
+    message: {
+      role: "assistant",
+      content: [{ type: "text", text: "pong" }],
+      usage: { input: 9, output: 1 },
+    },
+  }),
+].join("\n") + "\n";
+
+describe("PiHarnessExecutor — pi v3 event schema", () => {
+  it("extracts output and token counts from message_start/message_end events", async () => {
+    spawnBehaviors = [{ exitCode: 0, stdout: PI_V3_JSONL }];
+
+    const executor = new PiHarnessExecutor();
+    const result = await executor.run({
+      provider: "pi-harness",
+      model: "qwen/qwen3-coder-next",
+      prompt: "ping",
+      timeoutMs: 5000,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toBe("pong");
+    expect(result.inputTokens).toBe(9);
+    expect(result.outputTokens).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // DEFAULT_MAX_OUTPUT_CHARS constant
 // ---------------------------------------------------------------------------
 

--- a/tests/pipeline-compiler.test.ts
+++ b/tests/pipeline-compiler.test.ts
@@ -370,7 +370,10 @@ Phase: explore
   });
 
   it("auto-routes private pipeline phase to trusted runtime only", () => {
-    const pipeline = makePipeline(`## Task: Private auto
+    // ollama-pi is now explicit-only (control-plane box), so private auto-routing
+    // must land on another trusted host. Make the laptop available for this case.
+    const pipeline = makePipeline(
+      `## Task: Private auto
 
 - **Runtime:** pipeline
 - **Sensitivity:** private
@@ -381,8 +384,18 @@ Phase: review
   Runtime: auto
   Prompt: |
     Review private notes.
-`);
-    // Private must route to trusted (ollama)
+`,
+      [
+        {
+          name: "laptop",
+          baseUrl: "http://100.1.2.3:11434",
+          available: true,
+          models: ["qwen3.5:35b-a3b"],
+          lastChecked: Date.now(),
+        },
+      ],
+    );
+    // Private must route to a trusted runtime (ollama, laptop host)
     expect(pipeline.phases[0]?.dispatcherRuntime).toBe("ollama");
     expect(pipeline.phases[0]?.autoRouted).toBe(true);
   });

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -371,4 +371,93 @@ describe("routeTask", () => {
       expect(decision.selectedRuntime.id).toBe("legacy-runtime");
     });
   });
+
+  describe("price-aware tiebreaker (Task B)", () => {
+    // deepseek/deepseek-v4-flash: input=$0.09/M, output=$0.18/M → blended ~$0.135/M
+    // mistralai/mistral-medium-3.5: input=$1.65/M, output=$5.50/M → blended ~$3.575/M
+    const cheapPerToken = makeCandidate({
+      id: "cheap-per-token",
+      trustTier: "semi-trusted",
+      costModel: "per-token",
+      modelSize: "large",
+      available: true,
+      autoEligible: true,
+      defaultModel: "deepseek/deepseek-v4-flash",
+    });
+
+    const pricierPerToken = makeCandidate({
+      id: "pricier-per-token",
+      trustTier: "semi-trusted",
+      costModel: "per-token",
+      modelSize: "large",
+      available: true,
+      autoEligible: true,
+      defaultModel: "mistralai/mistral-medium-3.5",
+    });
+
+    const unpricedPerToken = makeCandidate({
+      id: "unpriced-per-token",
+      trustTier: "semi-trusted",
+      costModel: "per-token",
+      modelSize: "large",
+      available: true,
+      autoEligible: true,
+      // no defaultModel → unpriced
+    });
+
+    const subscriptionRuntime = makeCandidate({
+      id: "sub-runtime",
+      trustTier: "semi-trusted",
+      costModel: "subscription",
+      modelSize: "large",
+      available: true,
+      autoEligible: true,
+      defaultModel: "deepseek/deepseek-v4-flash", // same cheap price — should still lose to tier
+    });
+
+    it("among per-token candidates with same trust/size, cheaper defaultModel wins", () => {
+      const input: RouterInput = {
+        effectiveSensitivity: "internal",
+        availableRuntimes: [pricierPerToken, cheapPerToken],
+      };
+      const decision = routeTask(input);
+      expect(decision.selectedRuntime.id).toBe("cheap-per-token");
+    });
+
+    it("subscription tier still beats a cheaper-priced per-token candidate (tier dominance)", () => {
+      const input: RouterInput = {
+        effectiveSensitivity: "internal",
+        availableRuntimes: [cheapPerToken, subscriptionRuntime],
+      };
+      const decision = routeTask(input);
+      expect(decision.selectedRuntime.id).toBe("sub-runtime");
+    });
+
+    it("unpriced per-token ranks below a priced per-token", () => {
+      const input: RouterInput = {
+        effectiveSensitivity: "internal",
+        availableRuntimes: [unpricedPerToken, cheapPerToken],
+      };
+      const decision = routeTask(input);
+      expect(decision.selectedRuntime.id).toBe("cheap-per-token");
+    });
+
+    it("both unpriced per-token candidates → either can win (no error)", () => {
+      const unpriced2 = makeCandidate({
+        id: "unpriced-2",
+        trustTier: "semi-trusted",
+        costModel: "per-token",
+        modelSize: "large",
+        available: true,
+        autoEligible: true,
+      });
+      const input: RouterInput = {
+        effectiveSensitivity: "internal",
+        availableRuntimes: [unpricedPerToken, unpriced2],
+      };
+      // Should not throw; one of the two is selected
+      const decision = routeTask(input);
+      expect(["unpriced-per-token", "unpriced-2"]).toContain(decision.selectedRuntime.id);
+    });
+  });
 });

--- a/tests/runtime-registry.test.ts
+++ b/tests/runtime-registry.test.ts
@@ -211,12 +211,18 @@ describe("orchestrator v1 policy fields", () => {
     expect(entry!.autoEligible).toBe(false);
   });
 
-  it("existing one-shot runtimes are auto-eligible by default", () => {
-    for (const id of ["claude-sdk", "codex-spawn", "ollama-pi", "ollama-laptop", "ollama-orin"]) {
+  it("existing one-shot runtimes are auto-eligible by default (except ollama-pi)", () => {
+    for (const id of ["claude-sdk", "codex-spawn", "ollama-laptop", "ollama-orin"]) {
       const entry = getRegistryEntryById(id);
       expect(entry?.autoEligible).toBe(true);
       expect(entry?.family).toBe("one-shot");
     }
+  });
+
+  it("ollama-pi is explicit-only (control plane, not a general auto-routed worker)", () => {
+    const entry = getRegistryEntryById("ollama-pi");
+    expect(entry?.autoEligible).toBe(false);
+    expect(entry?.family).toBe("one-shot");
   });
 
   it("ollama entries are local-egress and not ZDR-flagged", () => {

--- a/tests/runtime-registry.test.ts
+++ b/tests/runtime-registry.test.ts
@@ -42,9 +42,9 @@ describe("RUNTIME_REGISTRY", () => {
     }
   });
 
-  it("cloud entries are semi-trusted", () => {
+  it("cloud entries are semi-trusted (except berget which is trusted/EU-sovereign)", () => {
     const cloudEntries = RUNTIME_REGISTRY.filter(
-      (r) => r.dispatcherRuntime !== "ollama",
+      (r) => r.dispatcherRuntime !== "ollama" && r.id !== "berget",
     );
     for (const entry of cloudEntries) {
       expect(entry.trustTier).toBe("semi-trusted");
@@ -235,9 +235,9 @@ describe("alias map (v1)", () => {
     expect(ALIAS_MAP_V1.version).toBe(1);
   });
 
-  it("contains the four v1 aliases", () => {
+  it("contains the five v1 aliases (four original + berget-sovereign)", () => {
     const aliases = Object.keys(ALIAS_MAP_V1.aliases).sort();
-    expect(aliases).toEqual(["large-reasoning", "medium", "pi-large-coder", "tiny"]);
+    expect(aliases).toEqual(["berget-sovereign", "large-reasoning", "medium", "pi-large-coder", "tiny"]);
   });
 
   it("tiny resolves to ollama-pi/qwen2.5:3b", () => {
@@ -278,5 +278,33 @@ describe("alias map (v1)", () => {
 
   it("resolveAlias throws on unknown alias", () => {
     expect(() => resolveAlias("nonexistent" as never)).toThrow(/Unknown alias/);
+  });
+
+  it("berget-sovereign resolves to berget runtime with mistral-small", () => {
+    const r = resolveAlias("berget-sovereign");
+    expect(r.runtimeId).toBe("berget");
+    expect(r.model).toBe("mistralai/mistral-small-3.2-24b-instruct");
+    expect(r.family).toBe("one-shot");
+  });
+});
+
+describe("berget runtime", () => {
+  it("getRegistryEntryById returns berget with correct fields", () => {
+    const entry = getRegistryEntryById("berget");
+    expect(entry).toBeDefined();
+    expect(entry!.provider).toBe("berget");
+    expect(entry!.egress).toBe("third-party");
+    expect(entry!.trustTier).toBe("trusted");
+    expect(entry!.autoEligible).toBe(false);
+    expect(entry!.family).toBe("one-shot");
+    expect(entry!.zdrRequired).toBe(false);
+    expect(entry!.dispatcherRuntime).toBe("berget");
+  });
+
+  it("berget is available:true in buildRuntimeCandidates (cloud runtime)", () => {
+    const candidates = buildRuntimeCandidates([]);
+    const berget = candidates.find((c) => c.id === "berget");
+    expect(berget).toBeDefined();
+    expect(berget!.available).toBe(true);
   });
 });

--- a/tests/runtime-registry.test.ts
+++ b/tests/runtime-registry.test.ts
@@ -242,9 +242,9 @@ describe("alias map (v1)", () => {
     expect(ALIAS_MAP_V1.version).toBe(1);
   });
 
-  it("contains the five v1 aliases (four original + berget-sovereign)", () => {
+  it("contains the four v1 aliases", () => {
     const aliases = Object.keys(ALIAS_MAP_V1.aliases).sort();
-    expect(aliases).toEqual(["berget-sovereign", "large-reasoning", "medium", "pi-large-coder", "tiny"]);
+    expect(aliases).toEqual(["large-reasoning", "medium", "pi-large-coder", "tiny"]);
   });
 
   it("tiny resolves to ollama-pi/qwen2.5:3b", () => {
@@ -287,11 +287,8 @@ describe("alias map (v1)", () => {
     expect(() => resolveAlias("nonexistent" as never)).toThrow(/Unknown alias/);
   });
 
-  it("berget-sovereign resolves to berget runtime with mistral-small", () => {
-    const r = resolveAlias("berget-sovereign");
-    expect(r.runtimeId).toBe("berget");
-    expect(r.model).toBe("mistralai/mistral-small-3.2-24b-instruct");
-    expect(r.family).toBe("one-shot");
+  it("resolveAlias throws on berget-sovereign (removed from alias map)", () => {
+    expect(() => resolveAlias("berget-sovereign" as never)).toThrow(/Unknown alias/);
   });
 });
 

--- a/tests/runtime-registry.test.ts
+++ b/tests/runtime-registry.test.ts
@@ -6,6 +6,7 @@ import {
   getAliasMap,
   getRegistryEntryById,
   getRuntimeMaxSensitivity,
+  parseActiveSubscriptions,
   resolveAlias,
 } from "../src/runtime-registry.js";
 import type { OllamaHost } from "../src/ollama-hosts.js";
@@ -306,5 +307,84 @@ describe("berget runtime", () => {
     const berget = candidates.find((c) => c.id === "berget");
     expect(berget).toBeDefined();
     expect(berget!.available).toBe(true);
+  });
+});
+
+describe("parseActiveSubscriptions", () => {
+  it("undefined returns undefined (all subscriptions active, backwards-compat)", () => {
+    expect(parseActiveSubscriptions(undefined)).toBeUndefined();
+  });
+
+  it("empty string returns undefined", () => {
+    expect(parseActiveSubscriptions("")).toBeUndefined();
+  });
+
+  it("whitespace-only string returns undefined", () => {
+    expect(parseActiveSubscriptions("   ")).toBeUndefined();
+  });
+
+  it("single runtime id returns a Set with that id", () => {
+    const result = parseActiveSubscriptions("claude-sdk");
+    expect(result).toBeInstanceOf(Set);
+    expect(result!.has("claude-sdk")).toBe(true);
+    expect(result!.size).toBe(1);
+  });
+
+  it("trims whitespace around comma-separated ids", () => {
+    const result = parseActiveSubscriptions("a, b ,c");
+    expect(result).toBeInstanceOf(Set);
+    expect(result!.has("a")).toBe(true);
+    expect(result!.has("b")).toBe(true);
+    expect(result!.has("c")).toBe(true);
+    expect(result!.size).toBe(3);
+  });
+
+  it("ignores empty segments from double commas", () => {
+    const result = parseActiveSubscriptions("claude-sdk,,codex-spawn");
+    expect(result).toBeInstanceOf(Set);
+    expect(result!.has("claude-sdk")).toBe(true);
+    expect(result!.has("codex-spawn")).toBe(true);
+    expect(result!.size).toBe(2);
+  });
+});
+
+describe("buildRuntimeCandidates with activeSubscriptions", () => {
+  it("with activeSubscriptions={claude-sdk}: claude-sdk available:true, codex-spawn available:false", () => {
+    const active = new Set(["claude-sdk"]);
+    const candidates = buildRuntimeCandidates([], { activeSubscriptions: active });
+    const claudeSdk = candidates.find((c) => c.id === "claude-sdk");
+    const codexSpawn = candidates.find((c) => c.id === "codex-spawn");
+    expect(claudeSdk?.available).toBe(true);
+    expect(codexSpawn?.available).toBe(false);
+  });
+
+  it("with activeSubscriptions=undefined: both claude-sdk and codex-spawn are available:true (regression)", () => {
+    const candidates = buildRuntimeCandidates([], { activeSubscriptions: undefined });
+    const claudeSdk = candidates.find((c) => c.id === "claude-sdk");
+    const codexSpawn = candidates.find((c) => c.id === "codex-spawn");
+    expect(claudeSdk?.available).toBe(true);
+    expect(codexSpawn?.available).toBe(true);
+  });
+
+  it("activeSubscriptions does not affect non-subscription runtimes (ollama stays available)", () => {
+    const piOnline: OllamaHost = {
+      name: "pi",
+      baseUrl: "http://127.0.0.1:11434",
+      available: true,
+      models: ["qwen2.5:3b"],
+      lastChecked: Date.now(),
+    };
+    const active = new Set(["claude-sdk"]); // does not include ollama runtimes
+    const candidates = buildRuntimeCandidates([piOnline], { activeSubscriptions: active });
+    const pi = candidates.find((c) => c.id === "ollama-pi");
+    expect(pi?.available).toBe(true); // free, unaffected by subscription filter
+  });
+
+  it("no opts argument keeps existing behaviour (both subscription runtimes available)", () => {
+    const candidates = buildRuntimeCandidates([]);
+    const claudeSdk = candidates.find((c) => c.id === "claude-sdk");
+    const codexSpawn = candidates.find((c) => c.id === "codex-spawn");
+    expect(claudeSdk?.available).toBe(true);
+    expect(codexSpawn?.available).toBe(true);
   });
 });


### PR DESCRIPTION
**Re-platforms Hugin from a Claude-Code-centric dispatcher into a vendor-neutral orchestrator** that owns ultracode/Workflow-style fanout itself. Workers are interchangeable, price-selected commodities (pi.dev harness + direct cloud-model calls via OpenRouter/Berget; local homeserver `/delegate` lands later). Full design: `docs/orchestrator-redesign.md`.

This is **PR1 (cloud lane)** — needs no new hardware, runnable today. Full suite: **1083 tests green**.

### Done (this PR)
- **1a — roster substrate**: Berget.ai EU-sovereign provider + `berget-sovereign` alias; `src/model-pricing.ts` $/M-token table (OpenRouter / Berget / Claude baseline) + `estimateCostUsd()`.
- **1b — price-aware router + configurable subscriptions**: `HUGIN_ACTIVE_SUBSCRIPTIONS` (vendor-neutral active-sub set); per-token price tiebreaker. `ollama-pi` demoted to explicit-only (control-plane box, not a general worker).
- **2 — worker-executor layer**: `WorkerExecutor` (pi-harness spawn + direct-model OpenAI-compat) returning output + tokens + cost; provider-agnostic (ZDR/sensitivity enforced above it).
- **3a — native fanout engine**: `runOrchestration()` = plan → concurrent cheap-worker fanout → optional verify → synthesize, via one injected `ModelInvoker`. Resilient (planner-parse fallback, survives worker failures).
- **3b — dispatcher wiring**: `Runtime: orchestrator` runs end-to-end; fail-closed sensitivity guard (private ⇒ sovereign/local providers only, zero spend otherwise); `HUGIN_ORCH_*` config; abort slot wired.

### Follow-up PRs
- **PR2** adaptive quality + cloud-worker verdict store — the "cheapest that *gets the job done*" learning layer + don't-re-test-known-bad (frozen latch).
- **PR3** savings tracker (actual multi-provider \$ vs all-Claude baseline). **PR4** Pi/BosGame host split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)