### PR TITLE
Preserve Broker identity across durable lifecycle

### DIFF
--- a/src/broker/handlers.ts
+++ b/src/broker/handlers.ts
@@ -74,11 +74,15 @@ function requireOwnedBrokerTask(
   res: Response,
   status: { content: string; tags: string[] },
 ): boolean {
-  if (!status.tags.includes("broker:mcp-v2") && !status.tags.includes("orch-v1")) {
+  const canonical = parseCanonicalEnvelope(status.content);
+  const historicalTagged = status.tags.includes("orch-v1");
+  if (!canonical.ok && !historicalTagged) {
     res.status(404).json({ error: "policy_rejected", message: "task is not a Broker task" });
     return false;
   }
-  const owner = storedBrokerPrincipal(status.content);
+  const owner = canonical.ok
+    ? canonical.envelope.broker_principal
+    : storedBrokerPrincipal(status.content);
   if (!owner || owner !== req.brokerPrincipal) {
     res.status(403).json({
       error: "policy_rejected",

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,7 @@ import {
 import {
   buildAwaitingApprovalTags,
   buildTerminalStatusTags,
+  getPersistentStatusTags,
 } from "./task-status-tags.js";
 import {
   buildStructuredTaskResult,
@@ -1887,23 +1888,9 @@ function buildClaimTags(
   baseTags: string[],
   lifecycle: string,
 ): string[] {
-  const runtimeTag = baseTags.find((t) => t.startsWith("runtime:"));
-  const typeTags = baseTags.filter((t) => t.startsWith("type:"));
-  const authorityTags = baseTags.filter((t) => t.startsWith("authority:"));
-  const sensitivityTags = baseTags.filter((t) => t.startsWith("sensitivity:"));
-  const routingTags = baseTags.filter((t) => t.startsWith("routing:"));
-  // `delivery:*` must survive lease renewal so the nonterminal
-  // `running + delivery:pending` checkpoint is not silently dropped when the
-  // lease renews mid-delivery (issue #68, debate R2 §A).
-  const deliveryTags = baseTags.filter((t) => t.startsWith("delivery:"));
   return [
     lifecycle,
-    ...(runtimeTag ? [runtimeTag] : []),
-    ...typeTags,
-    ...authorityTags,
-    ...sensitivityTags,
-    ...routingTags,
-    ...deliveryTags,
+    ...getPersistentStatusTags(baseTags),
     `claimed_by:${workerId}`,
     `lease_expires:${leaseExpiry()}`,
   ];

--- a/src/task-status-tags.ts
+++ b/src/task-status-tags.ts
@@ -5,6 +5,14 @@ const TYPE_PREFIX = "type:";
 const AUTHORITY_PREFIX = "authority:";
 const SENSITIVITY_PREFIX = "sensitivity:";
 const ROUTING_PREFIX = "routing:";
+// Durable MCP Broker identity/query tags must survive claim, renewal and the
+// terminal flip. hugin_await/list/rate use them to keep the canonical task
+// visible and principal-scoped after execution.
+const BROKER_PREFIX = "broker:";
+const ALIAS_PREFIX = "alias:";
+const TASK_TYPE_PREFIX = "task-type:";
+const RUNTIME_ROW_PREFIX = "runtime-row:";
+const IDEMPOTENCY_PREFIX = "idempotency:";
 // Runtime-owned artefact delivery (issue #68). `delivery:*` must survive lease
 // renewal AND the terminal status flip: the nonterminal `delivery:pending`
 // checkpoint and the terminal `delivery:verified`/`delivery:failed` markers are
@@ -28,7 +36,10 @@ function getRuntimeTag(tags: string[], runtimeFallback?: string): string | undef
   return tags.find((tag) => tag.startsWith(RUNTIME_PREFIX)) || runtimeFallback;
 }
 
-function getPersistentTags(tags: string[], runtimeFallback?: string): string[] {
+export function getPersistentStatusTags(
+  tags: string[],
+  runtimeFallback?: string,
+): string[] {
   const runtimeTag = getRuntimeTag(tags, runtimeFallback);
   const typeTags = tags.filter((tag) => tag.startsWith(TYPE_PREFIX));
   const policyTags = tags.filter((tag) => tag.startsWith(ON_DEP_FAILURE_PREFIX));
@@ -36,6 +47,11 @@ function getPersistentTags(tags: string[], runtimeFallback?: string): string[] {
   const sensitivityTags = tags.filter((tag) => tag.startsWith(SENSITIVITY_PREFIX));
   const routingTags = tags.filter((tag) => tag.startsWith(ROUTING_PREFIX));
   const deliveryTags = tags.filter((tag) => tag.startsWith(DELIVERY_PREFIX));
+  const brokerTags = tags.filter((tag) => tag.startsWith(BROKER_PREFIX));
+  const aliasTags = tags.filter((tag) => tag.startsWith(ALIAS_PREFIX));
+  const taskTypeTags = tags.filter((tag) => tag.startsWith(TASK_TYPE_PREFIX));
+  const runtimeRowTags = tags.filter((tag) => tag.startsWith(RUNTIME_ROW_PREFIX));
+  const idempotencyTags = tags.filter((tag) => tag.startsWith(IDEMPOTENCY_PREFIX));
 
   return dedupeTags([
     ...(runtimeTag ? [runtimeTag] : []),
@@ -45,6 +61,11 @@ function getPersistentTags(tags: string[], runtimeFallback?: string): string[] {
     ...sensitivityTags,
     ...routingTags,
     ...deliveryTags,
+    ...brokerTags,
+    ...aliasTags,
+    ...taskTypeTags,
+    ...runtimeRowTags,
+    ...idempotencyTags,
   ]);
 }
 
@@ -53,14 +74,14 @@ export function buildTerminalStatusTags(
   tags: string[],
   runtimeFallback?: string
 ): string[] {
-  return [status, ...getPersistentTags(tags, runtimeFallback)];
+  return [status, ...getPersistentStatusTags(tags, runtimeFallback)];
 }
 
 export function buildAwaitingApprovalTags(
   tags: string[],
   runtimeFallback?: string
 ): string[] {
-  return ["awaiting-approval", ...getPersistentTags(tags, runtimeFallback)];
+  return ["awaiting-approval", ...getPersistentStatusTags(tags, runtimeFallback)];
 }
 
 export function buildPipelineParentSuccessTags(tags: string[]): string[] {

--- a/tests/broker/handlers.test.ts
+++ b/tests/broker/handlers.test.ts
@@ -460,6 +460,31 @@ describe("POST /v1/delegate/await", () => {
     expect(body.result.task_id).toBe("t1");
   });
 
+  it("recovers ownership from a valid canonical envelope if old terminal tags lost the marker", async () => {
+    const submit = await fetch(`${harness.url}/v1/delegate/submit`, {
+      method: "POST", headers: authHeader(), body: JSON.stringify(validRequest()),
+    });
+    const { task_id } = await submit.json();
+    const statusKey = `tasks/${task_id}/status`;
+    const stored = harness.munin.reads[statusKey] as { content: string };
+    harness.munin.reads[statusKey] = {
+      ...stored,
+      tags: ["completed", "runtime:homeserver"],
+      updated_at: "2026-07-11T15:34:31Z",
+    };
+    harness.munin.reads[`tasks/${task_id}/result-structured`] = {
+      content: JSON.stringify({ task_id, bodyText: "ok" }),
+    };
+    const res = await fetch(`${harness.url}/v1/delegate/await`, {
+      method: "POST", headers: authHeader(), body: JSON.stringify({ task_id }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      status: "completed",
+      result: { task_id, bodyText: "ok" },
+    });
+  });
+
   it("returns failed with error result", async () => {
     harness.munin.reads["tasks/t1/status"] = {
       content: historicalBrokerStatus(),
@@ -481,16 +506,22 @@ describe("POST /v1/delegate/await", () => {
   });
 
   it("returns a cancelled canonical task as terminal instead of running", async () => {
-    harness.munin.reads["tasks/cancelled/status"] = {
-      content: historicalBrokerStatus(), tags: ["cancelled", "broker:mcp-v2"],
-      created_at: "ts", updated_at: "ts",
+    const submit = await fetch(`${harness.url}/v1/delegate/submit`, {
+      method: "POST", headers: authHeader(), body: JSON.stringify(validRequest()),
+    });
+    const { task_id } = await submit.json();
+    const statusKey = `tasks/${task_id}/status`;
+    const stored = harness.munin.reads[statusKey] as { content: string };
+    harness.munin.reads[statusKey] = {
+      ...stored, tags: ["cancelled", "runtime:homeserver", "broker:mcp-v2"],
+      updated_at: "ts",
     };
-    harness.munin.reads["tasks/cancelled/result-structured"] = {
+    harness.munin.reads[`tasks/${task_id}/result-structured`] = {
       content: JSON.stringify({ outcome: "cancelled", bodyText: "operator cancelled" }),
       tags: ["result-structured"], created_at: "ts", updated_at: "ts",
     };
     const res = await fetch(`${harness.url}/v1/delegate/await`, {
-      method: "POST", headers: authHeader(), body: JSON.stringify({ task_id: "cancelled" }),
+      method: "POST", headers: authHeader(), body: JSON.stringify({ task_id }),
     });
     expect(await res.json()).toMatchObject({
       status: "failed",

--- a/tests/task-status-tags.test.ts
+++ b/tests/task-status-tags.test.ts
@@ -4,9 +4,34 @@ import {
   buildPipelineParentCancelledTags,
   buildPipelineParentSuccessTags,
   buildTerminalStatusTags,
+  getPersistentStatusTags,
 } from "../src/task-status-tags.js";
 
 describe("task status tag helpers", () => {
+  it("preserves durable MCP Broker identity and query tags", () => {
+    const input = [
+      "running",
+      "runtime:homeserver",
+      "broker:mcp-v2",
+      "alias:m5",
+      "task-type:extract",
+      "runtime-row:homeserver-m5",
+      "idempotency:abc123",
+      "claimed_by:hugin-pi",
+    ];
+    const persistent = [
+      "completed",
+      "runtime:homeserver",
+      "broker:mcp-v2",
+      "alias:m5",
+      "task-type:extract",
+      "runtime-row:homeserver-m5",
+      "idempotency:abc123",
+    ];
+    expect(getPersistentStatusTags(input)).toEqual(persistent.slice(1));
+    expect(buildTerminalStatusTags("completed", input)).toEqual(persistent);
+  });
+
   it("preserves policy tags on terminal child tasks", () => {
     expect(
       buildTerminalStatusTags("completed", [


### PR DESCRIPTION
## Summary
- preserve broker/alias/task-type/runtime-row/idempotency tags through claim, lease renewal, and terminal finalization
- centralize persistent lifecycle-tag selection so running and terminal states cannot drift
- let await/rate recover principal ownership from a valid canonical envelope for tasks completed before this fix

## Live evidence
The #167 restart smoke completed successfully through M5 with verified output HUGIN167_LIVE_OK and ledgerId 1cf65112-da3d-4ad2-9e6e-2855d5a2ad63, but hugin_await returned 404 because terminal normalization had dropped broker:mcp-v2. This fixes that exact observed seam.

## Review and validation
- native Codex review: fixed claim-time tag loss in addition to terminal loss
- npm run build
- focused: 55 tests passed
- full: 91 files / 1538 tests passed
- git diff --check