### PR TITLE
Reserve dedicated Hugin Broker tailnet port

### DIFF
--- a/scripts/enable-broker.sh
+++ b/scripts/enable-broker.sh
@@ -23,9 +23,10 @@ if [ -z "$PI_HOST" ]; then
 fi
 REMOTE="magnus@$PI_HOST"
 REMOTE_ENV="/home/magnus/repos/hugin/.env"
-# Heimdall already owns 3033 on the Pi's tailnet address. Keep Hugin on a
-# dedicated production port; the generic Broker default remains 3033.
-BROKER_PORT="3034"
+# Heimdall owns 3033 and Ratatoskr owns 3034 on the Pi's tailnet address.
+# Keep Hugin on a dedicated production port; the generic Broker default
+# remains 3033 for other installations.
+BROKER_PORT="3035"
 
 DIST_PATH="/Users/magnus/repos/hugin/dist/mcp-server.js"
 if [ ! -f "$DIST_PATH" ]; then


### PR DESCRIPTION
## Summary
- reserve tailnet port 3035 for Hugin Broker
- document the verified production allocation: Heimdall 3033, Ratatoskr 3034, Hugin 3035

## Evidence
Pi socket inventory confirms 100.97.117.37:3035 is free while 3033 and 3034 are owned by healthy sibling services.

## Review and validation
- native Codex review: no findings
- bash -n scripts/enable-broker.sh
- git diff --check