### PR TITLE
fix(sdk-executor): capture and log child process stderr on failure

### DIFF
--- a/src/sdk-executor.ts
+++ b/src/sdk-executor.ts
@@ -45,6 +45,26 @@ export interface SdkExecutorOptions {
   abortController?: AbortController;
 }
 
+/**
+ * Format captured child stderr into a log block for task output on failure.
+ *
+ * Returns the formatted block (capped to the last 4000 chars of stderr) when
+ * `exitCode !== 0` and `stderrBuf` contains non-whitespace content.
+ * Returns null on success (exitCode 0) or when the buffer is empty/whitespace.
+ *
+ * Exported so it can be unit-tested independently without mocking the full SDK.
+ */
+export function formatChildStderr(
+  stderrBuf: string,
+  exitCode: number | "TIMEOUT",
+): string | null {
+  if (exitCode === 0 || !stderrBuf.trim()) {
+    return null;
+  }
+  const capped = stderrBuf.trim().slice(-4000);
+  return `\n[child stderr]\n${capped}\n`;
+}
+
 export async function executeSdkTask(
   task: SdkTaskConfig,
   taskId: string,
@@ -137,6 +157,9 @@ export async function executeSdkTask(
   let durationApiMs: number | null = null;
   let exitCode: number | "TIMEOUT" = 1;
   let queryInstance: Query | null = null;
+  // Accumulates stderr from the spawned Claude Code process.
+  // Declared outside try so the catch/finally can read it.
+  let stderrBuf = "";
 
   try {
     // Build MCP servers config so task-spawned agents get Munin access
@@ -210,6 +233,9 @@ export async function executeSdkTask(
           HOME: "/home/magnus",
           HUGIN_TASK_ID: taskId,
         },
+        // Capture stderr from the spawned Claude Code process.
+        // stderr is typed in Options as (data: string) => void — no cast needed.
+        stderr: (data: string) => { stderrBuf += data; },
       },
     });
 
@@ -288,6 +314,13 @@ export async function executeSdkTask(
       } catch {
         // Already closed
       }
+    }
+
+    // Append captured child stderr to the task log on failure.
+    // Capped to the last 4000 chars so very noisy processes don't flood the log.
+    const stderrBlock = formatChildStderr(stderrBuf, exitCode);
+    if (stderrBlock !== null) {
+      appendOutput(stderrBlock);
     }
 
     const durationS = Math.round((Date.now() - startMs) / 1000);

--- a/tests/sdk-executor.test.ts
+++ b/tests/sdk-executor.test.ts
@@ -8,7 +8,7 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
   query: vi.fn(),
 }));
 
-import { executeSdkTask, type SdkTaskConfig } from "../src/sdk-executor.js";
+import { executeSdkTask, formatChildStderr, type SdkTaskConfig } from "../src/sdk-executor.js";
 import { query } from "@anthropic-ai/claude-agent-sdk";
 
 const mockedQuery = vi.mocked(query);
@@ -205,6 +205,63 @@ describe("SDK executor", () => {
     });
   });
 
+  it("passes a stderr callback in query options", async () => {
+    const messages = [createMockResultSuccess("Done")];
+    mockedQuery.mockReturnValue(createMockQuery(messages) as ReturnType<typeof query>);
+
+    await executeSdkTask(makeTaskConfig(), "test-task-stderr-cb", tmpLogDir);
+
+    const call = mockedQuery.mock.calls[0]?.[0] as {
+      options?: { stderr?: unknown };
+    };
+    expect(typeof call?.options?.stderr).toBe("function");
+  });
+
+  it("includes child stderr in output and log when the process fails", async () => {
+    // Simulate: the query throws (process exited code 1), and stderr was captured
+    // by the callback before the throw.
+    let capturedStderrCb: ((data: string) => void) | undefined;
+    const gen = createMockQuery([]);
+    gen.next = async () => {
+      // Invoke the stderr callback to simulate output from the child process
+      capturedStderrCb?.("Error: authentication token expired\n");
+      throw new Error("Claude Code process exited with code 1");
+    };
+    mockedQuery.mockImplementation(({ options }) => {
+      capturedStderrCb = options?.stderr;
+      return gen as ReturnType<typeof query>;
+    });
+
+    const result = await executeSdkTask(makeTaskConfig(), "test-task-stderr-content", tmpLogDir);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("[child stderr]");
+    expect(result.output).toContain("authentication token expired");
+
+    const logContent = fs.readFileSync(result.logFile, "utf-8");
+    expect(logContent).toContain("[child stderr]");
+    expect(logContent).toContain("authentication token expired");
+  });
+
+  it("does not include [child stderr] in output on success", async () => {
+    let capturedStderrCb: ((data: string) => void) | undefined;
+    const gen = createMockQuery([createMockResultSuccess("All good.")]);
+    const originalNext = gen.next.bind(gen);
+    gen.next = async () => {
+      capturedStderrCb?.("some benign debug line\n");
+      return originalNext();
+    };
+    mockedQuery.mockImplementation(({ options }) => {
+      capturedStderrCb = options?.stderr;
+      return gen as ReturnType<typeof query>;
+    });
+
+    const result = await executeSdkTask(makeTaskConfig(), "test-task-stderr-success", tmpLogDir);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.output).not.toContain("[child stderr]");
+  });
+
   it("forwards muninSessionId as mcp-session-id header to the Munin MCP server", async () => {
     const messages = [createMockResultSuccess("Done")];
     mockedQuery.mockReturnValue(createMockQuery(messages) as ReturnType<typeof query>);
@@ -362,6 +419,53 @@ describe("SDK executor", () => {
     expect(result.exitCode).toBe("TIMEOUT");
     expect(onTimeout).toHaveBeenCalled();
     expect(result.output).toContain("TIMEOUT");
+  });
+});
+
+describe("formatChildStderr", () => {
+  it("returns null when exitCode is 0 (success), even with stderr content", () => {
+    expect(formatChildStderr("some error output", 0)).toBeNull();
+  });
+
+  it("returns null when stderrBuf is empty", () => {
+    expect(formatChildStderr("", 1)).toBeNull();
+  });
+
+  it("returns null when stderrBuf is whitespace-only", () => {
+    expect(formatChildStderr("   \n\t  ", 1)).toBeNull();
+  });
+
+  it("returns formatted block on non-zero exit code with stderr content", () => {
+    const result = formatChildStderr("Error: authentication failed\nCode: 1", 1);
+    expect(result).not.toBeNull();
+    expect(result).toContain("[child stderr]");
+    expect(result).toContain("Error: authentication failed");
+    expect(result).toContain("Code: 1");
+  });
+
+  it("returns formatted block on TIMEOUT exit code with stderr content", () => {
+    const result = formatChildStderr("timeout details", "TIMEOUT");
+    expect(result).not.toBeNull();
+    expect(result).toContain("[child stderr]");
+    expect(result).toContain("timeout details");
+  });
+
+  it("truncates stderrBuf to the last 4000 chars when it exceeds the cap", () => {
+    // Build a string: 5000 A's followed by 1000 B's = 6000 chars total.
+    // slice(-4000) keeps the last 4000: 3000 A's + 1000 B's.
+    // The first 2000 A's are discarded, so the result must not start with the
+    // leading A block but must contain the trailing B's.
+    const prefix = "A".repeat(5000);
+    const suffix = "B".repeat(1000);
+    const stderrBuf = prefix + suffix;
+    const result = formatChildStderr(stderrBuf, 1);
+    expect(result).not.toBeNull();
+    // The block must contain the tail (Bs)
+    expect(result).toContain("B".repeat(100));
+    // The captured content should be exactly 4000 chars (plus the wrapper lines)
+    const match = result!.match(/\[child stderr\]\n([\s\S]*)\n$/);
+    expect(match).not.toBeNull();
+    expect(match![1]!.length).toBeLessThanOrEqual(4000);
   });
 });
 


### PR DESCRIPTION
## Context — the outage

Today all SDK tasks failed with exit code 1 in 0 seconds. The executor's catch block logged only:

```
[SDK Error: Claude Code process exited with code 1]
```

No child stderr. No auth error message. No way to diagnose whether it was a token expiry, a missing binary, a bad env var, or something else. The root cause took much longer to identify than it should have.

## What this PR does

The Agent SDK's `query()` accepts a `stderr` callback in its `Options` type (`sdk.d.ts:1199`: `stderr?: (data: string) => void`). This PR wires it up so the spawned Claude Code process's stderr is captured and appended to the task log and returned output on failure.

Three changes in `src/sdk-executor.ts`:

1. **Accumulator** — `let stderrBuf = ""` declared outside `try` so catch/finally can read it.
2. **Callback** — `stderr: (data) => { stderrBuf += data; }` added to the `query()` options. The type is already present in the SDK — no `as any` or shim needed.
3. **Append on failure** — in the `finally` block (before the footer), calls `formatChildStderr(stderrBuf, exitCode)` which returns `\n[child stderr]\n<last 4000 chars>\n` when `exitCode !== 0` and there is non-empty stderr. Uses the existing `appendOutput` helper (goes to both log file and returned output).

A small exported pure helper `formatChildStderr(stderrBuf, exitCode)` encapsulates the logic so it can be unit-tested without mocking the SDK generator.

## Tests

- **Unit tests for `formatChildStderr`**: returns null on success (exitCode 0), returns null on empty/whitespace stderr, returns the formatted block on exitCode 1 and `"TIMEOUT"`, truncates to the last 4000 chars.
- **Integration tests on the executor**: `query` options include a `stderr` function; stderr content appears in both output and log file when the process throws; `[child stderr]` does not appear on success.

All 1129 tests pass. `tsc --strict` clean.

## Scope

Diagnostics only — no changes to auth, retry, error handling, or any other behaviour.