### PR TITLE
feat(homeserver): forward modelId/frontierModelId/verify on /delegate (#14)

### DIFF
--- a/src/homeserver-executor.ts
+++ b/src/homeserver-executor.ts
@@ -26,18 +26,30 @@ import * as path from "node:path";
 
 export type HomeserverPath = "chat" | "delegate";
 
+/** Declarative grading forwarded to the gateway /delegate `verify` field (gateway-api-contract.md). */
+export interface HomeserverVerifySpec {
+  nonEmpty?: boolean;
+  answerIs?: string;
+  contains?: string[];
+  matches?: string;
+  numeric?: number;
+  json?: boolean;
+  ci?: boolean;
+}
+
 export interface HomeserverTaskConfig {
   prompt: string;
   gatewayBaseUrl: string; // e.g. http://127.0.0.1:8080
   apiKey: string; // Bearer token (may be "" on a keyless loopback gateway)
   path: HomeserverPath;
-  /** Required for "chat" (the model to serve). Ignored on "delegate" (the gateway/ledger selects). */
+  /** Required for "chat" (the model to serve). On "delegate" it forces the local model id. */
   model?: string;
   /** Forwarded to /delegate as the ledger bucket. */
   taskType?: string;
-  /** Reserved for forward-compat: the gateway /delegate HTTP endpoint does not yet accept a
-   *  frontier model, so this is currently NOT sent. Re-wire once the gateway exposes escalation. */
+  /** Forwarded to /delegate: OpenRouter model id to escalate to when the local attempt is non-viable. */
   frontierModelId?: string;
+  /** Forwarded to /delegate: opt-in deterministic grading so the ledger learns pass/fail. */
+  verify?: HomeserverVerifySpec;
   timeoutMs: number;
   maxOutputChars: number;
   injectedContext?: string;
@@ -238,11 +250,13 @@ export async function executeHomeserverTask(
     const body: Record<string, unknown> =
       task.path === "delegate"
         ? {
-            // The gateway /delegate HTTP handler only accepts prompt + taskType
-            // (+ systemPrompt/maxTokens). It does NOT accept modelId or frontierModelId
-            // today, so we don't send them — see gateway-api-contract.md.
+            // Mirrors the gateway /delegate contract (gateway-api-contract.md):
+            // prompt + optional taskType / modelId / frontierModelId / verify.
             prompt: userMessage,
             ...(task.taskType ? { taskType: task.taskType } : {}),
+            ...(task.model ? { modelId: task.model } : {}),
+            ...(task.frontierModelId ? { frontierModelId: task.frontierModelId } : {}),
+            ...(task.verify ? { verify: task.verify } : {}),
           }
         : {
             model: task.model,

--- a/tests/homeserver-executor.test.ts
+++ b/tests/homeserver-executor.test.ts
@@ -186,9 +186,22 @@ describe("executeHomeserverTask — delegate path", () => {
     const body = JSON.parse((init as RequestInit).body as string);
     expect(body.taskType).toBe("extract");
     expect(typeof body.prompt).toBe("string");
-    // The gateway /delegate handler ignores these fields, so the executor must not send them.
-    expect(body.modelId).toBeUndefined();
-    expect(body.frontierModelId).toBeUndefined();
+    // The gateway /delegate handler now accepts these — forward them.
+    expect(body.modelId).toBe("qwen3-coder"); // makeTaskConfig default model
+    expect(body.frontierModelId).toBe("anthropic/claude-opus-4-5");
+  });
+
+  it("forwards an opt-in verify spec on the delegate path", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ delegated: true, outcome: "pass", score: 1, output: "1998" }));
+    await executeHomeserverTask(
+      makeTaskConfig({ path: "delegate", taskType: "extract", verify: { numeric: 1998, nonEmpty: true } }),
+      "delegate-verify",
+      tmpLogDir,
+    );
+    const body = JSON.parse((fetchMock.mock.calls[0]![1] as RequestInit).body as string);
+    expect(body.verify).toEqual({ numeric: 1998, nonEmpty: true });
   });
 
   it("maps outcome 'fail'/'error' to a non-zero exit code, but 'unverified' to 0", async () => {


### PR DESCRIPTION
The hugin half of home-server-inference-evaluation #14 (pairs with its PR #16).

Now that the gateway `/delegate` handler accepts `modelId`, `frontierModelId`, and an opt-in `verify` spec, re-enable the executor to send them (they were stripped during the #107 review because the gateway ignored them):
- adds `HomeserverVerifySpec` to the config
- forwards `task.model → modelId`, `task.frontierModelId`, and `task.verify` on the delegate path
- updates the stale "gateway ignores these" comments
- test: asserts the fields are sent + a new `verify`-passthrough case (17 tests, typecheck clean)

This activates the executor's dormant escalation and lets nightly delegations carry a deterministic check so the ledger learns real pass/fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)