### PR TITLE
Scope Claude task permissions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,7 @@ Content format:
 - **Context-budget:** 8000
 - **Sensitivity:** internal
 - **Capabilities:** tools, code, structured-output
+- **Permission profile:** read-only | trusted-code
 - **Group:** batch-20260323
 - **Sequence:** 1
 
@@ -86,6 +87,15 @@ Content format:
 **Sensitivity:** Optional `Sensitivity: public | internal | private` field. If omitted, Hugin infers sensitivity from the prompt (keyword detection), context path, and any context-refs. Cloud runtimes (claude, codex) are capped at `internal`; local runtimes (ollama) allow `private`. Tasks that exceed their runtime's sensitivity ceiling are rejected.
 
 **Auto-routing:** Use `Runtime: auto` to let Hugin select the runtime. The router filters by trust tier (sensitivity ceiling), availability (ollama host probes), and capabilities, then ranks by cost (free > subscription), trust (trusted > semi-trusted), and model size. Optional `Capabilities: tools, code, structured-output` narrows candidates. Explicit runtimes remain the default — `auto` is opt-in. Routing decisions are logged and included in structured results.
+
+**Claude SDK permission profiles:** `Runtime: claude` defaults to
+`Permission profile: read-only`, which runs Claude Code in `dontAsk` mode with
+only read-only local tools plus read-only Munin MCP tools pre-approved.
+`Permission profile: trusted-code` takes effect only when the task also declares
+`Capabilities: code`; use that pair only when the prompt/context is trusted
+enough to allow filesystem edits, shell commands, and outbound tool use. It
+preserves the historical full-bypass Claude Code lane for explicitly trusted
+code tasks.
 
 **Pipeline tasks:** Use `Runtime: pipeline` with a `### Pipeline` section instead of `### Prompt`. Pipeline phases use runtime IDs (`claude-sdk`, `codex-spawn`, `ollama-pi`, `ollama-laptop`, `ollama-orin`, or `auto`) which differ from standalone runtime names. Per-phase `Capabilities:` is supported.
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,13 @@
 # Hugin — Status
 
-**Last session:** 2026-07-03 (session 9 — homeserver (M5) sovereign orchestrator provider live, PR #137)
-**Branch:** main (clean at `3ab3208`; 0 PRs open)
+**Last session:** 2026-07-08 (#149 permission profiles — Claude SDK no longer defaults every task to full bypass; PR pending on `codex/task-permission-profiles`)
+**Branch:** `codex/task-permission-profiles` from main; local build + full suite green (1429 tests).
+
+## Latest — Claude SDK task permission profiles (#149, 2026-07-08)
+
+Implemented a cheapest-first least-privilege gate for `Runtime: claude`: tasks now default to `Permission profile: read-only`, which runs Claude Code in `dontAsk` mode with only read-only local tools and read-only Munin MCP tools pre-approved. The historical full-bypass lane is preserved only when the task explicitly declares both `Capabilities: code` and `Permission profile: trusted-code`; malformed or non-code trusted-code requests downgrade to read-only.
+
+Validation: `npm test -- tests/sdk-executor.test.ts tests/dispatcher.test.ts`, `npm run build`, and full `npm test` passed locally. M5 advisory review accepted in part: added the `Capabilities: code` guard and removed `TodoWrite` from the read-only tool allowlist; rejected the blanket recommendation to remove bypass entirely because #149 explicitly keeps full bypass for trusted code tasks.
 
 ## Session 9 (2026-07-03) — Homeserver (M5) wired as sovereign orchestrator provider + go-live (#137)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import {
   type MuninReadResult,
 } from "./munin-client.js";
 import { getFoundBatchEntry, extractTaskId, pickEarliestTask, selectNextTask, checkoutTaskBranch, finalizeTaskBranch, shouldReapExpiredLease, decideStartupRecovery, decideDeliveryRetry, finalizeTaskCompletion, resolveContext, normalizeRoot, DEFAULT_REPOS_ROOT } from "./task-helpers.js";
-import { executeSdkTask, type SdkExecutorResult, type SdkExecutorOptions, type SdkTaskConfig } from "./sdk-executor.js";
+import { executeSdkTask, type SdkExecutorResult, type SdkExecutorOptions, type SdkTaskConfig, type TaskPermissionProfile } from "./sdk-executor.js";
 import { classifyClaudeFailure } from "./failure-classification.js";
 import {
   decideAuthAlarm,
@@ -595,6 +595,7 @@ interface TaskConfig {
   contextResolution?: Awaited<ReturnType<typeof resolveContextRefs>>;
   pipeline?: TaskExecutionPipelineContext;
   capabilities?: RuntimeCapability[];
+  permissionProfile?: TaskPermissionProfile;
   autoRouted?: boolean;
   routingDecision?: RouterDecision;
   // Local-skill lane audit record (issue #84). Set when HUGIN_SKILL_LANE=on and
@@ -742,6 +743,9 @@ function parseTask(content: string): TaskConfig | null {
   const capabilitiesRaw = content.match(
     /\*\*Capabilities:\*\*\s*(.+)/i
   )?.[1]?.trim();
+  const permissionProfileRaw = content.match(
+    /\*\*Permission profile:\*\*\s*(.+)/i
+  )?.[1]?.trim()?.toLowerCase();
 
   // Extract prompt from ### Prompt section
   const promptMatch = content.match(/###\s*Prompt\s*\n([\s\S]+)$/i);
@@ -796,6 +800,10 @@ function parseTask(content: string): TaskConfig | null {
       ? sensitivitySchema.parse(declaredSensitivityRaw)
       : undefined,
     capabilities: validCapabilities.length > 0 ? validCapabilities : undefined,
+    permissionProfile:
+      permissionProfileRaw === "trusted-code" && validCapabilities.includes("code")
+        ? "trusted-code"
+        : "read-only",
     autoRouted: isAutoRoute || undefined,
     artifactManifest: artifactManifestResult.manifest ?? undefined,
     artifactManifestError: artifactManifestResult.error ?? undefined,
@@ -4038,6 +4046,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
             muninApiKey: config.muninApiKey,
             maxOutputChars: config.maxOutputChars,
             muninSessionId: munin.getSessionId(),
+            permissionProfile: task.permissionProfile,
           },
           taskId,
           LOG_DIR,
@@ -4098,6 +4107,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
             muninApiKey: config.muninApiKey,
             maxOutputChars: config.maxOutputChars,
             muninSessionId: munin.getSessionId(),
+            permissionProfile: task.permissionProfile,
           },
           taskId,
           LOG_DIR,
@@ -4190,6 +4200,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         maxOutputChars: config.maxOutputChars,
         model: task.model,
         muninSessionId: munin.getSessionId(),
+        permissionProfile: task.permissionProfile,
       },
       taskId,
       LOG_DIR,

--- a/src/sdk-executor.ts
+++ b/src/sdk-executor.ts
@@ -6,8 +6,52 @@ import { query, type Query } from "@anthropic-ai/claude-agent-sdk";
 type HttpMcpServer = { type: "http"; url: string; headers?: Record<string, string> };
 type StdioMcpServer = { type: "stdio"; command: string; args: string[]; env: Record<string, string> };
 type McpServerEntry = HttpMcpServer | StdioMcpServer;
+type ClaudePermissionMode = "default" | "acceptEdits" | "bypassPermissions" | "plan" | "dontAsk";
 
 const FRICTION_MCP_DIST_PATH = fileURLToPath(new URL("./friction-mcp.js", import.meta.url));
+
+export type TaskPermissionProfile = "read-only" | "trusted-code";
+
+export interface ClaudePermissionOptions {
+  permissionMode: ClaudePermissionMode;
+  allowDangerouslySkipPermissions?: boolean;
+  allowedTools?: string[];
+}
+
+const READ_ONLY_ALLOWED_TOOLS = [
+  "Read",
+  "LS",
+  "Glob",
+  "Grep",
+  "mcp__munin-memory__memory_orient",
+  "mcp__munin-memory__memory_resume",
+  "mcp__munin-memory__memory_read",
+  "mcp__munin-memory__memory_read_batch",
+  "mcp__munin-memory__memory_get",
+  "mcp__munin-memory__memory_query",
+  "mcp__munin-memory__memory_list",
+  "mcp__munin-memory__memory_history",
+  "mcp__munin-memory__memory_handoff",
+  "mcp__munin-memory__memory_commitments",
+  "mcp__munin-memory__memory_patterns",
+  "mcp__munin-memory__memory_status",
+] as const;
+
+export function buildClaudePermissionOptions(
+  profile: TaskPermissionProfile = "read-only",
+): ClaudePermissionOptions {
+  if (profile === "trusted-code") {
+    return {
+      permissionMode: "bypassPermissions",
+      allowDangerouslySkipPermissions: true,
+    };
+  }
+
+  return {
+    permissionMode: "dontAsk",
+    allowedTools: [...READ_ONLY_ALLOWED_TOOLS],
+  };
+}
 
 // --- Types ---
 
@@ -19,6 +63,7 @@ export interface SdkTaskConfig {
   muninApiKey: string;
   maxOutputChars: number;
   model?: string;
+  permissionProfile?: TaskPermissionProfile;
   /**
    * Stable mcp-session-id forwarded to the Agent SDK's Munin MCP client so all
    * MCP calls during this task share one session. Enables Munin's outcome-aware
@@ -86,6 +131,7 @@ export async function executeSdkTask(
       `Runtime: claude (agent-sdk)`,
       `Working dir: ${task.workingDir}`,
       `Timeout: ${task.timeoutMs}`,
+      `Permission profile: ${task.permissionProfile ?? "read-only"}`,
       `Started: ${startedAt}`,
       "===\n",
     ].join("\n"),
@@ -162,6 +208,8 @@ export async function executeSdkTask(
   let stderrBuf = "";
 
   try {
+    const permissionOptions = buildClaudePermissionOptions(task.permissionProfile);
+
     // Build MCP servers config so task-spawned agents get Munin access
     const mcpServers: Record<string, McpServerEntry> = {};
     if (task.muninUrl && task.muninApiKey) {
@@ -223,8 +271,7 @@ export async function executeSdkTask(
       options: {
         cwd: task.workingDir,
         abortController,
-        permissionMode: "bypassPermissions",
-        allowDangerouslySkipPermissions: true,
+        ...permissionOptions,
         persistSession: false,
         ...(task.model ? { model: task.model } : {}),
         ...(Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),

--- a/tests/dispatcher.test.ts
+++ b/tests/dispatcher.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect } from "vitest";
 import { resolveContext } from "../src/task-helpers.js";
 
 type RuntimeCapability = "tools" | "code" | "structured-output";
+type TaskPermissionProfile = "read-only" | "trusted-code";
 
 function parseTask(content: string, workspace = "/home/magnus/workspace") {
   const declaredRuntimeRaw =
@@ -65,6 +66,9 @@ function parseTask(content: string, workspace = "/home/magnus/workspace") {
   const capabilitiesRaw = content.match(
     /\*\*Capabilities:\*\*\s*(.+)/i
   )?.[1]?.trim();
+  const permissionProfileRaw = content.match(
+    /\*\*Permission profile:\*\*\s*(.+)/i
+  )?.[1]?.trim()?.toLowerCase();
 
   const promptMatch = content.match(/###\s*Prompt\s*\n([\s\S]+)$/i);
   const prompt = promptMatch?.[1]?.trim();
@@ -106,6 +110,10 @@ function parseTask(content: string, workspace = "/home/magnus/workspace") {
       : undefined,
     contextBudget: contextBudgetStr ? parseInt(contextBudgetStr) : undefined,
     capabilities: validCapabilities.length > 0 ? validCapabilities : undefined,
+    permissionProfile:
+      permissionProfileRaw === "trusted-code" && validCapabilities.includes("code")
+        ? "trusted-code" as TaskPermissionProfile
+        : "read-only" as TaskPermissionProfile,
     autoRouted: isAutoRoute || undefined,
   };
 }
@@ -839,6 +847,47 @@ Do it`;
     const task = parseTask(content);
     expect(task!.autoRouted).toBeUndefined();
     expect(task!.capabilities).toEqual(["tools"]);
+  });
+
+  it("should default Claude permission profile to read-only", () => {
+    const content = `## Task: Default permissions
+
+- **Runtime:** claude
+
+### Prompt
+Summarize the queue`;
+
+    const task = parseTask(content);
+    expect(task!.permissionProfile).toBe("read-only");
+  });
+
+  it("should parse explicit trusted-code permission profile", () => {
+    const content = `## Task: Trusted code
+
+- **Runtime:** claude
+- **Capabilities:** code
+- **Permission profile:** trusted-code
+
+### Prompt
+Implement a focused code change`;
+
+    const task = parseTask(content);
+    expect(task!.capabilities).toEqual(["code"]);
+    expect(task!.permissionProfile).toBe("trusted-code");
+  });
+
+  it("should downgrade trusted-code profile without code capability to read-only", () => {
+    const content = `## Task: Untrusted non-code
+
+- **Runtime:** claude
+- **Permission profile:** trusted-code
+
+### Prompt
+Summarize untrusted input`;
+
+    const task = parseTask(content);
+    expect(task!.capabilities).toBeUndefined();
+    expect(task!.permissionProfile).toBe("read-only");
   });
 
   it("should parse auto task with all fields", () => {

--- a/tests/sdk-executor.test.ts
+++ b/tests/sdk-executor.test.ts
@@ -8,7 +8,12 @@ vi.mock("@anthropic-ai/claude-agent-sdk", () => ({
   query: vi.fn(),
 }));
 
-import { executeSdkTask, formatChildStderr, type SdkTaskConfig } from "../src/sdk-executor.js";
+import {
+  buildClaudePermissionOptions,
+  executeSdkTask,
+  formatChildStderr,
+  type SdkTaskConfig,
+} from "../src/sdk-executor.js";
 import { query } from "@anthropic-ai/claude-agent-sdk";
 
 const mockedQuery = vi.mocked(query);
@@ -134,6 +139,26 @@ afterEach(() => {
 });
 
 describe("SDK executor", () => {
+  it("builds read-only Claude permission options by default", () => {
+    const options = buildClaudePermissionOptions();
+
+    expect(options.permissionMode).toBe("dontAsk");
+    expect(options.allowDangerouslySkipPermissions).toBeUndefined();
+    expect(options.allowedTools).toContain("Read");
+    expect(options.allowedTools).toContain("mcp__munin-memory__memory_query");
+    expect(options.allowedTools).not.toContain("Bash");
+    expect(options.allowedTools).not.toContain("Edit");
+    expect(options.allowedTools).not.toContain("TodoWrite");
+    expect(options.allowedTools).not.toContain("WebFetch");
+  });
+
+  it("builds bypass Claude permission options only for trusted-code", () => {
+    expect(buildClaudePermissionOptions("trusted-code")).toEqual({
+      permissionMode: "bypassPermissions",
+      allowDangerouslySkipPermissions: true,
+    });
+  });
+
   it("should return structured result on success", async () => {
     const messages = [
       createMockAssistantMessage("Here is the result of your task."),
@@ -185,7 +210,7 @@ describe("SDK executor", () => {
     expect(result.output).toContain("SDK Error: SDK internal crash");
   });
 
-  it("should call query with correct options", async () => {
+  it("should call query with read-only permissions by default", async () => {
     const messages = [createMockResultSuccess("Done")];
     mockedQuery.mockReturnValue(createMockQuery(messages) as ReturnType<typeof query>);
 
@@ -198,6 +223,31 @@ describe("SDK executor", () => {
       prompt: "Do the thing",
       options: expect.objectContaining({
         cwd: taskConfig.workingDir,
+        permissionMode: "dontAsk",
+        allowedTools: expect.arrayContaining(["Read", "Grep"]),
+        persistSession: false,
+      }),
+    });
+    const call = mockedQuery.mock.calls[0]?.[0] as {
+      options?: { allowDangerouslySkipPermissions?: boolean; allowedTools?: string[] };
+    };
+    expect(call.options?.allowDangerouslySkipPermissions).toBeUndefined();
+    expect(call.options?.allowedTools).not.toContain("Bash");
+  });
+
+  it("should call query with bypass permissions for trusted-code tasks", async () => {
+    const messages = [createMockResultSuccess("Done")];
+    mockedQuery.mockReturnValue(createMockQuery(messages) as ReturnType<typeof query>);
+
+    await executeSdkTask(
+      makeTaskConfig({ permissionProfile: "trusted-code" }),
+      "test-task-trusted-code",
+      tmpLogDir,
+    );
+
+    expect(mockedQuery).toHaveBeenCalledWith({
+      prompt: "Test prompt",
+      options: expect.objectContaining({
         permissionMode: "bypassPermissions",
         allowDangerouslySkipPermissions: true,
         persistSession: false,


### PR DESCRIPTION
## Summary
- default Claude SDK tasks to a read-only `dontAsk` permission profile instead of unconditional full bypass
- preserve the historical full-bypass lane only for tasks that explicitly declare both `Capabilities: code` and `Permission profile: trusted-code`
- document the new task field and pin parser/executor behavior with tests

Closes #149.

## Validation
- npm test -- tests/sdk-executor.test.ts tests/dispatcher.test.ts
- npm run build
- npm test
- git diff --check

## Review
- M5 advisory review via qwen3-coder-next-80b; accepted the guard that `trusted-code` must also declare `Capabilities: code` and removed `TodoWrite` from the read-only allowlist. Rejected removing bypass entirely because this issue explicitly preserves full bypass for explicitly trusted code tasks.
