### PR TITLE
Record honest task submission provenance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ maps to the `build` agent with `edit`/`bash` allowed.
 
 **Results:** Written to the same namespace under two keys:
 - `result` — human-readable markdown with exit code, timestamps, duration, and response body
-- `result-structured` — machine-readable JSON (Zod-validated) with schema version, lifecycle metadata, runtime metadata (requested vs effective model/host), sensitivity audit, and structured body. Prefer this for programmatic consumption.
+- `result-structured` — machine-readable JSON (Zod-validated) with schema version, lifecycle metadata, runtime metadata (requested vs effective model/host), sensitivity audit, honest submission provenance (`claimedSubmitter`, nullable `verifiedSubmitter`, signing policy/status/keyId), and structured body. Prefer this for programmatic consumption.
 
 ## Project structure
 
@@ -315,7 +315,8 @@ claude mcp add-json hugin '{"command":"node","args":["/Users/magnus/repos/hugin/
 | `HUGIN_INJECTION_POLICY` | `warn` | Prompt-injection policy for context-refs: `off` (no scan), `warn` (prepend warning banner), `block` (quarantine high-severity refs, task continues), `fail` (reject task). See `docs/security/prompt-injection-scanner.md`. |
 | `HUGIN_EXFIL_POLICY` | `warn` | Exfiltration scanner policy for task results: `off` (no scan), `warn` (log + append security-scan section), `flag` (warn + tag result `security:exfil-suspected`), `redact` (flag + replace matches with `[redacted: <pattern>]`). See `docs/security/exfiltration-scanner.md`. |
 | `HUGIN_EXTERNAL_POLICY` | `warn` | Provenance policy for externally sourced context-refs (entries tagged `source:external` or in the `signals/` namespace): `allow` (inject with banner only), `warn` (banner + log, default), `block` (quarantine external refs, task continues), `fail` (reject task). See `docs/security/provenance-enforcement.md`. |
-| `HUGIN_SIGNING_POLICY` | `off` | Task signature verification policy: `off` (skip), `warn` (log missing/invalid, never reject), `require` (reject tasks without a valid signature). See `docs/security/task-signing.md`. |
+| `HUGIN_SIGNING_POLICY` | `off` | Task signature verification policy: `off` (do not verify; record explicitly `unverified`), `warn` (log missing/invalid, never reject), `require` (reject tasks without a valid signature). See `docs/security/task-signing.md`. |
+| `HUGIN_SIGNING_MAX_AGE_S` | `900` | Maximum accepted age of an otherwise-valid signature. `0` disables the age window; future timestamps still use the verifier's bounded skew tolerance when the window is enabled. |
 | `HUGIN_SUBMITTER_KEYS` | — | Inline JSON keystore: `{"<keyId>": "<hex-secret>"}` (64-char hex preferred; base64 accepted). |
 | `HUGIN_SUBMITTER_KEYS_FILE` | — | Path to a JSON keystore file. Takes precedence over `HUGIN_SUBMITTER_KEYS`. |
 | `HUGIN_BROKER_HOST` | `127.0.0.1` | Bind address for the orchestrator-v1 broker (`/v1/delegate/*`). Set to the Tailscale interface IP in production. |

--- a/docs/security/task-signing.md
+++ b/docs/security/task-signing.md
@@ -80,7 +80,7 @@ Set `HUGIN_SIGNING_POLICY` on the Pi:
 
 | Policy | Effect |
 |--------|--------|
-| `off` (default) | Signatures ignored entirely. No verification, no logging. Zero-breakage default for the rollout period. |
+| `off` (default) | Signature is not verified. Results record `signatureStatus: "unverified"`, `verifiedSubmitter: null`, and any parseable claimed `keyId`; this must never be interpreted as valid identity. Zero-breakage default for the rollout period. |
 | `warn` | Verify when a signature is present; log missing / invalid / unknown-signer / submitter-mismatch / malformed. Never rejects. |
 | `require` | Reject any task that is missing a valid signature from a known signer. Pipeline parent tasks are rejected (v1 cannot bind ### Pipeline bodies yet); internally-generated children (`Submitted by: hugin`) are exempted. |
 
@@ -93,6 +93,28 @@ Rollout plan:
 2. Roll out signing helpers to every submitter
 3. Flip Pi to `warn`, watch logs for stragglers
 4. Flip to `require` once the log is clean for ≥72h
+
+## Result provenance
+
+Every current dispatcher terminal result, including pipeline parents, carries
+an additive `provenance` object in `result-structured`:
+
+```json
+{
+  "claimedSubmitter": "codex-cli",
+  "verifiedSubmitter": "codex-cli",
+  "policy": "require",
+  "signatureStatus": "valid",
+  "keyId": "codex-cli"
+}
+```
+
+`verifiedSubmitter` is non-null only after a valid HMAC check. Policy `off`, a
+missing/invalid/expired/future-skewed/mismatched signature, pipeline-v1
+limitations, and the internal-Hugin exemption all leave it null. Hugin also
+appends the same fields to the task lifecycle log as a `[provenance]` record.
+The field is optional in the schema only so historical schemaVersion 1 results
+remain readable; current dispatcher writers always populate it.
 
 ## Keys
 
@@ -147,6 +169,25 @@ Once both sides hold the secret, `hugin-sign` returns it locally and
 `sign-task.mjs --submitter claude-code --key-id claude-code` produces a
 signature the Pi verifies. The `keyId` must equal the submitter (`claude-code`)
 or be a `claude-code-<rotation>` alias.
+
+## Registering a non-Claude tenant keyId
+
+Use a tenant's own stable identity as both `Submitted by` and `keyId`; never
+reuse another tenant's signer. For example, to provision `codex-cli`:
+
+1. Generate a dedicated 32-byte secret on the tenant host and store it in that
+   tenant's credential store or environment as `HUGIN_SIGNING_SECRET`.
+2. Add the same secret under the exact `codex-cli` key in the Pi's
+   `HUGIN_SUBMITTER_KEYS` (or its keys file) and add `codex-cli` to
+   `HUGIN_ALLOWED_SUBMITTERS`.
+3. Sign with `--submitter codex-cli --key-id codex-cli`; rotation keys may use
+   `codex-cli-<rotation>` while retaining `Submitted by: codex-cli`.
+4. Validate under `warn` until both the lifecycle log and
+   `result-structured.provenance` report `verifiedSubmitter: "codex-cli"`, then
+   include that tenant in the readiness decision for `require`.
+
+Generate and transfer the shared secret through a secure channel; never print
+it into task content, logs, or repository files.
 
 ## Signing a task (submitter side)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,13 +121,17 @@ import {
 } from "./runtime-registry.js";
 import {
   extractSignatureField,
+  buildTaskSubmissionProvenance,
   loadKeyStoreFromEnv,
   parseNonNegativeIntEnv,
+  parseSignature,
   parseSigningPolicy,
+  signingPolicyRejects,
   verifyTaskSignature,
   type KeyStore,
   type SigningPolicy,
-  type VerificationResult,
+  type TaskSignatureAssessment,
+  type TaskSubmissionProvenance,
 } from "./task-signing.js";
 import { consultSkillLane } from "./skill/skill-lane-dispatch.js";
 import { readBrokerEnv, startBroker, type RunningBroker } from "./broker/server.js";
@@ -480,6 +484,9 @@ let lastQueueDepth = 0;
 let lastBlockedTaskCount = 0;
 const startedAt = Date.now();
 const pipelineSummaryManager = new PipelineSummaryManager();
+// Claim-time assessment cache. It prevents a signature that was valid when a
+// long task was admitted from being re-labelled expired at terminalization.
+const taskProvenance = new Map<string, TaskSubmissionProvenance>();
 
 interface CancellationRequest {
   reason: string;
@@ -955,23 +962,32 @@ function getSecurityViolationForTask(
 }
 
 interface SigningVerdict {
-  result: VerificationResult;
+  result: TaskSignatureAssessment;
+  provenance: TaskSubmissionProvenance;
   reject: boolean;
   message: string;
 }
 
-function verifyTaskEntrySignature(
+function assessTaskEntrySignature(
   taskNs: string,
   content: string,
   parsedTask: TaskConfig | null,
   submittedBy: string,
+  isPipeline: boolean,
 ): SigningVerdict {
   const policy = config.signingPolicy;
   const signatureRaw = extractSignatureField(content);
 
   if (policy === "off") {
+    const parsedSignature = parseSignature(signatureRaw);
+    const result: TaskSignatureAssessment = {
+      status: "unverified",
+      keyId: parsedSignature?.keyId,
+      reason: "signature verification disabled by policy",
+    };
     return {
-      result: signatureRaw ? { status: "valid" } : { status: "missing" },
+      result,
+      provenance: buildTaskSubmissionProvenance(submittedBy, policy, result),
       reject: false,
       message: "",
     };
@@ -984,23 +1000,46 @@ function verifyTaskEntrySignature(
   // When pipeline-aware signing ships (see docs/security/task-signing.md),
   // this exemption becomes a proper internal signing path.
   if (submittedBy === "hugin") {
-    return { result: { status: "valid" }, reject: false, message: "" };
+    const result: TaskSignatureAssessment = {
+      status: "internal-exempt",
+      reason: "internally-generated task is exempt from signature policy",
+    };
+    return {
+      result,
+      provenance: buildTaskSubmissionProvenance(submittedBy, policy, result),
+      reject: false,
+      message: "",
+    };
   }
 
   // Pipeline parent tasks don't produce a TaskConfig here — the HMAC
   // scheme binds prompt/context-refs, which pipelines express differently
   // (### Pipeline instead of ### Prompt). Until pipeline signing lands we
   // cannot accept these under `require`; `warn` passes through.
-  if (!parsedTask) {
-    if (policy === "require") {
+  if (isPipeline || !parsedTask) {
+    const parsedSignature = parseSignature(signatureRaw);
+    const result: TaskSignatureAssessment = {
+      status: "unverifiable",
+      keyId: parsedSignature?.keyId,
+      reason: isPipeline
+        ? "pipeline tasks cannot be verified by the v1 scheme"
+        : "task fields required by the v1 scheme could not be parsed",
+    };
+    if (signingPolicyRejects(policy, result.status)) {
       return {
-        result: { status: "missing" },
+        result,
+        provenance: buildTaskSubmissionProvenance(submittedBy, policy, result),
         reject: true,
         message:
-          "Task rejected by HUGIN_SIGNING_POLICY=require: pipeline tasks cannot be verified by the v1 scheme",
+          `Task rejected by HUGIN_SIGNING_POLICY=require: ${result.reason}`,
       };
     }
-    return { result: { status: "missing" }, reject: false, message: "" };
+    return {
+      result,
+      provenance: buildTaskSubmissionProvenance(submittedBy, policy, result),
+      reject: false,
+      message: "",
+    };
   }
 
   // Use the runtime *as declared in the task body*, not the resolved
@@ -1024,7 +1063,12 @@ function verifyTaskEntrySignature(
 
   if (result.status === "valid") {
     console.log(`[signing] task ${taskNs} signature valid (keyId=${result.keyId})`);
-    return { result, reject: false, message: "" };
+    return {
+      result,
+      provenance: buildTaskSubmissionProvenance(submittedBy, policy, result),
+      reject: false,
+      message: "",
+    };
   }
 
   const descriptor =
@@ -1034,15 +1078,59 @@ function verifyTaskEntrySignature(
 
   if (policy === "warn") {
     console.warn(`[signing] task ${taskNs} ${descriptor} — policy=warn, proceeding`);
-    return { result, reject: false, message: "" };
+    return {
+      result,
+      provenance: buildTaskSubmissionProvenance(submittedBy, policy, result),
+      reject: false,
+      message: "",
+    };
   }
 
   // policy === "require"
+  if (!signingPolicyRejects(policy, result.status)) {
+    return {
+      result,
+      provenance: buildTaskSubmissionProvenance(submittedBy, policy, result),
+      reject: false,
+      message: "",
+    };
+  }
   return {
     result,
+    provenance: buildTaskSubmissionProvenance(submittedBy, policy, result),
     reject: true,
     message: `Task rejected by HUGIN_SIGNING_POLICY=require: ${descriptor}`,
   };
+}
+
+function formatTaskProvenance(provenance: TaskSubmissionProvenance): string {
+  return (
+    `[provenance] claimed=${JSON.stringify(provenance.claimedSubmitter)} ` +
+    `verified=${provenance.verifiedSubmitter === null ? "none" : JSON.stringify(provenance.verifiedSubmitter)} ` +
+    `policy=${provenance.policy} signature=${provenance.signatureStatus} ` +
+    `keyId=${provenance.keyId === null ? "none" : JSON.stringify(provenance.keyId)}`
+  );
+}
+
+async function resolveTaskProvenance(
+  taskNs: string,
+  client: MuninClient,
+): Promise<TaskSubmissionProvenance> {
+  const cached = taskProvenance.get(taskNs);
+  if (cached) return cached;
+
+  const entry = await client.read(taskNs, "status");
+  const content = entry?.content ?? "";
+  const declaredRuntime = parseDeclaredRuntime(content);
+  const parsedTask =
+    declaredRuntime && declaredRuntime !== "pipeline" ? parseTask(content) : null;
+  return assessTaskEntrySignature(
+    taskNs,
+    content,
+    parsedTask,
+    parseSubmittedByField(content),
+    declaredRuntime === "pipeline",
+  ).provenance;
 }
 
 function getInjectionViolationForTask(task: TaskConfig): string | null {
@@ -1084,14 +1172,24 @@ async function writeStructuredTaskResult(
   classification?: string,
   client: MuninClient = munin,
 ): Promise<void> {
+  const provenance = result.provenance ?? await resolveTaskProvenance(taskNs, client);
   await client.write(
     taskNs,
     "result-structured",
-    JSON.stringify(buildStructuredTaskResult(result), null, 2),
+    JSON.stringify(buildStructuredTaskResult({ ...result, provenance }), null, 2),
     ["type:task-result", "type:task-result-structured"],
     undefined,
     classification,
   );
+  taskProvenance.delete(taskNs);
+  try {
+    await client.log(taskNs, formatTaskProvenance(provenance));
+  } catch (err) {
+    console.warn(
+      `[provenance] failed to append lifecycle log for ${taskNs}:`,
+      err instanceof Error ? err.message : String(err),
+    );
+  }
 }
 
 async function refreshPipelineSummary(
@@ -1213,11 +1311,11 @@ function createFailureStructuredResult(
 function getRuntimeFromTags(
   tags: string[],
   runtimeFallback = "runtime:claude"
-): DispatcherRuntime | "pipeline" {
+): DispatcherRuntime {
   return (tags.find((tag) => tag.startsWith("runtime:")) || runtimeFallback).replace(
     /^runtime:/,
     ""
-  ) as DispatcherRuntime | "pipeline";
+  ) as DispatcherRuntime;
 }
 
 function removeTag(tags: string[], tagToRemove: string): string[] {
@@ -2165,40 +2263,38 @@ async function reconcileDeliveryPending(
     entry.updated_at,
     classification,
   );
-  if ((runtime as string) !== "pipeline") {
-    await writeStructuredTaskResult(
-      taskNs,
-      buildStructuredTaskResult({
-        schemaVersion: 1,
-        taskId: extractTaskId(taskNs),
-        taskNamespace: taskNs,
-        lifecycle: ok ? "completed" : "failed",
-        outcome: ok ? "completed" : "failed",
-        runtime,
-        executor: "dispatcher",
-        resultSource: "delivery-reconciliation",
-        exitCode: ok ? 0 : 2,
-        completedAt: new Date().toISOString(),
-        bodyKind: "response",
-        bodyText: "",
-        errorMessage: ok ? undefined : delivery.error ?? "delivery failed",
-        artifactDelivery: {
-          ok: delivery.ok,
-          failureKind: delivery.failureKind,
-          artifacts: delivery.records.map((r) => ({
-            id: r.id,
-            status: r.status,
-            remote: r.remote,
-            bytes: r.bytes,
-            sha256: r.sha256,
-            error: r.error,
-          })),
-        },
-      }),
-      classification,
-      client,
-    );
-  }
+  await writeStructuredTaskResult(
+    taskNs,
+    buildStructuredTaskResult({
+      schemaVersion: 1,
+      taskId: extractTaskId(taskNs),
+      taskNamespace: taskNs,
+      lifecycle: ok ? "completed" : "failed",
+      outcome: ok ? "completed" : "failed",
+      runtime,
+      executor: "dispatcher",
+      resultSource: "delivery-reconciliation",
+      exitCode: ok ? 0 : 2,
+      completedAt: new Date().toISOString(),
+      bodyKind: "response",
+      bodyText: "",
+      errorMessage: ok ? undefined : delivery.error ?? "delivery failed",
+      artifactDelivery: {
+        ok: delivery.ok,
+        failureKind: delivery.failureKind,
+        artifacts: delivery.records.map((r) => ({
+          id: r.id,
+          status: r.status,
+          remote: r.remote,
+          bytes: r.bytes,
+          sha256: r.sha256,
+          error: r.error,
+        })),
+      },
+    }),
+    classification,
+    client,
+  );
   await client.log(
     taskNs,
     `Delivery reconciled: ${delivery.ok ? "verified" : "failed"}`,
@@ -2284,21 +2380,19 @@ async function recoverStaleTasks(): Promise<void> {
       const runtime = (runtimeTag || "runtime:claude").replace(
         /^runtime:/,
         ""
-      ) as DispatcherRuntime | "pipeline";
-      if (runtime !== "pipeline") {
-        await writeStructuredTaskResult(
+      ) as DispatcherRuntime;
+      await writeStructuredTaskResult(
+        result.namespace,
+        createFailureStructuredResult(
           result.namespace,
-          createFailureStructuredResult(
-            result.namespace,
-            runtime,
-            `Task recovered (${reason}, worker: ${claimedBy || "unknown"}, elapsed: ${elapsed}s)`,
-            {
-              executor: "dispatcher",
-              resultSource: "recovery",
-            }
-          )
-        );
-      }
+          runtime,
+          `Task recovered (${reason}, worker: ${claimedBy || "unknown"}, elapsed: ${elapsed}s)`,
+          {
+            executor: "dispatcher",
+            resultSource: "recovery",
+          }
+        )
+      );
       await munin.log(
         result.namespace,
         `Task recovered as failed (${reason}, worker: ${claimedBy || "unknown"}, elapsed: ${elapsed}s)`
@@ -2432,23 +2526,21 @@ async function reapExpiredLeases(): Promise<void> {
       // shared `munin` client here would attribute these writes to the active
       // task's task-scoped session (rotated at claim time in `executeTask`),
       // polluting the outcome-aware session telemetry from #48.
-      if (runtime !== "pipeline") {
-        await writeStructuredTaskResult(
-          result.namespace,
-          createFailureStructuredResult(result.namespace, runtime, errorMessage, {
-            executor: "dispatcher",
-            resultSource: "lease-reaper",
-            replyTo: task?.replyTo,
-            replyFormat: task?.replyFormat,
-            group: task?.group,
-            sequence: task?.sequence,
-            pipeline: task?.pipeline,
-            sensitivity: buildTaskSensitivitySnapshot(task?.sensitivityAssessment),
-          }),
-          classification,
-          reaperMunin,
-        );
-      }
+      await writeStructuredTaskResult(
+        result.namespace,
+        createFailureStructuredResult(result.namespace, runtime, errorMessage, {
+          executor: "dispatcher",
+          resultSource: "lease-reaper",
+          replyTo: task?.replyTo,
+          replyFormat: task?.replyFormat,
+          group: task?.group,
+          sequence: task?.sequence,
+          pipeline: task?.pipeline,
+          sensitivity: buildTaskSensitivitySnapshot(task?.sensitivityAssessment),
+        }),
+        classification,
+        reaperMunin,
+      );
       await reaperMunin.log(result.namespace, `Lease reaped: ${errorMessage}`);
       await promoteDependents(extractTaskId(result.namespace), reaperMunin);
       await refreshPipelineSummaryFromContent(entry.content, reaperMunin);
@@ -3053,30 +3145,28 @@ async function markTaskCancelled(
     classification
   );
 
-  if (runtime !== "pipeline") {
-    await writeStructuredTaskResult(
-      taskNs,
-      createCancelledStructuredResult(taskNs, runtime, reason, {
-        executor: options.executor,
-        resultSource: options.resultSource,
-        startedAt: options.startedAt,
-        completedAt,
-        durationSeconds: options.durationSeconds,
-        logFile: options.logFile,
-        replyTo: task?.replyTo,
-        replyFormat: task?.replyFormat,
-        group: task?.group,
-        sequence: task?.sequence,
-        pipeline: task?.pipeline,
-        runtimeMetadata: options.runtimeMetadata,
-        approval: approvalMetadata,
-        bodyKind: options.bodyKind,
-        bodyText: effectiveBodyText,
-        sensitivity: buildTaskSensitivitySnapshot(task?.sensitivityAssessment),
-      }),
-      classification,
-    );
-  }
+  await writeStructuredTaskResult(
+    taskNs,
+    createCancelledStructuredResult(taskNs, runtime, reason, {
+      executor: options.executor,
+      resultSource: options.resultSource,
+      startedAt: options.startedAt,
+      completedAt,
+      durationSeconds: options.durationSeconds,
+      logFile: options.logFile,
+      replyTo: task?.replyTo,
+      replyFormat: task?.replyFormat,
+      group: task?.group,
+      sequence: task?.sequence,
+      pipeline: task?.pipeline,
+      runtimeMetadata: options.runtimeMetadata,
+      approval: approvalMetadata,
+      bodyKind: options.bodyKind,
+      bodyText: effectiveBodyText,
+      sensitivity: buildTaskSensitivitySnapshot(task?.sensitivityAssessment),
+    }),
+    classification,
+  );
 
   await munin.log(taskNs, `Task cancelled: ${reason}`);
   if (task?.pipeline?.pipelineId) {
@@ -3451,7 +3541,7 @@ async function failTaskWithMessage(
     runtimeTagOverride ||
     entry.tags.find((tag) => tag.startsWith("runtime:")) ||
     "runtime:claude"
-  ).replace(/^runtime:/, "") as DispatcherRuntime | "pipeline";
+  ).replace(/^runtime:/, "") as DispatcherRuntime;
   const task = parseTask(entry.content);
   if (task && !task.sensitivityAssessment) {
     task.sensitivityAssessment = getTaskSensitivityAssessment(task);
@@ -3474,17 +3564,15 @@ async function failTaskWithMessage(
     undefined,
     classification
   );
-  if (runtime !== "pipeline") {
-    await writeStructuredTaskResult(
-      taskNs,
-      createFailureStructuredResult(taskNs, runtime, errorMessage, {
-        executor: "dispatcher",
-        resultSource: "dispatcher",
-        sensitivity: buildTaskSensitivitySnapshot(task?.sensitivityAssessment),
-      }),
-      classification,
-    );
-  }
+  await writeStructuredTaskResult(
+    taskNs,
+    createFailureStructuredResult(taskNs, runtime, errorMessage, {
+      executor: "dispatcher",
+      resultSource: "dispatcher",
+      sensitivity: buildTaskSensitivitySnapshot(task?.sensitivityAssessment),
+    }),
+    classification,
+  );
 }
 
 // --- Heartbeat ---
@@ -3629,12 +3717,14 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
   }
 
   // Verify task signature per HUGIN_SIGNING_POLICY
-  const signingVerdict = verifyTaskEntrySignature(
+  const signingVerdict = assessTaskEntrySignature(
     taskNs,
     entry.content,
     parsedTask,
     submittedBy,
+    declaredRuntime === "pipeline",
   );
+  taskProvenance.set(taskNs, signingVerdict.provenance);
   if (signingVerdict.reject) {
     console.warn(
       `Rejecting task ${taskNs}: signature ${signingVerdict.result.status}` +
@@ -3746,20 +3836,32 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         await failTaskWithMessage(taskNs, entry, `Auto-routing failed: ${errorMsg}`);
         await writeStructuredTaskResult(
           taskNs,
-          createFailureStructuredResult(taskNs, parsedTask.runtime, `Auto-routing failed: ${errorMsg}`, {
-            executor: "dispatcher",
-            resultSource: "router",
-            replyTo: parsedTask.replyTo,
-            replyFormat: parsedTask.replyFormat,
-            group: parsedTask.group,
-            sequence: parsedTask.sequence,
-            pipeline: parsedTask.pipeline,
-            sensitivity: buildTaskSensitivitySnapshot(sensitivityAssessment),
-            runtimeMetadata: {
-              autoRouted: true,
-              routingReason: `routing failed: ${errorMsg}`,
-            },
-          }),
+          {
+            ...createFailureStructuredResult(
+              taskNs,
+              parsedTask.runtime,
+              `Auto-routing failed: ${errorMsg}`,
+              {
+                executor: "dispatcher",
+                resultSource: "router",
+                replyTo: parsedTask.replyTo,
+                replyFormat: parsedTask.replyFormat,
+                group: parsedTask.group,
+                sequence: parsedTask.sequence,
+                pipeline: parsedTask.pipeline,
+                sensitivity: buildTaskSensitivitySnapshot(sensitivityAssessment),
+                runtimeMetadata: {
+                  autoRouted: true,
+                  routingReason: `routing failed: ${errorMsg}`,
+                },
+              },
+            ),
+            // failTaskWithMessage already emitted a generic structured result
+            // and cleared the cache. Preserve the original claim-time identity
+            // on this richer replacement instead of re-verifying at a later
+            // timestamp (which could relabel a boundary-age signature).
+            provenance: signingVerdict.provenance,
+          },
           classification,
         );
         await promoteDependents(extractTaskId(taskNs));
@@ -3869,6 +3971,10 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     parsedTask &&
     (await gatePendingTaskForApproval(taskNs, entry, parsedTask))
   ) {
+    // Awaiting approval is non-terminal. Do not retain an assessment for a
+    // task that can sit for days and may be edited/re-signed before it is
+    // returned to pending; it will be assessed again on the next claim.
+    taskProvenance.delete(taskNs);
     return { hadTask: true, queueDepth };
   }
 
@@ -3902,6 +4008,10 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
       entry.updated_at = claimResult.updated_at;
     }
   } catch (err) {
+    // Another dispatcher won the CAS. Its claim-time assessment owns the
+    // eventual result; retaining ours risks applying stale identity to a
+    // later re-submission under the same namespace.
+    taskProvenance.delete(taskNs);
     console.log(`Failed to claim ${taskNs} (concurrent claim?):`, err);
     return { hadTask: false, queueDepth };
   }
@@ -3924,6 +4034,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
           failTaskWithMessage,
           promoteDependents,
           refreshPipelineSummary,
+          writeStructuredResult: writeStructuredTaskResult,
         },
         taskNs,
         entry,

--- a/src/pipeline-dispatch.ts
+++ b/src/pipeline-dispatch.ts
@@ -12,6 +12,10 @@ import {
   buildPipelineParentSuccessTags,
   buildTerminalStatusTags,
 } from "./task-status-tags.js";
+import {
+  buildStructuredTaskResult,
+  type StructuredTaskResult,
+} from "./task-result-schema.js";
 
 export interface PipelineDispatchClient {
   readBatch(reads: MuninReadRequest[]): Promise<MuninReadResult[]>;
@@ -35,11 +39,17 @@ export interface PipelineDispatchHooks {
   ): Promise<void>;
   promoteDependents(completedTaskId: string): Promise<void>;
   refreshPipelineSummary(pipelineId: string): Promise<void>;
+  writeStructuredResult(
+    taskNs: string,
+    result: StructuredTaskResult,
+    classification?: string,
+  ): Promise<void>;
 }
 
 
 async function cancelCreatedChildren(
   client: PipelineDispatchClient,
+  hooks: PipelineDispatchHooks,
   createdDrafts: Array<{
     namespace: string;
     content: string;
@@ -64,6 +74,27 @@ async function cancelCreatedChildren(
         undefined,
         undefined,
         sensitivityToMuninClassification(draft.classification)
+      );
+      const runtime = (draft.tags.find((tag) => tag.startsWith("runtime:")) ?? "runtime:claude")
+        .replace(/^runtime:/, "") as StructuredTaskResult["runtime"];
+      await hooks.writeStructuredResult(
+        draft.namespace,
+        buildStructuredTaskResult({
+          schemaVersion: 1,
+          taskId: extractTaskId(draft.namespace),
+          taskNamespace: draft.namespace,
+          lifecycle: "cancelled",
+          outcome: "cancelled",
+          runtime,
+          executor: "dispatcher",
+          resultSource: "pipeline-decomposition-cleanup",
+          exitCode: "CANCELLED",
+          completedAt: new Date().toISOString(),
+          bodyKind: "error",
+          bodyText: "Pipeline decomposition aborted before parent commit",
+          errorMessage: "Pipeline decomposition aborted before parent commit",
+        }),
+        sensitivityToMuninClassification(draft.classification),
       );
       await client.log(
         draft.namespace,
@@ -163,7 +194,7 @@ export async function handlePipelineTask(
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     if (createdDrafts.length > 0) {
-      await cancelCreatedChildren(client, createdDrafts);
+      await cancelCreatedChildren(client, hooks, createdDrafts);
     }
     await hooks.failTaskWithMessage(
       taskNs,
@@ -175,6 +206,41 @@ export async function handlePipelineTask(
   }
 
   if (decompositionCommitted) {
+    try {
+      const bodyText = buildPipelineDecompositionResult(pipeline);
+      await hooks.writeStructuredResult(
+        taskNs,
+        buildStructuredTaskResult({
+          schemaVersion: 1,
+          taskId: pipelineId,
+          taskNamespace: taskNs,
+          lifecycle: "completed",
+          outcome: "completed",
+          runtime: "pipeline",
+          executor: "dispatcher",
+          resultSource: "pipeline-decomposition",
+          exitCode: 0,
+          completedAt: new Date().toISOString(),
+          bodyKind: "response",
+          bodyText,
+          sensitivity: {
+            declared: pipeline.declaredSensitivity,
+            effective: pipeline.sensitivity,
+            mismatch:
+              pipeline.declaredSensitivity !== undefined &&
+              pipeline.declaredSensitivity !== pipeline.sensitivity,
+          },
+        }),
+        sensitivityToMuninClassification(pipeline.sensitivity),
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      await client.log(
+        taskNs,
+        `Pipeline decomposition committed, but structured result write failed: ${message}`,
+      );
+    }
+
     try {
       await hooks.refreshPipelineSummary(pipelineId);
     } catch (err) {

--- a/src/task-result-schema.ts
+++ b/src/task-result-schema.ts
@@ -5,6 +5,10 @@ import {
   pipelineSensitivitySchema,
 } from "./pipeline-ir.js";
 import { sensitivitySchema } from "./sensitivity.js";
+import {
+  SIGNING_POLICIES,
+  TASK_SIGNATURE_STATUSES,
+} from "./task-signing.js";
 
 export const taskExecutionOutcomeSchema = z.enum([
   "completed",
@@ -33,6 +37,7 @@ export const dispatcherRuntimeSchema = z.enum([
   "opencode",
   "auto",
   "orchestrator",
+  "pipeline",
 ]);
 export type DispatcherRuntime = z.infer<typeof dispatcherRuntimeSchema>;
 
@@ -216,6 +221,21 @@ export const savingsSummarySchema = z.object({
 });
 export type SavingsSummaryRecord = z.infer<typeof savingsSummarySchema>;
 
+// Submission identity is additive/optional for compatibility with historical
+// schemaVersion=1 results, but every current dispatcher writer supplies it.
+// Null is explicit: absence of cryptographic verification must never be
+// mistaken for the claimed submitter being authenticated.
+export const taskSubmissionProvenanceSchema = z.object({
+  claimedSubmitter: z.string().min(1),
+  verifiedSubmitter: z.string().min(1).nullable(),
+  policy: z.enum(SIGNING_POLICIES),
+  signatureStatus: z.enum(TASK_SIGNATURE_STATUSES),
+  keyId: z.string().min(1).nullable(),
+});
+export type TaskSubmissionProvenance = z.infer<
+  typeof taskSubmissionProvenanceSchema
+>;
+
 export const structuredTaskResultSchema = z.object({
   schemaVersion: z.literal(1),
   taskId: z.string().min(1),
@@ -250,6 +270,7 @@ export const structuredTaskResultSchema = z.object({
   artifactDelivery: artifactDeliverySchema.optional(),
   orchestratorOutcomes: z.array(orchestratorOutcomeSchema).optional(),
   savings: savingsSummarySchema.optional(),
+  provenance: taskSubmissionProvenanceSchema.optional(),
 });
 export type StructuredTaskResult = z.infer<typeof structuredTaskResultSchema>;
 

--- a/src/task-signing.ts
+++ b/src/task-signing.ts
@@ -51,10 +51,72 @@ export type VerificationStatus =
   | "expired"
   | "future-skew";
 
+/**
+ * Status recorded in task provenance. `unverified` is deliberately distinct
+ * from `valid`: policy=off means Hugin did not authenticate the signature.
+ * `internal-exempt` and `unverifiable` describe policy exceptions, not proof
+ * of the claimed identity.
+ */
+export const TASK_SIGNATURE_STATUSES = [
+  "valid",
+  "invalid",
+  "missing",
+  "unknown-signer",
+  "submitter-mismatch",
+  "malformed",
+  "unsupported-version",
+  "expired",
+  "future-skew",
+  "unverified",
+  "internal-exempt",
+  "unverifiable",
+] as const;
+export type TaskSignatureStatus = (typeof TASK_SIGNATURE_STATUSES)[number];
+
+export const SIGNING_POLICIES = ["off", "warn", "require"] as const;
+
 export interface VerificationResult {
   status: VerificationStatus;
   keyId?: string;
   reason?: string;
+}
+
+export interface TaskSubmissionProvenance {
+  claimedSubmitter: string;
+  verifiedSubmitter: string | null;
+  policy: SigningPolicy;
+  signatureStatus: TaskSignatureStatus;
+  keyId: string | null;
+}
+
+export interface TaskSignatureAssessment {
+  status: TaskSignatureStatus;
+  keyId?: string;
+  reason?: string;
+}
+
+/** Convert a signature assessment into the stable result-structured shape. */
+export function buildTaskSubmissionProvenance(
+  claimedSubmitter: string,
+  policy: SigningPolicy,
+  assessment: TaskSignatureAssessment,
+): TaskSubmissionProvenance {
+  return {
+    claimedSubmitter,
+    verifiedSubmitter:
+      assessment.status === "valid" && assessment.keyId ? claimedSubmitter : null,
+    policy,
+    signatureStatus: assessment.status,
+    keyId: assessment.keyId ?? null,
+  };
+}
+
+/** `require` accepts a valid signature plus Hugin's existing internal exemption. */
+export function signingPolicyRejects(
+  policy: SigningPolicy,
+  status: TaskSignatureStatus,
+): boolean {
+  return policy === "require" && status !== "valid" && status !== "internal-exempt";
 }
 
 export interface VerifyOptions {
@@ -341,7 +403,7 @@ export function parseNonNegativeIntEnv(raw: string | undefined, fallback: number
   return Number.isFinite(n) && n >= 0 ? n : fallback;
 }
 
-export type SigningPolicy = "off" | "warn" | "require";
+export type SigningPolicy = (typeof SIGNING_POLICIES)[number];
 
 /**
  * Parse HUGIN_SIGNING_POLICY. Unset or blank → "off". Any other value that

--- a/tests/pipeline-dispatch.test.ts
+++ b/tests/pipeline-dispatch.test.ts
@@ -157,6 +157,25 @@ function createPipelineHooks(client: FakePipelineDispatchClient): {
           ["type:pipeline", "type:pipeline-summary"]
         );
       },
+      async writeStructuredResult(taskNs, result, classification) {
+        await client.write(
+          taskNs,
+          "result-structured",
+          JSON.stringify({
+            ...result,
+            provenance: {
+              claimedSubmitter: "Codex",
+              verifiedSubmitter: null,
+              policy: "off",
+              signatureStatus: "unverified",
+              keyId: null,
+            },
+          }),
+          ["type:task-result", "type:task-result-structured"],
+          undefined,
+          classification,
+        );
+      },
     },
     promotedTaskIds,
     refreshedPipelineIds,
@@ -227,6 +246,17 @@ describe("handlePipelineTask", () => {
     expect(parentResult?.content).toContain("- **Reply-format:** summary");
     expect(parentResult?.content).toContain("- **Group:** sprint-step3");
     expect(parentResult?.content).toContain("- **Sequence:** 2");
+    const parentStructured = JSON.parse(
+      client.get(taskNs, "result-structured")!.content,
+    );
+    expect(parentStructured.runtime).toBe("pipeline");
+    expect(parentStructured.provenance).toEqual({
+      claimedSubmitter: "Codex",
+      verifiedSubmitter: null,
+      policy: "off",
+      signatureStatus: "unverified",
+      keyId: null,
+    });
 
     const exploreStatus = client.get("tasks/20260403-valid-pipeline-explore", "status");
     expect(exploreStatus?.tags).toEqual([
@@ -408,6 +438,22 @@ Phase: Explore
     expect(
       client.get(compiled.phases[0]!.taskNamespace, "result")?.content
     ).toContain("Pipeline decomposition aborted before parent commit");
+    const rolledBackStructured = JSON.parse(
+      client.get(compiled.phases[0]!.taskNamespace, "result-structured")!.content,
+    );
+    expect(rolledBackStructured).toMatchObject({
+      lifecycle: "cancelled",
+      outcome: "cancelled",
+      runtime: "claude",
+      resultSource: "pipeline-decomposition-cleanup",
+      provenance: {
+        claimedSubmitter: "Codex",
+        verifiedSubmitter: null,
+        policy: "off",
+        signatureStatus: "unverified",
+        keyId: null,
+      },
+    });
     expect(client.get(compiled.phases[1]!.taskNamespace, "status")).toBeNull();
 
     const parentStatus = client.get(taskNs, "status");

--- a/tests/task-result-schema.test.ts
+++ b/tests/task-result-schema.test.ts
@@ -396,3 +396,50 @@ describe("structured task result schema — savings (PR3, S4)", () => {
     expect(result.savings).toBeUndefined();
   });
 });
+
+describe("structured task result schema — submission provenance (#146)", () => {
+  it("accepts honest unverifiable provenance on pipeline parents", () => {
+    const result = buildStructuredTaskResult({
+      schemaVersion: 1,
+      taskId: "20260710-pipeline",
+      taskNamespace: "tasks/20260710-pipeline",
+      lifecycle: "completed",
+      outcome: "completed",
+      runtime: "pipeline",
+      executor: "dispatcher",
+      resultSource: "pipeline-decomposition",
+      exitCode: 0,
+      completedAt: "2026-07-10T10:00:00Z",
+      bodyKind: "response",
+      bodyText: "compiled",
+      provenance: {
+        claimedSubmitter: "codex-cli",
+        verifiedSubmitter: null,
+        policy: "warn",
+        signatureStatus: "unverifiable",
+        keyId: "codex-cli",
+      },
+    });
+
+    expect(result.runtime).toBe("pipeline");
+    expect(result.provenance?.verifiedSubmitter).toBeNull();
+  });
+
+  it("keeps provenance optional so historical schemaVersion=1 results still parse", () => {
+    const result = buildStructuredTaskResult({
+      schemaVersion: 1,
+      taskId: "historical",
+      taskNamespace: "tasks/historical",
+      lifecycle: "failed",
+      outcome: "failed",
+      runtime: "claude",
+      executor: "dispatcher",
+      resultSource: "dispatcher",
+      exitCode: 1,
+      completedAt: "2026-07-10T10:00:00Z",
+      bodyKind: "error",
+      bodyText: "old result",
+    });
+    expect(result.provenance).toBeUndefined();
+  });
+});

--- a/tests/task-signing.test.ts
+++ b/tests/task-signing.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import {
   buildCanonicalPayload,
+  buildTaskSubmissionProvenance,
   canonicalizePrompt,
   extractSignatureField,
   loadKeyStoreFromEnv,
@@ -11,6 +12,7 @@ import {
   parseSignature,
   parseSigningPolicy,
   signTask,
+  signingPolicyRejects,
   verifyTaskSignature,
   type SigningParams,
   type VerifyOptions,
@@ -221,6 +223,75 @@ describe("parseSigningPolicy", () => {
     // A typo like `requrie` must fail loud, not fall back to off.
     expect(() => parseSigningPolicy("requrie")).toThrow(/invalid HUGIN_SIGNING_POLICY/);
     expect(() => parseSigningPolicy("yolo")).toThrow(/invalid HUGIN_SIGNING_POLICY/);
+  });
+});
+
+describe("structured task submission provenance", () => {
+  it("records policy=off as explicitly unverified even when a keyId is present", () => {
+    expect(
+      buildTaskSubmissionProvenance("codex-cli", "off", {
+        status: "unverified",
+        keyId: "codex-cli",
+      }),
+    ).toEqual({
+      claimedSubmitter: "codex-cli",
+      verifiedSubmitter: null,
+      policy: "off",
+      signatureStatus: "unverified",
+      keyId: "codex-cli",
+    });
+  });
+
+  it.each([
+    ["missing", null],
+    ["invalid", "codex-cli"],
+    ["expired", "codex-cli"],
+    ["future-skew", "codex-cli"],
+    ["submitter-mismatch", "other-tenant"],
+  ] as const)(
+    "keeps claimed submitter unverified for %s",
+    (status, keyId) => {
+      const provenance = buildTaskSubmissionProvenance("codex-cli", "warn", {
+        status,
+        keyId: keyId ?? undefined,
+      });
+      expect(provenance.verifiedSubmitter).toBeNull();
+      expect(provenance.signatureStatus).toBe(status);
+      expect(provenance.keyId).toBe(keyId);
+    },
+  );
+
+  it("sets verified submitter only for a valid signature", () => {
+    expect(
+      buildTaskSubmissionProvenance("codex-cli", "require", {
+        status: "valid",
+        keyId: "codex-cli",
+      }),
+    ).toEqual({
+      claimedSubmitter: "codex-cli",
+      verifiedSubmitter: "codex-cli",
+      policy: "require",
+      signatureStatus: "valid",
+      keyId: "codex-cli",
+    });
+  });
+
+  it.each([
+    "missing",
+    "invalid",
+    "expired",
+    "future-skew",
+    "submitter-mismatch",
+    "unverifiable",
+  ] as const)("require rejects %s", (status) => {
+    expect(signingPolicyRejects("require", status)).toBe(true);
+    expect(signingPolicyRejects("warn", status)).toBe(false);
+    expect(signingPolicyRejects("off", status)).toBe(false);
+  });
+
+  it("require accepts valid and the existing internal Hugin exemption", () => {
+    expect(signingPolicyRejects("require", "valid")).toBe(false);
+    expect(signingPolicyRejects("require", "internal-exempt")).toBe(false);
   });
 });
 


### PR DESCRIPTION
Closes #146.

## What changed

- Adds additive submission provenance to dispatcher `result-structured` documents: claimed submitter, nullable verified submitter, signing policy, signature status, and key id.
- Records `verifiedSubmitter` only after a valid HMAC check. Policy-off, invalid/missing/expired signatures, pipeline-v1 limitations, and the internal-Hugin exemption remain explicitly unverified.
- Covers pipeline parents and decomposition-cleanup children, including cancellation, compile/decomposition failure, shutdown, recovery, lease reaping, and delivery reconciliation terminal paths.
- Preserves claim-time verification across long executions and richer replacement result writes, while clearing cached assessments on approval waits and lost claim races.
- Keeps provenance optional under schema version 1 so historical structured results remain readable.
- Documents non-Claude tenant key registration and the staged off -> warn -> require rollout. No signing material is committed or logged.

## Why

`Submitted by:` is a claim, not proof of identity. Existing results did not distinguish claimed identity from cryptographically verified identity, and pipeline parents did not emit the normal structured result at all. This makes downstream audit and policy consumers treat identity honestly without breaking historical readers.

## Codex-native review

Review focused on identity/auth semantics, pipeline terminal paths, cache lifecycle, schema compatibility, and policy rollout.

Findings fixed before publication:

1. Recovered/reaped pipeline parents still skipped `result-structured`; all dispatcher terminal paths now write it.
2. Claim-time provenance could remain cached across an approval wait or lost claim CAS and become stale; those non-owned/non-terminal paths now clear it.
3. Auto-routing failure emits a richer replacement structured result after the generic failure writer; it now explicitly retains the original claim-time assessment instead of re-verifying at a later timestamp.

No remaining blocking findings. Residual risk is operational: `HUGIN_SIGNING_POLICY` remains `off` by default, so production should move to `warn` first and observe clean tenant coverage before `require`.

## Validation

- `npm test -- tests/task-signing.test.ts tests/task-result-schema.test.ts tests/pipeline-dispatch.test.ts` — 76 passed
- `npm run build` — passed
- `npm test` — 89 files / 1498 tests passed
- `git diff --check` — passed

## Merge/deploy gates

- GitHub build/test checks green on this exact head.
- Deploy with signing policy unchanged (`off`) first; verify service active and loopback `/health` reports `status: ok`, `polling: true`.
- Submit a safe probe and confirm `result-structured.provenance` plus the lifecycle `[provenance]` log. Under `off`, expect `verifiedSubmitter: null` and `signatureStatus: unverified`.
- Only move to `warn` after the deploy probe; do not move to `require` until all active tenants have valid dedicated keys and logs are clean for at least 72 hours.

