### PR TITLE
docs: session 5 — orchestrator shipped + M5 arrived

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,21 @@
 # Hugin — Status
 
-**Last session:** 2026-06-15 (session 4 — Orin deployed LIVE + registry fix #104 + pipeline demo)
-**Branch:** main (clean at `db86e14`; 0 PRs open)
+**Last session:** 2026-06-17 (session 5 — orchestrator re-platforming shipped + live-validated + merged)
+**Branch:** main (clean at the PR #108 merge; 0 PRs open)
+
+## Session 5 (2026-06-17) — Vendor-neutral orchestrator shipped (PR #108)
+
+A "big rethink": turn Hugin from a Claude-Code-centric dispatcher into a **vendor-neutral orchestrator** that owns ultracode/Workflow-style fan-out itself, using a roster of cheap cloud + local models picked by price, with **no Claude Code / harness lock-in**. Full design: `docs/orchestrator-redesign.md`.
+
+- **Decisions (research-backed):** Hugin OWNS orchestration (no OSS harness does externally-driveable fan-out well; pi.dev punts orchestration to the caller). pi.dev = future worker harness. Roster: OpenRouter (DeepSeek Flash etc.) + Berget.ai (EU-sovereign lane) + local via the ADR-004 homeserver gateway. Blended ~15–25× cheaper than all-Claude.
+- **Built `Runtime: orchestrator`** (`src/orchestrator/*`): plan → concurrent cheap-worker fan-out → optional verify → synthesize, all roles vendor-neutral `provider+model` bindings via one injected `ModelInvoker`. Plus `model-pricing.ts`, a price-aware router tiebreaker, configurable active subscriptions (`HUGIN_ACTIVE_SUBSCRIPTIONS`), `ollama-pi` demoted to explicit-only, and a fail-closed sensitivity guard (private ⇒ sovereign/local only, zero spend otherwise).
+- **Live-validated** end-to-end against OpenRouter (`deepseek-v4-flash`) + Berget (`Llama-3.1-8B`) + Google (`gemini-flash`): real fan-out → coherent synthesis, real `totalCostUsd`. Caught + fixed real bugs (pi v3 JSONL parser, Berget `max_tokens` OOM).
+- **Codex-reviewed** (gpt-5.5 xhigh, no critical findings): fixed 6 findings pre-merge; filed 3 follow-ups → issues **#110** (AbortSignal threading), **#111** (private+Berget lane), **#112** (configurable max_tokens + finish_reason).
+- **Merged PR [#108](https://github.com/Magnus-Gille/hugin/pull/108)** (full suite 1120 green, CI passed). Also synced **PR #107** (`homeserver-executor.ts`, the M5 gateway dual-path executor) which had landed on main meanwhile.
+- **M5 (BosGame Strix Halo 128GB) arrived 2026-06-17** — being provisioned by another agent. Unblocks the local `/delegate` lane, private-capable local workers, PR4 host split, and PR2's real ledger.
+- **Worktree retained:** `/Users/magnus/repos/hugin-orchestrator` (branch `feat/orchestrator-workflows`, merged) holds a gitignored `.env` with OpenRouter + Berget keys for live testing — reuse for PR2.
+
+**Next:** when the M5 gateway is reachable (Tailscale), wire a `homeserver` worker provider (uses `homeserver-executor.ts`, `HOMESERVER_GATEWAY_URL`). Then PR2 (learning/verdict layer) → PR3 (savings tracker) → PR4 (Pi control / M5 execution host split). **Redeploy main to the Pi** — it still runs pre-orchestrator code.
 
 ## Session 4 (2026-06-15) — Orin Nano GPU cell LIVE in Hugin
 


### PR DESCRIPTION
Session-5 handoff entry for STATUS.md. Records the orchestrator re-platforming (PR #108, merged + live-validated + Codex-reviewed), the M5 arrival, the roadmap (M5 wiring → PR2 → PR3 → PR4), open follow-ups #110/#111/#112, and the Pi-redeploy reminder. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)