### PR TITLE
Forward current homeserver delegate fields

### DIFF
--- a/src/homeserver-executor.ts
+++ b/src/homeserver-executor.ts
@@ -26,18 +26,45 @@ import * as path from "node:path";
 
 export type HomeserverPath = "chat" | "delegate";
 
+export type HomeserverResponseFormat =
+  | { type: "text" }
+  | { type: "json_object" }
+  | {
+      type: "json_schema";
+      json_schema: {
+        name: string;
+        schema: Record<string, unknown>;
+        strict?: boolean;
+      };
+    };
+
+export type HomeserverVerifierSpec = Record<string, unknown>;
+
 export interface HomeserverTaskConfig {
   prompt: string;
   gatewayBaseUrl: string; // e.g. http://127.0.0.1:8080
   apiKey: string; // Bearer token (may be "" on a keyless loopback gateway)
   path: HomeserverPath;
-  /** Required for "chat" (the model to serve). Ignored on "delegate" (the gateway/ledger selects). */
+  /** Required for "chat" (the model to serve). Prefer modelId for "delegate" pinning. */
   model?: string;
   /** Forwarded to /delegate as the ledger bucket. */
   taskType?: string;
-  /** Reserved for forward-compat: the gateway /delegate HTTP endpoint does not yet accept a
-   *  frontier model, so this is currently NOT sent. Re-wire once the gateway exposes escalation. */
+  /** Forwarded to /delegate when present. */
+  systemPrompt?: string;
+  /** Forwarded to /delegate when present. */
+  maxTokens?: number;
+  /** Forwarded to /delegate to pin the local model when present. */
+  modelId?: string;
+  /** Forwarded to /delegate to request a frontier fallback arm when present. */
   frontierModelId?: string;
+  /** Forwarded to /delegate so the gateway can record pass/fail ledger evidence. */
+  verifier?: HomeserverVerifierSpec;
+  /** Forwarded to /delegate for grammar-constrained JSON/text decoding. */
+  responseFormat?: HomeserverResponseFormat;
+  /** Forwarded to /delegate for provenance/accounting when the cloud brain is known. */
+  delegatorModelId?: string;
+  /** Forwarded to /delegate for savings/baseline accounting when present. */
+  premiumBaselineModelId?: string;
   timeoutMs: number;
   maxOutputChars: number;
   injectedContext?: string;
@@ -240,11 +267,18 @@ export async function executeHomeserverTask(
     const body: Record<string, unknown> =
       task.path === "delegate"
         ? {
-            // The gateway /delegate HTTP handler only accepts prompt + taskType
-            // (+ systemPrompt/maxTokens). It does NOT accept modelId or frontierModelId
-            // today, so we don't send them — see gateway-api-contract.md.
             prompt: userMessage,
             ...(task.taskType ? { taskType: task.taskType } : {}),
+            ...(task.systemPrompt !== undefined ? { systemPrompt: task.systemPrompt } : {}),
+            ...(task.maxTokens !== undefined ? { maxTokens: task.maxTokens } : {}),
+            ...(task.modelId !== undefined ? { modelId: task.modelId } : {}),
+            ...(task.frontierModelId !== undefined ? { frontierModelId: task.frontierModelId } : {}),
+            ...(task.verifier !== undefined ? { verifier: task.verifier } : {}),
+            ...(task.responseFormat !== undefined ? { responseFormat: task.responseFormat } : {}),
+            ...(task.delegatorModelId !== undefined ? { delegatorModelId: task.delegatorModelId } : {}),
+            ...(task.premiumBaselineModelId !== undefined
+              ? { premiumBaselineModelId: task.premiumBaselineModelId }
+              : {}),
           }
         : {
             model: task.model,

--- a/tests/homeserver-executor.test.ts
+++ b/tests/homeserver-executor.test.ts
@@ -163,7 +163,30 @@ describe("executeHomeserverTask — delegate path", () => {
     );
 
     const result = await executeHomeserverTask(
-      makeTaskConfig({ path: "delegate", taskType: "extract", frontierModelId: "anthropic/claude-opus-4-5" }),
+      makeTaskConfig({
+        path: "delegate",
+        taskType: "extract",
+        systemPrompt: "Return only the extracted year.",
+        maxTokens: 128,
+        modelId: "qwen3-coder",
+        frontierModelId: "anthropic/claude-opus-4-5",
+        verifier: { type: "numeric", expected: 1998 },
+        responseFormat: {
+          type: "json_schema",
+          json_schema: {
+            name: "year_result",
+            schema: {
+              type: "object",
+              properties: { year: { type: "number" } },
+              required: ["year"],
+              additionalProperties: false,
+            },
+            strict: true,
+          },
+        },
+        delegatorModelId: "anthropic/claude-sonnet-4-5",
+        premiumBaselineModelId: "anthropic/claude-opus-4-5",
+      }),
       "delegate-ok",
       tmpLogDir,
     );
@@ -186,9 +209,41 @@ describe("executeHomeserverTask — delegate path", () => {
     const body = JSON.parse((init as RequestInit).body as string);
     expect(body.taskType).toBe("extract");
     expect(typeof body.prompt).toBe("string");
-    // The gateway /delegate handler ignores these fields, so the executor must not send them.
-    expect(body.modelId).toBeUndefined();
-    expect(body.frontierModelId).toBeUndefined();
+    expect(body.systemPrompt).toBe("Return only the extracted year.");
+    expect(body.maxTokens).toBe(128);
+    expect(body.modelId).toBe("qwen3-coder");
+    expect(body.frontierModelId).toBe("anthropic/claude-opus-4-5");
+    expect(body.verifier).toEqual({ type: "numeric", expected: 1998 });
+    expect(body.responseFormat).toEqual({
+      type: "json_schema",
+      json_schema: {
+        name: "year_result",
+        schema: {
+          type: "object",
+          properties: { year: { type: "number" } },
+          required: ["year"],
+          additionalProperties: false,
+        },
+        strict: true,
+      },
+    });
+    expect(body.delegatorModelId).toBe("anthropic/claude-sonnet-4-5");
+    expect(body.premiumBaselineModelId).toBe("anthropic/claude-opus-4-5");
+  });
+
+  it("omits optional /delegate fields that are not present", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({ delegated: true, outcome: "unverified", output: "1998" }),
+    );
+
+    await executeHomeserverTask(makeTaskConfig({ path: "delegate", taskType: "extract" }), "delegate-min", tmpLogDir);
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body).toEqual({
+      prompt: expect.any(String),
+      taskType: "extract",
+    });
   });
 
   it("maps outcome 'fail'/'error' to a non-zero exit code, but 'unverified' to 0", async () => {


### PR DESCRIPTION
## Summary
- reconcile Hugin`s homeserver delegate executor with the current M5 `/delegate` gateway contract
- forward optional `systemPrompt`, `maxTokens`, `modelId`, `frontierModelId`, verifier, response format, `delegatorModelId`, and premium-baseline fields when present
- keep absent optional fields omitted from the request body

Closes #151.

## Validation
- `npm test -- tests/homeserver-executor.test.ts`
- `npm run build`
