### PR TITLE
fix(heimdall): declare Tasks + Task history panels in self-describe descriptor (#135)

### DIFF
--- a/src/heimdall-descriptor.ts
+++ b/src/heimdall-descriptor.ts
@@ -24,7 +24,13 @@ export const HEIMDALL_DESCRIPTOR = {
     platform: "bare-metal",
   },
   metrics: [],
-  panels: [],
+  // Tier-1 services own their panels: Heimdall's static known-panels fallback is
+  // not consulted once /heimdall.json exists, so the task views must be declared
+  // here (#135). Rendered live by Heimdall's plugins/hugin.js from the Munin DB.
+  panels: [
+    { id: "hugin-tasks", plugin: "hugin", view: "tasks", label: "Tasks", refresh: 60, fullWidth: true },
+    { id: "hugin-history", plugin: "hugin", view: "history", label: "Task history", refresh: 120, fullWidth: true },
+  ],
   alerts: { rules: [], active_count: 0, firing: [] },
   links: {
     self: "/heimdall.json",

--- a/tests/heimdall-descriptor.test.ts
+++ b/tests/heimdall-descriptor.test.ts
@@ -41,6 +41,18 @@ describe("HEIMDALL_DESCRIPTOR", () => {
     }
   });
 
+  it("declares the Tasks and Task history panels so Heimdall renders them (Tier-1 services own their panels, #135)", () => {
+    const panels = HEIMDALL_DESCRIPTOR.panels as ReadonlyArray<Record<string, unknown>>;
+
+    // Shape must match Heimdall's descriptor panel contract
+    // (heimdall src/contract/schema.js normalizePanels: id required; plugin/view/
+    // label/refresh/fullWidth pass through) and the pre-#116 known-panels set.
+    expect(panels).toEqual([
+      { id: "hugin-tasks", plugin: "hugin", view: "tasks", label: "Tasks", refresh: 60, fullWidth: true },
+      { id: "hugin-history", plugin: "hugin", view: "history", label: "Task history", refresh: 120, fullWidth: true },
+    ]);
+  });
+
   it("returns the expected static descriptor values", () => {
     expect(HEIMDALL_DESCRIPTOR).toMatchObject({
       service: {


### PR DESCRIPTION
Closes #135.

## Problem

Since the Heimdall v2 rework (Heimdall = platform, owning service = content), the ongoing Hugin tasks are not visible anywhere on the dashboard.

## Root cause

- #116 promoted hugin to **Tier-1 self-describing** (`GET /heimdall.json`).
- Heimdall's Tier-1 discovery takes panels from the descriptor and never consults its static `knownPanelsFor()` fallback, which had carried hugin's `Tasks` + `Task history` panels.
- Our descriptor declared `panels: []` → panels gone from `/services/hugin`; the old v1 `/tasks` page was retired in the same rework.

## Fix

Declare the two panels in `HEIMDALL_DESCRIPTOR.panels` with the exact shape Heimdall's fallback used (validated against heimdall `src/contract/schema.js` `normalizePanels`): `plugin: "hugin"` + `view: "tasks" | "history"`. Heimdall's existing `plugins/hugin.js` renders them live from the Munin DB — no push loop, no Heimdall change needed.

## Test plan

- [x] Red/green: new descriptor-panels test failed on `panels: []`, passes after the fix
- [x] Full suite 1184 green (83 files); `tsc` clean
- [ ] After deploy: `curl http://huginmunin:3032/heimdall.json | jq .panels` shows both panels
- [ ] Heimdall `/services/hugin` renders Tasks + Task history

🤖 Generated with [Claude Code](https://claude.com/claude-code)