### PR TITLE
fix(friction-mcp): tag real model on interactive friction events (#120)

### DIFF
--- a/scripts/sync-repos.sh
+++ b/scripts/sync-repos.sh
@@ -35,7 +35,7 @@ for dir in "$REPOS_DIR"/*/; do
 
     if ! fetch_output=$(git -C "$dir" fetch origin 2>&1); then
         log "FAIL  $repo_name — fetch failed: $fetch_output"
-        ((failed++))
+        (( failed++ )) || true
         continue
     fi
 
@@ -43,13 +43,13 @@ for dir in "$REPOS_DIR"/*/; do
 
     if [ $pull_rc -ne 0 ]; then
         log "DIVERGED  $repo_name — cannot fast-forward: $pull_output"
-        ((diverged++))
+        (( diverged++ )) || true
     elif echo "$pull_output" | grep -q "Already up to date"; then
         log "OK  $repo_name — already up to date"
-        ((up_to_date++))
+        (( up_to_date++ )) || true
     else
         log "SYNCED  $repo_name — $pull_output"
-        ((synced++))
+        (( synced++ )) || true
     fi
 done
 

--- a/src/friction-mcp.ts
+++ b/src/friction-mcp.ts
@@ -11,7 +11,9 @@
  *
  * Optional env:
  *   HUGIN_FRICTION_TASK_ID          — auto-tag events with task id (injected by SDK executor)
- *   HUGIN_FRICTION_MODEL_ID         — model identifier for the `model:<id>` tag (default "unknown")
+ *   HUGIN_FRICTION_MODEL_ID         — fallback model identifier for the `model:<id>` tag (default
+ *                                     "unknown"). The SDK executor injects this; interactive sessions
+ *                                     instead pass `model_id` as a tool input, which takes precedence.
  *   HUGIN_FRICTION_WRITE_TIMEOUT_MS — Munin write timeout, default 2000
  */
 

--- a/src/friction-mcp.ts
+++ b/src/friction-mcp.ts
@@ -48,7 +48,7 @@ function readOptionalNumber(name: string, fallback: number): number {
 export async function main(): Promise<void> {
   const muninUrl = readRequiredEnv("MUNIN_URL");
   const muninApiKey = readRequiredEnv("MUNIN_API_KEY");
-  const modelId = process.env.HUGIN_FRICTION_MODEL_ID ?? "unknown";
+  const modelId = process.env.HUGIN_FRICTION_MODEL_ID?.trim() || "unknown";
   const taskId = process.env.HUGIN_FRICTION_TASK_ID;
   const writeTimeoutMs = readOptionalNumber("HUGIN_FRICTION_WRITE_TIMEOUT_MS", 2_000);
 

--- a/src/friction/schema.ts
+++ b/src/friction/schema.ts
@@ -94,6 +94,13 @@ export const reportFrictionInputShape = {
     .max(200)
     .optional()
     .describe("Override for HUGIN_FRICTION_TASK_ID env."),
+  model_id: z
+    .string()
+    .max(200)
+    .optional()
+    .describe(
+      "Your own model identifier (e.g. claude-opus-4-8, claude-sonnet-4-6). Set this so the friction event is attributed to the right model — interactive sessions are not tagged via env. Falls back to the server's HUGIN_FRICTION_MODEL_ID env (default \"unknown\") when omitted.",
+    ),
   tags: z
     .array(z.string().max(80))
     .max(16)

--- a/src/friction/tool.ts
+++ b/src/friction/tool.ts
@@ -185,11 +185,11 @@ function pickTaskId(fromInput: string | undefined, fromDeps: string | undefined)
 
 /**
  * Caller-supplied model id (interactive sessions self-report) wins over the
- * process-wide env default. A blank/whitespace input falls back to deps so a
- * stray empty string never produces a `model:` tag with no value.
+ * process-wide env default. A blank/whitespace value at either layer falls
+ * through to the next, so a stray empty string (input OR a blank
+ * HUGIN_FRICTION_MODEL_ID env) never produces a `model:` tag with no value —
+ * the floor is always the documented `"unknown"`.
  */
 function pickModelId(fromInput: string | undefined, fromDeps: string): string {
-  const trimmed = fromInput?.trim();
-  if (trimmed) return trimmed;
-  return fromDeps;
+  return fromInput?.trim() || fromDeps.trim() || "unknown";
 }

--- a/src/friction/tool.ts
+++ b/src/friction/tool.ts
@@ -119,16 +119,17 @@ export function buildFrictionTool(deps: FrictionToolDeps): FrictionTool {
 
       const recordedAt = now();
       const resolvedTaskId = pickTaskId(input.task_id, deps.taskId);
+      const resolvedModelId = pickModelId(input.model_id, deps.modelId);
       const namespace = buildFrictionNamespace();
       const key = buildFrictionKey(resolvedTaskId, recordedAt);
       const tags = buildFrictionTags({
         input,
-        modelId: deps.modelId,
+        modelId: resolvedModelId,
         resolvedTaskId,
       });
       const content = buildFrictionContent({
         input,
-        modelId: deps.modelId,
+        modelId: resolvedModelId,
         resolvedTaskId,
         recordedAt,
       });
@@ -180,4 +181,15 @@ function pickTaskId(fromInput: string | undefined, fromDeps: string | undefined)
   const candidate = fromInput?.trim() || fromDeps?.trim();
   if (!candidate) return undefined;
   return sanitiseTaskId(candidate);
+}
+
+/**
+ * Caller-supplied model id (interactive sessions self-report) wins over the
+ * process-wide env default. A blank/whitespace input falls back to deps so a
+ * stray empty string never produces a `model:` tag with no value.
+ */
+function pickModelId(fromInput: string | undefined, fromDeps: string): string {
+  const trimmed = fromInput?.trim();
+  if (trimmed) return trimmed;
+  return fromDeps;
 }

--- a/tests/friction/tool.test.ts
+++ b/tests/friction/tool.test.ts
@@ -165,6 +165,25 @@ describe("report_friction tool — model id resolution", () => {
     const [, , , tags] = write.mock.calls[0]!;
     expect(tags).toContain("model:claude-sonnet-4-6");
   });
+
+  it("blank deps.modelId AND blank input → model:unknown, never an empty tag", async () => {
+    const write = vi.fn(async () => ({}));
+    const tool = buildFrictionTool({
+      munin: fakeMunin(write),
+      modelId: "   ",
+      now: () => FIXED_NOW,
+    });
+    await tool.handler({
+      friction_type: "ambiguity",
+      severity: "low",
+      summary: "x",
+      detail: "y",
+    });
+    const [, , content, tags] = write.mock.calls[0]!;
+    expect(tags).toContain("model:unknown");
+    expect((tags as string[]).some((t) => t === "model:" || t === "model:   ")).toBe(false);
+    expect(JSON.parse(content as string).model_id).toBe("unknown");
+  });
 });
 
 describe("report_friction tool — failure modes", () => {

--- a/tests/friction/tool.test.ts
+++ b/tests/friction/tool.test.ts
@@ -109,6 +109,64 @@ describe("report_friction tool — task id resolution", () => {
   });
 });
 
+describe("report_friction tool — model id resolution", () => {
+  it("input.model_id overrides deps.modelId in tags and content", async () => {
+    const write = vi.fn(async () => ({}));
+    const tool = buildFrictionTool({
+      munin: fakeMunin(write),
+      modelId: "unknown",
+      now: () => FIXED_NOW,
+    });
+    await tool.handler({
+      friction_type: "ambiguity",
+      severity: "low",
+      summary: "x",
+      detail: "y",
+      model_id: "claude-opus-4-8",
+    });
+    const [, , content, tags] = write.mock.calls[0]!;
+    expect(tags).toContain("model:claude-opus-4-8");
+    expect((tags as string[]).some((t) => t === "model:unknown")).toBe(false);
+    expect(JSON.parse(content as string).model_id).toBe("claude-opus-4-8");
+  });
+
+  it("falls back to deps.modelId when input.model_id absent", async () => {
+    const write = vi.fn(async () => ({}));
+    const tool = buildFrictionTool({
+      munin: fakeMunin(write),
+      modelId: "claude-sonnet-4-6",
+      now: () => FIXED_NOW,
+    });
+    await tool.handler({
+      friction_type: "ambiguity",
+      severity: "low",
+      summary: "x",
+      detail: "y",
+    });
+    const [, , content, tags] = write.mock.calls[0]!;
+    expect(tags).toContain("model:claude-sonnet-4-6");
+    expect(JSON.parse(content as string).model_id).toBe("claude-sonnet-4-6");
+  });
+
+  it("blank input.model_id falls back to deps.modelId (not empty tag)", async () => {
+    const write = vi.fn(async () => ({}));
+    const tool = buildFrictionTool({
+      munin: fakeMunin(write),
+      modelId: "claude-sonnet-4-6",
+      now: () => FIXED_NOW,
+    });
+    await tool.handler({
+      friction_type: "ambiguity",
+      severity: "low",
+      summary: "x",
+      detail: "y",
+      model_id: "   ",
+    });
+    const [, , , tags] = write.mock.calls[0]!;
+    expect(tags).toContain("model:claude-sonnet-4-6");
+  });
+});
+
 describe("report_friction tool — failure modes", () => {
   it("zod validation error → isError, kind input_validation", async () => {
     const write = vi.fn(async () => ({}));


### PR DESCRIPTION
Closes #120.

## Problem
`report_friction` only read the model id from `HUGIN_FRICTION_MODEL_ID`, which the SDK executor injects but interactive Code sessions never set. So all 36 `signals/friction` events were tagged `model:unknown` and stored `"model_id": "unknown"` — the corpus can't be sliced by model (blunting the RQ6/RQ7 delegation signal).

## Fix
Add an optional `model_id` input to the `report_friction` tool so an interactive session can self-report its own model. Precedence:

`input.model_id` (trimmed, non-empty) → `HUGIN_FRICTION_MODEL_ID` env → `"unknown"`

A blank/whitespace input falls back to the env default, so a stray empty string never produces a valueless `model:` tag. Threaded through both the tag set and the JSON content payload. The SDK-executor env path is unchanged (it still sets the fallback).

The tool description instructs the caller to set `model_id` to its own model identifier.

## Tests (red/green)
- `input.model_id` overrides env in both tags and content
- absent `model_id` falls back to env default
- blank `model_id` falls back to env default (no empty tag)

Full suite: 1132 passed, build clean. Backfilling old `unknown` events is not required (per the issue).