### PR TITLE
feat(signing): hugin-sign Keychain helper for laptop task signing (#119)

### DIFF
--- a/docs/security/task-signing.md
+++ b/docs/security/task-signing.md
@@ -120,9 +120,46 @@ items, Bitwarden, sealed envelope, etc.). The submitter stores it as
 the environment variable `HUGIN_SIGNING_SECRET`. **Never** commit secrets
 to the repo or log them.
 
+## Registering the `claude-code` keyId (laptop signing)
+
+The laptop `claude-code` submitter signs without a Pi round-trip by reading its
+secret from the macOS Keychain via `scripts/hugin-sign` (modelled on the
+`m5-auth` / himalaya pattern — the secret lives once in the Keychain, never in a
+dotfile or scratchpad). One-time setup binds the **same** hex secret to two
+places: the laptop Keychain (signer side) and the Pi's `HUGIN_SUBMITTER_KEYS`
+(verifier side).
+
+```bash
+# 1. Generate the shared secret (laptop).
+SECRET=$(openssl rand -hex 32)
+
+# 2. Store it in the laptop Keychain (signer side). `-U` upserts on rotation.
+security add-generic-password -s hugin-signing -a claude-code -U -w "$SECRET"
+
+# 3. Register the SAME secret on the Pi as the `claude-code` keyId (verifier side),
+#    merging into the existing HUGIN_SUBMITTER_KEYS in /home/magnus/repos/hugin/.env,
+#    then restart Hugin. Done by an operator with Pi access — the secret never
+#    transits the repo or a log. After this, clear it from the shell:  SECRET=
+```
+
+Once both sides hold the secret, `hugin-sign` returns it locally and
+`sign-task.mjs --submitter claude-code --key-id claude-code` produces a
+signature the Pi verifies. The `keyId` must equal the submitter (`claude-code`)
+or be a `claude-code-<rotation>` alias.
+
 ## Signing a task (submitter side)
 
 ```bash
+HUGIN_SIGNING_SECRET=$(hugin-sign) node scripts/sign-task.mjs \
+  --task-id 20260420-180000-a1b2 \
+  --submitter claude-code \
+  --submitted-at 2026-04-20T18:00:00Z \
+  --runtime claude \
+  --prompt-file /tmp/prompt.md \
+  --key-id claude-code
+# → v1:claude-code:abcdef1234...
+
+# Or, for any submitter with the secret already in env:
 HUGIN_SIGNING_SECRET=<hex> node scripts/sign-task.mjs \
   --task-id 20260420-180000-a1b2 \
   --submitter Codex-desktop \
@@ -178,7 +215,7 @@ Do the thing.
 | Submitter | Status | Notes |
 |-----------|--------|-------|
 | Ratatoskr | ✅ wired | `src/task-signing.ts` + `RATATOSKR_SIGNING_SECRET`. Cross-drift test spawns `sign-task.mjs`. |
-| `/submit-task` skill (claude-code) | ✅ wired | Step 7b invokes `scripts/sign-task.mjs` when `HUGIN_SIGNING_SECRET` is set. |
+| `/submit-task` skill (claude-code) | ⚠️ needs key registration | Step 7b invokes `scripts/sign-task.mjs`, sourcing the secret from the macOS Keychain via `scripts/hugin-sign` (service `hugin-signing`, account `claude-code`). This row previously claimed "✅ wired", but the laptop shell never set `HUGIN_SIGNING_SECRET`, so signing silently skipped (hugin#119). The helper fixes the laptop side; verification still requires a `claude-code` entry in the Pi's `HUGIN_SUBMITTER_KEYS` — see "Registering the claude-code keyId" below. |
 | claude-desktop / claude-web / claude-mobile | ⬜ deferred | No shell access to run the helper. Needs a Munin-side signer or a chat-host delegate before `require` is safe. |
 | Codex CLI (codex-desktop / codex-web / codex-mobile) | ⬜ deferred | Codex submits via `memory_write` MCP — needs either a CLI wrapper or an MCP signing tool. |
 

--- a/docs/security/task-signing.md
+++ b/docs/security/task-signing.md
@@ -130,16 +130,17 @@ places: the laptop Keychain (signer side) and the Pi's `HUGIN_SUBMITTER_KEYS`
 (verifier side).
 
 ```bash
-# 1. Generate the shared secret (laptop).
-SECRET=$(openssl rand -hex 32)
+# 0. Install hugin-sign onto PATH so it resolves as a bare command (once).
+ln -sf "$PWD/scripts/hugin-sign" ~/.local/bin/hugin-sign   # run from the hugin repo root
 
-# 2. Store it in the laptop Keychain (signer side). `-U` upserts on rotation.
-security add-generic-password -s hugin-signing -a claude-code -U -w "$SECRET"
+# 1. Generate the secret and store it straight into the laptop Keychain (signer
+#    side) — it is never echoed or left in a shell variable. `-U` upserts on rotation.
+security add-generic-password -s hugin-signing -a claude-code -U -w "$(openssl rand -hex 32)"
 
-# 3. Register the SAME secret on the Pi as the `claude-code` keyId (verifier side),
+# 2. Register the SAME secret on the Pi as the `claude-code` keyId (verifier side),
 #    merging into the existing HUGIN_SUBMITTER_KEYS in /home/magnus/repos/hugin/.env,
-#    then restart Hugin. Done by an operator with Pi access — the secret never
-#    transits the repo or a log. After this, clear it from the shell:  SECRET=
+#    then restart Hugin. An operator with Pi access reads the value back from the
+#    Keychain at that moment (e.g. `hugin-sign`) — it never transits the repo or a log.
 ```
 
 Once both sides hold the secret, `hugin-sign` returns it locally and
@@ -215,7 +216,7 @@ Do the thing.
 | Submitter | Status | Notes |
 |-----------|--------|-------|
 | Ratatoskr | ✅ wired | `src/task-signing.ts` + `RATATOSKR_SIGNING_SECRET`. Cross-drift test spawns `sign-task.mjs`. |
-| `/submit-task` skill (claude-code) | ⚠️ needs key registration | Step 7b invokes `scripts/sign-task.mjs`, sourcing the secret from the macOS Keychain via `scripts/hugin-sign` (service `hugin-signing`, account `claude-code`). This row previously claimed "✅ wired", but the laptop shell never set `HUGIN_SIGNING_SECRET`, so signing silently skipped (hugin#119). The helper fixes the laptop side; verification still requires a `claude-code` entry in the Pi's `HUGIN_SUBMITTER_KEYS` — see "Registering the claude-code keyId" below. |
+| `/submit-task` skill (claude-code) | ⚠️ needs key registration | This row previously claimed "✅ wired", but the laptop shell never set `HUGIN_SIGNING_SECRET`, so Step 7b's signing silently skipped (hugin#119). This repo adds `scripts/hugin-sign` (reads the secret from the macOS Keychain — service `hugin-signing`, account `claude-code`); the skill's Step 7b is updated to call it in a companion `claude-skills-private` PR. Even with both, verification requires a `claude-code` entry in the Pi's `HUGIN_SUBMITTER_KEYS` — see "Registering the claude-code keyId" below. Until that key is registered, submissions are unsigned (fine under `off`/`warn`). |
 | claude-desktop / claude-web / claude-mobile | ⬜ deferred | No shell access to run the helper. Needs a Munin-side signer or a chat-host delegate before `require` is safe. |
 | Codex CLI (codex-desktop / codex-web / codex-mobile) | ⬜ deferred | Codex submits via `memory_write` MCP — needs either a CLI wrapper or an MCP signing tool. |
 

--- a/scripts/hugin-sign
+++ b/scripts/hugin-sign
@@ -21,11 +21,15 @@
 # principal). The Pi must have a matching entry in HUGIN_SUBMITTER_KEYS for
 # verification to pass — see docs/security/task-signing.md.
 #
+# Install (once): symlink onto PATH so `hugin-sign` resolves as a bare command:
+#   ln -sf "$PWD/scripts/hugin-sign" ~/.local/bin/hugin-sign   # (~/.local/bin on PATH)
+#
 # One-time provisioning (run on the laptop; the secret transits a pipe into the
-# Keychain and never prints). Use the SAME hex on the Pi's HUGIN_SUBMITTER_KEYS:
-#   SECRET=$(openssl rand -hex 32)
-#   security add-generic-password -s hugin-signing -a claude-code -U -w "$SECRET"
-#   echo "store this on the Pi under HUGIN_SUBMITTER_KEYS as {\"claude-code\":\"$SECRET\"}"; SECRET=
+# Keychain and is NOT echoed). The SAME hex must also be registered on the Pi's
+# HUGIN_SUBMITTER_KEYS — do that by reading it back from the Keychain at
+# registration time (e.g. via `hugin-sign`), not by printing it here:
+#   security add-generic-password -s hugin-signing -a claude-code -U -w "$(openssl rand -hex 32)"
+#   # then register the claude-code keyId on the Pi — see docs/security/task-signing.md
 #
 # Rotate: re-run the provisioning (the `-U` upserts), then update the Pi's keystore.
 set -euo pipefail

--- a/scripts/hugin-sign
+++ b/scripts/hugin-sign
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# hugin-sign — the canonical, secret-safe way for the laptop to obtain the Hugin
+# task-signing secret (HUGIN_SIGNING_SECRET) for the `claude-code` submitter.
+#
+# The secret lives ONCE in the macOS Keychain (service "hugin-signing",
+# account "claude-code"), mirroring the himalaya / m5-auth pattern. Nothing
+# reads it from `~/.zshrc`, a scratchpad file, or the Pi's `.env` anymore — so
+# signing a task from the laptop no longer needs a Pi round-trip.
+#
+# Usage:
+#   HUGIN_SIGNING_SECRET=$(hugin-sign) node scripts/sign-task.mjs --task-id … --submitter claude-code …
+#   eval "$(hugin-sign --env)"        # export HUGIN_SIGNING_SECRET for a longer flow
+#
+# The secret is emitted ONLY for an EXACT bare call or an EXACT `--env`. `--help`/`-h`
+# and ANY other arguments (unknown flags OR trailing args after --env) print usage to
+# stderr WITHOUT touching the secret — a first-arg-only guard would leak the raw secret
+# on e.g. `hugin-sign --help` or `hugin-sign ""`.
+#
+# The keyId to pass to sign-task.mjs is `claude-code` (matches the `Submitted by:`
+# principal). The Pi must have a matching entry in HUGIN_SUBMITTER_KEYS for
+# verification to pass — see docs/security/task-signing.md.
+#
+# One-time provisioning (run on the laptop; the secret transits a pipe into the
+# Keychain and never prints). Use the SAME hex on the Pi's HUGIN_SUBMITTER_KEYS:
+#   SECRET=$(openssl rand -hex 32)
+#   security add-generic-password -s hugin-signing -a claude-code -U -w "$SECRET"
+#   echo "store this on the Pi under HUGIN_SUBMITTER_KEYS as {\"claude-code\":\"$SECRET\"}"; SECRET=
+#
+# Rotate: re-run the provisioning (the `-U` upserts), then update the Pi's keystore.
+set -euo pipefail
+
+readonly KEYCHAIN_SERVICE="hugin-signing"
+readonly KEYCHAIN_ACCOUNT="claude-code"
+
+usage() {
+  cat >&2 <<'USAGE'
+hugin-sign — emit the Hugin task-signing secret (claude-code) from the macOS Keychain.
+  hugin-sign            print the secret   (for: HUGIN_SIGNING_SECRET=$(hugin-sign))
+  hugin-sign --env      print: export HUGIN_SIGNING_SECRET=…
+The secret is read from Keychain service "hugin-signing", account "claude-code".
+If it is missing, provision it once (see the comment block in this script).
+USAGE
+}
+
+read_secret() {
+  local secret
+  if ! secret=$(security find-generic-password -s "$KEYCHAIN_SERVICE" -a "$KEYCHAIN_ACCOUNT" -w 2>/dev/null); then
+    echo "hugin-sign: no secret in Keychain (service=$KEYCHAIN_SERVICE account=$KEYCHAIN_ACCOUNT)." >&2
+    echo "hugin-sign: provision it once — see the comment block in $(command -v hugin-sign || echo this script)." >&2
+    return 1
+  fi
+  if [ -z "$secret" ]; then
+    echo "hugin-sign: Keychain entry exists but is empty." >&2
+    return 1
+  fi
+  printf '%s' "$secret"
+}
+
+# Emit the secret ONLY for an exact bare call or an exact `--env`.
+if [ "$#" -eq 0 ]; then
+  read_secret
+  echo
+elif [ "$#" -eq 1 ] && [ "$1" = "--env" ]; then
+  secret=$(read_secret)
+  printf 'export HUGIN_SIGNING_SECRET=%q\n' "$secret"
+else
+  usage
+  # `--help`/`-h` is a successful usage request; anything else is an error.
+  case "${1:-}" in
+    -h|--help) exit 0 ;;
+    *) exit 2 ;;
+  esac
+fi


### PR DESCRIPTION
Addresses #119 (hugin-repo portion).

## Problem
The `submit-task` skill instructs HMAC-signing with `HUGIN_SIGNING_SECRET`, but that var was never set in the laptop shell — it lived only in the Pi's `.env` and in Ratatoskr. So the rollout table's "claude-code ✅ wired" row was false: signing from the laptop **silently skipped** (Step 7b only ran when the var was set), forcing a Pi round-trip or a Telegram→Ratatoskr detour for any signed task (observed 2026-06-17).

## Change (hugin repo)
- **`scripts/hugin-sign`** — a secret-safe macOS Keychain reader (service `hugin-signing`, account `claude-code`), modelled on `m5-auth`/himalaya. The secret lives once in the Keychain, never in a dotfile or scratchpad. Sign locally with `HUGIN_SIGNING_SECRET=$(hugin-sign) node scripts/sign-task.mjs --submitter claude-code --key-id claude-code`. The arg guard emits the secret **only** on an exact bare call or exact `--env`; `--help` and any other args print usage with no secret leak. shellcheck-clean; guard paths smoke-tested.
- **`docs/security/task-signing.md`** — corrects the rollout table (`claude-code` → "⚠️ needs key registration") and adds a "Registering the claude-code keyId" section documenting the one-time laptop-Keychain + Pi-`HUGIN_SUBMITTER_KEYS` dual-bind.

## Out of scope (tracked separately)
- The `submit-task` SKILL.md Step 7b update (uses `hugin-sign`) — separate PR against `claude-skills-private`.
- **Operator step:** registering the matching `claude-code` keyId in the Pi's `HUGIN_SUBMITTER_KEYS` (a shared secret crossing trust domains — documented in the new docs section).

No code logic changed (`task-signing.ts` / `sign-task.mjs` already support a `claude-code` keyId); this adds the missing laptop signer + corrects the docs.