### PR TITLE
Preserve M5 execution provenance end to end (#163)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,8 @@ maps to the `build` agent with `edit`/`bash` allowed.
 - `result` — human-readable markdown with exit code, timestamps, duration, and response body
 - `result-structured` — machine-readable JSON (Zod-validated) with schema version, lifecycle metadata, runtime metadata (requested vs effective model/host), sensitivity audit, honest submission provenance (`claimedSubmitter`, nullable `verifiedSubmitter`, signing policy/status/keyId), and structured body. Prefer this for programmatic consumption.
 
+**M5 execution provenance (issue #163):** every M5 `/delegate` call — whether it arrives via the canonical #167 Broker leaf (`runtime:homeserver`) or as an orchestrator fan-out worker leaf — records the same canonical trace: `ledgerId` (the join key to M5's authoritative evidence row), effective `nodeId`/`modelId`, `taskType`, verification `outcome`/`score`, `verifier` identity + `verifierNotes`, `delegated`/`escalated` + `decisionReason`, route-policy `policyMode`/`policyAction`/`policyReason`, `priceCatalogVersion`, and `costTraceId`. It surfaces at `runtimeMetadata.delegation` for the direct path and per-leaf at `orchestratorOutcomes[].delegation` for fan-out. `src/m5-provenance.ts` is the **only** sanctioned producer: the gateway body is untrusted input, so it validates enums/bounds and DROPS anything out of contract rather than throwing — a malformed gateway value must never sink the `result-structured` write of an already-paid run (`buildStructuredTaskResult` calls `.parse()`). This is a **trace, not a verdict**: M5 remains the sole capability-evidence authority and Hugin never duplicates its judgements into a Hugin-owned capability store. Retrieving the row *by* `ledgerId` currently needs an id-addressable read on the gateway — filed as gille-inference#227.
+
 ## Project structure
 
 ```
@@ -168,6 +170,7 @@ hugin/
 │   ├── task-graph.ts             # Task dependency graph for pipelines
 │   ├── result-format.ts          # Result formatting utilities
 │   ├── artifact-delivery.ts      # Runtime-owned artefact delivery (#68): manifest parse/validate, target allowlist, rsync→sha256→mv deliver+verify
+│   ├── m5-provenance.ts         # M5 execution provenance (#163): the ONE sanitizer for /delegate responses (untrusted input — validates enums/bounds, drops out-of-contract values, never throws). Used by BOTH M5 call sites: homeserver-executor.ts and orchestrator/worker-executor.ts
 │   ├── model-pricing.ts          # Vendor-neutral $/M-token table for cost-aware routing and result metadata
 │   ├── orchestrator/             # Native fanout engine (Runtime: orchestrator)
 │   │   ├── engine.ts             # Top-level fanout loop: plan → fan-out workers → optional verify → synthesize

--- a/src/homeserver-executor.ts
+++ b/src/homeserver-executor.ts
@@ -21,6 +21,8 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { extractM5Provenance, sanitizeProviderTokenCount } from "./m5-provenance.js";
+import type { M5DelegationProvenance } from "./m5-provenance.js";
 import { resolveGatewayRootUrl } from "./orchestrator/provider-config.js";
 
 // --- Types ---
@@ -98,6 +100,14 @@ export interface HomeserverExecutorResult {
   modelId: string | null;
   verifierNotes: string | null;
   nodeId: string | null;
+  /**
+   * Full sanitized M5 execution provenance (issue #163). Superset of the flat
+   * fields above, which are retained for existing consumers and are derived
+   * from this. Null on the chat path. Includes the gateway's route-policy
+   * mode/action/reason and price-catalog version, which the flat fields never
+   * carried.
+   */
+  provenance: M5DelegationProvenance | null;
 }
 
 export interface HomeserverExecutorOptions {
@@ -238,6 +248,7 @@ export async function executeHomeserverTask(
     modelId: null,
     verifierNotes: null,
     nodeId: null,
+    provenance: null,
   };
 
   const finish = async (): Promise<HomeserverExecutorResult> => {
@@ -332,44 +343,51 @@ export async function executeHomeserverTask(
     }
 
     if (task.path === "delegate") {
-      // Non-streaming JSON: DelegationOutcome.
-      const outcome = (await res.json()) as {
-        delegated?: boolean;
-        escalate?: boolean;
-        outcome?: string;
-        score?: number | null;
-        output?: string;
-        decisionReason?: string;
-        ledgerId?: string;
+      // Non-streaming JSON: DelegationOutcome. The body is untrusted input
+      // (issue #163) — extractM5Provenance validates enums/bounds and drops
+      // anything out of contract, so a buggy or hostile gateway value cannot
+      // throw inside the downstream buildStructuredTaskResult .parse() and lose
+      // the result of an already-paid run.
+      const raw: unknown = await res.json();
+      const outcome = raw as {
+        output?: unknown;
+        frontierOutput?: unknown;
         metrics?: { promptTokens?: number; completionTokens?: number; latencyMs?: number };
-        frontierOutput?: string;
-        taskType?: string;
-        modelId?: string;
-        verifierNotes?: string;
-        nodeId?: string;
       };
-      const text = outcome.output ?? outcome.frontierOutput ?? "";
+      const provenance = extractM5Provenance(raw);
+
+      const text =
+        (typeof outcome.output === "string" ? outcome.output : undefined) ??
+        (typeof outcome.frontierOutput === "string" ? outcome.frontierOutput : undefined) ??
+        "";
       appendOutput(text);
       result.resultText = text.trim() || null;
-      result.delegated = outcome.delegated ?? null;
-      result.escalated = outcome.escalate ?? null;
-      result.outcome = outcome.outcome ?? null;
-      result.score = outcome.score ?? null;
-      result.decisionReason = outcome.decisionReason ?? null;
-      result.ledgerId = outcome.ledgerId ?? null;
-      result.taskType = outcome.taskType ?? null;
-      result.modelId = outcome.modelId ?? null;
-      result.verifierNotes = outcome.verifierNotes ?? null;
-      result.nodeId = outcome.nodeId ?? null;
-      result.promptTokens = outcome.metrics?.promptTokens ?? null;
-      result.completionTokens = outcome.metrics?.completionTokens ?? null;
+
+      result.provenance = provenance;
+      // Flat fields stay the public surface for existing consumers; they are now
+      // projections of the sanitized provenance rather than raw gateway values.
+      result.delegated = provenance.delegated ?? null;
+      result.escalated = provenance.escalated ?? null;
+      result.outcome = provenance.outcome ?? null;
+      result.score = provenance.score ?? null;
+      result.decisionReason = provenance.decisionReason ?? null;
+      result.ledgerId = provenance.ledgerId ?? null;
+      result.taskType = provenance.taskType ?? null;
+      result.modelId = provenance.modelId ?? null;
+      result.verifierNotes = provenance.verifierNotes ?? null;
+      result.nodeId = provenance.nodeId ?? null;
+
+      result.promptTokens = sanitizeProviderTokenCount(outcome.metrics?.promptTokens);
+      result.completionTokens = sanitizeProviderTokenCount(outcome.metrics?.completionTokens);
       if (result.promptTokens !== null || result.completionTokens !== null) {
         result.totalTokens = (result.promptTokens ?? 0) + (result.completionTokens ?? 0);
       }
-      if (typeof outcome.metrics?.latencyMs === "number") result.inferenceMs = outcome.metrics.latencyMs;
+      if (typeof outcome.metrics?.latencyMs === "number" && Number.isFinite(outcome.metrics.latencyMs)) {
+        result.inferenceMs = outcome.metrics.latencyMs;
+      }
       // A well-formed 200 DelegationOutcome can still report failure; don't mask fail/error
       // as a successful Hugin execution (that would suppress retry/escalation downstream).
-      result.exitCode = outcome.outcome === "fail" || outcome.outcome === "error" ? 1 : 0;
+      result.exitCode = provenance.outcome === "fail" || provenance.outcome === "error" ? 1 : 0;
       return finish();
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,7 @@ import {
   buildTerminalStatusTags,
   getPersistentStatusTags,
 } from "./task-status-tags.js";
+import { sanitizeProviderTokenCount } from "./m5-provenance.js";
 import {
   buildStructuredTaskResult,
   type DispatcherRuntime,
@@ -5059,16 +5060,13 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
             // Savings tracker (PR3, S4): thread the per-call token counts
             // already present on WorkerResult through into the structured
             // result. Coerced to the schema's nonnegative-integer contract —
-            // a non-integer provider value must degrade to null, not fail
-            // the whole result-structured write after a successful run.
-            inputTokens:
-              Number.isInteger(o.result.inputTokens) && (o.result.inputTokens as number) >= 0
-                ? o.result.inputTokens
-                : null,
-            outputTokens:
-              Number.isInteger(o.result.outputTokens) && (o.result.outputTokens as number) >= 0
-                ? o.result.outputTokens
-                : null,
+            // an out-of-contract provider value must degrade to null, not fail
+            // the whole result-structured write after a successful run. Uses
+            // the one shared sanitizer (#163) rather than repeating the
+            // predicate: the local copy checked Number.isInteger, which lets
+            // 2**53 through into a zod `.int()` that rejects it.
+            inputTokens: sanitizeProviderTokenCount(o.result.inputTokens),
+            outputTokens: sanitizeProviderTokenCount(o.result.outputTokens),
             ...(o.result.selectedNode ? { selectedNode: o.result.selectedNode } : {}),
             ...(o.result.effectiveNode ? { effectiveNode: o.result.effectiveNode } : {}),
             ...(o.result.fallbackTriggered !== undefined

--- a/src/index.ts
+++ b/src/index.ts
@@ -4982,17 +4982,15 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         ? {
             effectiveModel: homeserverResult.modelId ?? undefined,
             effectiveHost: homeserverResult.nodeId ?? "m5",
+            // Issue #163: the sanitized provenance is the whole delegation
+            // trace (node/model/verifier + route policy + price-catalog
+            // version). Spread it wholesale rather than re-listing fields, so a
+            // field added to the shared M5 shape can never be silently dropped
+            // here again. `taskType` keeps its historical fallback to the
+            // requested type when the gateway echoes none.
             delegation: {
+              ...(homeserverResult.provenance ?? {}),
               taskType: homeserverResult.taskType ?? task.homeserverTaskType,
-              modelId: homeserverResult.modelId ?? undefined,
-              nodeId: homeserverResult.nodeId ?? undefined,
-              outcome: homeserverResult.outcome ?? undefined,
-              score: homeserverResult.score ?? undefined,
-              decisionReason: homeserverResult.decisionReason ?? undefined,
-              ledgerId: homeserverResult.ledgerId ?? undefined,
-              verifierNotes: homeserverResult.verifierNotes ?? undefined,
-              delegated: homeserverResult.delegated ?? undefined,
-              escalated: homeserverResult.escalated ?? undefined,
             },
           }
         : isOllama
@@ -5081,6 +5079,12 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
             // exact error (e.g. `HTTP 503 server_busy retryAfterS=5`) so a
             // failed fanout leaf is diagnosable from the structured result.
             ...(o.result.error ? { error: o.result.error } : {}),
+            // M5 execution provenance (issue #163): the node/model/verifier that
+            // actually produced this leaf, plus the ledgerId that joins it to
+            // M5's authoritative evidence row. Present only for `homeserver`
+            // leaves that went through /delegate; already sanitized against the
+            // untrusted gateway response by src/m5-provenance.ts.
+            ...(o.result.delegation ? { delegation: o.result.delegation } : {}),
           }))
         : undefined;
 

--- a/src/m5-provenance.ts
+++ b/src/m5-provenance.ts
@@ -1,0 +1,180 @@
+/**
+ * Shared M5 `/delegate` execution provenance (issue #163).
+ *
+ * Hugin makes M5 `/delegate` calls from two independent places — the direct
+ * homeserver executor (`src/homeserver-executor.ts`, which backs the canonical
+ * #167 MCP-Broker leaf) and the orchestrator's worker fan-out
+ * (`src/orchestrator/worker-executor.ts`). Both used to parse the gateway
+ * response ad hoc, with different and incomplete field sets, and the
+ * orchestrator path then dropped what it did parse before the durable result.
+ *
+ * This module is the single place that turns a raw gateway response into the
+ * provenance Hugin stores. Two invariants:
+ *
+ *  1. **The gateway response is untrusted input.** Everything is validated for
+ *     type, enum membership, and bounds; anything out of contract is DROPPED,
+ *     never coerced and never thrown. A malformed field must not be able to
+ *     sink the `result-structured` write of an otherwise successful, paid run
+ *     (`buildStructuredTaskResult` calls `.parse()`, which throws) or bloat the
+ *     Munin doc.
+ *  2. **Hugin never re-judges capability.** These fields are copied for
+ *     traceability only. M5 remains the sole capability-evidence authority;
+ *     `ledgerId` is the join key back to its authoritative row.
+ */
+
+/** Outcome values the M5 gateway is contracted to emit. */
+export const M5_OUTCOMES = ["pass", "partial", "fail", "error", "unverified"] as const;
+export type M5Outcome = (typeof M5_OUTCOMES)[number];
+
+/** Bounds for free-text gateway strings copied into the durable result. */
+const MAX_ID_CHARS = 200;
+const MAX_REASON_CHARS = 1000;
+
+export interface M5DelegationProvenance {
+  /** Join key to the authoritative M5 ledger row. */
+  ledgerId?: string;
+  /** Node that actually executed the leaf (e.g. "m5", "orin"). */
+  nodeId?: string;
+  /** Model that actually executed the leaf — may differ from the one requested. */
+  modelId?: string;
+  /** Ledger bucket the gateway filed this call under. */
+  taskType?: string;
+  /** M5's verification outcome. Distinct from Hugin's own `ok`. */
+  outcome?: M5Outcome;
+  /** M5's verification score. Absent (not 0) when the gateway sends null. */
+  score?: number;
+  /** Why the gateway routed/delegated/escalated the way it did. */
+  decisionReason?: string;
+  /** Identity of the deterministic verifier that judged this call, if any. */
+  verifier?: string;
+  /** Free-text notes from that verifier. */
+  verifierNotes?: string;
+  /** Whether the gateway delegated to a local model. */
+  delegated?: boolean;
+  /** Whether the gateway escalated to a frontier model. */
+  escalated?: boolean;
+  /** Whether the gateway retried to satisfy a response-format contract. */
+  formatRetried?: boolean;
+  /** Route-policy version: the delegate policy's mode (e.g. "shadow", "enforce"). */
+  policyMode?: string;
+  /** Route-policy version: the action the policy actually took. */
+  policyAction?: string;
+  /** Route-policy version: why the policy took that action. */
+  policyReason?: string;
+  /** Price-catalog version the gateway costed this call against. */
+  priceCatalogVersion?: string;
+  /** The gateway's cost-trace row id, for joins that need the cost view. */
+  costTraceId?: string;
+}
+
+/**
+ * Provider-reported token counts are only trusted as nonnegative integers;
+ * anything else (fractional estimates, negatives, NaN, non-numbers) → null.
+ * Shared by both M5 call sites so the same contract holds on each.
+ */
+export function sanitizeProviderTokenCount(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
+}
+
+function str(v: unknown, max: number): string | undefined {
+  if (typeof v !== "string") return undefined;
+  const trimmed = v.trim();
+  if (trimmed.length === 0) return undefined; // never emit a schema-invalid min(1) value
+  return trimmed.slice(0, max);
+}
+
+function bool(v: unknown): boolean | undefined {
+  return typeof v === "boolean" ? v : undefined;
+}
+
+function num(v: unknown): number | undefined {
+  return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+}
+
+function obj(v: unknown): Record<string, unknown> | undefined {
+  return v !== null && typeof v === "object" && !Array.isArray(v)
+    ? (v as Record<string, unknown>)
+    : undefined;
+}
+
+function outcome(v: unknown): M5Outcome | undefined {
+  return typeof v === "string" && (M5_OUTCOMES as readonly string[]).includes(v)
+    ? (v as M5Outcome)
+    : undefined;
+}
+
+/**
+ * Extract M5 execution provenance from a raw `/delegate` response.
+ *
+ * Total and non-throwing: junk in yields `{}`, never an exception. Every key is
+ * omitted rather than set to null/undefined so the result spreads cleanly into
+ * an exactOptionalPropertyTypes-style object literal.
+ */
+export function extractM5Provenance(raw: unknown): M5DelegationProvenance {
+  const r = obj(raw);
+  if (!r) return {};
+
+  const policy = obj(r["delegatePolicy"]) ?? {};
+  const evidence = obj(policy["evidence"]) ?? {};
+  const costTrace = obj(r["costTrace"]) ?? {};
+
+  // `ledgerId` is the join key; the cost trace echoes it as `delegationId`.
+  // Prefer the top-level field and fall back, so a response that only carries
+  // the cost view is still joinable.
+  const ledgerId =
+    str(r["ledgerId"], MAX_ID_CHARS) ?? str(costTrace["delegationId"], MAX_ID_CHARS);
+
+  const p: M5DelegationProvenance = {};
+  if (ledgerId !== undefined) p.ledgerId = ledgerId;
+
+  const nodeId = str(r["nodeId"], MAX_ID_CHARS);
+  if (nodeId !== undefined) p.nodeId = nodeId;
+
+  const modelId = str(r["modelId"], MAX_ID_CHARS);
+  if (modelId !== undefined) p.modelId = modelId;
+
+  const taskType = str(r["taskType"], MAX_ID_CHARS);
+  if (taskType !== undefined) p.taskType = taskType;
+
+  const oc = outcome(r["outcome"]);
+  if (oc !== undefined) p.outcome = oc;
+
+  const score = num(r["score"]);
+  if (score !== undefined) p.score = score;
+
+  const decisionReason = str(r["decisionReason"], MAX_REASON_CHARS);
+  if (decisionReason !== undefined) p.decisionReason = decisionReason;
+
+  const verifier = str(evidence["verifier"], MAX_ID_CHARS);
+  if (verifier !== undefined) p.verifier = verifier;
+
+  const verifierNotes = str(r["verifierNotes"], MAX_REASON_CHARS);
+  if (verifierNotes !== undefined) p.verifierNotes = verifierNotes;
+
+  const delegated = bool(r["delegated"]);
+  if (delegated !== undefined) p.delegated = delegated;
+
+  // The gateway calls it `escalate`; Hugin's durable field is `escalated`.
+  const escalated = bool(r["escalate"]);
+  if (escalated !== undefined) p.escalated = escalated;
+
+  const formatRetried = bool(r["formatRetried"]);
+  if (formatRetried !== undefined) p.formatRetried = formatRetried;
+
+  const policyMode = str(policy["mode"], MAX_ID_CHARS);
+  if (policyMode !== undefined) p.policyMode = policyMode;
+
+  const policyAction = str(policy["action"], MAX_ID_CHARS);
+  if (policyAction !== undefined) p.policyAction = policyAction;
+
+  const policyReason = str(policy["reason"], MAX_REASON_CHARS);
+  if (policyReason !== undefined) p.policyReason = policyReason;
+
+  const priceCatalogVersion = str(costTrace["priceCatalogVersion"], MAX_ID_CHARS);
+  if (priceCatalogVersion !== undefined) p.priceCatalogVersion = priceCatalogVersion;
+
+  const costTraceId = str(costTrace["id"], MAX_ID_CHARS);
+  if (costTraceId !== undefined) p.costTraceId = costTraceId;
+
+  return p;
+}

--- a/src/m5-provenance.ts
+++ b/src/m5-provenance.ts
@@ -68,12 +68,17 @@ export interface M5DelegationProvenance {
 }
 
 /**
- * Provider-reported token counts are only trusted as nonnegative integers;
+ * Provider-reported token counts are only trusted as nonnegative SAFE integers;
  * anything else (fractional estimates, negatives, NaN, non-numbers) → null.
  * Shared by both M5 call sites so the same contract holds on each.
+ *
+ * `Number.isSafeInteger`, not `Number.isInteger`: zod 4's `.int()` rejects
+ * values beyond the safe-integer range, so `2**53` would pass an isInteger
+ * check here and then THROW inside buildStructuredTaskResult's `.parse()` —
+ * losing the result of an already-paid run. Verified against zod 4.3.6.
  */
 export function sanitizeProviderTokenCount(value: unknown): number | null {
-  return typeof value === "number" && Number.isInteger(value) && value >= 0 ? value : null;
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : null;
 }
 
 function str(v: unknown, max: number): string | undefined {
@@ -87,8 +92,13 @@ function bool(v: unknown): boolean | undefined {
   return typeof v === "boolean" ? v : undefined;
 }
 
-function num(v: unknown): number | undefined {
-  return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+/**
+ * M5 verification scores are a 0..1 scale (observed live: 0, 0.2, 0.7, 1, null).
+ * A finite-but-out-of-scale value is out of contract and is DROPPED — retaining
+ * it would turn a buggy gateway value into a wrong-but-plausible trace.
+ */
+function score(v: unknown): number | undefined {
+  return typeof v === "number" && Number.isFinite(v) && v >= 0 && v <= 1 ? v : undefined;
 }
 
 function obj(v: unknown): Record<string, unknown> | undefined {
@@ -139,8 +149,8 @@ export function extractM5Provenance(raw: unknown): M5DelegationProvenance {
   const oc = outcome(r["outcome"]);
   if (oc !== undefined) p.outcome = oc;
 
-  const score = num(r["score"]);
-  if (score !== undefined) p.score = score;
+  const scoreValue = score(r["score"]);
+  if (scoreValue !== undefined) p.score = scoreValue;
 
   const decisionReason = str(r["decisionReason"], MAX_REASON_CHARS);
   if (decisionReason !== undefined) p.decisionReason = decisionReason;

--- a/src/orchestrator/worker-executor.ts
+++ b/src/orchestrator/worker-executor.ts
@@ -731,9 +731,19 @@ export class HomeserverDelegateWorkerExecutor implements WorkerExecutor {
           };
         }
 
+        // Issue #163: preserve the M5 execution trace. Sanitized from the raw
+        // (untrusted) gateway body and extracted BEFORE operational validation,
+        // so a response carrying a usable trace (real ledgerId/node/model) but
+        // one malformed operational field still surfaces the ledger key — that
+        // is precisely the response an operator needs to diagnose, and the call
+        // was paid for either way.
+        const delegation = extractM5Provenance(parsed);
+        const withDelegation = (result: WorkerResult): WorkerResult =>
+          Object.keys(delegation).length > 0 ? { ...result, delegation } : result;
+
         const outcome = extractDelegationOutcome(parsed);
         if (!outcome.ok) {
-          return { kind: "done", result: failResult(outcome.error, model) };
+          return { kind: "done", result: withDelegation(failResult(outcome.error, model)) };
         }
 
         const inputTokens = sanitizeTokenCount(outcome.metrics?.promptTokens);
@@ -746,15 +756,9 @@ export class HomeserverDelegateWorkerExecutor implements WorkerExecutor {
         const outcomeStatus = typeof outcome.outcome === "string" ? outcome.outcome : null;
         const failed = outcomeStatus === "fail" || outcomeStatus === "error";
 
-        // Issue #163: preserve the M5 execution trace. Sanitized from the raw
-        // (untrusted) gateway body, not from the narrow parse type above — a
-        // failed leaf is exactly when an operator most needs the ledger row, so
-        // this is attached on both the ok and failed branches.
-        const delegation = extractM5Provenance(parsed);
-
         return {
           kind: "done",
-          result: {
+          result: withDelegation({
             ok: !failed,
             output,
             provider: req.provider,
@@ -764,8 +768,7 @@ export class HomeserverDelegateWorkerExecutor implements WorkerExecutor {
             costUsd,
             latencyMs: Date.now() - start,
             ...(failed ? { error: `Delegation outcome: ${outcomeStatus}` } : {}),
-            ...(Object.keys(delegation).length > 0 ? { delegation } : {}),
-          },
+          }),
         };
       } finally {
         clearTimeout(timer);

--- a/src/orchestrator/worker-executor.ts
+++ b/src/orchestrator/worker-executor.ts
@@ -19,6 +19,8 @@ import type {
   HomeserverResponseFormat,
   HomeserverVerifierSpec,
 } from "../homeserver-executor.js";
+import { extractM5Provenance, sanitizeProviderTokenCount } from "../m5-provenance.js";
+import type { M5DelegationProvenance } from "../m5-provenance.js";
 import { estimateCostUsd } from "../model-pricing.js";
 import { getRegistryEntryById } from "../runtime-registry.js";
 import {
@@ -245,6 +247,13 @@ export interface WorkerResult {
   fallbackTriggered?: boolean;
   /** Status-derived Orin fallback signal, never request content. */
   fallbackReason?: string;
+  /**
+   * M5 execution provenance for this leaf (issue #163). Set only on the
+   * `/delegate` path; `ledgerId` is the join key back to M5's authoritative
+   * evidence row. Sanitized from the untrusted gateway response by
+   * src/m5-provenance.ts — never trusted verbatim.
+   */
+  delegation?: M5DelegationProvenance;
 }
 
 export interface WorkerExecutor {
@@ -737,6 +746,12 @@ export class HomeserverDelegateWorkerExecutor implements WorkerExecutor {
         const outcomeStatus = typeof outcome.outcome === "string" ? outcome.outcome : null;
         const failed = outcomeStatus === "fail" || outcomeStatus === "error";
 
+        // Issue #163: preserve the M5 execution trace. Sanitized from the raw
+        // (untrusted) gateway body, not from the narrow parse type above — a
+        // failed leaf is exactly when an operator most needs the ledger row, so
+        // this is attached on both the ok and failed branches.
+        const delegation = extractM5Provenance(parsed);
+
         return {
           kind: "done",
           result: {
@@ -749,6 +764,7 @@ export class HomeserverDelegateWorkerExecutor implements WorkerExecutor {
             costUsd,
             latencyMs: Date.now() - start,
             ...(failed ? { error: `Delegation outcome: ${outcomeStatus}` } : {}),
+            ...(Object.keys(delegation).length > 0 ? { delegation } : {}),
           },
         };
       } finally {
@@ -1063,11 +1079,14 @@ function buildPiArgs(
 /**
  * Provider-reported token counts are only trusted as nonnegative integers;
  * anything else (fractional estimates, negatives, NaN, non-numbers) → null.
+ *
+ * Re-exported from src/m5-provenance.ts (issue #163) so the direct homeserver
+ * executor applies the identical contract — a fractional count from either M5
+ * path would otherwise fail the structured result's `.int()` constraint and
+ * poison the savings store.
  */
 function sanitizeTokenCount(value: unknown): number | null {
-  return typeof value === "number" && Number.isInteger(value) && value >= 0
-    ? value
-    : null;
+  return sanitizeProviderTokenCount(value);
 }
 
 function buildHeaders(provider: string, apiKey: string): Record<string, string> {

--- a/src/task-result-schema.ts
+++ b/src/task-result-schema.ts
@@ -94,6 +94,43 @@ export const skillRouteSchema = z.object({
 });
 export type SkillRoute = z.infer<typeof skillRouteSchema>;
 
+// M5 execution provenance (issue #163). ONE canonical shape, shared by both
+// places Hugin delegates to M5: `runtimeMetadata.delegation` (the direct
+// homeserver executor, which backs the canonical #167 MCP-Broker leaf) and
+// `orchestratorOutcomes[].delegation` (each orchestrator fan-out leaf). Before
+// #163 the orchestrator path carried none of this, so a fanout leaf could not
+// be traced to the node/model/verifier that produced it.
+//
+// Every field is optional: a gateway that omits one, or emits one out of
+// contract, must degrade to "absent" rather than fail the result-structured
+// write of an already-successful, paid run. src/m5-provenance.ts is the only
+// sanctioned producer — it validates enums/bounds on the untrusted gateway
+// response so this schema never sees a value it would reject.
+//
+// This is a TRACE, not a verdict: `ledgerId` joins back to M5's authoritative
+// evidence row. Hugin never duplicates M5's capability judgement into a
+// Hugin-owned capability store.
+export const delegationProvenanceSchema = z.object({
+  ledgerId: z.string().min(1).optional(),
+  nodeId: z.string().min(1).optional(),
+  modelId: z.string().min(1).optional(),
+  taskType: z.string().min(1).optional(),
+  outcome: z.string().min(1).optional(),
+  score: z.number().optional(),
+  decisionReason: z.string().min(1).optional(),
+  verifier: z.string().min(1).optional(),
+  verifierNotes: z.string().min(1).optional(),
+  delegated: z.boolean().optional(),
+  escalated: z.boolean().optional(),
+  formatRetried: z.boolean().optional(),
+  policyMode: z.string().min(1).optional(),
+  policyAction: z.string().min(1).optional(),
+  policyReason: z.string().min(1).optional(),
+  priceCatalogVersion: z.string().min(1).optional(),
+  costTraceId: z.string().min(1).optional(),
+});
+export type DelegationProvenance = z.infer<typeof delegationProvenanceSchema>;
+
 export const taskExecutionRuntimeMetadataSchema = z.object({
   requestedModel: z.string().min(1).optional(),
   effectiveModel: z.string().min(1).optional(),
@@ -105,18 +142,7 @@ export const taskExecutionRuntimeMetadataSchema = z.object({
   routingReason: z.string().min(1).optional(),
   eliminatedRuntimes: z.array(routingEliminationSchema).optional(),
   skillRoute: skillRouteSchema.optional(),
-  delegation: z.object({
-    taskType: z.string().min(1).optional(),
-    modelId: z.string().min(1).optional(),
-    nodeId: z.string().min(1).optional(),
-    outcome: z.string().min(1).optional(),
-    score: z.number().optional(),
-    decisionReason: z.string().min(1).optional(),
-    ledgerId: z.string().min(1).optional(),
-    verifierNotes: z.string().min(1).optional(),
-    delegated: z.boolean().optional(),
-    escalated: z.boolean().optional(),
-  }).optional(),
+  delegation: delegationProvenanceSchema.optional(),
 });
 export type TaskExecutionRuntimeMetadata = z.infer<
   typeof taskExecutionRuntimeMetadataSchema
@@ -197,6 +223,11 @@ export const orchestratorOutcomeSchema = z.object({
   // structured result instead of reading as mysterious agent flakiness.
   // Absent for successful workers.
   error: z.string().min(1).optional(),
+  // M5 execution provenance for this leaf (issue #163) — additive + optional,
+  // same non-breaking rationale as the fields above. Present only for workers
+  // that actually went through the M5 `/delegate` lane (provider `homeserver`);
+  // absent for OpenRouter/Berget/pi-harness leaves, which have no M5 ledger row.
+  delegation: delegationProvenanceSchema.optional(),
 });
 export type OrchestratorOutcomeRecord = z.infer<typeof orchestratorOutcomeSchema>;
 

--- a/src/task-result-schema.ts
+++ b/src/task-result-schema.ts
@@ -4,6 +4,7 @@ import {
   pipelineSideEffectIdSchema,
   pipelineSensitivitySchema,
 } from "./pipeline-ir.js";
+import { M5_OUTCOMES } from "./m5-provenance.js";
 import { sensitivitySchema } from "./sensitivity.js";
 import {
   SIGNING_POLICIES,
@@ -115,8 +116,10 @@ export const delegationProvenanceSchema = z.object({
   nodeId: z.string().min(1).optional(),
   modelId: z.string().min(1).optional(),
   taskType: z.string().min(1).optional(),
-  outcome: z.string().min(1).optional(),
-  score: z.number().optional(),
+  // Enum + bounds declared here as well as in the sanitizer, so the contract
+  // cannot silently drift between the two (Codex review of #163).
+  outcome: z.enum(M5_OUTCOMES).optional(),
+  score: z.number().min(0).max(1).optional(),
   decisionReason: z.string().min(1).optional(),
   verifier: z.string().min(1).optional(),
   verifierNotes: z.string().min(1).optional(),

--- a/tests/homeserver-executor.test.ts
+++ b/tests/homeserver-executor.test.ts
@@ -251,6 +251,66 @@ describe("executeHomeserverTask — delegate path", () => {
     expect(body.premiumBaselineModelId).toBe("anthropic/claude-opus-4-5");
   });
 
+  // Issue #163: the direct path already carried the flat delegation fields, but
+  // dropped the gateway's policy/cost-version trace and never validated the
+  // response — so a single out-of-contract value could throw inside
+  // buildStructuredTaskResult and lose the result of a paid run.
+  it("captures the gateway's route-policy and price-catalog provenance (#163)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse({
+        delegated: true, escalate: false, outcome: "unverified", output: "PROV_OK",
+        nodeId: "m5", modelId: "mellum", taskType: "qa-factual",
+        ledgerId: "487bae49-e751-4fc8-a10c-8f12f6aa59a4",
+        formatRetried: false,
+        delegatePolicy: {
+          mode: "shadow", action: "shadow", reason: "no verifier-backed lane",
+          evidence: { verifier: "answerIs" },
+        },
+        costTrace: {
+          id: "fc5e98f9-2d7c-4792-b2c3-c936d29d44fb",
+          priceCatalogVersion: "2026-07-08",
+        },
+      }),
+    );
+
+    const result = await executeHomeserverTask(
+      makeTaskConfig({ path: "delegate", taskType: "qa-factual" }), "delegate-prov", tmpLogDir,
+    );
+
+    const p = result.provenance!;
+    expect(p.ledgerId).toBe("487bae49-e751-4fc8-a10c-8f12f6aa59a4");
+    expect(p.nodeId).toBe("m5");
+    expect(p.verifier).toBe("answerIs");
+    expect(p.policyMode).toBe("shadow");
+    expect(p.policyAction).toBe("shadow");
+    expect(p.policyReason).toBe("no verifier-backed lane");
+    expect(p.priceCatalogVersion).toBe("2026-07-08");
+    expect(p.costTraceId).toBe("fc5e98f9-2d7c-4792-b2c3-c936d29d44fb");
+    expect(p.formatRetried).toBe(false);
+    // The pre-existing flat fields keep working for current consumers.
+    expect(result.ledgerId).toBe("487bae49-e751-4fc8-a10c-8f12f6aa59a4");
+    expect(result.nodeId).toBe("m5");
+  });
+
+  it("drops an out-of-contract gateway score instead of poisoning the result (#163)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      // A non-numeric score would previously flow straight into
+      // runtimeMetadata.delegation.score (z.number()) and throw inside
+      // buildStructuredTaskResult — losing the whole result of a paid run.
+      jsonResponse({ delegated: true, outcome: "pass", score: "high", output: "ok", ledgerId: "l-1" }),
+    );
+
+    const result = await executeHomeserverTask(
+      makeTaskConfig({ path: "delegate" }), "delegate-badscore", tmpLogDir,
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.resultText).toBe("ok");
+    expect(result.score).toBeNull(); // dropped, not coerced, not thrown
+    expect(result.provenance?.score).toBeUndefined();
+    expect(result.provenance?.ledgerId).toBe("l-1");
+  });
+
   it("omits optional /delegate fields that are not present", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       jsonResponse({ delegated: true, outcome: "unverified", output: "1998" }),

--- a/tests/m5-provenance.test.ts
+++ b/tests/m5-provenance.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { extractM5Provenance } from "../src/m5-provenance.js";
+import { extractM5Provenance, sanitizeProviderTokenCount } from "../src/m5-provenance.js";
 
 // Verbatim shape of a real M5 gateway /delegate response, captured live from
 // the tailnet gateway on 2026-07-11. Ground truth for what we must preserve.
@@ -121,6 +121,33 @@ describe("extractM5Provenance", () => {
     const p = extractM5Provenance({ ledgerId: "", decisionReason: "   " });
     expect(p.ledgerId).toBeUndefined();
     expect(p.decisionReason).toBeUndefined();
+  });
+
+  // Codex review of #163: Zod 4's .int() rejects values outside the safe-integer
+  // range even though Number.isInteger() accepts them — so an unsafe-integer
+  // token count would sail through the sanitizer and then throw inside
+  // buildStructuredTaskResult, losing the result of a paid run. Verified against
+  // zod 4.3.6: Number.isInteger(2**53) === true, but z.number().int() rejects it.
+  it("drops token counts outside the safe-integer range", () => {
+    expect(sanitizeProviderTokenCount(42)).toBe(42);
+    expect(sanitizeProviderTokenCount(0)).toBe(0);
+    expect(sanitizeProviderTokenCount(Number.MAX_SAFE_INTEGER)).toBe(Number.MAX_SAFE_INTEGER);
+    expect(sanitizeProviderTokenCount(Number.MAX_SAFE_INTEGER + 1)).toBeNull();
+    expect(sanitizeProviderTokenCount(-1)).toBeNull();
+    expect(sanitizeProviderTokenCount(1.5)).toBeNull();
+    expect(sanitizeProviderTokenCount("50")).toBeNull();
+    expect(sanitizeProviderTokenCount(Number.NaN)).toBeNull();
+  });
+
+  // Codex review of #163: a finite-but-out-of-scale score was being retained as
+  // a valid trace. M5's real scale is 0..1 (observed live: 0, 0.2, 0.7, 1, null).
+  it("drops a score outside M5's 0..1 scale", () => {
+    expect(extractM5Provenance({ score: 0 }).score).toBe(0);
+    expect(extractM5Provenance({ score: 0.7 }).score).toBe(0.7);
+    expect(extractM5Provenance({ score: 1 }).score).toBe(1);
+    expect(extractM5Provenance({ score: -1 }).score).toBeUndefined();
+    expect(extractM5Provenance({ score: 2 }).score).toBeUndefined();
+    expect(extractM5Provenance({ score: 100 }).score).toBeUndefined();
   });
 
   it("never throws on junk input", () => {

--- a/tests/m5-provenance.test.ts
+++ b/tests/m5-provenance.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+import { extractM5Provenance } from "../src/m5-provenance.js";
+
+// Verbatim shape of a real M5 gateway /delegate response, captured live from
+// the tailnet gateway on 2026-07-11. Ground truth for what we must preserve.
+const LIVE_M5_RESPONSE = {
+  delegated: true,
+  escalate: false,
+  taskType: "qa-factual",
+  nodeId: "m5",
+  modelId: "mellum",
+  decisionReason:
+    "viable (10/10 pass, rate 1) + delegate-policy(shadow): shadow — no verifier-backed lane",
+  outcome: "unverified",
+  score: null,
+  output: "PROV_OK",
+  metrics: { latencyMs: 15502, ttftMs: 15462, promptTokens: 50, completionTokens: 5 },
+  ledgerId: "487bae49-e751-4fc8-a10c-8f12f6aa59a4",
+  formatRetried: false,
+  delegatePolicy: {
+    mode: "shadow",
+    action: "shadow",
+    reason: "no verifier-backed lane; production should escalate until checking is cheap",
+    requiredSuccessRate: 0.95,
+    productionSource: true,
+    evidence: { taskType: "qa-factual", modelId: "mellum", verifier: null, attempts: 0 },
+  },
+  costTrace: {
+    id: "fc5e98f9-2d7c-4792-b2c3-c936d29d44fb",
+    delegationId: "487bae49-e751-4fc8-a10c-8f12f6aa59a4",
+    priceCatalogVersion: "2026-07-08",
+    costStatus: "unverified",
+  },
+};
+
+describe("extractM5Provenance", () => {
+  it("preserves the full provenance set from a real gateway response", () => {
+    const p = extractM5Provenance(LIVE_M5_RESPONSE);
+
+    // The join key to the authoritative M5 ledger row (#163 acceptance).
+    expect(p.ledgerId).toBe("487bae49-e751-4fc8-a10c-8f12f6aa59a4");
+    // Effective node + model actually used (may differ from what we requested).
+    expect(p.nodeId).toBe("m5");
+    expect(p.modelId).toBe("mellum");
+    expect(p.taskType).toBe("qa-factual");
+    // Verification outcome/score.
+    expect(p.outcome).toBe("unverified");
+    expect(p.score).toBeUndefined(); // null score is absent, not 0
+    // Escalation decision.
+    expect(p.delegated).toBe(true);
+    expect(p.escalated).toBe(false);
+    expect(p.decisionReason).toContain("viable");
+    // Route/policy version.
+    expect(p.policyMode).toBe("shadow");
+    expect(p.policyAction).toBe("shadow");
+    expect(p.policyReason).toContain("no verifier-backed lane");
+    expect(p.priceCatalogVersion).toBe("2026-07-08");
+    expect(p.costTraceId).toBe("fc5e98f9-2d7c-4792-b2c3-c936d29d44fb");
+    expect(p.formatRetried).toBe(false);
+  });
+
+  it("captures verifier identity when the gateway ran a verifier", () => {
+    const p = extractM5Provenance({
+      ...LIVE_M5_RESPONSE,
+      outcome: "pass",
+      score: 1,
+      verifierNotes: "answerIs matched exactly",
+      delegatePolicy: {
+        ...LIVE_M5_RESPONSE.delegatePolicy,
+        evidence: { ...LIVE_M5_RESPONSE.delegatePolicy.evidence, verifier: "answerIs" },
+      },
+    });
+    expect(p.verifier).toBe("answerIs");
+    expect(p.verifierNotes).toBe("answerIs matched exactly");
+    expect(p.outcome).toBe("pass");
+    expect(p.score).toBe(1);
+  });
+
+  // --- Untrusted input: bounds + enums (#163 "treat provider responses as
+  // untrusted"). A hostile/buggy gateway value must be DROPPED, never thrown,
+  // and never allowed to poison the downstream Zod contract.
+
+  it("drops a non-numeric score instead of throwing", () => {
+    const p = extractM5Provenance({ ...LIVE_M5_RESPONSE, score: "high" });
+    expect(p.score).toBeUndefined();
+    expect(p.ledgerId).toBe("487bae49-e751-4fc8-a10c-8f12f6aa59a4"); // rest survives
+  });
+
+  it("drops a non-finite score", () => {
+    expect(extractM5Provenance({ score: Number.NaN }).score).toBeUndefined();
+    expect(extractM5Provenance({ score: Number.POSITIVE_INFINITY }).score).toBeUndefined();
+  });
+
+  it("drops an out-of-enum outcome", () => {
+    expect(extractM5Provenance({ outcome: "pass" }).outcome).toBe("pass");
+    expect(extractM5Provenance({ outcome: "totally-made-up" }).outcome).toBeUndefined();
+    expect(extractM5Provenance({ outcome: 42 }).outcome).toBeUndefined();
+  });
+
+  it("drops non-string ids and non-boolean flags", () => {
+    const p = extractM5Provenance({
+      ledgerId: { evil: true },
+      nodeId: 7,
+      modelId: null,
+      delegated: "yes",
+      escalate: 1,
+    });
+    expect(p.ledgerId).toBeUndefined();
+    expect(p.nodeId).toBeUndefined();
+    expect(p.modelId).toBeUndefined();
+    expect(p.delegated).toBeUndefined();
+    expect(p.escalated).toBeUndefined();
+  });
+
+  it("caps unbounded strings so a hostile gateway cannot bloat the Munin doc", () => {
+    const p = extractM5Provenance({ decisionReason: "x".repeat(10_000) });
+    expect(p.decisionReason!.length).toBeLessThanOrEqual(1000);
+  });
+
+  it("drops empty strings rather than emitting schema-invalid min(1) values", () => {
+    const p = extractM5Provenance({ ledgerId: "", decisionReason: "   " });
+    expect(p.ledgerId).toBeUndefined();
+    expect(p.decisionReason).toBeUndefined();
+  });
+
+  it("never throws on junk input", () => {
+    expect(() => extractM5Provenance(null)).not.toThrow();
+    expect(() => extractM5Provenance("nope")).not.toThrow();
+    expect(() => extractM5Provenance([])).not.toThrow();
+    expect(() => extractM5Provenance({ delegatePolicy: "not-an-object" })).not.toThrow();
+    expect(() => extractM5Provenance({ costTrace: 5 })).not.toThrow();
+    expect(extractM5Provenance(null)).toEqual({});
+  });
+
+  it("falls back to costTrace.delegationId when ledgerId is absent", () => {
+    const p = extractM5Provenance({
+      costTrace: { delegationId: "d-9", priceCatalogVersion: "2026-07-08" },
+    });
+    expect(p.ledgerId).toBe("d-9");
+  });
+});

--- a/tests/orchestrator/worker-executor.test.ts
+++ b/tests/orchestrator/worker-executor.test.ts
@@ -491,6 +491,110 @@ describe("HomeserverDelegateWorkerExecutor — /delegate worker path", () => {
     });
     expect(body.verifier).toBeUndefined();
     expect(body.responseFormat).toBeUndefined();
+
+    // Issue #163: the ledger id must survive onto the result, not just be parsed
+    // and dropped — it is the join key back to M5's authoritative evidence row.
+    expect(result.delegation?.ledgerId).toBe("ledger-1");
+  });
+
+  it("preserves the full M5 execution provenance on the worker result (#163)", async () => {
+    vi.stubEnv("HOMESERVER_GATEWAY_URL", "http://100.76.72.59:8080");
+    vi.stubEnv("HOMESERVER_GATEWAY_API_KEY", "hs-test-key");
+
+    vi.stubGlobal("fetch", vi.fn().mockImplementation(async () =>
+      delegateResponse({
+        delegated: true,
+        escalate: false,
+        taskType: "extract",
+        nodeId: "orin",
+        modelId: "qwen2.5-coder:3b",
+        outcome: "pass",
+        score: 1,
+        decisionReason: "viable (10/10 pass, rate 1)",
+        verifierNotes: "answerIs matched exactly",
+        output: "leaf",
+        ledgerId: "487bae49-e751-4fc8-a10c-8f12f6aa59a4",
+        formatRetried: false,
+        delegatePolicy: {
+          mode: "shadow",
+          action: "shadow",
+          reason: "no verifier-backed lane",
+          evidence: { verifier: "answerIs" },
+        },
+        costTrace: {
+          id: "fc5e98f9-2d7c-4792-b2c3-c936d29d44fb",
+          delegationId: "487bae49-e751-4fc8-a10c-8f12f6aa59a4",
+          priceCatalogVersion: "2026-07-08",
+        },
+        metrics: { promptTokens: 30, completionTokens: 7 },
+      })
+    ));
+
+    const result = await new HomeserverDelegateWorkerExecutor().run({
+      provider: "homeserver", model: "qwen2.5-coder:3b", prompt: "extract this",
+      taskType: "extract", timeoutMs: 5000,
+    });
+
+    const d = result.delegation!;
+    expect(d.ledgerId).toBe("487bae49-e751-4fc8-a10c-8f12f6aa59a4");
+    expect(d.nodeId).toBe("orin");
+    expect(d.modelId).toBe("qwen2.5-coder:3b");
+    expect(d.taskType).toBe("extract");
+    expect(d.outcome).toBe("pass");
+    expect(d.score).toBe(1);
+    expect(d.verifier).toBe("answerIs");
+    expect(d.verifierNotes).toBe("answerIs matched exactly");
+    expect(d.delegated).toBe(true);
+    expect(d.escalated).toBe(false);
+    expect(d.policyMode).toBe("shadow");
+    expect(d.policyAction).toBe("shadow");
+    expect(d.priceCatalogVersion).toBe("2026-07-08");
+    expect(d.costTraceId).toBe("fc5e98f9-2d7c-4792-b2c3-c936d29d44fb");
+  });
+
+  it("still preserves provenance when the M5 leaf reports a failed outcome (#163)", async () => {
+    vi.stubEnv("HOMESERVER_GATEWAY_URL", "http://100.76.72.59:8080");
+    vi.stubEnv("HOMESERVER_GATEWAY_API_KEY", "hs-test-key");
+
+    vi.stubGlobal("fetch", vi.fn().mockImplementation(async () =>
+      delegateResponse({
+        delegated: true, outcome: "fail", score: 0, output: "bad",
+        ledgerId: "ledger-fail", nodeId: "m5",
+        decisionReason: "verifier rejected",
+      })
+    ));
+
+    const result = await new HomeserverDelegateWorkerExecutor().run({
+      provider: "homeserver", model: "mellum", prompt: "p", timeoutMs: 5000,
+    });
+
+    // A failed leaf is exactly when an operator most needs the ledger row.
+    expect(result.ok).toBe(false);
+    expect(result.delegation?.ledgerId).toBe("ledger-fail");
+    expect(result.delegation?.outcome).toBe("fail");
+    expect(result.delegation?.decisionReason).toBe("verifier rejected");
+  });
+
+  it("drops out-of-contract gateway provenance without failing the leaf (#163)", async () => {
+    vi.stubEnv("HOMESERVER_GATEWAY_URL", "http://100.76.72.59:8080");
+    vi.stubEnv("HOMESERVER_GATEWAY_API_KEY", "hs-test-key");
+
+    vi.stubGlobal("fetch", vi.fn().mockImplementation(async () =>
+      delegateResponse({
+        delegated: true, outcome: "unverified", output: "ok",
+        ledgerId: "ledger-2",
+        score: "high", // hostile/buggy: not a number
+      })
+    ));
+
+    const result = await new HomeserverDelegateWorkerExecutor().run({
+      provider: "homeserver", model: "mellum", prompt: "p", timeoutMs: 5000,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.output).toBe("ok");
+    expect(result.delegation?.score).toBeUndefined(); // dropped, not coerced
+    expect(result.delegation?.ledgerId).toBe("ledger-2"); // rest survives
   });
 
   it("pins an Orin-routed owner leaf with nodeId and reports the selected node", async () => {

--- a/tests/orchestrator/worker-executor.test.ts
+++ b/tests/orchestrator/worker-executor.test.ts
@@ -597,6 +597,39 @@ describe("HomeserverDelegateWorkerExecutor — /delegate worker path", () => {
     expect(result.delegation?.ledgerId).toBe("ledger-2"); // rest survives
   });
 
+  // Codex review of #163: the response-VALIDATION failure branch returned
+  // failResult() with no provenance attached. A gateway that sends a usable
+  // trace (real ledgerId/node/model) alongside one malformed operational field
+  // would lose the ledger join key at exactly the moment an operator needs it to
+  // diagnose the bad response. Provenance is now extracted straight off the
+  // parsed body, before operational validation.
+  it("keeps provenance when the gateway body fails operational validation (#163)", async () => {
+    vi.stubEnv("HOMESERVER_GATEWAY_URL", "http://100.76.72.59:8080");
+    vi.stubEnv("HOMESERVER_GATEWAY_API_KEY", "hs-test-key");
+
+    vi.stubGlobal("fetch", vi.fn().mockImplementation(async () =>
+      delegateResponse({
+        // Usable, well-formed provenance...
+        ledgerId: "ledger-diagnose-me",
+        nodeId: "orin",
+        modelId: "qwen2.5-coder:3b",
+        delegated: true,
+        // ...but a malformed operational field: output must be a string.
+        output: 12345,
+      })
+    ));
+
+    const result = await new HomeserverDelegateWorkerExecutor().run({
+      provider: "homeserver", model: "qwen2.5-coder:3b", prompt: "p", timeoutMs: 5000,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("output");
+    // The paid call still happened and M5 still wrote a ledger row — keep the key.
+    expect(result.delegation?.ledgerId).toBe("ledger-diagnose-me");
+    expect(result.delegation?.nodeId).toBe("orin");
+  });
+
   it("pins an Orin-routed owner leaf with nodeId and reports the selected node", async () => {
     vi.stubEnv("HOMESERVER_GATEWAY_URL", "http://100.76.72.59:8080");
     vi.stubEnv("HOMESERVER_GATEWAY_API_KEY", "hs-test-key");

--- a/tests/task-result-schema.test.ts
+++ b/tests/task-result-schema.test.ts
@@ -19,6 +19,78 @@ describe("structured task result schema", () => {
     });
     expect(result.runtimeMetadata?.delegation?.ledgerId).toBe("ledger-1");
   });
+
+  // Issue #163: the orchestrator fan-out path delegated to M5 too, but dropped
+  // every M5 provenance field before the durable result — so an operator could
+  // not tell which node/model/verifier produced a fanout leaf, nor join it back
+  // to the authoritative M5 ledger row.
+  it("preserves M5 delegation provenance on orchestrator fanout outcomes", () => {
+    const result = buildStructuredTaskResult({
+      schemaVersion: 1, taskId: "orch-1", taskNamespace: "tasks/orch-1",
+      lifecycle: "completed", outcome: "completed", runtime: "orchestrator",
+      executor: "orchestrator", resultSource: "orchestrator", exitCode: 0,
+      completedAt: "2026-07-11T12:00:00Z", bodyKind: "response", bodyText: "ok",
+      orchestratorOutcomes: [
+        {
+          subtaskId: "s1", taskType: "extract", provider: "homeserver",
+          model: "qwen3-30b-instruct", ok: true, verdictOk: null,
+          costUsd: 0, latencyMs: 1200,
+          delegation: {
+            ledgerId: "487bae49-e751-4fc8-a10c-8f12f6aa59a4",
+            nodeId: "orin", modelId: "qwen2.5-coder:3b", taskType: "extract",
+            outcome: "unverified", decisionReason: "viable (10/10 pass)",
+            verifier: "answerIs", delegated: true, escalated: false,
+            policyMode: "shadow", policyAction: "shadow",
+            priceCatalogVersion: "2026-07-08",
+            costTraceId: "fc5e98f9-2d7c-4792-b2c3-c936d29d44fb",
+          },
+        },
+      ],
+    });
+    const d = result.orchestratorOutcomes?.[0]?.delegation;
+    expect(d?.ledgerId).toBe("487bae49-e751-4fc8-a10c-8f12f6aa59a4");
+    expect(d?.nodeId).toBe("orin");
+    expect(d?.modelId).toBe("qwen2.5-coder:3b");
+    expect(d?.verifier).toBe("answerIs");
+    expect(d?.policyMode).toBe("shadow");
+    expect(d?.priceCatalogVersion).toBe("2026-07-08");
+  });
+
+  it("keeps the delegation block optional so non-M5 workers still validate", () => {
+    const result = buildStructuredTaskResult({
+      schemaVersion: 1, taskId: "orch-2", taskNamespace: "tasks/orch-2",
+      lifecycle: "completed", outcome: "completed", runtime: "orchestrator",
+      executor: "orchestrator", resultSource: "orchestrator", exitCode: 0,
+      completedAt: "2026-07-11T12:00:00Z", bodyKind: "response", bodyText: "ok",
+      orchestratorOutcomes: [
+        {
+          subtaskId: "s1", taskType: "summarize", provider: "openrouter",
+          model: "deepseek-v4-flash", ok: true, verdictOk: true,
+          costUsd: 0.0001, latencyMs: 900,
+        },
+      ],
+    });
+    expect(result.orchestratorOutcomes?.[0]?.delegation).toBeUndefined();
+  });
+
+  it("accepts the widened M5 provenance fields on runtimeMetadata.delegation", () => {
+    const result = buildStructuredTaskResult({
+      schemaVersion: 1, taskId: "mcp-m5-def", taskNamespace: "tasks/mcp-m5-def",
+      lifecycle: "completed", outcome: "completed", runtime: "homeserver",
+      executor: "homeserver-delegate", resultSource: "homeserver-delegate", exitCode: 0,
+      completedAt: "2026-07-11T12:00:00Z", bodyKind: "response", bodyText: "ok",
+      runtimeMetadata: {
+        delegation: {
+          ledgerId: "ledger-2", verifier: "answerIs", policyMode: "shadow",
+          policyAction: "shadow", policyReason: "no verifier-backed lane",
+          priceCatalogVersion: "2026-07-08", costTraceId: "ct-1", formatRetried: false,
+        },
+      },
+    });
+    expect(result.runtimeMetadata?.delegation?.policyMode).toBe("shadow");
+    expect(result.runtimeMetadata?.delegation?.priceCatalogVersion).toBe("2026-07-08");
+    expect(result.runtimeMetadata?.delegation?.costTraceId).toBe("ct-1");
+  });
   it("accepts completed pipeline phase results", () => {
     const result = buildStructuredTaskResult({
       schemaVersion: 1,


### PR DESCRIPTION
Closes #163.

## The gap

Hugin delegates to M5 from **two** independent places, and they behaved differently:

- `src/homeserver-executor.ts` — the direct executor backing the canonical #167 Broker leaf. Carried a **partial** trace.
- `src/orchestrator/worker-executor.ts` — the orchestrator's fan-out worker. Parsed a few fields and then **dropped every one of them** before the durable result.

So an orchestrator leaf could not be traced to the node, model, or verifier that produced it, and nothing joined back to M5's authoritative ledger row. The existing test even stubbed `ledgerId: "ledger-1"` and never asserted it survived — the drop was invisible to CI.

Probing the live gateway showed the response is also **richer than either path knew**: `delegatePolicy` (mode/action/reason — the route-policy version), `costTrace` (with `priceCatalogVersion` and a `delegationId`), and `formatRetried` were parsed by nobody.

## What this does

- **`src/m5-provenance.ts`** — one sanctioned sanitizer for the `/delegate` response, shared by both call sites. The gateway body is **untrusted input**: it validates types/enums/bounds and **drops** out-of-contract values rather than throwing or coercing.
- Threads provenance through `WorkerResult` into `orchestratorOutcomes[].delegation`, on **every** post-JSON branch — a failed leaf is exactly when an operator most needs the ledger row.
- One shared `delegationProvenanceSchema` behind both `runtimeMetadata.delegation` and the per-leaf outcome, widened with what neither path captured: verifier identity, route-policy mode/action/reason, `priceCatalogVersion`, `costTraceId`, `formatRetried`.
- Additive + optional throughout, so old Zod readers strip it — no schema-version bump.

## Latent bug fixed on the way

`buildStructuredTaskResult` calls Zod `.parse()` (**throws**) and `delegation.score` was `z.number()`. A non-numeric `score` from the gateway would have **sunk the `result-structured` write of a successful, PAID run**. Out-of-contract values now degrade to absent.

## Trace, not verdict

M5 remains the sole capability-evidence authority. Hugin copies these fields for traceability only and never duplicates M5's judgements into a Hugin-owned capability store (Codex independently confirmed no such path exists).

## Review

Codex (`gpt-5.6-sol`, high effort) found **3 Mediums, all real, all fixed** — each verified against ground truth first rather than taken on faith:

1. `Number.isInteger` vs zod 4's `.int()` — confirmed empirically against zod 4.3.6 that `Number.isInteger(2**53)` is `true` but `.int()` rejects it, so an unsafe-integer token count reached a `.parse()` that throws. Now `Number.isSafeInteger`; the dispatcher's duplicate (identically buggy) predicate now calls the shared sanitizer.
2. Out-of-scale `score` retained as a valid trace — confirmed M5's real scale by reading its live ledger (observed: `0, 0.2, 0.7, 1, null`), so the 0..1 bound is evidence-backed. Enum + bounds now also declared in the schema so it can't drift from the sanitizer.
3. Provenance lost on the response-validation failure branch — now extracted before operational validation, so a usable trace survives a malformed operational field.

Codex also confirmed no exit-code regression in the refactored direct executor and no provenance mixing across the Orin fallback attempts.

## Verification

- Suite **92 files / 1559 tests** green; `tsc` clean; `git diff --check` clean.
- **Live smoke against the real M5 gateway**, through the real executor: an orchestrator leaf returned `SMOKE163_OK` and stored `ledgerId a26af641-2c83-45e1-905c-62de0ba2d76e` with node, model, policy mode/action and price-catalog version intact **through Zod into the durable document**; the row M5 wrote agrees on node/model/taskType/outcome.

## Known limitation — the last hop is blocked on M5

#163's acceptance asks that an operator retrieve the authoritative M5 row *by* the recorded id. **M5's API does not currently allow that**: `GET /ledger` `recent[]` rows carry **no id field at all**, and `?id=` / `?delegationId=` are accepted (HTTP 200) but **silently ignored** — still returning all 20 rows. Joining by id would require exactly the timestamp archaeology #163 sets out to eliminate.

Hugin's half is complete and verified: the join key is durably recorded. The id-addressable read is filed against the gateway as **Magnus-Gille/gille-inference#227**. I'd suggest #163 stays open until that lands and the by-id join can be demonstrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)