### PR TITLE
[codex] Add OpenCode harness runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ Content format:
 ```markdown
 ## Task: <title>
 
-- **Runtime:** claude | codex | ollama
+- **Runtime:** claude | codex | ollama | opencode
 - **Context:** repo:heimdall
 - **Working dir:** /home/magnus/workspace
 - **Timeout:** 300000
@@ -79,6 +79,8 @@ Content format:
 - `Context-budget:` — max characters for injected context (default 8000). Truncated from end if exceeded.
 
 **Type tags:** Tags matching `type:*` (e.g., `type:research`, `type:email`) are carried forward through the task lifecycle (pending → running → completed/failed).
+
+**OpenCode harness runtime:** `Runtime: opencode` is an explicit M5-backed coding harness lane. It uses a temp OpenCode config, streams `opencode run --format json`, records tool/test/diff events, and removes the temp config after each run. It is explicit-only and capped at `internal` sensitivity for now. `Permission profile: read-only` denies edit/bash through the OpenCode `plan` agent; `Capabilities: code` + `Permission profile: trusted-code` uses the `build` agent with edit/bash allowed.
 
 **Artefact delivery (`### Artifacts` manifest, issue #68):** A task may declare an `### Artifacts` section so **Hugin (not the agent)** owns and verifies delivery of the deliverables; the agent only writes to the declared local staging paths and makes no delivery claims.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ Content format:
 ```markdown
 ## Task: <title>
 
-- **Runtime:** claude | codex | ollama | pipeline | auto | orchestrator
+- **Runtime:** claude | codex | ollama | opencode | pipeline | auto | orchestrator
 - **Context:** repo:heimdall
 - **Working dir:** /home/magnus/workspace
 - **Timeout:** 300000
@@ -96,6 +96,16 @@ only read-only local tools plus read-only Munin MCP tools pre-approved.
 enough to allow filesystem edits, shell commands, and outbound tool use. It
 preserves the historical full-bypass Claude Code lane for explicitly trusted
 code tasks.
+
+**OpenCode harness runtime:** `Runtime: opencode` is an explicit, M5-backed
+coding harness lane. It writes a temporary OpenCode config pointing at the
+OpenAI-compatible M5 gateway, runs `opencode run --format json`, captures
+normalized tool/test/diff events, and removes the temp config directory after
+the run. It is explicit-only (`opencode-m5`, not auto-routed) and capped at
+`internal` sensitivity until the harness/audit path has production evidence.
+`Permission profile: read-only` maps to the OpenCode `plan` agent with
+`edit`/`bash` denied; `Capabilities: code` + `Permission profile: trusted-code`
+maps to the `build` agent with `edit`/`bash` allowed.
 
 **Pipeline tasks:** Use `Runtime: pipeline` with a `### Pipeline` section instead of `### Prompt`. Pipeline phases use runtime IDs (`claude-sdk`, `codex-spawn`, `ollama-pi`, `ollama-laptop`, `ollama-orin`, or `auto`) which differ from standalone runtime names. Per-phase `Capabilities:` is supported.
 
@@ -338,8 +348,13 @@ claude mcp add-json hugin '{"command":"node","args":["/Users/magnus/repos/hugin/
 | `ARXIV_STORAGE_PATH` | — | Directory where arxiv-mcp-server caches downloaded papers. Forwarded into the arxiv MCP subprocess environment. |
 | `HUGIN_ACTIVE_SUBSCRIPTIONS` | (all active) | Comma-separated runtime IDs of subscriptions you actually pay for (e.g. `claude-sdk`). Subscription-cost runtimes are auto-eligible only if listed here; unset = all active subscription runtimes are eligible. Vendor-neutral — Claude today, Berget Code / ChatGPT later. |
 | `BERGET_API_KEY` | — | API key for the Berget.ai EU-sovereign provider (OpenAI-compatible, base URL `https://api.berget.ai/v1`). Required for any orchestrator role bound to the `berget` provider. One of the two recognized sovereign providers for `Sensitivity: private` orchestrator tasks (the other is `homeserver`). |
-| `HOMESERVER_GATEWAY_URL` | — | Root URL of the M5 local-inference gateway (e.g. `http://100.76.72.59:8080`, no `/v1` — no path/credentials/query at all). Enables the orchestrator's `homeserver` provider (base URL resolved + validated at request time, `/v1` appended) and the standalone (not-yet-dispatcher-wired) `homeserver-executor.ts`. The host MUST be loopback/private-LAN/tailnet (`100.64/10`, `.ts.net`, `.local`, single-label); a public host is rejected before any model call and is never egress-allowlisted — sovereignty must not hinge on a typo'd env var. A sovereign host is auto-added to the egress allowlist. |
+| `HOMESERVER_GATEWAY_URL` | — | Root URL of the M5 local-inference gateway (e.g. `http://100.76.72.59:8080`, no `/v1` — no path/credentials/query at all). Enables the orchestrator's `homeserver` provider (base URL resolved + validated at request time, `/v1` appended), the standalone `homeserver-executor.ts`, and the default `Runtime: opencode` M5 provider config (OpenCode appends/uses `/v1`). The host MUST be loopback/private-LAN/tailnet (`100.64/10`, `.ts.net`, `.local`, single-label); a public host is rejected before any model call and is never egress-allowlisted — sovereignty must not hinge on a typo'd env var. A sovereign host is auto-added to the egress allowlist. |
 | `HOMESERVER_GATEWAY_API_KEY` | — | Bearer token for the M5 gateway. Required for any orchestrator role bound to `homeserver` (the orchestrator path has no keyless-loopback carve-out — over the tailnet a key is always required). |
+| `HUGIN_OPENCODE_BASE_URL` | `HOMESERVER_GATEWAY_URL` | Optional override for the OpenCode runtime's OpenAI-compatible base URL. May be a gateway root URL or `/v1`; Hugin normalizes it to `/v1` and rejects public hosts or extra paths. A keyless non-loopback URL is refused. |
+| `HUGIN_OPENCODE_API_KEY` | `HOMESERVER_GATEWAY_API_KEY` | Optional override for the OpenCode runtime provider API key. Passed to the child process as `HUGIN_OPENCODE_PROVIDER_API_KEY`; never written into the temp config. |
+| `HUGIN_OPENCODE_PROVIDER` | `m5` | Provider id written into the temp OpenCode config and used in `--model <provider>/<model>`. |
+| `HUGIN_OPENCODE_MODEL` | `qwen3-coder-next-80b` | Default model for `Runtime: opencode` tasks without a `Model:` field. |
+| `HUGIN_OPENCODE_CMD` | `opencode` | OpenCode executable path. Override on the Pi if the binary is not on the service PATH. |
 | `HUGIN_ORCH_PLANNER_MODEL` | (see `DEFAULT_ORCHESTRATOR_CONFIG`) | Override the planner role model. Format: `provider\|model` (e.g. `openrouter\|anthropic/claude-3.5-sonnet`). Omit the `provider\|` prefix to keep the role's default provider. |
 | `HUGIN_ORCH_WORKER_MODEL` | (see `DEFAULT_ORCHESTRATOR_CONFIG`) | Override the worker role model. Default: DeepSeek Flash via OpenRouter. |
 | `HUGIN_ORCH_VERIFIER_MODEL` | (see `DEFAULT_ORCHESTRATOR_CONFIG`) | Override the verifier role model. Verifier pass only runs when `HUGIN_ORCH_VERIFY=on`. |

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,11 +1,37 @@
 # Hugin — Status
 
-**Last session:** 2026-07-08 (#149 permission profiles — PR #150 deployed to huginmunin; deploy metadata repaired)
-**Branch:** main; service active/healthy on huginmunin. Production runtime includes PR #150 and
-the later #152 homeserver delegate-field fix; exact latest deployment marker is
+**Last session:** 2026-07-08 (Codex) — OpenCode harness adapter spike
+**Branch:** codex/opencode-harness-adapter; production still runs `main` on huginmunin.
+
+## Latest — OpenCode harness adapter spike (2026-07-08)
+
+Added an explicit `Runtime: opencode` lane for the Grimnir agent-harness decoupling track. The lane
+uses a temporary OpenCode config pointed at the M5/OpenAI-compatible gateway, runs
+`opencode run --format json`, captures normalized tool/test/diff events, and removes the temp config
+directory after execution.
+
+- **Runtime shape:** registry entry `opencode-m5`, explicit-only (`autoEligible:false`), harness
+  family, local egress, capped at `internal` sensitivity for now.
+- **Permissions:** `read-only` maps to OpenCode `plan` with `edit`/`bash` denied; `Capabilities:
+  code` + `Permission profile: trusted-code` maps to `build` with `edit`/`bash` allowed.
+- **Config:** defaults to `HOMESERVER_GATEWAY_URL` + `HOMESERVER_GATEWAY_API_KEY`, with
+  `HUGIN_OPENCODE_*` overrides for base URL, key, provider id, default model, and executable path.
+- **Tests:** focused executor tests use a fake `opencode` binary to prove temp config/env/cleanup and
+  JSONL event normalization without spending M5 tokens. Local `npm run build`, focused runtime tests,
+  `npm test`, and `git diff --check` passed. M5 advisory review reported no blocking issues.
+
+### Pending / next
+
+- PR/review/merge the branch.
+- After merge/deploy, submit a small live `Runtime: opencode` fixture task on huginmunin using M5.
+- Keep Claude as fallback until OpenCode has production traces plus Verdandi/audit identity coverage.
+
+## Previous — Claude SDK task permission profiles (#149, 2026-07-08)
+
+**Production state before this branch:** service active/healthy on huginmunin. Production runtime
+includes PR #150 and the later #152 homeserver delegate-field fix; exact latest deployment marker is
 `/home/magnus/repos/hugin/.deployed-commit`.
 
-## Latest — Claude SDK task permission profiles (#149, 2026-07-08)
 
 Implemented a cheapest-first least-privilege gate for `Runtime: claude`: tasks now default to `Permission profile: read-only`, which runs Claude Code in `dontAsk` mode with only read-only local tools and read-only Munin MCP tools pre-approved. The historical full-bypass lane is preserved only when the task explicitly declares both `Capabilities: code` and `Permission profile: trusted-code`; malformed or non-code trusted-code requests downgrade to read-only.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,11 @@ import {
   type AuthAlarmState,
 } from "./auth-alarm.js";
 import { executeOllamaTask } from "./ollama-executor.js";
+import {
+  executeOpencodeTask,
+  loadOpencodeGatewayConfig,
+  type OpencodeExecutorResult,
+} from "./opencode-executor.js";
 import { configureHosts, resolveOllamaHost, getHostStatus, probeAllHosts, warmModel, getLoadedModels } from "./ollama-hosts.js";
 import { resolveContextRefs } from "./context-loader.js";
 import { parseExternalPolicy, type ExternalPolicy } from "./provenance.js";
@@ -109,6 +114,7 @@ import {
 import { routeTask, type RouterDecision } from "./router.js";
 import {
   buildRuntimeCandidates,
+  isAutoRoutableDispatcherRuntime,
   isLegacyDispatcherRuntime,
   parseActiveSubscriptions,
   type RuntimeCapability,
@@ -439,6 +445,7 @@ let currentTaskConfig: TaskConfig | null = null;
 let currentChild: ChildProcess | null = null;
 let currentSdkAbort: AbortController | null = null;
 let currentOllamaAbort: AbortController | null = null;
+let currentOpencodeAbort: AbortController | null = null;
 let currentOrchestratorAbort: AbortController | null = null;
 // Runtime-owned artefact delivery (issue #68). Aborted by operator cancel /
 // shutdown so a hung `ssh`/`rsync` cannot wedge the single dispatcher slot.
@@ -573,7 +580,7 @@ const orchSavingsStore = savingsLayerEnabled
 
 interface TaskConfig {
   prompt: string;
-  runtime: "claude" | "codex" | "ollama" | "orchestrator";
+  runtime: "claude" | "codex" | "ollama" | "opencode" | "orchestrator";
   workingDir: string;
   context?: string;
   timeoutMs: number;
@@ -616,7 +623,7 @@ interface TaskConfig {
 type DeclaredRuntime = TaskConfig["runtime"] | "pipeline" | "auto";
 
 function parseDeclaredRuntime(content: string): DeclaredRuntime | undefined {
-  return content.match(/\*\*Runtime:\*\*\s*(claude|codex|ollama|pipeline|auto|orchestrator)/i)?.[1]?.toLowerCase() as
+  return content.match(/\*\*Runtime:\*\*\s*(claude|codex|ollama|opencode|pipeline|auto|orchestrator)/i)?.[1]?.toLowerCase() as
     | DeclaredRuntime
     | undefined;
 }
@@ -666,6 +673,7 @@ function parseTask(content: string): TaskConfig | null {
       | "claude"
       | "codex"
       | "ollama"
+      | "opencode"
       | "orchestrator"
       | undefined;
   const workingDir = content.match(
@@ -1808,6 +1816,9 @@ function requestCancellationForCurrentTask(request: CancellationRequest): void {
   }
   if (currentOllamaAbort && !currentOllamaAbort.signal.aborted) {
     currentOllamaAbort.abort(request.reason);
+  }
+  if (currentOpencodeAbort && !currentOpencodeAbort.signal.aborted) {
+    currentOpencodeAbort.abort(request.reason);
   }
   if (currentOrchestratorAbort && !currentOrchestratorAbort.signal.aborted) {
     currentOrchestratorAbort.abort(request.reason);
@@ -3707,13 +3718,13 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
           availableRuntimes: candidates,
         });
         // Auto-router is contractually required to exclude autoEligible:false
-        // runtimes (openrouter, pi-harness). Verify rather than cast — if this
+        // runtimes (opencode, openrouter, pi-harness). Verify rather than cast — if this
         // ever fires, the contract was violated upstream and the dispatcher
         // cannot execute the selection.
         const selectedRuntime = decision.selectedRuntime.dispatcherRuntime;
-        if (!isLegacyDispatcherRuntime(selectedRuntime)) {
+        if (!isAutoRoutableDispatcherRuntime(selectedRuntime)) {
           throw new Error(
-            `Auto-router selected non-legacy runtime "${selectedRuntime}" — ` +
+            `Auto-router selected non-auto-routable runtime "${selectedRuntime}" — ` +
               `autoEligible filter contract violated. selected_id=${decision.selectedRuntime.id}`,
           );
         }
@@ -3976,8 +3987,17 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
 
     const isOllama = task.runtime === "ollama";
     const isClaude = task.runtime === "claude";
+    const isOpencode = task.runtime === "opencode";
     const isOrchestrator = task.runtime === "orchestrator";
-    const executorLabel = isOllama ? "ollama" : isClaude ? "agent-sdk" : isOrchestrator ? "orchestrator" : "spawn";
+    const executorLabel = isOllama
+      ? "ollama"
+      : isClaude
+        ? "agent-sdk"
+        : isOpencode
+          ? "opencode"
+          : isOrchestrator
+            ? "orchestrator"
+            : "spawn";
 
     // Capture quota before task execution (skip for ollama — it's Claude-specific)
     const quotaBefore = isOllama ? { q5: null, q7: null } : await fetchQuota();
@@ -4003,6 +4023,8 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     // runtime and whenever savings weren't computed for this run.
     let orchSavings: SavingsSummary | null = null;
     let ollamaJournalExtras: Record<string, unknown> = {};
+    let opencodeJournalExtras: Record<string, unknown> = {};
+    let opencodeResult: OpencodeExecutorResult | null = null;
     let effectiveExecutor = executorLabel;
     let fallbackTriggered = false;
     let fallbackReason: string | null = null;
@@ -4235,6 +4257,67 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     logFile = sdkResult.logFile;
     resultText = sdkResult.resultText;
     costUsd = sdkResult.costUsd;
+    } else if (isOpencode) {
+    console.log(`Using OpenCode executor for task ${taskNs}`);
+    const opencodeGateway = loadOpencodeGatewayConfig(process.env);
+    if (!opencodeGateway) {
+      exitCode = 1;
+      output =
+        "Runtime opencode is not configured: set HOMESERVER_GATEWAY_URL + HOMESERVER_GATEWAY_API_KEY " +
+        "or HUGIN_OPENCODE_BASE_URL + HUGIN_OPENCODE_API_KEY";
+      logFile = path.join(LOG_DIR, `${taskId}.log`);
+      fs.writeFileSync(
+        logFile,
+        [
+          "=== Hugin Task Log (opencode) ===",
+          `Task: ${taskNs}`,
+          output,
+          "",
+        ].join("\n"),
+      );
+      opencodeJournalExtras = {
+        runtime_requested: "opencode",
+        runtime_effective: "none",
+        opencode_configured: false,
+      };
+    } else {
+      const opencodeAbort = new AbortController();
+      currentOpencodeAbort = opencodeAbort;
+      opencodeResult = await executeOpencodeTask(
+        {
+          prompt: task.prompt,
+          workingDir: task.workingDir,
+          timeoutMs: task.timeoutMs,
+          maxOutputChars: config.maxOutputChars,
+          gatewayBaseUrl: opencodeGateway.gatewayBaseUrl,
+          apiKey: opencodeGateway.apiKey,
+          providerId: opencodeGateway.providerId,
+          model: task.model || opencodeGateway.defaultModel,
+          permissionProfile: task.permissionProfile || "read-only",
+          opencodeCommand: opencodeGateway.opencodeCommand,
+        },
+        taskId,
+        LOG_DIR,
+        { abortController: opencodeAbort },
+      );
+      exitCode = opencodeResult.exitCode;
+      output = opencodeResult.output;
+      logFile = opencodeResult.logFile;
+      resultText = opencodeResult.resultText;
+      currentOpencodeAbort = null;
+      opencodeJournalExtras = {
+        runtime_requested: "opencode",
+        runtime_effective: "opencode",
+        opencode_configured: true,
+        model_effective: opencodeResult.model,
+        opencode_agent: opencodeResult.agent,
+        permission_profile: opencodeResult.permissionProfile,
+        tool_calls: opencodeResult.toolCalls.length,
+        changed_files: opencodeResult.changedFiles,
+        test_commands: opencodeResult.testCommands,
+        config_dir_removed: opencodeResult.configDirRemoved,
+      };
+    }
     } else if (isOrchestrator) {
     // --- Orchestrator execution path ---
     console.log(`Using orchestrator executor for task ${taskNs}`);
@@ -4314,6 +4397,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     stopLeaseRenewal();
     currentSdkAbort = null;
     currentOllamaAbort = null;
+    currentOpencodeAbort = null;
     currentOrchestratorAbort = null;
 
     const durationMs = Date.now() - startMs;
@@ -4415,12 +4499,12 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     let rawBodyText: string;
     let structuredBodyKind: TaskExecutionBodyKind;
 
-    if ((isClaude || isOllama || isOrchestrator) && resultText) {
-      resultSource = effectiveExecutor;
+    if ((isClaude || isOllama || isOrchestrator || isOpencode) && resultText) {
+      resultSource = isOpencode ? "opencode-json" : effectiveExecutor;
       rawBodyText = resultText;
       structuredBodyKind = "response";
       resultBody = `### Response\n\n${resultText}`;
-    } else if (!isClaude && !isOllama && !isOrchestrator) {
+    } else if (!isClaude && !isOllama && !isOrchestrator && !isOpencode) {
       const hookResult = readHookResult(taskId);
       if (hookResult) {
         resultSource = "hook";
@@ -4736,9 +4820,18 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
                 : undefined,
           }
         : task.model
+          ? isOpencode && opencodeResult
+            ? {
+                requestedModel: task.model,
+                effectiveModel: opencodeResult.model,
+              }
+            : {
+                requestedModel: task.model,
+                effectiveModel: task.model,
+              }
+          : isOpencode && opencodeResult
           ? {
-              requestedModel: task.model,
-              effectiveModel: task.model,
+              effectiveModel: opencodeResult.model,
             }
           : undefined;
 
@@ -5031,6 +5124,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
       cancellation_source: cancellation?.sourceNamespace || null,
       // Ollama-specific fields (null/absent for non-ollama tasks)
       ...ollamaJournalExtras,
+      ...opencodeJournalExtras,
     });
 
     currentTask = null;
@@ -5041,6 +5135,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     stopCancellationWatch();
     currentSdkAbort = null;
     currentOllamaAbort = null;
+    currentOpencodeAbort = null;
     currentOrchestratorAbort = null;
     currentCancellation = null;
     currentTask = null;
@@ -5267,6 +5362,11 @@ async function shutdown(signal: string): Promise<void> {
   if (currentOllamaAbort) {
     console.log("Aborting running ollama task...");
     currentOllamaAbort.abort();
+  }
+
+  if (currentOpencodeAbort) {
+    console.log("Aborting running OpenCode task...");
+    currentOpencodeAbort.abort();
   }
 
   if (currentChild && !currentChild.killed) {

--- a/src/opencode-executor.ts
+++ b/src/opencode-executor.ts
@@ -1,0 +1,511 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { isSovereignGatewayHost } from "./orchestrator/provider-config.js";
+
+export type OpencodePermissionProfile = "read-only" | "trusted-code";
+
+export interface OpencodeGatewayConfig {
+  gatewayBaseUrl: string;
+  apiKey: string;
+  providerId: string;
+  defaultModel: string;
+  opencodeCommand: string;
+}
+
+export interface OpencodeTaskConfig {
+  prompt: string;
+  workingDir: string;
+  timeoutMs: number;
+  maxOutputChars: number;
+  gatewayBaseUrl: string;
+  apiKey: string;
+  providerId: string;
+  model: string;
+  permissionProfile: OpencodePermissionProfile;
+  opencodeCommand?: string;
+}
+
+export interface OpencodeProviderConfig {
+  $schema: string;
+  provider: Record<
+    string,
+    {
+      npm: "@ai-sdk/openai-compatible";
+      name: string;
+      options: {
+        baseURL: string;
+        apiKey: string;
+      };
+      models: Record<string, { name: string }>;
+    }
+  >;
+  permission: {
+    edit: "allow" | "deny";
+    bash: "allow" | "deny";
+  };
+}
+
+export interface OpencodeRunPlan {
+  args: string[];
+  agent: "plan" | "build";
+  cliModel: string;
+  modelId: string;
+  config: OpencodeProviderConfig;
+}
+
+export interface OpencodeToolCall {
+  type: "tool";
+  tool: string;
+  status?: string;
+  command?: string;
+  file?: string;
+  exitCode?: number;
+  additions?: number;
+  deletions?: number;
+  diff?: string;
+}
+
+export interface OpencodeTextEvent {
+  type: "text";
+  text: string;
+}
+
+export interface OpencodeStepFinishEvent {
+  type: "step_finish";
+  reason?: string;
+  cost?: number;
+  tokens?: {
+    input?: number;
+    output?: number;
+    total?: number;
+  };
+}
+
+export type OpencodeNormalizedEvent =
+  | OpencodeToolCall
+  | OpencodeTextEvent
+  | OpencodeStepFinishEvent;
+
+export interface OpencodeExecutorResult {
+  exitCode: number | "TIMEOUT";
+  output: string;
+  logFile: string;
+  resultText: string | null;
+  model: string;
+  agent: "plan" | "build";
+  permissionProfile: OpencodePermissionProfile;
+  toolCalls: OpencodeToolCall[];
+  changedFiles: string[];
+  testCommands: string[];
+  events: OpencodeNormalizedEvent[];
+  configDir: string;
+  configDirRemoved: boolean;
+}
+
+export interface OpencodeExecutorOptions {
+  abortController?: AbortController;
+}
+
+const DEFAULT_PROVIDER_ID = "m5";
+const DEFAULT_MODEL = "qwen3-coder-next-80b";
+const PROVIDER_API_KEY_ENV = "HUGIN_OPENCODE_PROVIDER_API_KEY";
+
+function isLoopbackUrl(url: string): boolean {
+  try {
+    const host = new URL(url).hostname.replace(/^\[|\]$/g, "");
+    return host === "localhost" || host === "127.0.0.1" || host === "::1";
+  } catch {
+    return false;
+  }
+}
+
+function normalizeOpenAiBaseUrl(raw: string): string {
+  const stripped = raw.trim().replace(/\/+$/, "");
+  if (!stripped) return stripped;
+  const parsed = new URL(stripped);
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error("OpenCode gateway URL must use http or https");
+  }
+  if (parsed.username || parsed.password || parsed.search || parsed.hash) {
+    throw new Error("OpenCode gateway URL must not include credentials, query, or fragment");
+  }
+  if (!isSovereignGatewayHost(parsed.hostname)) {
+    throw new Error("OpenCode gateway URL must be loopback/private-LAN/tailnet");
+  }
+  const pathname = parsed.pathname.replace(/\/+$/, "") || "/";
+  if (pathname === "/v1") {
+    return parsed.toString().replace(/\/+$/, "");
+  }
+  if (pathname !== "/") {
+    throw new Error("OpenCode gateway URL must be a gateway root or /v1 base URL");
+  }
+  parsed.pathname = path.posix.join(parsed.pathname, "v1");
+  return parsed.toString().replace(/\/+$/, "");
+}
+
+export function loadOpencodeGatewayConfig(
+  env: NodeJS.ProcessEnv = process.env,
+): OpencodeGatewayConfig | null {
+  const rawBase = (env.HUGIN_OPENCODE_BASE_URL || env.HOMESERVER_GATEWAY_URL || "").trim();
+  if (!rawBase) return null;
+
+  let gatewayBaseUrl: string;
+  try {
+    gatewayBaseUrl = normalizeOpenAiBaseUrl(rawBase);
+  } catch {
+    return null;
+  }
+
+  const apiKey = (
+    env.HUGIN_OPENCODE_API_KEY ||
+    env.HOMESERVER_GATEWAY_API_KEY ||
+    env.M5_API_KEY ||
+    ""
+  ).trim();
+  if (!apiKey && !isLoopbackUrl(gatewayBaseUrl)) return null;
+
+  return {
+    gatewayBaseUrl,
+    apiKey,
+    providerId: (env.HUGIN_OPENCODE_PROVIDER || DEFAULT_PROVIDER_ID).trim() || DEFAULT_PROVIDER_ID,
+    defaultModel: (env.HUGIN_OPENCODE_MODEL || DEFAULT_MODEL).trim() || DEFAULT_MODEL,
+    opencodeCommand: (env.HUGIN_OPENCODE_CMD || "opencode").trim() || "opencode",
+  };
+}
+
+function resolveModel(providerId: string, requestedModel: string): {
+  modelId: string;
+  cliModel: string;
+} {
+  const trimmed = requestedModel.trim();
+  const prefix = `${providerId}/`;
+  const modelId = trimmed.startsWith(prefix) ? trimmed.slice(prefix.length) : trimmed;
+  return { modelId, cliModel: `${providerId}/${modelId}` };
+}
+
+export function buildOpencodeRunPlan(task: OpencodeTaskConfig): OpencodeRunPlan {
+  const permission =
+    task.permissionProfile === "trusted-code"
+      ? { edit: "allow" as const, bash: "allow" as const }
+      : { edit: "deny" as const, bash: "deny" as const };
+  const agent = task.permissionProfile === "trusted-code" ? "build" : "plan";
+  const { modelId, cliModel } = resolveModel(task.providerId, task.model);
+  const config: OpencodeProviderConfig = {
+    $schema: "https://opencode.ai/config.json",
+    provider: {
+      [task.providerId]: {
+        npm: "@ai-sdk/openai-compatible",
+        name: `${task.providerId} Gateway`,
+        options: {
+          baseURL: task.gatewayBaseUrl,
+          apiKey: `{env:${PROVIDER_API_KEY_ENV}}`,
+        },
+        models: {
+          [modelId]: { name: modelId },
+        },
+      },
+    },
+    permission,
+  };
+
+  return {
+    agent,
+    cliModel,
+    modelId,
+    config,
+    args: [
+      "run",
+      "--dir",
+      task.workingDir,
+      "--model",
+      cliModel,
+      "--agent",
+      agent,
+      "--format",
+      "json",
+      task.prompt,
+    ],
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" ? (value as Record<string, unknown>) : {};
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+export function normalizeOpenCodeEvent(raw: unknown): OpencodeNormalizedEvent | null {
+  const event = asRecord(raw);
+  const type = asString(event.type);
+  const part = asRecord(event.part);
+
+  if (type === "text") {
+    const text = asString(part.text);
+    return text ? { type: "text", text } : null;
+  }
+
+  if (type === "step_finish") {
+    const tokensRaw = asRecord(part.tokens);
+    const normalized: OpencodeStepFinishEvent = {
+      type: "step_finish",
+      reason: asString(part.reason),
+      cost: asNumber(part.cost),
+    };
+    const tokens = {
+      input: asNumber(tokensRaw.input),
+      output: asNumber(tokensRaw.output),
+      total: asNumber(tokensRaw.total),
+    };
+    if (
+      tokens.input !== undefined ||
+      tokens.output !== undefined ||
+      tokens.total !== undefined
+    ) {
+      normalized.tokens = tokens;
+    }
+    return normalized;
+  }
+
+  if (type !== "tool_use") return null;
+
+  const tool = asString(part.tool);
+  if (!tool) return null;
+
+  const state = asRecord(part.state);
+  const input = asRecord(state.input);
+  const metadata = asRecord(state.metadata);
+  const filediff = asRecord(metadata.filediff);
+  const normalized: OpencodeToolCall = {
+    type: "tool",
+    tool,
+    status: asString(state.status),
+    command: asString(input.command),
+    file: asString(input.filePath) || asString(filediff.file),
+    exitCode: asNumber(metadata.exit),
+    additions: asNumber(filediff.additions),
+    deletions: asNumber(filediff.deletions),
+    diff: asString(metadata.diff),
+  };
+
+  return normalized;
+}
+
+function renderSummary(
+  result: Pick<
+    OpencodeExecutorResult,
+    "model" | "agent" | "permissionProfile" | "toolCalls" | "changedFiles" | "testCommands"
+  >,
+  textEvents: string[],
+): string {
+  const lines = [
+    "### OpenCode Summary",
+    "",
+    `- **Model:** ${result.model}`,
+    `- **Agent:** ${result.agent}`,
+    `- **Permission profile:** ${result.permissionProfile}`,
+    `- **Tool calls:** ${result.toolCalls.length}`,
+  ];
+
+  if (result.changedFiles.length > 0) {
+    lines.push(`- **Changed files:** ${result.changedFiles.join(", ")}`);
+  }
+  if (result.testCommands.length > 0) {
+    lines.push(`- **Test commands:** ${result.testCommands.join(", ")}`);
+  }
+  if (textEvents.length > 0) {
+    lines.push("", "### Final Message", "", textEvents[textEvents.length - 1] as string);
+  }
+
+  return lines.join("\n");
+}
+
+export async function executeOpencodeTask(
+  task: OpencodeTaskConfig,
+  taskId: string,
+  logDir: string,
+  options?: OpencodeExecutorOptions,
+): Promise<OpencodeExecutorResult> {
+  const plan = buildOpencodeRunPlan(task);
+  const configDir = fs.mkdtempSync(path.join(os.tmpdir(), "hugin-opencode-"));
+  const logFile = path.join(logDir, `${taskId}.log`);
+  const startedAt = new Date().toISOString();
+
+  fs.mkdirSync(task.workingDir, { recursive: true });
+  fs.mkdirSync(logDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(configDir, "opencode.json"),
+    JSON.stringify(plan.config, null, 2),
+  );
+
+  const logStream = fs.createWriteStream(logFile, { encoding: "utf-8" });
+  logStream.on("error", () => {});
+  logStream.write(
+    [
+      "=== Hugin Task Log (opencode) ===",
+      `Task: ${taskId}`,
+      `Runtime: opencode`,
+      `Working dir: ${task.workingDir}`,
+      `Model: ${plan.cliModel}`,
+      `Agent: ${plan.agent}`,
+      `Permission profile: ${task.permissionProfile}`,
+      `Gateway: ${task.gatewayBaseUrl}`,
+      `Timeout: ${task.timeoutMs}ms`,
+      `Started: ${startedAt}`,
+      "===\n",
+    ].join("\n"),
+  );
+
+  const events: OpencodeNormalizedEvent[] = [];
+  const textEvents: string[] = [];
+  const toolCalls: OpencodeToolCall[] = [];
+  let output = "";
+  let jsonLineBuffer = "";
+  let child: ChildProcess | null = null;
+  let timedOut = false;
+  let configDirRemoved = false;
+
+  const appendOutput = (text: string) => {
+    output += text;
+    if (output.length > task.maxOutputChars * 2) {
+      output = output.slice(-task.maxOutputChars);
+    }
+    logStream.write(text);
+  };
+
+  const consumeJsonLines = (text: string) => {
+    jsonLineBuffer += text;
+    let newlineIndex = jsonLineBuffer.indexOf("\n");
+    while (newlineIndex >= 0) {
+      const line = jsonLineBuffer.slice(0, newlineIndex).trim();
+      jsonLineBuffer = jsonLineBuffer.slice(newlineIndex + 1);
+      if (line) {
+        try {
+          const normalized = normalizeOpenCodeEvent(JSON.parse(line));
+          if (normalized) {
+            events.push(normalized);
+            if (normalized.type === "text") textEvents.push(normalized.text);
+            if (normalized.type === "tool") toolCalls.push(normalized);
+          }
+        } catch {
+          // Keep raw line in the log/output; malformed JSON is not fatal.
+        }
+      }
+      newlineIndex = jsonLineBuffer.indexOf("\n");
+    }
+  };
+
+  const finish = async (exitCode: number | "TIMEOUT"): Promise<OpencodeExecutorResult> => {
+    if (jsonLineBuffer.trim()) {
+      consumeJsonLines("\n");
+    }
+    const changedFiles = [
+      ...new Set(
+        toolCalls
+          .filter((call) => call.tool === "edit" && call.file)
+          .map((call) => call.file as string),
+      ),
+    ];
+    const testCommands = [
+      ...new Set(
+        toolCalls
+          .filter((call) => call.tool === "bash" && call.command && /(^|[;&|]\s*)npm\s+test\b/.test(call.command))
+          .map((call) => call.command as string),
+      ),
+    ];
+
+    const resultBase = {
+      model: plan.cliModel,
+      agent: plan.agent,
+      permissionProfile: task.permissionProfile,
+      toolCalls,
+      changedFiles,
+      testCommands,
+    };
+    const resultText = renderSummary(resultBase, textEvents);
+
+    logStream.write(
+      [
+        "\n===",
+        `Exit code: ${exitCode}`,
+        `Tool calls: ${toolCalls.length}`,
+        `Changed files: ${changedFiles.join(", ") || "none"}`,
+        `Completed: ${new Date().toISOString()}`,
+        "===\n",
+      ].join("\n"),
+    );
+    await new Promise<void>((resolve) => logStream.end(() => resolve()));
+    fs.rmSync(configDir, { recursive: true, force: true });
+    configDirRemoved = !fs.existsSync(configDir);
+
+    return {
+      exitCode,
+      output: output.slice(-task.maxOutputChars),
+      logFile,
+      resultText,
+      configDir,
+      configDirRemoved,
+      events,
+      ...resultBase,
+    };
+  };
+
+  return new Promise((resolve) => {
+    const abortController = new AbortController();
+    let settled = false;
+    const settle = async (exitCode: number | "TIMEOUT") => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(await finish(exitCode));
+    };
+    if (options?.abortController) {
+      if (options.abortController.signal.aborted) abortController.abort();
+      else options.abortController.signal.addEventListener("abort", () => abortController.abort());
+    }
+
+    const timer = setTimeout(() => abortController.abort(), task.timeoutMs);
+    abortController.signal.addEventListener("abort", () => {
+      timedOut = true;
+      child?.kill("SIGTERM");
+      setTimeout(() => {
+        if (child && !child.killed) child.kill("SIGKILL");
+      }, 5_000).unref();
+    });
+
+    child = spawn(task.opencodeCommand || "opencode", plan.args, {
+      cwd: task.workingDir,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        OPENCODE_CONFIG_DIR: configDir,
+        [PROVIDER_API_KEY_ENV]: task.apiKey,
+        HUGIN_TASK_ID: taskId,
+      },
+    });
+
+    child.stdout?.on("data", (chunk: Buffer) => {
+      const text = chunk.toString("utf-8");
+      appendOutput(text);
+      consumeJsonLines(text);
+    });
+    child.stderr?.on("data", (chunk: Buffer) => appendOutput(chunk.toString("utf-8")));
+
+    child.on("error", async (err) => {
+      appendOutput(`\n[OpenCode spawn error: ${err.message}]\n`);
+      await settle(1);
+    });
+
+    child.on("close", async (code) => {
+      await settle(timedOut ? "TIMEOUT" : code ?? 1);
+    });
+  });
+}

--- a/src/pipeline-compiler.ts
+++ b/src/pipeline-compiler.ts
@@ -16,7 +16,6 @@ import { routeTask } from "./router.js";
 import {
   buildRuntimeCandidates,
   getRegistryEntryById,
-  isLegacyDispatcherRuntime,
   type RuntimeCapability,
 } from "./runtime-registry.js";
 import {
@@ -32,6 +31,14 @@ import {
 } from "./sensitivity.js";
 import { MAX_DEPENDENCIES } from "./task-graph.js";
 import type { OllamaHost } from "./ollama-hosts.js";
+
+type PipelineDispatcherRuntime = PipelinePhaseIR["dispatcherRuntime"];
+
+function isPipelineDispatcherRuntime(
+  runtime: string,
+): runtime is PipelineDispatcherRuntime {
+  return runtime === "claude" || runtime === "codex" || runtime === "ollama";
+}
 
 interface ParsedPipelinePhase {
   name: string;
@@ -520,13 +527,13 @@ export function compilePipelineTask(
     });
 
     // Pipeline phases are constrained to PipelineRuntimeId (claude-sdk/
-    // codex-spawn/ollama-pi/ollama-laptop), all of which carry legacy
-    // dispatcher runtimes. Orchestrator runtimes (openrouter, pi-harness) are
-    // not pipeline-eligible. Verify rather than cast.
+    // codex-spawn/ollama-pi/ollama-laptop/ollama-orin), all of which carry the
+    // original pipeline dispatcher runtimes. Harness runtimes such as OpenCode
+    // are explicit task-level lanes for now, not pipeline phases.
     const phaseDispatcherRuntime = runtime.dispatcherRuntime;
-    if (!isLegacyDispatcherRuntime(phaseDispatcherRuntime)) {
+    if (!isPipelineDispatcherRuntime(phaseDispatcherRuntime)) {
       throw new Error(
-        `Pipeline runtime "${resolvedRuntimeId}" resolved to non-legacy dispatcher runtime ` +
+        `Pipeline runtime "${resolvedRuntimeId}" resolved to non-pipeline dispatcher runtime ` +
           `"${phaseDispatcherRuntime}" — orchestrator runtimes are not pipeline-eligible. ` +
           `Phase "${phase.name}".`,
       );

--- a/src/runtime-registry.ts
+++ b/src/runtime-registry.ts
@@ -1,11 +1,10 @@
 import type { OllamaHost } from "./ollama-hosts.js";
 import type { Sensitivity } from "./sensitivity.js";
 
-// Legacy dispatcher runtimes — the three the in-process executor knows how to
-// run today (src/index.ts spawn/SDK paths). The dispatcher's TaskConfig.runtime
-// is constrained to this narrow set; orchestrator runtimes never flow through
-// the legacy dispatcher.
-export type LegacyDispatcherRuntime = "claude" | "codex" | "ollama";
+// Direct dispatcher runtimes that src/index.ts can execute in-process.
+// Orchestrator runtimes never flow through this path.
+export type LegacyDispatcherRuntime = "claude" | "codex" | "ollama" | "opencode";
+export type AutoRoutableDispatcherRuntime = "claude" | "codex" | "ollama";
 
 // Wider union covering every runtime the registry can describe, including
 // orchestrator-only runtimes that are reachable via the broker (Step 4) but
@@ -21,12 +20,23 @@ const LEGACY_DISPATCHER_RUNTIMES: ReadonlySet<DispatcherRuntime> = new Set([
   "claude",
   "codex",
   "ollama",
+  "opencode",
+]);
+const AUTO_ROUTABLE_DISPATCHER_RUNTIMES: ReadonlySet<DispatcherRuntime> = new Set([
+  "claude",
+  "codex",
+  "ollama",
 ]);
 
 export function isLegacyDispatcherRuntime(
   runtime: DispatcherRuntime,
 ): runtime is LegacyDispatcherRuntime {
   return LEGACY_DISPATCHER_RUNTIMES.has(runtime);
+}
+export function isAutoRoutableDispatcherRuntime(
+  runtime: DispatcherRuntime,
+): runtime is AutoRoutableDispatcherRuntime {
+  return AUTO_ROUTABLE_DISPATCHER_RUNTIMES.has(runtime);
 }
 export type RuntimeCapability = "tools" | "code" | "structured-output";
 export type TrustTier = "trusted" | "semi-trusted";
@@ -37,6 +47,7 @@ export type Provider =
   | "anthropic"
   | "openai-spawn"
   | "ollama-local"
+  | "opencode"
   | "openrouter"
   | "pi-harness"
   | "berget";
@@ -147,6 +158,21 @@ export const RUNTIME_REGISTRY: readonly RuntimeDefinition[] = [
     zdrRequired: false,
     autoEligible: true,
     family: "one-shot",
+  },
+  {
+    id: "opencode-m5",
+    dispatcherRuntime: "opencode",
+    trustTier: "semi-trusted",
+    costModel: "free",
+    modelSize: "large",
+    capabilities: ["tools", "code"],
+    provider: "opencode",
+    egress: "local",
+    zdrRequired: false,
+    autoEligible: false,
+    family: "harness",
+    defaultModel: "qwen3-coder-next-80b",
+    harnessCmd: "opencode",
   },
   {
     id: "openrouter",

--- a/src/task-result-schema.ts
+++ b/src/task-result-schema.ts
@@ -30,6 +30,7 @@ export const dispatcherRuntimeSchema = z.enum([
   "claude",
   "codex",
   "ollama",
+  "opencode",
   "auto",
   "orchestrator",
 ]);

--- a/tests/dispatcher.test.ts
+++ b/tests/dispatcher.test.ts
@@ -12,12 +12,13 @@ type TaskPermissionProfile = "read-only" | "trusted-code";
 
 function parseTask(content: string, workspace = "/home/magnus/workspace") {
   const declaredRuntimeRaw =
-    content.match(/\*\*Runtime:\*\*\s*(claude|codex|ollama|auto)/i)?.[1]?.toLowerCase();
+    content.match(/\*\*Runtime:\*\*\s*(claude|codex|ollama|opencode|auto)/i)?.[1]?.toLowerCase();
   const isAutoRoute = declaredRuntimeRaw === "auto";
   const runtime = (isAutoRoute ? undefined : declaredRuntimeRaw) as
       | "claude"
       | "codex"
       | "ollama"
+      | "opencode"
       | undefined;
   const workingDir = content.match(
     /\*\*Working dir:\*\*\s*(.+)/i
@@ -248,6 +249,26 @@ Also add tests.`;
     expect(task).not.toBeNull();
     expect(task!.prompt).toContain("Read the file src/index.ts");
     expect(task!.prompt).toContain("Also add tests.");
+  });
+
+  it("should parse Runtime: opencode as an explicit harness runtime", () => {
+    const content = `## Task: OpenCode task
+
+- **Runtime:** opencode
+- **Capabilities:** code
+- **Permission profile:** trusted-code
+- **Model:** qwen3-coder-next-80b
+
+### Prompt
+Fix the failing test and run npm test.`;
+
+    const task = parseTask(content);
+    expect(task).not.toBeNull();
+    expect(task!.runtime).toBe("opencode");
+    expect(task!.autoRouted).toBeUndefined();
+    expect(task!.capabilities).toEqual(["code"]);
+    expect(task!.permissionProfile).toBe("trusted-code");
+    expect(task!.model).toBe("qwen3-coder-next-80b");
   });
 
   it("should handle missing optional fields", () => {

--- a/tests/opencode-executor.test.ts
+++ b/tests/opencode-executor.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import {
+  buildOpencodeRunPlan,
+  executeOpencodeTask,
+  loadOpencodeGatewayConfig,
+  normalizeOpenCodeEvent,
+  type OpencodeTaskConfig,
+} from "../src/opencode-executor.js";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "hugin-opencode-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function makeTask(overrides?: Partial<OpencodeTaskConfig>): OpencodeTaskConfig {
+  return {
+    prompt: "Fix the failing test.",
+    workingDir: path.join(tmpDir, "repo"),
+    timeoutMs: 30_000,
+    maxOutputChars: 5_000,
+    gatewayBaseUrl: "http://127.0.0.1:8080/v1",
+    apiKey: "",
+    providerId: "m5",
+    model: "qwen3-coder-next-80b",
+    permissionProfile: "trusted-code",
+    ...overrides,
+  };
+}
+
+describe("loadOpencodeGatewayConfig", () => {
+  it("returns null when no OpenCode or homeserver gateway URL is configured", () => {
+    expect(loadOpencodeGatewayConfig({} as NodeJS.ProcessEnv)).toBeNull();
+  });
+
+  it("uses HOMESERVER_GATEWAY_URL and appends /v1 for OpenAI-compatible config", () => {
+    const cfg = loadOpencodeGatewayConfig({
+      HOMESERVER_GATEWAY_URL: "http://100.76.72.59:8080/",
+      HOMESERVER_GATEWAY_API_KEY: "owner-key",
+    } as NodeJS.ProcessEnv);
+
+    expect(cfg).toEqual({
+      gatewayBaseUrl: "http://100.76.72.59:8080/v1",
+      apiKey: "owner-key",
+      providerId: "m5",
+      defaultModel: "qwen3-coder-next-80b",
+      opencodeCommand: "opencode",
+    });
+  });
+
+  it("honors HUGIN_OPENCODE_* overrides", () => {
+    const cfg = loadOpencodeGatewayConfig({
+      HUGIN_OPENCODE_BASE_URL: "http://127.0.0.1:9999/v1/",
+      HUGIN_OPENCODE_API_KEY: "k",
+      HUGIN_OPENCODE_PROVIDER: "local",
+      HUGIN_OPENCODE_MODEL: "mellum",
+      HUGIN_OPENCODE_CMD: "/opt/bin/opencode",
+    } as NodeJS.ProcessEnv);
+
+    expect(cfg).toEqual({
+      gatewayBaseUrl: "http://127.0.0.1:9999/v1",
+      apiKey: "k",
+      providerId: "local",
+      defaultModel: "mellum",
+      opencodeCommand: "/opt/bin/opencode",
+    });
+  });
+
+  it("refuses a keyless non-loopback gateway", () => {
+    expect(
+      loadOpencodeGatewayConfig({
+        HUGIN_OPENCODE_BASE_URL: "http://100.76.72.59:8080/v1",
+      } as NodeJS.ProcessEnv),
+    ).toBeNull();
+  });
+
+  it("accepts a keyless loopback gateway for local-only development", () => {
+    expect(
+      loadOpencodeGatewayConfig({
+        HUGIN_OPENCODE_BASE_URL: "http://127.0.0.1:8080",
+      } as NodeJS.ProcessEnv),
+    ).toMatchObject({
+      gatewayBaseUrl: "http://127.0.0.1:8080/v1",
+      apiKey: "",
+    });
+  });
+
+  it("refuses public or path-scoped gateway URLs even with an API key", () => {
+    expect(
+      loadOpencodeGatewayConfig({
+        HUGIN_OPENCODE_BASE_URL: "https://example.com",
+        HUGIN_OPENCODE_API_KEY: "owner-key",
+      } as NodeJS.ProcessEnv),
+    ).toBeNull();
+    expect(
+      loadOpencodeGatewayConfig({
+        HUGIN_OPENCODE_BASE_URL: "http://100.76.72.59:8080/api",
+        HUGIN_OPENCODE_API_KEY: "owner-key",
+      } as NodeJS.ProcessEnv),
+    ).toBeNull();
+  });
+});
+
+describe("buildOpencodeRunPlan", () => {
+  it("denies edit and bash in read-only mode", () => {
+    const plan = buildOpencodeRunPlan(makeTask({ permissionProfile: "read-only" }));
+
+    expect(plan.agent).toBe("plan");
+    expect(plan.config.permission).toEqual({ edit: "deny", bash: "deny" });
+    expect(plan.args).toContain("--format");
+    expect(plan.args).toContain("json");
+  });
+
+  it("allows edit and bash in trusted-code mode", () => {
+    const plan = buildOpencodeRunPlan(makeTask({ permissionProfile: "trusted-code" }));
+
+    expect(plan.agent).toBe("build");
+    expect(plan.config.permission).toEqual({ edit: "allow", bash: "allow" });
+    expect(plan.cliModel).toBe("m5/qwen3-coder-next-80b");
+    expect(plan.config.provider.m5.models["qwen3-coder-next-80b"]).toEqual({
+      name: "qwen3-coder-next-80b",
+    });
+  });
+});
+
+describe("normalizeOpenCodeEvent", () => {
+  it("extracts bash, edit, and text events from OpenCode JSONL", () => {
+    const bash = normalizeOpenCodeEvent({
+      type: "tool_use",
+      part: {
+        type: "tool",
+        tool: "bash",
+        state: {
+          status: "completed",
+          input: { command: "npm test 2>&1" },
+          metadata: { exit: 0 },
+        },
+      },
+    });
+    const edit = normalizeOpenCodeEvent({
+      type: "tool_use",
+      part: {
+        type: "tool",
+        tool: "edit",
+        state: {
+          status: "completed",
+          metadata: {
+            filediff: {
+              file: "/tmp/repo/math.js",
+              additions: 1,
+              deletions: 1,
+            },
+            diff: "@@ diff",
+          },
+        },
+      },
+    });
+    const text = normalizeOpenCodeEvent({
+      type: "text",
+      part: { text: "Fixed math.js and tests pass." },
+    });
+
+    expect(bash).toMatchObject({
+      type: "tool",
+      tool: "bash",
+      status: "completed",
+      command: "npm test 2>&1",
+      exitCode: 0,
+    });
+    expect(edit).toMatchObject({
+      type: "tool",
+      tool: "edit",
+      file: "/tmp/repo/math.js",
+      additions: 1,
+      deletions: 1,
+    });
+    expect(text).toEqual({ type: "text", text: "Fixed math.js and tests pass." });
+  });
+});
+
+describe("executeOpencodeTask", () => {
+  it("runs opencode with a temp config, captures normalized events, and removes the config dir", async () => {
+    const repoDir = path.join(tmpDir, "repo");
+    const logDir = path.join(tmpDir, "logs");
+    fs.mkdirSync(repoDir, { recursive: true });
+
+    const fakeOpencode = path.join(tmpDir, "opencode-fake.mjs");
+    fs.writeFileSync(
+      fakeOpencode,
+      `#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+const configDir = process.env.OPENCODE_CONFIG_DIR;
+fs.writeFileSync(path.join(process.cwd(), "observed.json"), JSON.stringify({
+  argv: process.argv.slice(2),
+  configDir,
+  config: JSON.parse(fs.readFileSync(path.join(configDir, "opencode.json"), "utf8")),
+  apiKey: process.env.HUGIN_OPENCODE_PROVIDER_API_KEY
+}));
+console.log(JSON.stringify({ type: "tool_use", part: { type: "tool", tool: "bash", state: { status: "completed", input: { command: "npm test 2>&1" }, metadata: { exit: 0 } } } }));
+console.log(JSON.stringify({ type: "tool_use", part: { type: "tool", tool: "edit", state: { status: "completed", metadata: { filediff: { file: path.join(process.cwd(), "math.js"), additions: 1, deletions: 1 }, diff: "@@ diff" } } } }));
+console.log(JSON.stringify({ type: "text", part: { text: "Fixed math.js and tests pass." } }));
+`,
+      { mode: 0o755 },
+    );
+
+    const result = await executeOpencodeTask(
+      makeTask({
+        workingDir: repoDir,
+        apiKey: "owner-key",
+        opencodeCommand: fakeOpencode,
+      }),
+      "opencode-ok",
+      logDir,
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.resultText).toContain("Fixed math.js");
+    expect(result.toolCalls.map((t) => t.tool)).toEqual(["bash", "edit"]);
+    expect(result.changedFiles).toEqual([path.join(fs.realpathSync(repoDir), "math.js")]);
+    expect(result.testCommands).toEqual(["npm test 2>&1"]);
+    expect(result.configDirRemoved).toBe(true);
+    expect(fs.existsSync(result.configDir)).toBe(false);
+
+    const observed = JSON.parse(
+      fs.readFileSync(path.join(repoDir, "observed.json"), "utf8"),
+    );
+    expect(observed.argv).toEqual([
+      "run",
+      "--dir",
+      repoDir,
+      "--model",
+      "m5/qwen3-coder-next-80b",
+      "--agent",
+      "build",
+      "--format",
+      "json",
+      "Fix the failing test.",
+    ]);
+    expect(observed.config.permission).toEqual({ edit: "allow", bash: "allow" });
+    expect(observed.apiKey).toBe("owner-key");
+  });
+});

--- a/tests/runtime-registry.test.ts
+++ b/tests/runtime-registry.test.ts
@@ -6,6 +6,8 @@ import {
   getAliasMap,
   getRegistryEntryById,
   getRuntimeMaxSensitivity,
+  isAutoRoutableDispatcherRuntime,
+  isLegacyDispatcherRuntime,
   parseActiveSubscriptions,
   resolveAlias,
 } from "../src/runtime-registry.js";
@@ -19,6 +21,7 @@ describe("RUNTIME_REGISTRY", () => {
     expect(ids).toContain("ollama-pi");
     expect(ids).toContain("ollama-laptop");
     expect(ids).toContain("ollama-orin");
+    expect(ids).toContain("opencode-m5");
     expect(ids).toContain("openrouter");
     expect(ids).toContain("pi-harness");
   });
@@ -209,6 +212,26 @@ describe("orchestrator v1 policy fields", () => {
     expect(entry!.harnessFlags).toEqual(["--no-session", "--provider", "openrouter"]);
     expect(entry!.zdrRequired).toBe(true);
     expect(entry!.autoEligible).toBe(false);
+  });
+
+  it("opencode-m5 is a local explicit-only harness runtime", () => {
+    const entry = getRegistryEntryById("opencode-m5");
+    expect(entry).toBeDefined();
+    expect(entry!.dispatcherRuntime).toBe("opencode");
+    expect(entry!.provider).toBe("opencode");
+    expect(entry!.egress).toBe("local");
+    expect(entry!.family).toBe("harness");
+    expect(entry!.harnessCmd).toBe("opencode");
+    expect(entry!.autoEligible).toBe(false);
+    expect(entry!.capabilities).toEqual(["tools", "code"]);
+  });
+
+  it("opencode is executable but excluded from the auto-routable dispatcher subset", () => {
+    expect(isLegacyDispatcherRuntime("opencode")).toBe(true);
+    expect(isAutoRoutableDispatcherRuntime("opencode")).toBe(false);
+    expect(isAutoRoutableDispatcherRuntime("claude")).toBe(true);
+    expect(isAutoRoutableDispatcherRuntime("codex")).toBe(true);
+    expect(isAutoRoutableDispatcherRuntime("ollama")).toBe(true);
   });
 
   it("existing one-shot runtimes are auto-eligible by default (except ollama-pi)", () => {

--- a/tests/sensitivity.test.ts
+++ b/tests/sensitivity.test.ts
@@ -319,6 +319,7 @@ describe("sensitivity helpers", () => {
   it("treats cloud runtimes as internal-only and ollama as private-safe", () => {
     expect(getDispatcherRuntimeMaxSensitivity("claude")).toBe("internal");
     expect(getDispatcherRuntimeMaxSensitivity("codex")).toBe("internal");
+    expect(getDispatcherRuntimeMaxSensitivity("opencode")).toBe("internal");
     expect(getDispatcherRuntimeMaxSensitivity("ollama")).toBe("private");
   });
 

--- a/tests/task-result-schema.test.ts
+++ b/tests/task-result-schema.test.ts
@@ -139,6 +139,30 @@ describe("structured task result schema", () => {
     expect(result.approval?.status).toBe("approved");
   });
 
+  it("accepts opencode harness task results", () => {
+    const result = buildStructuredTaskResult({
+      schemaVersion: 1,
+      taskId: "20260708-opencode",
+      taskNamespace: "tasks/20260708-opencode",
+      lifecycle: "completed",
+      outcome: "completed",
+      runtime: "opencode",
+      executor: "opencode",
+      resultSource: "opencode-json",
+      exitCode: 0,
+      completedAt: "2026-07-08T12:00:00Z",
+      bodyKind: "response",
+      bodyText: "Fixed math.js and tests pass.",
+      runtimeMetadata: {
+        requestedModel: "qwen3-coder-next-80b",
+        effectiveModel: "m5/qwen3-coder-next-80b",
+      },
+    });
+
+    expect(result.runtime).toBe("opencode");
+    expect(result.runtimeMetadata?.effectiveModel).toBe("m5/qwen3-coder-next-80b");
+  });
+
   it("accepts orchestratorOutcomes (verdict layer V8) with a mix of ok/verdict states", () => {
     const result = buildStructuredTaskResult({
       schemaVersion: 1,


### PR DESCRIPTION
## Summary
- add an explicit `Runtime: opencode` dispatcher lane backed by an OpenCode temp config pointed at the local/tailnet M5 OpenAI-compatible gateway
- map Hugin permission profiles to OpenCode agents (`read-only` -> `plan` with edit/bash denied, `trusted-code` -> `build` with edit/bash allowed)
- record normalized OpenCode tool/test/diff events in task results and journal extras while keeping `opencode-m5` explicit-only and out of auto/pipeline routing

## Validation
- `npm run build`
- `npm test -- tests/opencode-executor.test.ts tests/dispatcher.test.ts tests/runtime-registry.test.ts tests/sensitivity.test.ts tests/task-result-schema.test.ts tests/pipeline-compiler.test.ts tests/router.test.ts`
- `git diff --check`
- `npm test`
- M5 advisory code review via `/delegate` using `qwen3-coder-next-80b`: no blocking issues; one real explicit-only guard concern addressed before this PR

## Notes
- A laptop live OpenCode fixture was observed fixing a failing test through M5, but the wrapper process was manually interrupted before it returned a clean executor summary. Treat production validation as a follow-up after deploy.
