### PR TITLE
Make Broker alias availability truthful

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,7 @@ hugin/
 │   └── broker/                   # Orchestrator-v1 broker (Tailscale-only HTTP, /v1/delegate/*)
 │       ├── server.ts             # Express app + opt-in startup (HUGIN_BROKER_KEYS)
 │       ├── handlers.ts           # submit/await/rate/list/models endpoint handlers
+│       ├── executor-capabilities.ts # Live executor truth shared by submit/models/worker
 │       ├── orch-worker.ts        # Polls Munin for orch-v1 tasks, claims via CAS, dispatches to OpenRouter
 │       ├── openrouter-executor.ts # OpenRouter one-shot delegation runner
 │       ├── reconciliation.ts     # Periodic sweep: backfill journal events for orch-v1 tasks
@@ -193,10 +194,16 @@ MUNIN_API_KEY=<same key Munin uses>
 | `HUGIN_BROKER_KEYS` | — | Inline JSON keystore: `{"<principal>": "<token>"}`. Setting either this or `HUGIN_BROKER_KEYS_FILE` enables the broker. |
 | `HUGIN_BROKER_KEYS_FILE` | — | Path to a JSON keystore file for the broker. Takes precedence over `HUGIN_BROKER_KEYS`. |
 | `HUGIN_BROKER_RECONCILIATION_INTERVAL_MS` | `60000` | Interval between reconciliation sweeps (backfills journal events for orch-v1 tasks visible in Munin). |
-| `OPENROUTER_API_KEY` | — | OpenRouter API key. When set on a Pi-side broker, the orch-worker is enabled and dispatches `runtime: openrouter, family: one-shot` tasks. |
+| `OPENROUTER_API_KEY` | — | OpenRouter API key. When set on a Pi-side broker, the orch-worker is enabled and `large-reasoning` appears in `/v1/delegate/models`. Without it the Broker advertises no executable aliases and rejects submissions; it never queues an undrainable task. |
 | `OPENROUTER_REFERER` | `https://hugin.local` | `HTTP-Referer` header sent on OpenRouter requests (provider attribution). |
 | `OPENROUTER_APP_TITLE` | `hugin-orch-v1` | `X-Title` header sent on OpenRouter requests. |
 | `HUGIN_BROKER_URL` | — | hugin-mcp only (laptop side): URL of the Pi broker, e.g. `http://huginmunin.<tailnet>.ts.net:3033`. |
 | `HUGIN_BROKER_TOKEN` | — | hugin-mcp only: bearer token registered in the Pi's `HUGIN_BROKER_KEYS`. |
 | `HUGIN_MCP_SUBMITTER` | `claude-code` | hugin-mcp only: `orchestrator_submitter` principal stamped on each delegation envelope. |
 | `HUGIN_MCP_REQUEST_TIMEOUT_MS` | `60000` | hugin-mcp only: per-request HTTP timeout against the broker. |
+
+**Broker alias rule:** the four v1 aliases remain the historical protocol
+catalogue, but `/v1/delegate/models` is the live execution contract. Submission
+must fail before any durable write unless the requested alias is present in
+that response. The MCP discovers this set at startup and disables
+`hugin_submit` if discovery fails or returns no enabled aliases.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,6 +194,7 @@ hugin/
 │   │   └── tools.ts              # 5 MCP tools (hugin_submit/await/rate/list/models) with envelope autofill
 │   └── broker/                   # Orchestrator-v1 broker (Tailscale-only HTTP, /v1/delegate/*)
 │       ├── server.ts             # Express app + opt-in startup (HUGIN_BROKER_KEYS)
+│       ├── executor-capabilities.ts # Live executor truth shared by submit/models/worker
 │       ├── handlers.ts           # submit/await/rate/list/models endpoint handlers
 │       ├── auth.ts               # Bearer-token middleware, constant-time compare
 │       ├── idempotency.ts        # In-memory idempotency-key dedupe (§3.1)
@@ -272,13 +273,19 @@ Claude Code  ⟷  hugin-mcp (stdio)  ⟶  HTTP /v1/delegate/* (Tailscale)  ⟶  
 ```
 
 **Tools exposed:**
-- `hugin_submit` — submit a delegation task
+- `hugin_submit` — submit a delegation task; its alias enum is built from the live Broker discovery result and is disabled when discovery finds no enabled executor
 - `hugin_await` — read current task state
 - `hugin_rate` — append a rating event for a completed task
 - `hugin_list` — list recent delegated tasks
-- `hugin_models` — read the active alias map and runtime registry
+- `hugin_models` — read only aliases with enabled executors and their backing runtime rows
 
 The MCP layer fills in protocol envelope fields (`envelope_version`, `alias_map_version`, `idempotency_key`, `orchestrator_session_id`, `orchestrator_submitter`) so callers only think about the task itself.
+
+The four v1 aliases remain the historical wire catalogue. They are not all
+live routes: as of 2026-07-11 only `large-reasoning` has a Broker executor, and
+only when the Pi has `OPENROUTER_API_KEY`. Never infer executability from the
+compiled alias map; `/v1/delegate/models` is authoritative. The Broker rejects
+an unavailable alias before idempotency reservation or durable writes.
 
 **Required env (orchestrator side):**
 - `HUGIN_BROKER_URL` — e.g. `http://huginmunin.<tailnet>.ts.net:3033`
@@ -325,7 +332,7 @@ claude mcp add-json hugin '{"command":"node","args":["/Users/magnus/repos/hugin/
 | `HUGIN_BROKER_KEYS` | — | Inline JSON keystore: `{"<principal>": "<token>"}`. Setting either this or `HUGIN_BROKER_KEYS_FILE` enables the broker. |
 | `HUGIN_BROKER_KEYS_FILE` | — | Path to a JSON keystore file for the broker. Takes precedence over `HUGIN_BROKER_KEYS`. |
 | `HUGIN_BROKER_RECONCILIATION_INTERVAL_MS` | `60000` | Interval between reconciliation sweeps (backfills journal events for orch-v1 tasks visible in Munin). |
-| `OPENROUTER_API_KEY` | — | Enables the orch-v1 OpenRouter worker (Step 5b). Required to actually execute one-shot delegations; without it the broker still accepts submissions but tasks stay `pending`. |
+| `OPENROUTER_API_KEY` | — | Enables the orch-v1 OpenRouter worker. With it, `large-reasoning` is advertised as executable; without it the Broker advertises no executable aliases and rejects submissions before durable state is created. |
 | `OPENROUTER_REFERER` | `https://hugin.local` | `HTTP-Referer` header value sent to OpenRouter (used for ranking/attribution). |
 | `OPENROUTER_APP_TITLE` | `hugin-orch-v1` | `X-Title` header value sent to OpenRouter. |
 | `HUGIN_FRICTION_INJECTION` | `off` | Set to `on` to inject `friction-mcp` into Claude SDK tasks. Each task gets `report_friction` available as an MCP tool. Default off — opt-in until signal quality is established. |

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,40 @@
 # Hugin — Status
 
-**Last session:** 2026-07-10 (Codex) — #160 merged and deployed to Hugin-Munin
-**Branch:** `main`; production `/home/magnus/repos/hugin` is `main@cbb1f13`.
+**Last session:** 2026-07-11 (Codex) — truthful Broker routing and roadmap reconciliation (#168)
+**Branch:** `main`; production includes PR #168, deployed to Hugin-Munin on 2026-07-11.
+
+## Latest — truthful MCP Broker routing + roadmap reset (#168, 2026-07-11)
+
+PR [#168](https://github.com/Magnus-Gille/hugin/pull/168) closed the defect where
+the MCP Broker advertised and accepted aliases that no worker could drain.
+
+- Added one executor-capability truth shared by submission, `/models`, and the
+  worker. `large-reasoning` is executable only when the OpenRouter worker is
+  configured; `tiny`, `medium`, and `pi-large-coder` remain historical protocol
+  aliases but are rejected before idempotency reservation or durable writes.
+- `/v1/delegate/models` now returns only enabled aliases and their backing
+  runtime rows. hugin-mcp builds its submit enum from that live response and
+  disables submission if discovery fails or returns no enabled executor.
+- Alias-map version skew is rejected explicitly. Historical envelopes and
+  journal rows remain parseable.
+- Native Codex review found no blocking defects and strengthened the test that
+  proves rejected aliases consume neither journal state nor the idempotency key.
+  Claude review was intentionally skipped because it was unavailable. Full
+  suite: 91 files / 1518 tests green; TypeScript build and CI green.
+
+Roadmap reconciliation completed alongside the PR:
+
+- Added #163 provenance, #164 learning-loop health, #165 role-validation trial,
+  #166 truthful Broker routing, and #167 canonical durable Hugin→M5 leaf.
+- Closed solved/superseded #147, #138, #141, and #84.
+- Transferred cross-repo ownership: Hugin #98 → Grimnir #77, #117 → Grimnir
+  #78, and #162 → claude-config #2.
+- Corrected closed #38 and #129 to Done; removed optional #153 deploy hygiene
+  from the active Roadmap while leaving the issue open.
+
+**Next:** implement #167 as the architectural seam, with #163 provenance in the
+same or immediately following slice. Keep the mini-Conductor and skill lane
+frozen while #165 gathers evidence through 2026-08-22.
 
 ## Latest — Reviewed Orin macro route (#160, 2026-07-10)
 

--- a/docs/orchestrator-v1-data-model.md
+++ b/docs/orchestrator-v1-data-model.md
@@ -35,9 +35,19 @@ What v1 does **not** cover:
 
 ---
 
-## 2. Aliases (v1 active set)
+## 2. Aliases (v1 protocol catalogue and live availability)
 
 Aliases split into two families: one-shot aliases (`tiny`, `medium`, `large-reasoning`) and harness aliases (`pi-large-coder`).
+
+This table is the versioned protocol catalogue, **not** a promise that every
+alias is executable by every live Broker process. `GET /v1/delegate/models`
+is authoritative for the enabled set on that process and returns only aliases
+with a worker that can actually claim them, plus only their backing runtime
+rows. As of 2026-07-11 the only implemented Broker executor is OpenRouter
+one-shot (`large-reasoning`), and it is enabled only when
+`OPENROUTER_API_KEY` is configured. Without that key, the live alias list is
+empty. The other catalogue entries remain parseable for historical envelopes
+and journal rows but are rejected at submission until an executor ships.
 
 | Alias | Family | Harness | Backing model | Host | Runtime | Notes |
 |---|---|---|---|---|---|---|
@@ -49,6 +59,8 @@ Aliases split into two families: one-shot aliases (`tiny`, `medium`, `large-reas
 Alias governance rules:
 - Manual promotion only. No silent retargeting.
 - Each alias change bumps `alias_map_version` (monotonic integer).
+- Executor availability does not bump `alias_map_version`; it is live instance
+  state surfaced by `/models`.
 - Journal records `alias_requested` AND `model_effective` per delegation.
 - For harness aliases, journal also records `harness_version` (the `pi` CLI version at execution time).
 - Cross-version corpus comparisons require explicit segmentation by `alias_map_version` and (for harness rows) `harness_version`.
@@ -149,7 +161,13 @@ interface BrokerAnnotations {
 }
 ```
 
-The broker validates: `envelope_version === 1`, bearer token → known principal, idempotency key not seen (or seen with same prompt hash — see §3.1), alias is currently active, sensitivity ≤ runtime ceiling, prompt non-empty. Rejects with a typed error otherwise.
+The broker validates: `envelope_version === 1`, bearer token → known principal,
+`alias_map_version` exactly matches the Broker catalogue, the alias has an
+enabled executor in this process, idempotency key not seen (or seen with the
+same prompt hash — see §3.1), sensitivity ≤ runtime ceiling, and prompt
+non-empty. Unimplemented aliases fail with non-retryable `alias_unavailable`;
+an implemented but disabled executor fails with retryable `alias_unavailable`.
+Both checks happen before idempotency reservation or any durable write.
 
 ### 3.1 Idempotency-key reuse semantics
 
@@ -576,6 +594,9 @@ This section locks the durability model.
 
 The broker's `POST /v1/delegate/submit` performs writes in this order:
 
+0. **Validate version + executor availability.** Reject stale alias maps and
+   aliases without an enabled executor before reserving idempotency or writing
+   Munin/journal state.
 1. **Acquire dedupe lock** on the `idempotency_key` (in-memory; non-durable). If another submission with the same key is in-flight, queue this one or reject.
 2. **Munin write:** create `tasks/<task_id>` with the full envelope (request + `BrokerAnnotations`) and tags `["pending", "runtime:<runtime>", "orch-v1"]`. This write must succeed before the broker returns `200 OK` to the MCP. *This is the durability boundary — once Munin acks, the submission is durable.*
 3. **Journal append:** write `delegation_submitted` to `~/.hugin/delegation-events.jsonl`. If this fails, log a warning but do not roll back the Munin write — the event is reconstructible from the Munin envelope. Periodic reconciliation (§12.5) will detect and backfill missing journal entries.

--- a/src/broker/executor-capabilities.ts
+++ b/src/broker/executor-capabilities.ts
@@ -1,0 +1,67 @@
+/**
+ * Broker executor capability truth.
+ *
+ * Alias mappings are a durable protocol catalogue. This module answers the
+ * separate operational question: can this Broker process actually drain a
+ * submitted task for that resolved runtime/family right now?
+ */
+
+import { ALIAS_MAP_V1 } from "../runtime-registry.js";
+import { resolveAliasForBroker } from "./alias-resolution.js";
+import type { Alias, AliasResolved } from "./types.js";
+
+export interface BrokerExecutorCapabilities {
+  openrouterOneShot: boolean;
+}
+
+export type BrokerAliasAvailability =
+  | { executable: true }
+  | {
+      executable: false;
+      reason: "no_executor_implemented" | "executor_disabled";
+      retryable: boolean;
+    };
+
+export function brokerExecutorCapabilities(options: {
+  openrouterEnabled: boolean;
+}): BrokerExecutorCapabilities {
+  return { openrouterOneShot: options.openrouterEnabled };
+}
+
+export function isBrokerExecutorImplemented(resolved: AliasResolved): boolean {
+  return resolved.runtime === "openrouter" && resolved.family === "one-shot";
+}
+
+export function brokerAliasAvailability(
+  resolved: AliasResolved,
+  capabilities: BrokerExecutorCapabilities,
+): BrokerAliasAvailability {
+  if (!isBrokerExecutorImplemented(resolved)) {
+    return {
+      executable: false,
+      reason: "no_executor_implemented",
+      retryable: false,
+    };
+  }
+  if (!capabilities.openrouterOneShot) {
+    return {
+      executable: false,
+      reason: "executor_disabled",
+      retryable: true,
+    };
+  }
+  return { executable: true };
+}
+
+export function executableBrokerAliases(
+  capabilities: BrokerExecutorCapabilities,
+): Alias[] {
+  return Object.values(ALIAS_MAP_V1.aliases)
+    .map((entry) => entry.alias)
+    .filter((alias) =>
+      brokerAliasAvailability(
+        resolveAliasForBroker(alias).alias_resolved,
+        capabilities,
+      ).executable,
+    );
+}

--- a/src/broker/handlers.ts
+++ b/src/broker/handlers.ts
@@ -20,6 +20,11 @@ import {
   type AliasMap,
 } from "../runtime-registry.js";
 import { POLICY_VERSION, resolveAliasForBroker } from "./alias-resolution.js";
+import {
+  brokerAliasAvailability,
+  executableBrokerAliases,
+  type BrokerExecutorCapabilities,
+} from "./executor-capabilities.js";
 import type { DelegationJournal } from "./journal.js";
 import { projectDelegations } from "./journal.js";
 import type { IdempotencyIndex } from "./idempotency.js";
@@ -39,6 +44,7 @@ export interface BrokerHandlerDependencies {
   taskStore: BrokerTaskStore;
   journal: DelegationJournal;
   idempotency: IdempotencyIndex;
+  executorCapabilities: BrokerExecutorCapabilities;
   now?: () => Date;
 }
 
@@ -70,6 +76,15 @@ export function createSubmitHandler(deps: BrokerHandlerDependencies) {
       return;
     }
 
+    if (request.alias_map_version !== ALIAS_MAP_V1.version) {
+      res.status(409).json({
+        error: "policy_rejected",
+        message: `alias_map_version ${request.alias_map_version} does not match Broker version ${ALIAS_MAP_V1.version}`,
+        alias_map_version: ALIAS_MAP_V1.version,
+      });
+      return;
+    }
+
     let aliasResolution;
     try {
       aliasResolution = resolveAliasForBroker(request.alias_requested);
@@ -77,6 +92,21 @@ export function createSubmitHandler(deps: BrokerHandlerDependencies) {
       res.status(400).json({
         error: "alias_unknown",
         message: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
+
+    const availability = brokerAliasAvailability(
+      aliasResolution.alias_resolved,
+      deps.executorCapabilities,
+    );
+    if (!availability.executable) {
+      res.status(availability.retryable ? 503 : 409).json({
+        error: "alias_unavailable",
+        message: `alias '${request.alias_requested}' is configured but has no live Broker executor`,
+        reason: availability.reason,
+        retryable: availability.retryable,
+        executable_aliases: executableBrokerAliases(deps.executorCapabilities),
       });
       return;
     }
@@ -327,17 +357,19 @@ export function createListHandler(deps: BrokerHandlerDependencies) {
   };
 }
 
-export function createModelsHandler() {
+export function createModelsHandler(capabilities: BrokerExecutorCapabilities) {
   return async (_req: Request, res: Response): Promise<void> => {
     const map: AliasMap = ALIAS_MAP_V1;
-    const aliases = Object.values(map.aliases).map((entry) => ({
-      ...entry,
-      runtime_row_id: entry.runtimeId,
-    }));
+    const executable = new Set(executableBrokerAliases(capabilities));
+    const aliases = Object.values(map.aliases)
+      .filter((entry) => executable.has(entry.alias))
+      .map((entry) => ({
+        ...entry,
+        runtime_row_id: entry.runtimeId,
+      }));
+    const executableRuntimeIds = new Set(aliases.map((entry) => entry.runtimeId));
     const rows = RUNTIME_REGISTRY.filter((row) =>
-      row.dispatcherRuntime === "ollama" ||
-      row.dispatcherRuntime === "openrouter" ||
-      row.dispatcherRuntime === "pi-harness",
+      executableRuntimeIds.has(row.id),
     ).map((row) => ({
       id: row.id,
       runtime: row.dispatcherRuntime,

--- a/src/broker/orch-worker.ts
+++ b/src/broker/orch-worker.ts
@@ -49,6 +49,7 @@ import {
   type DelegationEnvelope,
   type DelegationError,
 } from "./types.js";
+import { isBrokerExecutorImplemented } from "./executor-capabilities.js";
 
 export const DEFAULT_POLL_INTERVAL_MS = 30_000;
 /**
@@ -262,10 +263,7 @@ export class OrchWorker {
   }
 
   private canHandle(envelope: DelegationEnvelope): boolean {
-    return (
-      envelope.alias_resolved.runtime === "openrouter" &&
-      envelope.alias_resolved.family === "one-shot"
-    );
+    return isBrokerExecutorImplemented(envelope.alias_resolved);
   }
 
   private leaseDurationFor(envelope: DelegationEnvelope): number {

--- a/src/broker/server.ts
+++ b/src/broker/server.ts
@@ -55,7 +55,11 @@ export function buildBrokerApp(config: BrokerServerConfig): Express {
   app.post("/v1/delegate/rate", auth, createRateHandler(config.deps));
   app.post("/v1/delegate/list", auth, createListHandler(config.deps));
   app.get("/v1/delegate/list", auth, createListHandler(config.deps));
-  app.get("/v1/delegate/models", auth, createModelsHandler());
+  app.get(
+    "/v1/delegate/models",
+    auth,
+    createModelsHandler(config.deps.executorCapabilities),
+  );
 
   return app;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,7 @@ import {
 } from "./task-signing.js";
 import { consultSkillLane } from "./skill/skill-lane-dispatch.js";
 import { readBrokerEnv, startBroker, type RunningBroker } from "./broker/server.js";
+import { brokerExecutorCapabilities } from "./broker/executor-capabilities.js";
 import { BrokerTaskStore } from "./broker/task-store.js";
 import { DelegationJournal } from "./broker/journal.js";
 import { IdempotencyIndex } from "./broker/idempotency.js";
@@ -5564,6 +5565,10 @@ if (brokerEnv.enabled) {
   const journal = new DelegationJournal({ path: brokerHome });
   const taskStore = new BrokerTaskStore(munin);
   const idempotency = new IdempotencyIndex();
+  const orKey = process.env.OPENROUTER_API_KEY?.trim();
+  const executorCapabilities = brokerExecutorCapabilities({
+    openrouterEnabled: Boolean(orKey),
+  });
   brokerReconciler = new BrokerReconciler({
     taskStore,
     journal,
@@ -5573,7 +5578,7 @@ if (brokerEnv.enabled) {
     host: brokerEnv.host,
     port: brokerEnv.port,
     keys: brokerEnv.keys,
-    deps: { taskStore, journal, idempotency },
+    deps: { taskStore, journal, idempotency, executorCapabilities },
   })
     .then((rb) => {
       runningBroker = rb;
@@ -5585,7 +5590,6 @@ if (brokerEnv.enabled) {
         `Broker reconciler: every ${config.brokerReconciliationIntervalMs}ms (journal: ${brokerHome})`,
       );
 
-      const orKey = process.env.OPENROUTER_API_KEY?.trim();
       if (orKey) {
         const orClient = new OpenRouterClient({
           apiKey: orKey,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -26,6 +26,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { BrokerClient } from "./mcp/broker-client.js";
 import { ALIAS_MAP_VERSION, buildTools, type HuginTool } from "./mcp/tools.js";
+import { aliasSchema, type Alias } from "./broker/types.js";
 
 const SERVER_NAME = "hugin-mcp";
 const SERVER_VERSION = "0.1.0";
@@ -44,13 +45,19 @@ function readRequiredEnv(name: string): string {
  * carry the live value instead of a hard-coded constant. The broker
  * uses this to detect orchestrator skew when it bumps the alias map.
  *
- * If `/v1/delegate/models` is unreachable or returns an unexpected
- * shape, fall back to the compiled-in {@link ALIAS_MAP_VERSION}: this
- * keeps startup non-blocking on transient network errors, at the cost
- * of submitting a possibly-stale version (which the broker will
- * surface as a normal version-skew error on the first submit).
+ * If `/v1/delegate/models` is unreachable or malformed, retain the compiled
+ * alias-map version for diagnostics but return an empty executable alias set.
+ * That keeps MCP startup non-blocking while disabling submission until the
+ * client reconnects and successfully discovers the Broker contract.
  */
-async function discoverAliasMapVersion(broker: BrokerClient): Promise<number> {
+interface BrokerContractDiscovery {
+  aliasMapVersion: number;
+  executableAliases: Alias[];
+}
+
+async function discoverBrokerContract(
+  broker: BrokerClient,
+): Promise<BrokerContractDiscovery> {
   try {
     const response = await broker.models();
     if (
@@ -58,20 +65,35 @@ async function discoverAliasMapVersion(broker: BrokerClient): Promise<number> {
       typeof response === "object" &&
       "alias_map_version" in response
     ) {
-      const candidate = (response as { alias_map_version: unknown }).alias_map_version;
+      const candidate = (response as { alias_map_version: unknown })
+        .alias_map_version;
       if (typeof candidate === "number" && Number.isInteger(candidate) && candidate > 0) {
-        return candidate;
+        const rawAliases = "aliases" in response
+          ? (response as { aliases: unknown }).aliases
+          : undefined;
+        const executableAliases = Array.isArray(rawAliases)
+          ? rawAliases.flatMap((entry) => {
+              if (!entry || typeof entry !== "object" || !("alias" in entry)) {
+                return [];
+              }
+              const parsed = aliasSchema.safeParse(
+                (entry as { alias: unknown }).alias,
+              );
+              return parsed.success ? [parsed.data] : [];
+            })
+          : [];
+        return { aliasMapVersion: candidate, executableAliases };
       }
     }
     process.stderr.write(
-      `hugin-mcp: /v1/delegate/models did not advertise alias_map_version; using ${ALIAS_MAP_VERSION}\n`,
+      `hugin-mcp: /v1/delegate/models did not advertise a valid contract; submission disabled (compiled alias map ${ALIAS_MAP_VERSION})\n`,
     );
   } catch (err) {
     process.stderr.write(
-      `hugin-mcp: failed to fetch alias_map_version (${err instanceof Error ? err.message : String(err)}); using ${ALIAS_MAP_VERSION}\n`,
+      `hugin-mcp: failed to discover Broker contract (${err instanceof Error ? err.message : String(err)}); submission disabled (compiled alias map ${ALIAS_MAP_VERSION})\n`,
     );
   }
-  return ALIAS_MAP_VERSION;
+  return { aliasMapVersion: ALIAS_MAP_VERSION, executableAliases: [] };
 }
 
 function readOptionalNumber(name: string, fallback: number): number {
@@ -92,12 +114,13 @@ export async function main(): Promise<void> {
   const requestTimeoutMs = readOptionalNumber("HUGIN_MCP_REQUEST_TIMEOUT_MS", 60_000);
 
   const broker = new BrokerClient({ baseUrl, bearerToken, requestTimeoutMs });
-  const aliasMapVersion = await discoverAliasMapVersion(broker);
+  const brokerContract = await discoverBrokerContract(broker);
   const tools = buildTools({
     broker,
     sessionId: randomUUID(),
     submitter,
-    aliasMapVersion,
+    aliasMapVersion: brokerContract.aliasMapVersion,
+    executableAliases: brokerContract.executableAliases,
   });
 
   const server = new McpServer({ name: SERVER_NAME, version: SERVER_VERSION });

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -15,6 +15,7 @@ import { randomUUID } from "node:crypto";
 import { z } from "zod";
 import {
   aliasSchema,
+  type Alias,
   ratingSchema,
   sensitivitySchema,
   taskTypeSchema,
@@ -58,6 +59,12 @@ export interface ToolDeps {
    * detect orchestrator skew when it bumps the alias map.
    */
   aliasMapVersion?: number;
+  /**
+   * Alias set advertised by the live Broker `/models` response. An empty set
+   * disables `hugin_submit` in the MCP schema. Tests and embedded callers that
+   * omit this retain the one currently implemented alias.
+   */
+  executableAliases?: readonly Alias[];
   /** UUID generator (overridable for tests). */
   newId?: () => string;
 }
@@ -71,11 +78,11 @@ export const submitInputShape = {
     .min(1)
     .describe("The full task prompt to hand to the runtime."),
   alias_requested: aliasSchema.describe(
-    "Logical alias (`tiny` / `medium` / `large-reasoning` / `pi-large-coder`). The broker resolves this to a runtime row.",
+    "Logical alias. The live executable set is discovered from `hugin_models` when the MCP starts.",
   ),
   worktree: worktreeSpecSchema
     .optional()
-    .describe("Required for `pi-large-coder` (harness aliases). Omit for one-shots."),
+    .describe("Reserved for future harness aliases. Omit for the current one-shot alias."),
   sensitivity: sensitivitySchema
     .optional()
     .describe("Caps which runtimes can run this task. Defaults to `internal`."),
@@ -199,17 +206,30 @@ export function buildTools(deps: ToolDeps): {
   models: HuginTool<z.infer<typeof modelsInputSchema>>;
 } {
   const newId = deps.newId ?? randomUUID;
+  const executableAliases = deps.executableAliases ?? ["large-reasoning"];
+  const executableAliasInput = executableAliases.length > 0
+    ? z.enum(executableAliases as [Alias, ...Alias[]])
+    : z.never();
+  const activeSubmitInputShape = {
+    ...submitInputShape,
+    alias_requested: executableAliasInput.describe(
+      executableAliases.length > 0
+        ? `Executable logical alias. Live set: ${executableAliases.join(", ")}.`
+        : "No Broker alias currently has an enabled executor; submission is disabled.",
+    ),
+  };
+  const activeSubmitInputSchema = z.object(activeSubmitInputShape);
 
   const submit: HuginTool<z.infer<typeof submitInputSchema>> = {
     name: "hugin_submit",
     title: "Submit a delegation task to Hugin",
     description:
       "Hand a task off to the Pi-side broker for execution on a cheaper or differently-capable runtime. Returns the assigned task_id and the `idempotency_key` used (auto-generated if not supplied) — pass that key back as `idempotency_key` to safely retry the same logical request.",
-    inputShape: submitInputShape,
+    inputShape: activeSubmitInputShape,
     handler: async (rawInput) => {
       let idempotencyKey: string | undefined;
       try {
-        const input = submitInputSchema.parse(rawInput);
+        const input = activeSubmitInputSchema.parse(rawInput);
         idempotencyKey = input.idempotency_key ?? newId();
         const payload = {
           envelope_version: ENVELOPE_VERSION,
@@ -291,7 +311,7 @@ export function buildTools(deps: ToolDeps): {
     name: "hugin_models",
     title: "Read the active alias map and runtime registry",
     description:
-      "Returns the current alias map (`tiny`/`medium`/`large-reasoning`/`pi-large-coder`) and the runtime rows the broker can dispatch to.",
+      "Returns only aliases with a live Broker executor and the runtime rows they can actually dispatch to.",
     inputShape: modelsInputShape,
     handler: async () => {
       try {

--- a/tests/broker/executor-capabilities.test.ts
+++ b/tests/broker/executor-capabilities.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { resolveAliasForBroker } from "../../src/broker/alias-resolution.js";
+import {
+  brokerAliasAvailability,
+  brokerExecutorCapabilities,
+  executableBrokerAliases,
+  isBrokerExecutorImplemented,
+} from "../../src/broker/executor-capabilities.js";
+
+describe("Broker executor capabilities", () => {
+  const enabled = brokerExecutorCapabilities({ openrouterEnabled: true });
+  const disabled = brokerExecutorCapabilities({ openrouterEnabled: false });
+
+  it("marks only the implemented OpenRouter one-shot alias executable", () => {
+    expect(executableBrokerAliases(enabled)).toEqual(["large-reasoning"]);
+    expect(
+      isBrokerExecutorImplemented(
+        resolveAliasForBroker("large-reasoning").alias_resolved,
+      ),
+    ).toBe(true);
+  });
+
+  it.each(["tiny", "medium", "pi-large-coder"] as const)(
+    "classifies %s as unimplemented and non-retryable",
+    (alias) => {
+      expect(
+        brokerAliasAvailability(
+          resolveAliasForBroker(alias).alias_resolved,
+          enabled,
+        ),
+      ).toEqual({
+        executable: false,
+        reason: "no_executor_implemented",
+        retryable: false,
+      });
+    },
+  );
+
+  it("advertises no alias when the OpenRouter executor is disabled", () => {
+    expect(executableBrokerAliases(disabled)).toEqual([]);
+    expect(
+      brokerAliasAvailability(
+        resolveAliasForBroker("large-reasoning").alias_resolved,
+        disabled,
+      ),
+    ).toEqual({
+      executable: false,
+      reason: "executor_disabled",
+      retryable: true,
+    });
+  });
+});

--- a/tests/broker/handlers.test.ts
+++ b/tests/broker/handlers.test.ts
@@ -196,6 +196,17 @@ describe("POST /v1/delegate/submit", () => {
       expect(body.retryable).toBe(false);
       expect(body.executable_aliases).toEqual(["large-reasoning"]);
       expect(harness.munin.writes).toHaveLength(0);
+      expect(await harness.journal.readAll()).toEqual([]);
+
+      // Availability rejection happens before idempotency reservation: the
+      // same logical key remains usable for an executable alias.
+      const supported = await fetch(`${harness.url}/v1/delegate/submit`, {
+        method: "POST",
+        headers: authHeader(),
+        body: JSON.stringify(validRequest()),
+      });
+      expect(supported.status).toBe(202);
+      expect(harness.munin.writes).toHaveLength(1);
     },
   );
 

--- a/tests/broker/handlers.test.ts
+++ b/tests/broker/handlers.test.ts
@@ -7,6 +7,7 @@ import { buildBrokerApp, startBroker, type RunningBroker } from "../../src/broke
 import { BrokerTaskStore, ORCH_V1_TAG } from "../../src/broker/task-store.js";
 import { DelegationJournal } from "../../src/broker/journal.js";
 import { IdempotencyIndex } from "../../src/broker/idempotency.js";
+import { brokerExecutorCapabilities } from "../../src/broker/executor-capabilities.js";
 import type { MuninClient } from "../../src/munin-client.js";
 
 const SECRET = "a".repeat(64);
@@ -55,7 +56,12 @@ beforeEach(async () => {
     host: "127.0.0.1",
     port: 0,
     keys: { "claude-code": SECRET },
-    deps: { taskStore, journal, idempotency },
+    deps: {
+      taskStore,
+      journal,
+      idempotency,
+      executorCapabilities: brokerExecutorCapabilities({ openrouterEnabled: true }),
+    },
   });
   const addr = broker.server.address() as AddressInfo;
   harness = {
@@ -88,7 +94,7 @@ function validRequest(overrides: Record<string, unknown> = {}) {
     orchestrator_submitter: "claude-code",
     task_type: "summarize",
     prompt: "Summarize the README.",
-    alias_requested: "tiny",
+    alias_requested: "large-reasoning",
     alias_map_version: 1,
     ...overrides,
   };
@@ -175,15 +181,35 @@ describe("POST /v1/delegate/submit", () => {
     expect(res.status).toBe(400);
   });
 
-  it("rejects harness alias without worktree", async () => {
+  it.each(["tiny", "medium", "pi-large-coder"])(
+    "rejects configured alias %s when no live Broker executor exists",
+    async (alias) => {
+      const res = await fetch(`${harness.url}/v1/delegate/submit`, {
+        method: "POST",
+        headers: authHeader(),
+        body: JSON.stringify(validRequest({ alias_requested: alias })),
+      });
+      expect(res.status).toBe(409);
+      const body = await res.json();
+      expect(body.error).toBe("alias_unavailable");
+      expect(body.reason).toBe("no_executor_implemented");
+      expect(body.retryable).toBe(false);
+      expect(body.executable_aliases).toEqual(["large-reasoning"]);
+      expect(harness.munin.writes).toHaveLength(0);
+    },
+  );
+
+  it("rejects alias-map version skew before creating durable state", async () => {
     const res = await fetch(`${harness.url}/v1/delegate/submit`, {
       method: "POST",
       headers: authHeader(),
-      body: JSON.stringify(validRequest({ alias_requested: "pi-large-coder" })),
+      body: JSON.stringify(validRequest({ alias_map_version: 99 })),
     });
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(409);
     const body = await res.json();
-    expect(body.message).toContain("harness aliases require a worktree");
+    expect(body.error).toBe("policy_rejected");
+    expect(body.alias_map_version).toBe(1);
+    expect(harness.munin.writes).toHaveLength(0);
   });
 
   it("rejects worktree on non-harness alias", async () => {
@@ -192,7 +218,7 @@ describe("POST /v1/delegate/submit", () => {
       headers: authHeader(),
       body: JSON.stringify(
         validRequest({
-          alias_requested: "tiny",
+          alias_requested: "large-reasoning",
           worktree: { repo: "hugin", base_ref: "main" },
         }),
       ),
@@ -393,21 +419,70 @@ describe("GET /v1/delegate/list", () => {
     const body = await res.json();
     expect(body.rows).toHaveLength(1);
     expect(body.total).toBe(1);
-    expect(body.rows[0].envelope.alias_requested).toBe("tiny");
+    expect(body.rows[0].envelope.alias_requested).toBe("large-reasoning");
   });
 });
 
 describe("GET /v1/delegate/models", () => {
-  it("returns alias map + runtime rows + policy_version", async () => {
+  it("advertises only aliases and runtime rows backed by a live executor", async () => {
     const res = await fetch(`${harness.url}/v1/delegate/models`, {
       headers: { authorization: `Bearer ${SECRET}` },
     });
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.alias_map_version).toBe(1);
-    expect(body.aliases.length).toBeGreaterThan(0);
-    expect(body.runtime_rows.length).toBeGreaterThan(0);
+    expect(body.aliases.map((entry: { alias: string }) => entry.alias)).toEqual([
+      "large-reasoning",
+    ]);
+    expect(body.runtime_rows.map((row: { id: string }) => row.id)).toEqual([
+      "openrouter",
+    ]);
     expect(body.policy_version).toBe("zdr-v1+rlv-v1");
+  });
+
+  it("advertises nothing and rejects large-reasoning when its executor is disabled", async () => {
+    const tmpDir = mkdtempSync(path.join(tmpdir(), "broker-disabled-"));
+    const munin = new FakeMunin();
+    const broker = await startBroker({
+      host: "127.0.0.1",
+      port: 0,
+      keys: { "claude-code": SECRET },
+      deps: {
+        taskStore: new BrokerTaskStore(munin as unknown as MuninClient),
+        journal: new DelegationJournal({ path: path.join(tmpDir, "events.jsonl") }),
+        idempotency: new IdempotencyIndex(),
+        executorCapabilities: brokerExecutorCapabilities({
+          openrouterEnabled: false,
+        }),
+      },
+    });
+    try {
+      const addr = broker.server.address() as AddressInfo;
+      const url = `http://127.0.0.1:${addr.port}`;
+      const models = await fetch(`${url}/v1/delegate/models`, {
+        headers: { authorization: `Bearer ${SECRET}` },
+      });
+      const modelBody = await models.json();
+      expect(modelBody.aliases).toEqual([]);
+      expect(modelBody.runtime_rows).toEqual([]);
+
+      const submit = await fetch(`${url}/v1/delegate/submit`, {
+        method: "POST",
+        headers: authHeader(),
+        body: JSON.stringify(validRequest()),
+      });
+      expect(submit.status).toBe(503);
+      expect(await submit.json()).toMatchObject({
+        error: "alias_unavailable",
+        reason: "executor_disabled",
+        retryable: true,
+        executable_aliases: [],
+      });
+      expect(munin.writes).toHaveLength(0);
+    } finally {
+      await broker.close();
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });
 
@@ -423,6 +498,9 @@ describe("buildBrokerApp (in-process)", () => {
           path: path.join(harness.tmpDir, "ignored.jsonl"),
         }),
         idempotency: new IdempotencyIndex(),
+        executorCapabilities: brokerExecutorCapabilities({
+          openrouterEnabled: true,
+        }),
       },
     });
     expect(app).toBeDefined();

--- a/tests/mcp/tools.test.ts
+++ b/tests/mcp/tools.test.ts
@@ -40,7 +40,7 @@ describe("buildTools — hugin_submit", () => {
     const result = await tools.submit.handler({
       task_type: "summarize",
       prompt: "Summarize this.",
-      alias_requested: "tiny",
+      alias_requested: "large-reasoning",
     });
 
     expect(result.isError).toBeUndefined();
@@ -53,7 +53,7 @@ describe("buildTools — hugin_submit", () => {
       parent_task_id: undefined,
       task_type: "summarize",
       prompt: "Summarize this.",
-      alias_requested: "tiny",
+      alias_requested: "large-reasoning",
       alias_map_version: ALIAS_MAP_VERSION,
       worktree: undefined,
       sensitivity: undefined,
@@ -81,7 +81,7 @@ describe("buildTools — hugin_submit", () => {
     await tools.submit.handler({
       task_type: "summarize",
       prompt: "p",
-      alias_requested: "tiny",
+      alias_requested: "large-reasoning",
     });
 
     expect(submit.mock.calls[0]![0]).toMatchObject({ alias_map_version: 7 });
@@ -100,7 +100,7 @@ describe("buildTools — hugin_submit", () => {
     await tools.submit.handler({
       task_type: "summarize",
       prompt: "p",
-      alias_requested: "tiny",
+      alias_requested: "large-reasoning",
     });
 
     expect(submit.mock.calls[0]![0]).toMatchObject({
@@ -123,7 +123,7 @@ describe("buildTools — hugin_submit", () => {
     const result = await tools.submit.handler({
       task_type: "summarize",
       prompt: "p",
-      alias_requested: "tiny",
+      alias_requested: "large-reasoning",
     });
 
     expect(result.isError).toBe(true);
@@ -151,7 +151,7 @@ describe("buildTools — hugin_submit", () => {
     const result = await tools.submit.handler({
       task_type: "summarize",
       prompt: "p",
-      alias_requested: "tiny",
+      alias_requested: "large-reasoning",
     });
 
     expect(parseResult(result)).toMatchObject({
@@ -172,7 +172,7 @@ describe("buildTools — hugin_submit", () => {
     await tools.submit.handler({
       task_type: "summarize",
       prompt: "p",
-      alias_requested: "tiny",
+      alias_requested: "large-reasoning",
       idempotency_key: "22222222-2222-4222-8222-222222222222",
     });
 
@@ -181,8 +181,8 @@ describe("buildTools — hugin_submit", () => {
     });
   });
 
-  it("forwards worktree spec for pi-large-coder harness aliases", async () => {
-    const submit = vi.fn(async () => ({ task_id: "t3" }));
+  it("does not advertise or submit aliases without a live Broker executor", async () => {
+    const submit = vi.fn(async () => ({ task_id: "should-not-call" }));
     const broker = fakeBroker({ submit });
     const tools = buildTools({
       broker,
@@ -198,15 +198,35 @@ describe("buildTools — hugin_submit", () => {
       worktree: { repo: "hugin", base_ref: "main" },
       sensitivity: "internal",
       timeout_ms: 600_000,
+    } as unknown as Parameters<typeof tools.submit.handler>[0]);
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result)).toMatchObject({
+      error: { kind: "input_validation" },
+    });
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it("fails closed when Broker discovery found zero executable aliases", async () => {
+    const submit = vi.fn(async () => ({ task_id: "should-not-call" }));
+    const tools = buildTools({
+      broker: fakeBroker({ submit }),
+      sessionId: "sess",
+      submitter: "claude-code",
+      executableAliases: [],
     });
 
-    expect(result.isError).toBeUndefined();
-    expect(submit.mock.calls[0]![0]).toMatchObject({
-      alias_requested: "pi-large-coder",
-      worktree: { repo: "hugin", base_ref: "main" },
-      sensitivity: "internal",
-      timeout_ms: 600_000,
+    const result = await tools.submit.handler({
+      task_type: "summarize",
+      prompt: "p",
+      alias_requested: "large-reasoning",
     });
+
+    expect(result.isError).toBe(true);
+    expect(parseResult(result)).toMatchObject({
+      error: { kind: "input_validation" },
+    });
+    expect(submit).not.toHaveBeenCalled();
   });
 
   it("returns an isError result with input_validation kind when input is invalid", async () => {
@@ -221,7 +241,7 @@ describe("buildTools — hugin_submit", () => {
     const result = await tools.submit.handler({
       task_type: "summarize",
       prompt: "",
-      alias_requested: "tiny",
+      alias_requested: "large-reasoning",
     } as unknown as Parameters<typeof tools.submit.handler>[0]);
 
     expect(result.isError).toBe(true);
@@ -245,7 +265,7 @@ describe("buildTools — hugin_submit", () => {
     const result = await tools.submit.handler({
       task_type: "summarize",
       prompt: "p",
-      alias_requested: "tiny",
+      alias_requested: "large-reasoning",
     });
 
     expect(result.isError).toBe(true);
@@ -272,7 +292,7 @@ describe("buildTools — hugin_submit", () => {
     const result = await tools.submit.handler({
       task_type: "summarize",
       prompt: "p",
-      alias_requested: "tiny",
+      alias_requested: "large-reasoning",
     });
 
     expect(result.isError).toBe(true);


### PR DESCRIPTION
## What changed

- derives one live Broker executor-capability contract from the same OpenRouter configuration that starts the worker
- rejects unimplemented or disabled aliases before idempotency reservation, Munin writes, or journal events
- makes `/v1/delegate/models` return only enabled aliases and their backing runtime rows
- makes hugin-mcp build its submit alias schema from live discovery and disable submission when discovery fails or returns no executor
- rejects alias-map version skew explicitly while retaining all four aliases for historical envelope/journal parsing
- updates the Broker contract and both agent instruction files

## Why

The Broker advertised and accepted four aliases even though only OpenRouter one-shot tasks had a worker. Three aliases could remain pending forever, and `large-reasoning` could do the same when `OPENROUTER_API_KEY` was absent. This made accepted work look runnable and allowed authenticated queue exhaustion.

## Validation

- `npm test` — 91 files, 1518 tests green
- `npm run build`
- `git diff --check`

Closes #166