### PR TITLE
feat(orchestrator): thread AbortSignal so timeout/cancel aborts in-flight model calls (#110)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4493,6 +4493,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     stopCancellationWatch();
     currentSdkAbort = null;
     currentOllamaAbort = null;
+    currentOrchestratorAbort = null;
     currentCancellation = null;
     currentTask = null;
     currentTaskConfig = null;

--- a/src/orchestrator/engine.ts
+++ b/src/orchestrator/engine.ts
@@ -162,8 +162,10 @@ export async function runOrchestration(
   taskPrompt: string,
   invoker: ModelInvoker,
   config?: Partial<OrchestratorConfig>,
+  opts?: { signal?: AbortSignal },
 ): Promise<OrchestrationResult> {
   const cfg: OrchestratorConfig = { ...DEFAULT_ORCHESTRATOR_CONFIG, ...config };
+  const signal = opts?.signal;
   const allCosts: (number | null)[] = [];
   const warnings: string[] = [];
   let totalLatencyMs = 0;
@@ -171,7 +173,7 @@ export async function runOrchestration(
   // -------------------------------------------------------------------------
   // 1. Plan
   // -------------------------------------------------------------------------
-  const planResp = await invoker.invoke("planner", buildPlannerPrompt(taskPrompt));
+  const planResp = await invoker.invoke("planner", buildPlannerPrompt(taskPrompt), { signal });
   allCosts.push(planResp.costUsd ?? null);
   totalLatencyMs += planResp.latencyMs;
   if (planResp.ok && planResp.truncated) {
@@ -192,7 +194,9 @@ export async function runOrchestration(
     plan.subtasks,
     cfg.maxConcurrency,
     async (subtask): Promise<SubtaskOutcome> => {
-      const result = await invoker.invoke("worker", buildWorkerPrompt(taskPrompt, subtask));
+      const result = await invoker.invoke("worker", buildWorkerPrompt(taskPrompt, subtask), {
+        signal,
+      });
       allCosts.push(result.costUsd ?? null);
       totalLatencyMs += result.latencyMs;
       if (result.ok && result.truncated) {
@@ -213,6 +217,7 @@ export async function runOrchestration(
       const verifyResp = await invoker.invoke(
         "verifier",
         buildVerifierPrompt(outcome.subtask, outcome.result.output),
+        { signal },
       );
       allCosts.push(verifyResp.costUsd ?? null);
       totalLatencyMs += verifyResp.latencyMs;
@@ -254,6 +259,7 @@ export async function runOrchestration(
     const synthResp = await invoker.invoke(
       "synthesizer",
       buildSynthesizerPrompt(taskPrompt, successfulOutcomes),
+      { signal },
     );
     allCosts.push(synthResp.costUsd ?? null);
     totalLatencyMs += synthResp.latencyMs;

--- a/src/orchestrator/model-invoker.ts
+++ b/src/orchestrator/model-invoker.ts
@@ -17,7 +17,7 @@ export interface ModelInvoker {
   invoke(
     role: OrchestratorRole,
     prompt: string,
-    opts?: { systemPrompt?: string },
+    opts?: { systemPrompt?: string; signal?: AbortSignal },
   ): Promise<WorkerResult>;
 }
 
@@ -39,7 +39,7 @@ export function createModelInvoker(
     async invoke(
       role: OrchestratorRole,
       prompt: string,
-      opts?: { systemPrompt?: string },
+      opts?: { systemPrompt?: string; signal?: AbortSignal },
     ): Promise<WorkerResult> {
       const binding = roles[role];
       const executor = factory(binding.provider);
@@ -51,6 +51,7 @@ export function createModelInvoker(
         timeoutMs: defaults.timeoutMs,
         maxOutputChars: defaults.maxOutputChars,
         maxTokens: binding.maxTokens ?? defaults.maxTokens,
+        signal: opts?.signal,
       });
     },
   };

--- a/src/orchestrator/orchestrator-executor.ts
+++ b/src/orchestrator/orchestrator-executor.ts
@@ -87,10 +87,11 @@ function buildSummary(
  * Run a task through the orchestration engine, enforcing sensitivity guards
  * and a task-level timeout.
  *
- * The `deps.signal` abort is checked before and after the engine run but does
- * NOT cancel in-flight model calls mid-engine (per-call timeouts via
- * `config.perCallTimeoutMs` bound spend). TODO: wire AbortSignal into
- * ModelInvoker.invoke() for mid-engine cancellation.
+ * Cancellation (issue #110): an internal AbortController is threaded into the
+ * engine and every model call. It fires when EITHER the task-level timeout wins
+ * the race OR the operator/shutdown `deps.signal` aborts — so a timeout/cancel
+ * aborts in-flight fetch/child work instead of letting it spend until the
+ * per-call timeout. Per-call timeouts remain the backstop.
  */
 export async function runOrchestratorTask(
   input: OrchestratorTaskInput,
@@ -125,15 +126,21 @@ export async function runOrchestratorTask(
   onLog?.(`[orchestrator] starting (strategy will be determined by planner)`);
 
   // --- 3. Task-level timeout race ---
+  // Internal controller threaded into the engine (issue #110). It aborts when
+  // the timeout wins OR the caller's signal fires, cancelling in-flight calls.
+  const engineAbort = new AbortController();
+  const forwardCallerAbort = () => engineAbort.abort();
+  deps.signal?.addEventListener("abort", forwardCallerAbort, { once: true });
+
   let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
 
   const timeoutPromise = new Promise<"TIMEOUT">((resolve) => {
     timeoutHandle = setTimeout(() => resolve("TIMEOUT"), input.timeoutMs);
   });
 
-  const enginePromise = runOrchestration(input.prompt, deps.invoker, config).then(
-    (result): OrchestrationResult | "TIMEOUT" => result,
-  );
+  const enginePromise = runOrchestration(input.prompt, deps.invoker, config, {
+    signal: engineAbort.signal,
+  }).then((result): OrchestrationResult | "TIMEOUT" => result);
 
   // Race the engine against the timeout.
   let raceResult: OrchestrationResult | "TIMEOUT";
@@ -141,6 +148,10 @@ export async function runOrchestratorTask(
     raceResult = await Promise.race([enginePromise, timeoutPromise]);
   } finally {
     if (timeoutHandle !== null) clearTimeout(timeoutHandle);
+    // If the timeout won, abort the still-running engine so its in-flight model
+    // calls are cancelled rather than left spending until their per-call timeout.
+    if (!engineAbort.signal.aborted) engineAbort.abort();
+    deps.signal?.removeEventListener("abort", forwardCallerAbort);
   }
 
   // --- 4. Handle abort signal after run (if race completed first) ---

--- a/src/orchestrator/worker-executor.ts
+++ b/src/orchestrator/worker-executor.ts
@@ -43,6 +43,12 @@ export interface WorkerRequest {
   maxOutputChars?: number;
   /** Completion-token cap sent to the model. Defaults to DEFAULT_MAX_TOKENS. */
   maxTokens?: number;
+  /**
+   * External cancellation signal (issue #110). When it fires, the in-flight
+   * fetch / child process is aborted; when already aborted at entry, run()
+   * short-circuits without spending. Combined with the per-call timeout.
+   */
+  signal?: AbortSignal;
 }
 
 export interface WorkerResult {
@@ -99,6 +105,21 @@ export class DirectModelExecutor implements WorkerExecutor {
     const start = Date.now();
     const maxOutput = req.maxOutputChars ?? DEFAULT_MAX_OUTPUT_CHARS;
 
+    // Short-circuit an already-cancelled call before spending anything (issue #110).
+    if (req.signal?.aborted) {
+      return {
+        ok: false,
+        output: "",
+        provider: req.provider,
+        model: req.model,
+        inputTokens: null,
+        outputTokens: null,
+        costUsd: null,
+        latencyMs: Date.now() - start,
+        error: "Request aborted before it started",
+      };
+    }
+
     const providerCfg = getProviderConfig(req.provider);
     if (!providerCfg) {
       return {
@@ -145,8 +166,17 @@ export class DirectModelExecutor implements WorkerExecutor {
       max_tokens: req.maxTokens ?? DEFAULT_MAX_TOKENS,
     };
 
+    // Combine the per-call timeout with the caller's cancellation signal
+    // (issue #110): whichever fires first aborts the fetch. `timedOut` lets us
+    // report the right reason (timeout vs external cancel).
     const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), req.timeoutMs);
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, req.timeoutMs);
+    const onExternalAbort = () => controller.abort();
+    req.signal?.addEventListener("abort", onExternalAbort, { once: true });
 
     try {
       let response: Response;
@@ -158,9 +188,11 @@ export class DirectModelExecutor implements WorkerExecutor {
           signal: controller.signal,
         });
       } catch (fetchErr) {
-        const errMsg = isAbortError(fetchErr)
-          ? `Request timed out after ${req.timeoutMs}ms`
-          : `Network error: ${fetchErr instanceof Error ? fetchErr.message : String(fetchErr)}`;
+        const errMsg = !isAbortError(fetchErr)
+          ? `Network error: ${fetchErr instanceof Error ? fetchErr.message : String(fetchErr)}`
+          : timedOut
+            ? `Request timed out after ${req.timeoutMs}ms`
+            : "Request aborted";
         return {
           ok: false,
           output: "",
@@ -208,7 +240,9 @@ export class DirectModelExecutor implements WorkerExecutor {
             outputTokens: null,
             costUsd: null,
             latencyMs: Date.now() - start,
-            error: `Response body stalled and timed out after ${req.timeoutMs}ms`,
+            error: timedOut
+              ? `Response body stalled and timed out after ${req.timeoutMs}ms`
+              : "Request aborted while reading the response body",
           };
         }
         return {
@@ -258,6 +292,7 @@ export class DirectModelExecutor implements WorkerExecutor {
       };
     } finally {
       clearTimeout(timer);
+      req.signal?.removeEventListener("abort", onExternalAbort);
     }
   }
 }
@@ -293,12 +328,28 @@ export class PiHarnessExecutor implements WorkerExecutor {
       };
     }
 
+    // Short-circuit an already-cancelled call before spawning (issue #110).
+    if (req.signal?.aborted) {
+      return {
+        ok: false,
+        output: "",
+        provider: req.provider,
+        model: req.model,
+        inputTokens: null,
+        outputTokens: null,
+        costUsd: null,
+        latencyMs: Date.now() - start,
+        error: "Process aborted before it started",
+      };
+    }
+
     const args = buildPiArgs(req, entry);
 
     return new Promise<WorkerResult>((resolve) => {
       let stdout = "";
       let stderr = "";
       let killed = false;
+      let abortedBySignal = false;
 
       let child: ReturnType<typeof spawn>;
       try {
@@ -325,6 +376,15 @@ export class PiHarnessExecutor implements WorkerExecutor {
         child.kill("SIGTERM");
       }, req.timeoutMs);
 
+      // External cancellation (issue #110): kill the child when the caller's
+      // signal fires. `abortedBySignal` distinguishes it from a timeout kill.
+      const onExternalAbort = () => {
+        abortedBySignal = true;
+        killed = true;
+        child.kill("SIGTERM");
+      };
+      req.signal?.addEventListener("abort", onExternalAbort, { once: true });
+
       child.stdout?.on("data", (chunk: Buffer) => {
         stdout += chunk.toString();
       });
@@ -334,6 +394,7 @@ export class PiHarnessExecutor implements WorkerExecutor {
 
       child.on("error", (err) => {
         clearTimeout(killTimer);
+        req.signal?.removeEventListener("abort", onExternalAbort);
         resolve({
           ok: false,
           output: "",
@@ -349,6 +410,7 @@ export class PiHarnessExecutor implements WorkerExecutor {
 
       child.on("close", (code) => {
         clearTimeout(killTimer);
+        req.signal?.removeEventListener("abort", onExternalAbort);
 
         if (killed) {
           resolve({
@@ -360,7 +422,9 @@ export class PiHarnessExecutor implements WorkerExecutor {
             outputTokens: null,
             costUsd: null,
             latencyMs: Date.now() - start,
-            error: `Process timed out after ${req.timeoutMs}ms`,
+            error: abortedBySignal
+              ? "Process aborted"
+              : `Process timed out after ${req.timeoutMs}ms`,
           });
           return;
         }

--- a/src/orchestrator/worker-executor.ts
+++ b/src/orchestrator/worker-executor.ts
@@ -167,15 +167,18 @@ export class DirectModelExecutor implements WorkerExecutor {
     };
 
     // Combine the per-call timeout with the caller's cancellation signal
-    // (issue #110): whichever fires first aborts the fetch. `timedOut` lets us
-    // report the right reason (timeout vs external cancel).
+    // (issue #110): whichever fires first aborts the fetch. `abortReason` is
+    // first-writer-wins so the reported reason (timeout vs external cancel) is
+    // attributed to whichever actually fired first, even if the other follows
+    // before the fetch/body rejection settles.
     const controller = new AbortController();
-    let timedOut = false;
-    const timer = setTimeout(() => {
-      timedOut = true;
+    let abortReason: "timeout" | "external" | null = null;
+    const abortWith = (reason: "timeout" | "external") => {
+      if (abortReason === null) abortReason = reason;
       controller.abort();
-    }, req.timeoutMs);
-    const onExternalAbort = () => controller.abort();
+    };
+    const timer = setTimeout(() => abortWith("timeout"), req.timeoutMs);
+    const onExternalAbort = () => abortWith("external");
     req.signal?.addEventListener("abort", onExternalAbort, { once: true });
 
     try {
@@ -190,7 +193,7 @@ export class DirectModelExecutor implements WorkerExecutor {
       } catch (fetchErr) {
         const errMsg = !isAbortError(fetchErr)
           ? `Network error: ${fetchErr instanceof Error ? fetchErr.message : String(fetchErr)}`
-          : timedOut
+          : abortReason === "timeout"
             ? `Request timed out after ${req.timeoutMs}ms`
             : "Request aborted";
         return {
@@ -240,7 +243,7 @@ export class DirectModelExecutor implements WorkerExecutor {
             outputTokens: null,
             costUsd: null,
             latencyMs: Date.now() - start,
-            error: timedOut
+            error: abortReason === "timeout"
               ? `Response body stalled and timed out after ${req.timeoutMs}ms`
               : "Request aborted while reading the response body",
           };
@@ -348,8 +351,10 @@ export class PiHarnessExecutor implements WorkerExecutor {
     return new Promise<WorkerResult>((resolve) => {
       let stdout = "";
       let stderr = "";
-      let killed = false;
-      let abortedBySignal = false;
+      // First-writer-wins kill reason (issue #110): whichever of the per-call
+      // timeout or the external abort fires first owns the reported reason, so a
+      // later kill of the other kind can't mislabel it before `close` arrives.
+      let killReason: "timeout" | "external" | null = null;
 
       let child: ReturnType<typeof spawn>;
       try {
@@ -371,18 +376,15 @@ export class PiHarnessExecutor implements WorkerExecutor {
         return;
       }
 
-      const killTimer = setTimeout(() => {
-        killed = true;
-        child.kill("SIGTERM");
-      }, req.timeoutMs);
-
-      // External cancellation (issue #110): kill the child when the caller's
-      // signal fires. `abortedBySignal` distinguishes it from a timeout kill.
-      const onExternalAbort = () => {
-        abortedBySignal = true;
-        killed = true;
+      const killWith = (reason: "timeout" | "external") => {
+        if (killReason === null) killReason = reason;
         child.kill("SIGTERM");
       };
+      const killTimer = setTimeout(() => killWith("timeout"), req.timeoutMs);
+
+      // External cancellation (issue #110): kill the child when the caller's
+      // signal fires. The reason is recorded first-writer-wins.
+      const onExternalAbort = () => killWith("external");
       req.signal?.addEventListener("abort", onExternalAbort, { once: true });
 
       child.stdout?.on("data", (chunk: Buffer) => {
@@ -412,7 +414,7 @@ export class PiHarnessExecutor implements WorkerExecutor {
         clearTimeout(killTimer);
         req.signal?.removeEventListener("abort", onExternalAbort);
 
-        if (killed) {
+        if (killReason !== null) {
           resolve({
             ok: false,
             output: "",
@@ -422,7 +424,7 @@ export class PiHarnessExecutor implements WorkerExecutor {
             outputTokens: null,
             costUsd: null,
             latencyMs: Date.now() - start,
-            error: abortedBySignal
+            error: killReason === "external"
               ? "Process aborted"
               : `Process timed out after ${req.timeoutMs}ms`,
           });

--- a/tests/orchestrator/engine.test.ts
+++ b/tests/orchestrator/engine.test.ts
@@ -127,6 +127,33 @@ describe("runOrchestration — truncation warnings (issue #112)", () => {
   });
 });
 
+describe("runOrchestration — AbortSignal threading (issue #110)", () => {
+  it("forwards opts.signal into every invoke call (planner, workers, synthesizer)", async () => {
+    const controller = new AbortController();
+    const seenSignals: (AbortSignal | undefined)[] = [];
+    const counters = new Map<OrchestratorRole, number>();
+    const queues = new Map<OrchestratorRole, WorkerResult[]>([
+      ["planner", [ok(VALID_PLAN_3, 0.01)]],
+      ["worker", [ok("W1"), ok("W2"), ok("W3")]],
+      ["synthesizer", [ok("Final")]],
+    ]);
+    const invoker: ModelInvoker = {
+      invoke: vi.fn(async (role: OrchestratorRole, _prompt: string, opts?: { signal?: AbortSignal }) => {
+        seenSignals.push(opts?.signal);
+        const idx = counters.get(role) ?? 0;
+        counters.set(role, idx + 1);
+        return (queues.get(role) ?? [])[idx] ?? fail(`none for ${role}[${idx}]`);
+      }),
+    };
+
+    await runOrchestration("task", invoker, undefined, { signal: controller.signal });
+
+    // planner + 3 workers + synthesizer = 5 calls, all carrying the signal
+    expect(seenSignals.length).toBe(5);
+    expect(seenSignals.every((s) => s === controller.signal)).toBe(true);
+  });
+});
+
 describe("runOrchestration — single fallback", () => {
   it("planner returns garbage → strategy single → 1 worker → finalOutput == worker output, no synth call", async () => {
     const synthSpy = vi.fn();

--- a/tests/orchestrator/model-invoker.test.ts
+++ b/tests/orchestrator/model-invoker.test.ts
@@ -99,6 +99,22 @@ describe("createModelInvoker", () => {
     expect(capturedRequests[1].maxTokens).toBe(32000);
   });
 
+  it("threads opts.signal into WorkerRequest.signal (issue #110)", async () => {
+    const capturedRequests: WorkerRequest[] = [];
+    const mockExecutor: WorkerExecutor = {
+      run: vi.fn(async (req: WorkerRequest) => {
+        capturedRequests.push(req);
+        return makeResult("out");
+      }),
+    };
+
+    const invoker = createModelInvoker(roles, { timeoutMs: 5000 }, () => mockExecutor);
+    const controller = new AbortController();
+
+    await invoker.invoke("worker", "do it", { signal: controller.signal });
+    expect(capturedRequests[0].signal).toBe(controller.signal);
+  });
+
   it("passes systemPrompt when provided", async () => {
     const capturedRequests: WorkerRequest[] = [];
     const mockExecutor: WorkerExecutor = {

--- a/tests/orchestrator/orchestrator-executor.test.ts
+++ b/tests/orchestrator/orchestrator-executor.test.ts
@@ -127,6 +127,55 @@ describe("runOrchestratorTask", () => {
     expect(invokeSpy).not.toHaveBeenCalled();
   });
 
+  it("task timeout aborts the signal threaded into the engine (issue #110)", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    const invoker: ModelInvoker = {
+      invoke: vi.fn(async (_role: string, _prompt: string, opts?: { signal?: AbortSignal }) => {
+        capturedSignal = opts?.signal;
+        // Outlast the 50ms task timeout so the timeout wins the race.
+        await new Promise((r) => setTimeout(r, 500));
+        return makeSuccessResult("late");
+      }),
+    };
+
+    const result = await runOrchestratorTask(
+      { ...defaultInput, timeoutMs: 50 },
+      DEFAULT_ORCHESTRATOR_CONFIG,
+      { invoker },
+    );
+
+    expect(result.exitCode).toBe("TIMEOUT");
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal!.aborted).toBe(true);
+  });
+
+  it("forwards deps.signal abort into the engine signal mid-run (issue #110)", async () => {
+    const outer = new AbortController();
+    let capturedSignal: AbortSignal | undefined;
+    const invoker: ModelInvoker = {
+      invoke: vi.fn(async (role: string, _prompt: string, opts?: { signal?: AbortSignal }) => {
+        capturedSignal = opts?.signal;
+        // Abort the operator/deps signal while the first (planner) call is in flight.
+        outer.abort();
+        await new Promise((r) => setTimeout(r, 10));
+        if (role === "planner") {
+          return makeSuccessResult(
+            JSON.stringify({ strategy: "single", subtasks: [{ id: "t1", prompt: "Do it" }] }),
+          );
+        }
+        return makeSuccessResult("worker output");
+      }),
+    };
+
+    await runOrchestratorTask(defaultInput, DEFAULT_ORCHESTRATOR_CONFIG, {
+      invoker,
+      signal: outer.signal,
+    });
+
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal!.aborted).toBe(true);
+  });
+
   it("timeout path: invoker that never resolves + tiny timeoutMs → exitCode TIMEOUT", async () => {
     const invoker = buildMockInvoker({ neverResolve: true });
 

--- a/tests/orchestrator/worker-executor.test.ts
+++ b/tests/orchestrator/worker-executor.test.ts
@@ -557,6 +557,50 @@ describe("DirectModelExecutor — external AbortSignal (issue #110)", () => {
   });
 });
 
+describe("DirectModelExecutor — abort-reason attribution is first-writer-wins (issue #110)", () => {
+  it("reports 'aborted' when the external abort precedes the timeout, even if the timer fires before the fetch settles", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-key");
+    vi.useFakeTimers();
+    try {
+      // fetch rejects with AbortError only when its (internal) signal aborts,
+      // and the rejection settles on a LATER macrotask (like real fetch teardown)
+      // — long enough that the per-call timeout timer fires in between.
+      vi.stubGlobal("fetch", vi.fn((_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener("abort", () => {
+            setTimeout(
+              () => reject(Object.assign(new Error("aborted"), { name: "AbortError" })),
+              100,
+            );
+          });
+        }),
+      ));
+
+      const controller = new AbortController();
+      const executor = new DirectModelExecutor();
+      const pending = executor.run({
+        provider: "openrouter",
+        model: "deepseek/deepseek-v4-flash",
+        prompt: "hi",
+        timeoutMs: 50, // fires AFTER the external abort but BEFORE the rejection settles
+        signal: controller.signal,
+      });
+
+      // External abort fires FIRST at t=0 → reason must lock to "external"…
+      controller.abort();
+      // …the timeout timer fires at t=50 (would flip timedOut), rejection at t=100.
+      await vi.advanceTimersByTimeAsync(200);
+
+      const result = await pending;
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/abort/i);
+      expect(result.error).not.toMatch(/timed out/i);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
 // ---------------------------------------------------------------------------
 // PiHarnessExecutor
 // ---------------------------------------------------------------------------

--- a/tests/orchestrator/worker-executor.test.ts
+++ b/tests/orchestrator/worker-executor.test.ts
@@ -477,13 +477,18 @@ describe("DirectModelExecutor — malformed response bodies (Fix #3)", () => {
 });
 
 describe("DirectModelExecutor — timeout/abort path", () => {
-  it("returns ok=false with timeout error when fetch is aborted", async () => {
+  it("returns ok=false with timeout error when the per-call timeout fires", async () => {
     vi.stubEnv("OPENROUTER_API_KEY", "test-key");
 
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockRejectedValue(Object.assign(new Error("aborted"), { name: "AbortError" })),
-    );
+    // fetch that only rejects once its signal (the internal timeout controller)
+    // aborts — i.e. a genuine timeout, not an immediate/external cancel.
+    vi.stubGlobal("fetch", vi.fn((_url: string, init: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        init.signal?.addEventListener("abort", () => {
+          reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+        });
+      }),
+    ));
 
     const executor = new DirectModelExecutor();
     const result = await executor.run({
@@ -496,6 +501,59 @@ describe("DirectModelExecutor — timeout/abort path", () => {
     expect(result.ok).toBe(false);
     expect(result.error).toMatch(/timed out/i);
     expect(result.output).toBe("");
+  });
+});
+
+describe("DirectModelExecutor — external AbortSignal (issue #110)", () => {
+  it("short-circuits without calling fetch when signal is already aborted", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-key");
+    const fetchMock = vi.fn().mockResolvedValue(successResponse("should not happen"));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const controller = new AbortController();
+    controller.abort();
+
+    const executor = new DirectModelExecutor();
+    const result = await executor.run({
+      provider: "openrouter",
+      model: "deepseek/deepseek-v4-flash",
+      prompt: "hi",
+      timeoutMs: 5000,
+      signal: controller.signal,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/abort/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("aborts the in-flight fetch when the external signal fires", async () => {
+    vi.stubEnv("OPENROUTER_API_KEY", "test-key");
+    // fetch mock that rejects with AbortError when its passed signal aborts.
+    vi.stubGlobal("fetch", vi.fn((_url: string, init: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        init.signal?.addEventListener("abort", () => {
+          reject(Object.assign(new Error("aborted"), { name: "AbortError" }));
+        });
+      }),
+    ));
+
+    const controller = new AbortController();
+    const executor = new DirectModelExecutor();
+    const pending = executor.run({
+      provider: "openrouter",
+      model: "deepseek/deepseek-v4-flash",
+      prompt: "hi",
+      timeoutMs: 60000, // long — the abort, not the timeout, must end the call
+      signal: controller.signal,
+    });
+
+    controller.abort();
+    const result = await pending;
+
+    expect(result.ok).toBe(false);
+    expect(result.output).toBe("");
+    expect(result.error).toMatch(/abort/i);
   });
 });
 
@@ -630,6 +688,51 @@ describe("PiHarnessExecutor — timeout path", () => {
 
     expect(result.ok).toBe(false);
     expect(result.error).toMatch(/timed out/i);
+  });
+});
+
+describe("PiHarnessExecutor — external AbortSignal (issue #110)", () => {
+  it("does not spawn when the signal is already aborted", async () => {
+    spawnBehaviors = [{ exitCode: 0, stdout: PI_JSONL_SUCCESS }];
+    const controller = new AbortController();
+    controller.abort();
+
+    const executor = new PiHarnessExecutor();
+    const result = await executor.run({
+      provider: "pi-harness",
+      model: "qwen/qwen3-coder-next",
+      prompt: "hi",
+      timeoutMs: 5000,
+      signal: controller.signal,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/abort/i);
+    expect(spawnCalls.length).toBe(0);
+  });
+
+  it("kills the child when the signal fires mid-run", async () => {
+    // Child would run for 500ms; we abort well before that.
+    spawnBehaviors = [{ exitCode: 0, stdout: PI_JSONL_SUCCESS, delayMs: 500 }];
+    const controller = new AbortController();
+
+    const executor = new PiHarnessExecutor();
+    const pending = executor.run({
+      provider: "pi-harness",
+      model: "qwen/qwen3-coder-next",
+      prompt: "hi",
+      timeoutMs: 60000, // long — the abort, not the timeout, must end it
+      signal: controller.signal,
+    });
+
+    // Let the spawn happen, then abort.
+    await new Promise((r) => setTimeout(r, 20));
+    controller.abort();
+    const result = await pending;
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/abort/i);
+    expect(spawnCalls.length).toBe(1);
   });
 });
 


### PR DESCRIPTION
Closes #110.

> **Stacked on #125** (base = `fix/orch-max-tokens-finish-reason`). GitHub retargets this to `main` once #125 merges. Review #125 first.

## Problem

`runOrchestratorTask` raced `runOrchestration()` against a task-level timeout but never cancelled the losing engine promise. `DirectModelExecutor` built its own `AbortController` tied only to the per-call timeout, and neither `WorkerRequest` nor `ModelInvoker.invoke()` carried a signal. So a timeout/cancel could finalize the task while planner/worker/synth calls **kept spending until their per-call timeout**. Shutdown/cancel aborted `currentOrchestratorAbort`, but the signal reached nothing, and the `pollOnce` `finally` never cleared that slot.

Current behaviour was *safe* (per-call timeouts bound spend) — this tightens cancellation so a timeout/cancel stops spend promptly.

## Fix

- `WorkerRequest.signal` + `ModelInvoker.invoke(opts.signal)`; `createModelInvoker` threads it into every `WorkerRequest`.
- `runOrchestration` accepts `opts.signal` and passes it to **every** invoke (planner, workers, verifier, synthesizer).
- **`DirectModelExecutor`**: short-circuits an already-aborted call before spending; combines `req.signal` with the per-call timeout controller so an external abort cancels the in-flight `fetch`; reports timeout vs cancel distinctly; removes the listener in `finally`.
- **`PiHarnessExecutor`**: short-circuits when pre-aborted; kills the child when the signal fires mid-run (`abortedBySignal` distinguishes it from a timeout kill).
- **`runOrchestratorTask`**: an internal `AbortController` is threaded into the engine and aborted when the timeout wins the race **or** `deps.signal` fires; the caller-abort listener is forwarded and cleaned up in `finally`.
- **`index.ts`**: the `pollOnce` `finally` now clears `currentOrchestratorAbort` alongside the SDK/Ollama slots (leak fix).

## Tests

Red/green TDD — 8 new tests, confirmed failing first:
- `worker-executor`: DirectModel already-aborted short-circuit (no fetch) + in-flight fetch abort; PiHarness pre-aborted no-spawn + mid-run child kill.
- `model-invoker`: `opts.signal` → `WorkerRequest.signal`.
- `engine`: signal forwarded into all 5 invokes.
- `orchestrator-executor`: task timeout aborts the engine signal; `deps.signal` abort forwarded mid-run.

Also updated the pre-existing timeout test to simulate a *real* timeout (signal-driven fetch rejection) now that timeout and cancel are reported distinctly.

Full suite green: **1160 tests pass**, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)