### PR TITLE
fix: prevent set -e from aborting sync-repos.sh on zero counters

### DIFF
--- a/scripts/sync-repos.sh
+++ b/scripts/sync-repos.sh
@@ -35,7 +35,7 @@ for dir in "$REPOS_DIR"/*/; do
 
     if ! fetch_output=$(git -C "$dir" fetch origin 2>&1); then
         log "FAIL  $repo_name — fetch failed: $fetch_output"
-        ((failed++))
+        (( failed++ )) || true
         continue
     fi
 
@@ -43,13 +43,13 @@ for dir in "$REPOS_DIR"/*/; do
 
     if [ $pull_rc -ne 0 ]; then
         log "DIVERGED  $repo_name — cannot fast-forward: $pull_output"
-        ((diverged++))
+        (( diverged++ )) || true
     elif echo "$pull_output" | grep -q "Already up to date"; then
         log "OK  $repo_name — already up to date"
-        ((up_to_date++))
+        (( up_to_date++ )) || true
     else
         log "SYNCED  $repo_name — $pull_output"
-        ((synced++))
+        (( synced++ )) || true
     fi
 done
 


### PR DESCRIPTION
## Summary

- `(( x++ ))` returns exit code 1 when `x=0` because the pre-increment value is 0 (falsy in arithmetic context). Under `set -euo pipefail` this silently kills the script after the very first repo it processes, leaving all remaining repos unsynced.
- Fix: append `|| true` to all four counter increments (`failed`, `diverged`, `up_to_date`, `synced`).

## Root cause (confirmed on huginmunin)

The service was running on schedule (timer enabled, Linger=yes, every 15 min), but:
1. The script processed only the first alphabetical repo (`gille-ai`, "already up to date")
2. `(( up_to_date++ ))` with `up_to_date=0` → evaluates to 0 → `set -e` exits the script
3. All subsequent repos skipped; service exits with code 1

The "no journal entries" symptom from issue #24 was a secondary mystery: the user journal socket (`/run/user/1000/journal/`) doesn't exist on huginmunin, so `journalctl --user` finds nothing — but the logs *were* landing in the system journal under PID 1178 (the user manager). The service was running; it was just failing silently and incompletely.

## nas.local status

nas.local has no `~/.config/systemd/user/` directory and no sync-repos units installed. Its only repo (`mimir`) pulls from huginmunin's local git, not GitHub. The stale-ref observation from the issue was a point-in-time state; currently in sync.

## Test plan

- [ ] After `deploy-pi.sh` lands the fixed script on huginmunin, run `systemctl --user start sync-repos.service`
- [ ] Confirm `journalctl` (system journal, grep for PID 1178) shows all repos processed through to the "Done. synced=..." summary line
- [ ] Confirm service exits 0 (`systemctl --user status sync-repos.service` shows "active (exited)" not "failed")
- [ ] Close grimnir issue #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)