### PR TITLE
Learning-loop health panel + durable-handoff evidence (#164)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,25 @@ maps to the `build` agent with `edit`/`bash` allowed.
 
 **M5 execution provenance (issue #163):** every M5 `/delegate` call — whether it arrives via the canonical #167 Broker leaf (`runtime:homeserver`) or as an orchestrator fan-out worker leaf — records the same canonical trace: `ledgerId` (the join key to M5's authoritative evidence row), effective `nodeId`/`modelId`, `taskType`, verification `outcome`/`score`, `verifier` identity + `verifierNotes`, `delegated`/`escalated` + `decisionReason`, route-policy `policyMode`/`policyAction`/`policyReason`, `priceCatalogVersion`, and `costTraceId`. It surfaces at `runtimeMetadata.delegation` for the direct path and per-leaf at `orchestratorOutcomes[].delegation` for fan-out. `src/m5-provenance.ts` is the **only** sanctioned producer: the gateway body is untrusted input, so it validates enums/bounds and DROPS anything out of contract rather than throwing — a malformed gateway value must never sink the `result-structured` write of an already-paid run (`buildStructuredTaskResult` calls `.parse()`). This is a **trace, not a verdict**: M5 remains the sole capability-evidence authority and Hugin never duplicates its judgements into a Hugin-owned capability store. Retrieving the row *by* `ledgerId` currently needs an id-addressable read on the gateway — filed as gille-inference#227.
 
+## Learning-loop health (issue #164)
+
+`GET /heimdall.json` serves live **typed** panels (`stat`/`table`/`status`) that Heimdall renders with zero Heimdall-side code — so this surface is Hugin-owned end to end, unlike the `plugin`/`view` panels which need a matching renderer in the heimdall repo.
+
+Two evidence planes, deliberately **not** collapsed into one verdict:
+
+1. **M5 capability evidence** — "can this execution cell do the task?" Read from the M5 gateway ledger. M5 stays the sole capability authority; Hugin never keeps a competing capability store.
+2. **Hugin product evidence** — "was durable delegation actually useful enough to keep?" The `#165` trial gate that decides keep/reduce/remove on **2026-08-22**, computed from the broker task corpus: task count, distinct producers, useful completion (from `hugin_rate`), durable handoffs, rescue/redo.
+
+**Honesty rules, enforced in code:**
+- **No percentage without an `n`.** A rate over zero verified samples is `null`, never `0` — "not checked" and "failed" are different facts.
+- **An unmeasured metric reports `not-instrumented`**, never a flattering zero. Maintenance time and incident counts have no data source and say so.
+- Infra errors are excluded from quality rates; they are not evidence about a model.
+- A capped table **discloses what it dropped**.
+
+**Durable handoffs** (`src/broker/await-observation.ts`) are the criterion that proves a *durable* broker earns its keep. We cannot observe an L1 session *closing*, so we record the conservative, positively-observable proxy: **a terminal result collected by a different `orchestrator_session_id` than the one that submitted the task**. A different MCP process means the original conductor is gone and the work outlived it. It under-counts rather than over-counts. Recorded fire-and-forget on `/v1/delegate/await`, only when the evidence actually changes (the await path is a hot poll loop), and its failure can never affect a client's await.
+
+**Broker tasks are identified by their embedded envelope, not by the `broker:mcp-v2` tag** — tasks written before PR #173 lost that tag during terminal-status normalization, and keying off it under-counts the very trial the panel measures.
+
 ## Project structure
 
 ```
@@ -170,6 +189,8 @@ hugin/
 │   ├── task-graph.ts             # Task dependency graph for pipelines
 │   ├── result-format.ts          # Result formatting utilities
 │   ├── artifact-delivery.ts      # Runtime-owned artefact delivery (#68): manifest parse/validate, target allowlist, rsync→sha256→mv deliver+verify
+│   ├── learning-loop-health.ts   # Learning-loop health (#164), PURE: the two evidence planes (M5 capability / Hugin product) + #165 trial gate + Heimdall typed panels. No percentage without an `n`; an unmeasured metric reports `not-instrumented`, never a flattering zero
+│   ├── learning-loop-collector.ts # Learning-loop health (#164), IO: bounded + TTL-cached + fail-open collection of ledger + broker-task evidence. Can never break /heimdall.json
 │   ├── m5-provenance.ts         # M5 execution provenance (#163): the ONE sanitizer for /delegate responses (untrusted input — validates enums/bounds, drops out-of-contract values, never throws). Used by BOTH M5 call sites: homeserver-executor.ts and orchestrator/worker-executor.ts
 │   ├── model-pricing.ts          # Vendor-neutral $/M-token table for cost-aware routing and result metadata
 │   ├── orchestrator/             # Native fanout engine (Runtime: orchestrator)
@@ -196,6 +217,7 @@ hugin/
 │   │   ├── broker-client.ts      # HTTP client for /v1/delegate/* (bearer auth, AbortController timeout)
 │   │   └── tools.ts              # 5 MCP tools (hugin_submit/await/rate/list/models) with envelope autofill
 │   └── broker/                   # Orchestrator-v1 broker (Tailscale-only HTTP, /v1/delegate/*)
+│       ├── await-observation.ts  # Durable-handoff evidence (#164): folds each await into a per-task observation. `durableHandoff` = a terminal result collected by a DIFFERENT orchestrator session than the one that submitted it
 │       ├── server.ts             # Express app + opt-in startup (HUGIN_BROKER_KEYS)
 │       ├── executor-capabilities.ts # Live executor truth shared by submit/models/worker
 │       ├── handlers.ts           # submit/await/rate/list/models endpoint handlers

--- a/src/broker/await-observation.ts
+++ b/src/broker/await-observation.ts
@@ -37,11 +37,19 @@ export type AwaitLifecycle =
   | "awaiting-approval"
   | "unknown";
 
-const TERMINAL: ReadonlySet<AwaitLifecycle> = new Set<AwaitLifecycle>([
-  "completed",
-  "failed",
-  "cancelled",
-]);
+/**
+ * ONLY `completed` is evidence for the gate.
+ *
+ * #165 asks for tasks that *complete* after the initiating session closes. A
+ * `failed` or `cancelled` task collected by a later session proves the broker
+ * stayed durable, but it is not a completion — counting it toward the gate would
+ * pad the headline number with work that delivered nothing. The caller records
+ * `completed` only once the structured result has actually been loaded and is
+ * about to be returned, so a `completed` status whose result checkpoint is still
+ * missing (the client gets a retryable internal error and collects nothing) is
+ * not counted either.
+ */
+const EVIDENCE_LIFECYCLE: AwaitLifecycle = "completed";
 
 /** Bound the stored set — an await is client-driven, so this is untrusted growth. */
 const MAX_SESSION_IDS = 8;
@@ -54,9 +62,20 @@ export interface AwaitObservation {
   awaitSessionIds: string[];
   firstAwaitAt: string;
   lastAwaitAt: string;
-  /** At least one await saw the task in a terminal state. */
+  /** A COMPLETED result was actually collected by someone. */
   terminalCollected: boolean;
-  /** A session OTHER than the submitter collected a terminal result. */
+  /**
+   * A session other than the submitter collected the completed result.
+   *
+   * A PROXY, and imperfect in both directions — the panel says so:
+   *  - It can MISS durability (a task that outlived its session but was never
+   *    collected).
+   *  - It can OVER-count (the session id is client-asserted and minted per MCP
+   *    *process*, so an MCP restart inside a still-live L1 session mints a new
+   *    id and trips this). Codex flagged this; the original "under-counts
+   *    rather than over-counts" claim was simply wrong.
+   * Never present this as a measurement of session closure.
+   */
   durableHandoff: boolean;
 }
 
@@ -82,7 +101,7 @@ export function deriveAwaitObservation(
   prev: AwaitObservation | null,
   event: AwaitEvent
 ): { next: AwaitObservation; changed: boolean } {
-  const isTerminal = TERMINAL.has(event.lifecycle);
+  const isTerminal = event.lifecycle === EVIDENCE_LIFECYCLE;
 
   // The handoff is proven only when a KNOWN, DIFFERENT session collects a
   // terminal result. Unknown session (legacy client) or unknown submitter

--- a/src/broker/await-observation.ts
+++ b/src/broker/await-observation.ts
@@ -1,0 +1,126 @@
+/**
+ * Durable-handoff evidence for the #165 role-validation trial (issue #164).
+ *
+ * The trial gate asks for "at least 5 tasks complete after the initiating L1
+ * session closes" — the criterion that decides whether a *durable* macro-broker
+ * earns its keep, as opposed to a synchronous call the conductor could have made
+ * itself. Nothing in Hugin recorded it: `/v1/delegate/await` only ever READ
+ * state, so there was no await log, no session-closed event, and no way to tell
+ * whether a result outlived the session that asked for it.
+ *
+ * We cannot observe an L1 session *closing* — Claude Code sessions don't
+ * announce their death, and absence of polling is not proof of it. So we record
+ * the conservative, positively-observable proxy instead:
+ *
+ *   **durableHandoff** — a terminal result was collected by an
+ *   `orchestrator_session_id` DIFFERENT from the one that submitted the task.
+ *
+ * A different MCP process (hence a different session id, minted at server
+ * startup) collecting the result means the original conductor is gone and the
+ * work outlived it. That is strictly stronger evidence than "the session
+ * closed": it shows the durability was not merely available but actually USED.
+ * It under-counts rather than over-counts — a task that completed after its
+ * session died but was never collected is real durability we don't claim. State
+ * the proxy honestly in the panel; never present it as a direct measurement of
+ * session closure.
+ *
+ * Monotonic: evidence is added, never retracted.
+ */
+
+/** Lifecycle values an await can observe. */
+export type AwaitLifecycle =
+  | "pending"
+  | "running"
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "awaiting-approval"
+  | "unknown";
+
+const TERMINAL: ReadonlySet<AwaitLifecycle> = new Set<AwaitLifecycle>([
+  "completed",
+  "failed",
+  "cancelled",
+]);
+
+/** Bound the stored set — an await is client-driven, so this is untrusted growth. */
+const MAX_SESSION_IDS = 8;
+
+export interface AwaitObservation {
+  schemaVersion: 1;
+  /** The session that submitted the task, from the stored envelope. */
+  submitSessionId: string | null;
+  /** Distinct sessions that have awaited this task (capped). */
+  awaitSessionIds: string[];
+  firstAwaitAt: string;
+  lastAwaitAt: string;
+  /** At least one await saw the task in a terminal state. */
+  terminalCollected: boolean;
+  /** A session OTHER than the submitter collected a terminal result. */
+  durableHandoff: boolean;
+}
+
+export interface AwaitEvent {
+  /** Awaiting session. Null for a legacy client that sends none. */
+  sessionId: string | null;
+  at: string;
+  lifecycle: AwaitLifecycle;
+  /** Submitting session, from the envelope. Null when unknown. */
+  submitSessionId: string | null;
+}
+
+/**
+ * Fold an await into the stored observation.
+ *
+ * `changed` reports whether the new value is worth PERSISTING. The await
+ * endpoint is a hot polling path, so a same-session re-poll that reveals nothing
+ * new must not trigger a Munin write — only genuinely new evidence (a first
+ * observation, a new session id, a first terminal collection, or a newly proven
+ * handoff) is. `lastAwaitAt` alone deliberately does not count as a change.
+ */
+export function deriveAwaitObservation(
+  prev: AwaitObservation | null,
+  event: AwaitEvent
+): { next: AwaitObservation; changed: boolean } {
+  const isTerminal = TERMINAL.has(event.lifecycle);
+
+  // The handoff is proven only when a KNOWN, DIFFERENT session collects a
+  // terminal result. Unknown session (legacy client) or unknown submitter
+  // proves nothing — claim nothing.
+  const provesHandoff =
+    isTerminal &&
+    event.sessionId !== null &&
+    event.submitSessionId !== null &&
+    event.sessionId !== event.submitSessionId;
+
+  const priorSessions = prev?.awaitSessionIds ?? [];
+  const isNewSession =
+    event.sessionId !== null &&
+    !priorSessions.includes(event.sessionId) &&
+    priorSessions.length < MAX_SESSION_IDS;
+
+  const awaitSessionIds = isNewSession
+    ? [...priorSessions, event.sessionId as string]
+    : priorSessions;
+
+  const terminalCollected = (prev?.terminalCollected ?? false) || isTerminal;
+  const durableHandoff = (prev?.durableHandoff ?? false) || provesHandoff;
+
+  const next: AwaitObservation = {
+    schemaVersion: 1,
+    submitSessionId: event.submitSessionId ?? prev?.submitSessionId ?? null,
+    awaitSessionIds,
+    firstAwaitAt: prev?.firstAwaitAt ?? event.at,
+    lastAwaitAt: event.at,
+    terminalCollected,
+    durableHandoff,
+  };
+
+  const changed =
+    prev === null ||
+    isNewSession ||
+    terminalCollected !== prev.terminalCollected ||
+    durableHandoff !== prev.durableHandoff;
+
+  return { next, changed };
+}

--- a/src/broker/handlers.ts
+++ b/src/broker/handlers.ts
@@ -38,6 +38,7 @@ import {
   rateRequestSchema,
   type DelegationEnvelope,
 } from "./types.js";
+import type { AwaitLifecycle } from "./await-observation.js";
 import type { AuthenticatedRequest } from "./auth.js";
 
 export interface BrokerHandlerDependencies {
@@ -298,6 +299,25 @@ export function createAwaitHandler(deps: BrokerHandlerDependencies) {
     if (!requireOwnedBrokerTask(req, res, status)) return;
 
     const lifecycle = pickLifecycleTag(status.tags);
+
+    // Durable-handoff evidence for the #165 trial (#164). Fire-and-forget:
+    // recorded AFTER ownership is enforced, never awaited, and its failure can
+    // never affect the client's await. Evidence collection must not be able to
+    // break the thing it observes.
+    void deps.taskStore
+      .recordAwait(parsed.task_id, {
+        sessionId: parsed.orchestrator_session_id ?? null,
+        at: new Date().toISOString(),
+        lifecycle: (lifecycle ?? "unknown") as AwaitLifecycle,
+      })
+      .catch((err: unknown) => {
+        console.warn(
+          `[broker] await-observation write failed for ${parsed.task_id}: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+        );
+      });
+
     if (lifecycle === "completed") {
       const result = await deps.taskStore.readStructuredResult(parsed.task_id);
       if (!result) {

--- a/src/broker/handlers.ts
+++ b/src/broker/handlers.ts
@@ -300,27 +300,49 @@ export function createAwaitHandler(deps: BrokerHandlerDependencies) {
 
     const lifecycle = pickLifecycleTag(status.tags);
 
-    // Durable-handoff evidence for the #165 trial (#164). Fire-and-forget:
-    // recorded AFTER ownership is enforced, never awaited, and its failure can
-    // never affect the client's await. Evidence collection must not be able to
-    // break the thing it observes.
-    void deps.taskStore
-      .recordAwait(parsed.task_id, {
-        sessionId: parsed.orchestrator_session_id ?? null,
-        at: new Date().toISOString(),
-        lifecycle: (lifecycle ?? "unknown") as AwaitLifecycle,
-      })
-      .catch((err: unknown) => {
-        console.warn(
-          `[broker] await-observation write failed for ${parsed.task_id}: ${
-            err instanceof Error ? err.message : String(err)
-          }`
-        );
-      });
+    /**
+     * Durable-handoff evidence for the #165 trial (#164). Fire-and-forget:
+     * recorded AFTER ownership is enforced, never awaited, and its failure can
+     * never affect the client's await — evidence collection must not be able to
+     * break the thing it observes.
+     *
+     * `evidenceLifecycle` is what the client ACTUALLY collected, not merely what
+     * the status tag said: a `completed` task whose result checkpoint is still
+     * missing returns a retryable error and collected nothing, so it must not
+     * count toward "tasks completed after the session closed". The already-read
+     * `status` is handed down so the recorder needn't re-read it on this hot
+     * polling path.
+     */
+    const recordEvidence = (evidenceLifecycle: AwaitLifecycle): void => {
+      void deps.taskStore
+        .recordAwait(
+          parsed.task_id,
+          {
+            sessionId: parsed.orchestrator_session_id ?? null,
+            at: new Date().toISOString(),
+            lifecycle: evidenceLifecycle,
+          },
+          status
+        )
+        .catch((err: unknown) => {
+          console.warn(
+            `[broker] await-observation write failed for ${parsed.task_id}: ${
+              err instanceof Error ? err.message : String(err)
+            }`
+          );
+        });
+    };
+
+    if (lifecycle !== "completed") {
+      recordEvidence((lifecycle ?? "unknown") as AwaitLifecycle);
+    }
 
     if (lifecycle === "completed") {
       const result = await deps.taskStore.readStructuredResult(parsed.task_id);
       if (!result) {
+        // Status says completed but the result checkpoint is missing: the client
+        // gets a retryable error and collects NOTHING. Not gate evidence.
+        recordEvidence("unknown");
         res.status(200).json({
           status: "failed",
           error: {
@@ -333,6 +355,9 @@ export function createAwaitHandler(deps: BrokerHandlerDependencies) {
         });
         return;
       }
+      // A completed result was genuinely handed to the caller — this, and only
+      // this, is evidence for the #165 completed-after-session criterion.
+      recordEvidence("completed");
       res.status(200).json({
         status: "completed",
         result: JSON.parse(result.content),

--- a/src/broker/task-store.ts
+++ b/src/broker/task-store.ts
@@ -65,6 +65,9 @@ export interface SubmitTaskParams {
 }
 
 export class BrokerTaskStore {
+  /** Per-task guard so a poll storm cannot pile up un-awaited observation writes. */
+  private readonly awaitWritesInFlight = new Set<string>();
+
   constructor(private readonly munin: MuninClient) {}
 
   async submit(params: SubmitTaskParams): Promise<void> {
@@ -117,36 +120,81 @@ export class BrokerTaskStore {
   /**
    * Fold one await into the task's durable-handoff observation.
    *
-   * Lossy and best-effort BY DESIGN — the caller must never await this on the
-   * request path. This is trial evidence, not billing: a dropped write under a
-   * concurrent-poll race costs one data point, and the monotonic derivation
-   * means a genuine handoff will be re-proven by any later collecting await.
-   * Blocking or failing a client's `await` to record evidence about that await
-   * would be exactly backwards.
+   * Best-effort — the caller must never await this on the request path, and a
+   * failure must never affect the client's await.
+   *
+   * Three things this has to get right, all found by review:
+   *
+   *  - **CAS, not blind overwrite.** The read-modify-write is guarded by
+   *    `expected_updated_at` and retried once. Without it, two overlapping
+   *    writers (a deploy/restart overlap, or concurrent polls) can have a later
+   *    writer with a stale `durableHandoff:false` fold clobber an earlier
+   *    `true` — permanently erasing proven evidence. The in-memory fold is
+   *    monotonic; persistence has to be too.
+   *  - **Bounded hot-path work.** `/v1/delegate/await` is a poll loop. The
+   *    caller hands down the `status` it already read, and a per-task in-flight
+   *    guard means a burst of polls can't enqueue a pile of un-awaited writes
+   *    faster than a slow Munin drains them.
+   *  - **Only write real evidence.** `changed` gates the write, so a re-poll
+   *    that reveals nothing new costs no write at all.
    */
   async recordAwait(
     taskId: string,
-    event: Omit<AwaitEvent, "submitSessionId">
+    event: Omit<AwaitEvent, "submitSessionId">,
+    knownStatus?: { content: string; updated_at?: string } | null
   ): Promise<void> {
-    const status = await this.readStatus(taskId);
-    const envelope = status ? parseStoredEnvelope(status.content) : null;
-    const prev = await this.readAwaitObservation(taskId);
+    // Hot-path guard: one in-flight observation write per task. A poll storm
+    // must not create an unbounded backlog of un-awaited Munin writes.
+    if (this.awaitWritesInFlight.has(taskId)) return;
+    this.awaitWritesInFlight.add(taskId);
+    try {
+      const status = knownStatus ?? (await this.readStatus(taskId));
+      const envelope = status ? parseStoredEnvelope(status.content) : null;
+      const classification =
+        envelope?.sensitivity === "private" ? "client-restricted" : "internal";
 
-    const { next, changed } = deriveAwaitObservation(prev, {
-      ...event,
-      submitSessionId: envelope?.orchestrator_session_id ?? null,
-    });
-    // Hot polling path: only persist genuinely new evidence.
-    if (!changed) return;
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const current = await this.munin.read(
+          namespaceForTaskId(taskId),
+          AWAIT_OBSERVATION_KEY
+        );
+        let prev: AwaitObservation | null = null;
+        if (current) {
+          try {
+            prev = JSON.parse(current.content) as AwaitObservation;
+          } catch {
+            prev = null; // corrupt doc: start over rather than throw
+          }
+        }
 
-    await this.munin.write(
-      namespaceForTaskId(taskId),
-      AWAIT_OBSERVATION_KEY,
-      JSON.stringify(next),
-      ["broker:mcp-v2", "await-observation"],
-      undefined,
-      envelope?.sensitivity === "private" ? "client-restricted" : "internal",
-    );
+        const { next, changed } = deriveAwaitObservation(prev, {
+          ...event,
+          submitSessionId: envelope?.orchestrator_session_id ?? null,
+        });
+        if (!changed) return;
+
+        try {
+          await this.munin.write(
+            namespaceForTaskId(taskId),
+            AWAIT_OBSERVATION_KEY,
+            JSON.stringify(next),
+            ["broker:mcp-v2", "await-observation"],
+            // CAS: refuse the write if someone else moved the doc under us.
+            current?.updated_at,
+            classification,
+          );
+          return;
+        } catch (err) {
+          // Lost the CAS race — re-read and re-fold. The derivation ORs the
+          // previous evidence in, so the retry preserves the other writer's
+          // proof instead of overwriting it. One retry, then give up: this is
+          // evidence, not billing, and it must never spin on the hot path.
+          if (attempt === 1) throw err;
+        }
+      }
+    } finally {
+      this.awaitWritesInFlight.delete(taskId);
+    }
   }
 
   async writeFeedback(taskId: string, feedback: Record<string, unknown>): Promise<void> {

--- a/src/broker/task-store.ts
+++ b/src/broker/task-store.ts
@@ -24,6 +24,8 @@ import type {
 } from "./types.js";
 import { delegationEnvelopeSchema, delegationRequestSchema } from "./types.js";
 import { hashPayload } from "./idempotency.js";
+import { deriveAwaitObservation } from "./await-observation.js";
+import type { AwaitEvent, AwaitObservation } from "./await-observation.js";
 
 export interface DelegationResultLike {
   task_id: string;
@@ -35,6 +37,8 @@ export const ORCH_V1_TAG = "orch-v1";
 export const STATUS_KEY = "status";
 export const RESULT_STRUCTURED_KEY = "result-structured";
 export const RESULT_ERROR_KEY = "result-error";
+/** Durable-handoff evidence for the #165 trial (#164). */
+export const AWAIT_OBSERVATION_KEY = "await-observation";
 
 export interface TaskStoreConfig {
   munin: MuninClient;
@@ -93,6 +97,56 @@ export class BrokerTaskStore {
   async readErrorResult(taskId: string) {
     const ns = namespaceForTaskId(taskId);
     return this.munin.read(ns, RESULT_ERROR_KEY);
+  }
+
+  /**
+   * Durable-handoff evidence (#164). Read the stored await observation, if any.
+   */
+  async readAwaitObservation(taskId: string): Promise<AwaitObservation | null> {
+    const entry = await this.munin.read(namespaceForTaskId(taskId), AWAIT_OBSERVATION_KEY);
+    if (!entry) return null;
+    try {
+      return JSON.parse(entry.content) as AwaitObservation;
+    } catch {
+      // A corrupt observation is evidence we lost, not a reason to fail an
+      // await. Start over rather than throw on the hot read path.
+      return null;
+    }
+  }
+
+  /**
+   * Fold one await into the task's durable-handoff observation.
+   *
+   * Lossy and best-effort BY DESIGN — the caller must never await this on the
+   * request path. This is trial evidence, not billing: a dropped write under a
+   * concurrent-poll race costs one data point, and the monotonic derivation
+   * means a genuine handoff will be re-proven by any later collecting await.
+   * Blocking or failing a client's `await` to record evidence about that await
+   * would be exactly backwards.
+   */
+  async recordAwait(
+    taskId: string,
+    event: Omit<AwaitEvent, "submitSessionId">
+  ): Promise<void> {
+    const status = await this.readStatus(taskId);
+    const envelope = status ? parseStoredEnvelope(status.content) : null;
+    const prev = await this.readAwaitObservation(taskId);
+
+    const { next, changed } = deriveAwaitObservation(prev, {
+      ...event,
+      submitSessionId: envelope?.orchestrator_session_id ?? null,
+    });
+    // Hot polling path: only persist genuinely new evidence.
+    if (!changed) return;
+
+    await this.munin.write(
+      namespaceForTaskId(taskId),
+      AWAIT_OBSERVATION_KEY,
+      JSON.stringify(next),
+      ["broker:mcp-v2", "await-observation"],
+      undefined,
+      envelope?.sensitivity === "private" ? "client-restricted" : "internal",
+    );
   }
 
   async writeFeedback(taskId: string, feedback: Record<string, unknown>): Promise<void> {

--- a/src/broker/types.ts
+++ b/src/broker/types.ts
@@ -184,6 +184,10 @@ export type RateRequest = z.infer<typeof rateRequestSchema>;
 
 export const awaitRequestSchema = z.object({
   task_id: z.string().min(1),
+  // Durable-handoff evidence (#164). OPTIONAL on purpose: an older hugin-mcp
+  // sends no session id, and must keep working — it simply proves nothing. See
+  // src/broker/await-observation.ts.
+  orchestrator_session_id: z.string().min(1).optional(),
 });
 export type AwaitRequest = z.infer<typeof awaitRequestSchema>;
 

--- a/src/heimdall-descriptor.ts
+++ b/src/heimdall-descriptor.ts
@@ -59,12 +59,15 @@ export const HEIMDALL_DESCRIPTOR = {
  * Fail-open: any collection failure yields honest "no evidence available"
  * panels rather than a broken descriptor.
  */
-export async function buildLearningLoopHealthPanels(
+export function buildLearningLoopHealthPanels(
   collector: LearningLoopCollector
-): Promise<TypedPanel[]> {
-  const { ledger, tasks } = await collector.collect();
+): TypedPanel[] {
+  // Synchronous by design: `collect()` is stale-while-revalidate and returns
+  // immediately. The descriptor must never wait on a cold corpus walk — hanging
+  // /heimdall.json blanks Hugin's whole Heimdall page (#135).
+  const { ledger, tasks, available, readFailures, truncated } = collector.collect();
   const capability = computeCapabilityPlane(ledger);
-  const product = computeProductPlane(tasks);
+  const product = computeProductPlane(tasks, { available, readFailures, truncated });
   const policy = deriveRoutePolicy(tasks, capability);
   return buildLearningLoopPanels({ capability, product, policy });
 }
@@ -82,13 +85,13 @@ export function registerHeimdallDescriptorRoute(
   app: Application,
   collector?: LearningLoopCollector
 ): void {
-  app.get("/heimdall.json", async (_req, res) => {
+  app.get("/heimdall.json", (_req, res) => {
     if (!collector) {
       res.json(HEIMDALL_DESCRIPTOR);
       return;
     }
     try {
-      const learningPanels = await buildLearningLoopHealthPanels(collector);
+      const learningPanels = buildLearningLoopHealthPanels(collector);
       res.json({
         ...HEIMDALL_DESCRIPTOR,
         panels: [...HEIMDALL_DESCRIPTOR.panels, ...learningPanels],

--- a/src/heimdall-descriptor.ts
+++ b/src/heimdall-descriptor.ts
@@ -6,6 +6,14 @@
  */
 
 import type { Application } from "express";
+import {
+  buildLearningLoopPanels,
+  computeCapabilityPlane,
+  computeProductPlane,
+  deriveRoutePolicy,
+  type TypedPanel,
+} from "./learning-loop-health.js";
+import type { LearningLoopCollector } from "./learning-loop-collector.js";
 
 export const HEIMDALL_DESCRIPTOR = {
   _schema: "https://heimdall.gille.ai/schema/service/v1",
@@ -41,11 +49,57 @@ export const HEIMDALL_DESCRIPTOR = {
 } as const;
 
 /**
+ * Build the learning-loop health panels (#164) from collected evidence.
+ *
+ * These are Heimdall TYPED panels (`stat`/`table`/`status`), which Heimdall
+ * renders natively with zero per-panel code — unlike the `plugin`/`view` panels
+ * above, which require a matching renderer in the heimdall repo. That is what
+ * keeps this a Hugin-only change.
+ *
+ * Fail-open: any collection failure yields honest "no evidence available"
+ * panels rather than a broken descriptor.
+ */
+export async function buildLearningLoopHealthPanels(
+  collector: LearningLoopCollector
+): Promise<TypedPanel[]> {
+  const { ledger, tasks } = await collector.collect();
+  const capability = computeCapabilityPlane(ledger);
+  const product = computeProductPlane(tasks);
+  const policy = deriveRoutePolicy(tasks, capability);
+  return buildLearningLoopPanels({ capability, product, policy });
+}
+
+/**
  * Register the GET /heimdall.json route on the given Express app.
  * No auth required — same open posture as /health.
+ *
+ * When a collector is supplied, the learning-loop health panels (#164) are
+ * appended to the static descriptor panels. The route NEVER fails on their
+ * account: a collector error degrades to the static descriptor, because a
+ * broken /heimdall.json would blank Hugin's whole Heimdall page (#135).
  */
-export function registerHeimdallDescriptorRoute(app: Application): void {
-  app.get("/heimdall.json", (_req, res) => {
-    res.json(HEIMDALL_DESCRIPTOR);
+export function registerHeimdallDescriptorRoute(
+  app: Application,
+  collector?: LearningLoopCollector
+): void {
+  app.get("/heimdall.json", async (_req, res) => {
+    if (!collector) {
+      res.json(HEIMDALL_DESCRIPTOR);
+      return;
+    }
+    try {
+      const learningPanels = await buildLearningLoopHealthPanels(collector);
+      res.json({
+        ...HEIMDALL_DESCRIPTOR,
+        panels: [...HEIMDALL_DESCRIPTOR.panels, ...learningPanels],
+      });
+    } catch (err) {
+      console.warn(
+        `[heimdall] learning-loop panels unavailable, serving static descriptor: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+      res.json(HEIMDALL_DESCRIPTOR);
+    }
   });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,7 @@ import {
   buildTerminalStatusTags,
   getPersistentStatusTags,
 } from "./task-status-tags.js";
+import { LearningLoopCollector } from "./learning-loop-collector.js";
 import { sanitizeProviderTokenCount } from "./m5-provenance.js";
 import {
   buildStructuredTaskResult,
@@ -5457,7 +5458,16 @@ app.get("/health", (_req, res) => {
   });
 });
 
-registerHeimdallDescriptorRoute(app);
+// Learning-loop health panels (#164). Its own LedgerClient (cached, fail-open)
+// so the dashboard surface does not depend on the verdict layer being enabled.
+// The collector is bounded + TTL-cached and can never break /heimdall.json.
+registerHeimdallDescriptorRoute(
+  app,
+  new LearningLoopCollector({
+    munin,
+    ledgerClient: new LedgerClient({ env: process.env }),
+  })
+);
 
 // --- Graceful shutdown ---
 

--- a/src/learning-loop-collector.ts
+++ b/src/learning-loop-collector.ts
@@ -1,0 +1,239 @@
+/**
+ * Learning-loop evidence collector (issue #164) — the IO half.
+ *
+ * Gathers the raw material for src/learning-loop-health.ts's pure computation:
+ *   - M5 capability evidence from the gateway ledger (already cached + fail-open).
+ *   - Hugin product evidence from the broker task corpus in Munin: each task's
+ *     lifecycle, submitting principal, `hugin_rate` feedback, durable-handoff
+ *     observation, and the M5 route-policy provenance stored on its result (#163).
+ *
+ * Two hard constraints:
+ *
+ *   1. **Never break /heimdall.json.** The descriptor endpoint is unauthenticated
+ *      and is polled by Heimdall every 60s. Any failure here degrades to "no
+ *      evidence available" — it never throws, and it never blocks the route.
+ *   2. **Bounded and cached.** Collecting is O(tasks × reads); a 60s dashboard
+ *      poll must not re-walk the corpus. Results are cached for
+ *      DEFAULT_COLLECT_TTL_MS and the corpus scan is capped.
+ */
+
+import type { MuninClient } from "./munin-client.js";
+import type { LedgerClientLike } from "./orchestrator/ledger-client.js";
+import type { Ledger } from "./orchestrator/ledger-client.js";
+import type { ProductTaskEvidence } from "./learning-loop-health.js";
+import { parseStoredEnvelope } from "./broker/task-store.js";
+import type { AwaitObservation } from "./broker/await-observation.js";
+
+/** Dashboard-facing data: refresh a few times an hour, not every 60s poll. */
+export const DEFAULT_COLLECT_TTL_MS = 300_000;
+/** Cap the corpus walk — trial evidence, not a full audit. */
+export const DEFAULT_MAX_TASKS = 200;
+
+const LIFECYCLE_TAGS = ["completed", "failed", "cancelled", "running", "pending"] as const;
+
+function pickLifecycle(tags: string[]): string {
+  return LIFECYCLE_TAGS.find((t) => tags.includes(t)) ?? "unknown";
+}
+
+export interface LearningLoopEvidence {
+  ledger: Ledger | null;
+  tasks: ProductTaskEvidence[];
+}
+
+export interface CollectorOptions {
+  munin: MuninClient;
+  ledgerClient: LedgerClientLike;
+  ttlMs?: number;
+  maxTasks?: number;
+  now?: () => number;
+}
+
+export class LearningLoopCollector {
+  private readonly munin: MuninClient;
+  private readonly ledgerClient: LedgerClientLike;
+  private readonly ttlMs: number;
+  private readonly maxTasks: number;
+  private readonly now: () => number;
+  private cache: { data: LearningLoopEvidence; at: number } | null = null;
+  /** Coalesce concurrent collections — a burst of polls must not fan out. */
+  private inFlight: Promise<LearningLoopEvidence> | null = null;
+
+  constructor(opts: CollectorOptions) {
+    this.munin = opts.munin;
+    this.ledgerClient = opts.ledgerClient;
+    this.ttlMs = opts.ttlMs ?? DEFAULT_COLLECT_TTL_MS;
+    this.maxTasks = opts.maxTasks ?? DEFAULT_MAX_TASKS;
+    this.now = opts.now ?? (() => Date.now());
+  }
+
+  async collect(): Promise<LearningLoopEvidence> {
+    const nowMs = this.now();
+    if (this.cache && nowMs - this.cache.at < this.ttlMs) return this.cache.data;
+    if (this.inFlight) return this.inFlight;
+
+    this.inFlight = this.collectUncached()
+      .then((data) => {
+        this.cache = { data, at: this.now() };
+        return data;
+      })
+      .catch(() => {
+        // Fail open: an unreachable Munin/ledger must never break the dashboard
+        // endpoint. "No evidence available" is rendered honestly downstream.
+        const empty: LearningLoopEvidence = { ledger: null, tasks: [] };
+        return empty;
+      })
+      .finally(() => {
+        this.inFlight = null;
+      });
+
+    return this.inFlight;
+  }
+
+  private async collectUncached(): Promise<LearningLoopEvidence> {
+    const [ledger, tasks] = await Promise.all([
+      this.ledgerClient.getLedger().catch(() => null),
+      this.collectTasks().catch(() => [] as ProductTaskEvidence[]),
+    ]);
+    return { ledger, tasks };
+  }
+
+  /**
+   * Find every broker task's namespace.
+   *
+   * Deliberately NOT a single `broker:mcp-v2` tag query. Broker tasks written
+   * before PR #173 lost that marker during terminal-status normalization — the
+   * exact seam #173 fixed — so the tag alone silently under-counts the corpus
+   * (it reported 0 tasks against a production Munin that held 1). Under-counting
+   * the trial it exists to measure is the one thing this panel must never do.
+   *
+   * So: union the tagged entries (any key — a task's `feedback` or
+   * `await-observation` doc still carries the tag even when its status doesn't)
+   * with the `runtime:homeserver` status entries that back the canonical leaf,
+   * then let collectOne() confirm each by the definitive marker — an embedded,
+   * parseable broker envelope.
+   */
+  private async collectTasks(): Promise<ProductTaskEvidence[]> {
+    const [tagged, homeserver] = await Promise.all([
+      this.munin
+        .query({
+          query: "task",
+          tags: ["broker:mcp-v2"],
+          namespace: "tasks/",
+          entry_type: "state",
+          limit: this.maxTasks,
+        })
+        .catch(() => ({ results: [], total: 0 })),
+      this.munin
+        .query({
+          query: "task",
+          tags: ["runtime:homeserver"],
+          namespace: "tasks/",
+          entry_type: "state",
+          limit: this.maxTasks,
+        })
+        .catch(() => ({ results: [], total: 0 })),
+    ]);
+
+    const namespaces = [
+      ...new Set(
+        [...tagged.results, ...homeserver.results]
+          .map((r) => r.namespace)
+          .filter((ns): ns is string => typeof ns === "string")
+      ),
+    ].slice(0, this.maxTasks);
+
+    const tasks: ProductTaskEvidence[] = [];
+    for (const ns of namespaces) {
+      const evidence = await this.collectOne(ns).catch(() => null);
+      if (evidence) tasks.push(evidence);
+    }
+    return tasks;
+  }
+
+  private async collectOne(namespace: string): Promise<ProductTaskEvidence | null> {
+    const status = await this.munin.read(namespace, "status");
+    if (!status) return null;
+
+    // The envelope is the definitive broker marker — present and revalidated at
+    // claim time, and unlike the status tag it was never dropped. A task without
+    // one is an ordinary dispatcher task, not part of the #165 corpus.
+    const envelope = parseStoredEnvelope(status.content);
+    if (!envelope) return null;
+
+    const taskId = namespace.replace(/^tasks\//, "");
+
+    const [feedback, observation, structured] = await Promise.all([
+      this.munin.read(namespace, "feedback").catch(() => null),
+      this.munin.read(namespace, "await-observation").catch(() => null),
+      this.munin.read(namespace, "result-structured").catch(() => null),
+    ]);
+
+    let rating: ProductTaskEvidence["rating"] = null;
+    let verificationOutcome: string | null = null;
+    if (feedback) {
+      try {
+        const parsed = JSON.parse(feedback.content) as {
+          rating?: string;
+          verification_outcome?: string;
+        };
+        if (
+          parsed.rating === "pass" ||
+          parsed.rating === "partial" ||
+          parsed.rating === "redo" ||
+          parsed.rating === "wrong"
+        ) {
+          rating = parsed.rating;
+        }
+        verificationOutcome = parsed.verification_outcome ?? null;
+      } catch {
+        // A corrupt feedback doc is one lost data point, not a broken panel.
+      }
+    }
+
+    let durableHandoff = false;
+    if (observation) {
+      try {
+        durableHandoff =
+          (JSON.parse(observation.content) as AwaitObservation).durableHandoff === true;
+      } catch {
+        /* ignore */
+      }
+    }
+
+    // Route-policy provenance, from #163's stored M5 delegation trace.
+    let delegation: ProductTaskEvidence["delegation"];
+    if (structured) {
+      try {
+        const parsed = JSON.parse(structured.content) as {
+          runtimeMetadata?: {
+            delegation?: {
+              policyMode?: string;
+              policyAction?: string;
+              priceCatalogVersion?: string;
+            };
+          };
+        };
+        const d = parsed.runtimeMetadata?.delegation;
+        if (d?.policyMode || d?.policyAction || d?.priceCatalogVersion) {
+          delegation = {
+            ...(d.policyMode ? { policyMode: d.policyMode } : {}),
+            ...(d.policyAction ? { policyAction: d.policyAction } : {}),
+            ...(d.priceCatalogVersion ? { priceCatalogVersion: d.priceCatalogVersion } : {}),
+          };
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+
+    return {
+      taskId,
+      lifecycle: pickLifecycle(status.tags ?? []),
+      submitter: envelope?.orchestrator_submitter ?? null,
+      rating,
+      verificationOutcome,
+      durableHandoff,
+      ...(delegation ? { delegation } : {}),
+    };
+  }
+}

--- a/src/learning-loop-collector.ts
+++ b/src/learning-loop-collector.ts
@@ -38,6 +38,32 @@ function pickLifecycle(tags: string[]): string {
 export interface LearningLoopEvidence {
   ledger: Ledger | null;
   tasks: ProductTaskEvidence[];
+  /**
+   * Whether the task corpus was actually readable. A failed query must NOT
+   * degrade into an empty task list that renders as a measured zero — "we could
+   * not look" and "we looked and found nothing" are different facts, and the
+   * whole point of this panel is not to confuse them.
+   */
+  available: boolean;
+  /** Per-task reads that failed — counts derived from this are a lower bound. */
+  readFailures: number;
+  /** The corpus walk hit its cap — counts derived from this are a lower bound. */
+  truncated: boolean;
+}
+
+const UNAVAILABLE: LearningLoopEvidence = {
+  ledger: null,
+  tasks: [],
+  available: false,
+  readFailures: 0,
+  truncated: false,
+};
+
+interface CorpusResult {
+  tasks: ProductTaskEvidence[];
+  available: boolean;
+  readFailures: number;
+  truncated: boolean;
 }
 
 export interface CollectorOptions {
@@ -66,9 +92,29 @@ export class LearningLoopCollector {
     this.now = opts.now ?? (() => Date.now());
   }
 
-  async collect(): Promise<LearningLoopEvidence> {
+  /**
+   * Return the best evidence available RIGHT NOW, without ever blocking the
+   * caller on a cold walk.
+   *
+   * `/heimdall.json` is unauthenticated and polled every 60s, and a cold
+   * collection is up to `maxTasks` × several serialized Munin reads — easily
+   * tens of seconds. Awaiting that on the request path would hang the descriptor
+   * and blank Hugin's whole Heimdall page (the #135 regression), no exception
+   * required. So: stale-while-revalidate. Serve the cached snapshot (even if
+   * stale) or an explicit "unavailable" immediately, and refresh in the
+   * background.
+   */
+  collect(): LearningLoopEvidence {
     const nowMs = this.now();
-    if (this.cache && nowMs - this.cache.at < this.ttlMs) return this.cache.data;
+    const fresh = this.cache !== null && nowMs - this.cache.at < this.ttlMs;
+    if (!fresh) void this.refresh();
+    // Stale data is still honest data; "unavailable" is honest too. Neither is
+    // worth hanging the dashboard for.
+    return this.cache?.data ?? UNAVAILABLE;
+  }
+
+  /** Force a collection and wait for it. For tests and warmup, not the hot path. */
+  async refresh(): Promise<LearningLoopEvidence> {
     if (this.inFlight) return this.inFlight;
 
     this.inFlight = this.collectUncached()
@@ -77,10 +123,9 @@ export class LearningLoopCollector {
         return data;
       })
       .catch(() => {
-        // Fail open: an unreachable Munin/ledger must never break the dashboard
-        // endpoint. "No evidence available" is rendered honestly downstream.
-        const empty: LearningLoopEvidence = { ledger: null, tasks: [] };
-        return empty;
+        // Fail open — but as "unavailable", never as an empty measured corpus.
+        // A rejected collection is NOT cached, so the next tick retries.
+        return UNAVAILABLE;
       })
       .finally(() => {
         this.inFlight = null;
@@ -90,11 +135,13 @@ export class LearningLoopCollector {
   }
 
   private async collectUncached(): Promise<LearningLoopEvidence> {
-    const [ledger, tasks] = await Promise.all([
+    const [ledger, corpus] = await Promise.all([
       this.ledgerClient.getLedger().catch(() => null),
-      this.collectTasks().catch(() => [] as ProductTaskEvidence[]),
+      this.collectTasks().catch(
+        (): CorpusResult => ({ tasks: [], available: false, readFailures: 0, truncated: false })
+      ),
     ]);
-    return { ledger, tasks };
+    return { ledger, ...corpus };
   }
 
   /**
@@ -112,7 +159,10 @@ export class LearningLoopCollector {
    * then let collectOne() confirm each by the definitive marker — an embedded,
    * parseable broker envelope.
    */
-  private async collectTasks(): Promise<ProductTaskEvidence[]> {
+  private async collectTasks(): Promise<CorpusResult> {
+    // A FAILED query is not an empty corpus. If we cannot enumerate the tasks,
+    // say the corpus is unavailable — never let it collapse into a confident
+    // zero downstream.
     const [tagged, homeserver] = await Promise.all([
       this.munin
         .query({
@@ -122,7 +172,8 @@ export class LearningLoopCollector {
           entry_type: "state",
           limit: this.maxTasks,
         })
-        .catch(() => ({ results: [], total: 0 })),
+        .then((r) => ({ ok: true as const, r }))
+        .catch(() => ({ ok: false as const })),
       this.munin
         .query({
           query: "task",
@@ -131,23 +182,35 @@ export class LearningLoopCollector {
           entry_type: "state",
           limit: this.maxTasks,
         })
-        .catch(() => ({ results: [], total: 0 })),
+        .then((r) => ({ ok: true as const, r }))
+        .catch(() => ({ ok: false as const })),
     ]);
 
-    const namespaces = [
+    if (!tagged.ok && !homeserver.ok) {
+      return { tasks: [], available: false, readFailures: 0, truncated: false };
+    }
+
+    const all = [
       ...new Set(
-        [...tagged.results, ...homeserver.results]
+        [...(tagged.ok ? tagged.r.results : []), ...(homeserver.ok ? homeserver.r.results : [])]
           .map((r) => r.namespace)
           .filter((ns): ns is string => typeof ns === "string")
       ),
-    ].slice(0, this.maxTasks);
+    ];
+    const namespaces = all.slice(0, this.maxTasks);
+    // A cap that hides what it dropped turns a lower bound into a fact.
+    const truncated = all.length > namespaces.length || !tagged.ok || !homeserver.ok;
 
     const tasks: ProductTaskEvidence[] = [];
+    let readFailures = 0;
     for (const ns of namespaces) {
-      const evidence = await this.collectOne(ns).catch(() => null);
+      const evidence = await this.collectOne(ns).catch(() => {
+        readFailures++;
+        return null;
+      });
       if (evidence) tasks.push(evidence);
     }
-    return tasks;
+    return { tasks, available: true, readFailures, truncated };
   }
 
   private async collectOne(namespace: string): Promise<ProductTaskEvidence | null> {
@@ -210,6 +273,8 @@ export class LearningLoopCollector {
               policyMode?: string;
               policyAction?: string;
               priceCatalogVersion?: string;
+              modelId?: string;
+              taskType?: string;
             };
           };
         };
@@ -219,6 +284,10 @@ export class LearningLoopCollector {
             ...(d.policyMode ? { policyMode: d.policyMode } : {}),
             ...(d.policyAction ? { policyAction: d.policyAction } : {}),
             ...(d.priceCatalogVersion ? { priceCatalogVersion: d.priceCatalogVersion } : {}),
+            // Needed to tie a route-policy claim to the exact ledger row that
+            // backs it, instead of to any verified sample anywhere.
+            ...(d.modelId ? { modelId: d.modelId } : {}),
+            ...(d.taskType ? { taskType: d.taskType } : {}),
           };
         }
       } catch {
@@ -233,6 +302,8 @@ export class LearningLoopCollector {
       rating,
       verificationOutcome,
       durableHandoff,
+      // Deterministic ordering for "most recent policy" — never array order.
+      ...(status.updated_at ? { updatedAt: status.updated_at } : {}),
       ...(delegation ? { delegation } : {}),
     };
   }

--- a/src/learning-loop-health.ts
+++ b/src/learning-loop-health.ts
@@ -1,0 +1,452 @@
+/**
+ * Learning-loop health (issue #164) — pure computation.
+ *
+ * Two evidence planes, deliberately NOT collapsed into one verdict, because
+ * they answer different questions:
+ *
+ *   1. **M5 capability evidence** — "can this execution cell do this task?"
+ *      Authority: the M5 gateway's ledger. Hugin READS it; it never re-judges
+ *      capability or keeps a competing capability store.
+ *   2. **Hugin product evidence** — "was durable delegation actually useful
+ *      enough to keep?" Authority: Hugin's own task corpus, ratings, and
+ *      durable-handoff observations. This is what the #165 role-validation
+ *      trial decides on, on 2026-08-22.
+ *
+ * The governing rule throughout is HONESTY ABOUT DENOMINATORS:
+ *
+ *   - No percentage without an `n`. A rate over zero verified samples is
+ *     `null`, never `0` — "we haven't checked" and "it failed" are different
+ *     facts, and conflating them is how a shadow lane starts looking healthy.
+ *   - A metric with no data source reports `not-instrumented`, never a
+ *     flattering zero. A gate criterion nobody measures must not silently read
+ *     as satisfied.
+ *   - Attempts that errored (infra) are excluded from quality rates; they are
+ *     not evidence about the model.
+ *
+ * Content-blind: only counts, ids, and enums. No prompt or result text.
+ */
+
+import type { Ledger } from "./orchestrator/ledger-client.js";
+
+/** How much can be concluded from a row's evidence. */
+export type EvidenceMaturity =
+  /** Has verified pass/fail samples — actionable. */
+  | "verified"
+  /** Calls happened but nothing was ever verified — NOT evidence of quality. */
+  | "unverified"
+  /** The route policy is observing but not enforcing. */
+  | "shadow"
+  /** Nothing attempted yet. */
+  | "aspirational";
+
+export interface CapabilityRow {
+  taskType: string;
+  modelId: string;
+  attempts: number;
+  passes: number;
+  fails: number;
+  errors: number;
+  /** passes + fails. The denominator that a quality rate is honest about. */
+  verifiedSamples: number;
+  /** null when verifiedSamples === 0 — no percentage without n. */
+  qualityRate: number | null;
+  maturity: EvidenceMaturity;
+  recommendation: string;
+  frozen: boolean;
+}
+
+export interface CapabilityPlane {
+  /** False when the ledger was unreachable — distinct from "no evidence". */
+  available: boolean;
+  rows: CapabilityRow[];
+  totalAttempts: number;
+  totalVerifiedSamples: number;
+  /** Calls are reaching the cell at all. */
+  evidenceArriving: boolean;
+  /** At least one row has verified evidence strong enough to act on. */
+  actionable: boolean;
+}
+
+export interface RoutePolicy {
+  policyMode: string | null;
+  policyAction: string | null;
+  priceCatalogVersion: string | null;
+  /** True only when the policy ENFORCES a route AND verified evidence backs it. */
+  evidenceDrivenRouteChange: boolean;
+  explanation: string;
+}
+
+export type TrialCriterionState = "met" | "not-met" | "not-instrumented";
+
+export interface TrialCriterion {
+  id: string;
+  label: string;
+  /** null ⇒ not instrumented. Never a stand-in zero. */
+  observed: number | null;
+  target: number;
+  unit: string;
+  state: TrialCriterionState;
+  note?: string;
+}
+
+export interface ProductPlane {
+  substantiveTasks: number;
+  producers: string[];
+  ratedTasks: number;
+  usefulTasks: number;
+  /** null when ratedTasks === 0 — unrated is not the same as unuseful. */
+  usefulRate: number | null;
+  durableHandoffs: number;
+  rescueRedo: number;
+  criteria: TrialCriterion[];
+}
+
+/** One broker task's product evidence. Content-blind by construction. */
+export interface ProductTaskEvidence {
+  taskId: string;
+  lifecycle: string;
+  submitter: string | null;
+  rating: "pass" | "partial" | "redo" | "wrong" | null;
+  verificationOutcome: string | null;
+  /** A LATER session collected the terminal result (src/broker/await-observation.ts). */
+  durableHandoff: boolean;
+  delegation?: {
+    policyMode?: string;
+    policyAction?: string;
+    priceCatalogVersion?: string;
+  };
+}
+
+/** Heimdall's typed-panel kinds — rendered with zero Heimdall code. */
+export interface TypedPanel {
+  id: string;
+  label: string;
+  kind: "stat" | "timeseries" | "table" | "status";
+  fullWidth?: boolean;
+  refresh?: number;
+  [key: string]: unknown;
+}
+
+// --- #165 gate thresholds (from the issue, verbatim) ---
+const GATE_SUBSTANTIVE_TASKS = 10;
+const GATE_PRODUCERS = 2;
+const GATE_USEFUL_RATE = 0.7;
+const GATE_DURABLE_HANDOFFS = 5;
+
+/** The live ledger carries ~100 rows; a dashboard table needs a ranked subset. */
+const MAX_CAPABILITY_ROWS = 15;
+
+export function computeCapabilityPlane(ledger: Ledger | null): CapabilityPlane {
+  if (!ledger) {
+    // Unreachable ledger is NOT "zero evidence" — say so, don't render a zero.
+    return {
+      available: false,
+      rows: [],
+      totalAttempts: 0,
+      totalVerifiedSamples: 0,
+      evidenceArriving: false,
+      actionable: false,
+    };
+  }
+
+  const rows: CapabilityRow[] = ledger.report.map((r) => {
+    const passes = r.passes ?? 0;
+    const fails = r.fails ?? 0;
+    const attempts = r.attempts ?? 0;
+    const verifiedSamples = passes + fails;
+
+    return {
+      taskType: r.taskType,
+      modelId: r.modelId,
+      attempts,
+      passes,
+      fails,
+      errors: r.errors ?? 0,
+      verifiedSamples,
+      // Errors are infra, not model quality — excluded from the denominator.
+      qualityRate: verifiedSamples > 0 ? passes / verifiedSamples : null,
+      maturity:
+        attempts === 0 ? "aspirational" : verifiedSamples > 0 ? "verified" : "unverified",
+      recommendation: r.recommendation,
+      frozen: r.frozen ?? false,
+    };
+  });
+
+  const totalAttempts = rows.reduce((n, r) => n + r.attempts, 0);
+  const totalVerifiedSamples = rows.reduce((n, r) => n + r.verifiedSamples, 0);
+
+  return {
+    available: true,
+    rows,
+    totalAttempts,
+    totalVerifiedSamples,
+    evidenceArriving: totalAttempts > 0,
+    actionable: totalVerifiedSamples > 0,
+  };
+}
+
+/**
+ * Derive the observed route policy from the M5 provenance Hugin now stores on
+ * its task results (#163) plus the capability plane.
+ *
+ * An "evidence-driven route change" is claimed ONLY when the gateway policy is
+ * actually enforcing a route AND there is verified evidence behind it. A policy
+ * in `shadow` — the current production state — is reported as exactly that:
+ * routing is still shadow/manual, and no route has yet changed because of
+ * evidence. #164 asks for one or the other, honestly.
+ */
+export function deriveRoutePolicy(
+  tasks: ProductTaskEvidence[],
+  capability: CapabilityPlane
+): RoutePolicy {
+  // Most recent task carrying delegation provenance wins.
+  const withProvenance = tasks.filter((t) => t.delegation?.policyMode);
+  const latest = withProvenance[withProvenance.length - 1]?.delegation;
+
+  const policyMode = latest?.policyMode ?? null;
+  const policyAction = latest?.policyAction ?? null;
+  const priceCatalogVersion = latest?.priceCatalogVersion ?? null;
+
+  if (!policyMode) {
+    return {
+      policyMode: null,
+      policyAction: null,
+      priceCatalogVersion,
+      evidenceDrivenRouteChange: false,
+      explanation:
+        "No route-policy provenance recorded yet — no M5-delegated task has stored a policy mode.",
+    };
+  }
+
+  const isShadow = policyMode === "shadow";
+  const backedByVerifiedEvidence = capability.actionable;
+  const evidenceDrivenRouteChange = !isShadow && backedByVerifiedEvidence;
+
+  let explanation: string;
+  if (isShadow) {
+    explanation =
+      `Routing is still shadow/manual: the M5 delegate policy is in "${policyMode}" mode, ` +
+      `so it observes and records evidence but does not change any route. ` +
+      `No route change has been caused by verified evidence.`;
+  } else if (evidenceDrivenRouteChange) {
+    explanation =
+      `Route policy "${policyMode}" is enforcing action "${policyAction}" ` +
+      `backed by ${capability.totalVerifiedSamples} verified sample(s).`;
+  } else {
+    explanation =
+      `Route policy "${policyMode}" reports action "${policyAction}", but no verified ` +
+      `evidence backs it yet — treat the route as manual, not evidence-driven.`;
+  }
+
+  return {
+    policyMode,
+    policyAction,
+    priceCatalogVersion,
+    evidenceDrivenRouteChange,
+    explanation,
+  };
+}
+
+function gateState(observed: number | null, target: number): TrialCriterionState {
+  if (observed === null) return "not-instrumented";
+  return observed >= target ? "met" : "not-met";
+}
+
+export function computeProductPlane(tasks: ProductTaskEvidence[]): ProductPlane {
+  const substantiveTasks = tasks.length;
+
+  const producers = [
+    ...new Set(tasks.map((t) => t.submitter).filter((s): s is string => !!s)),
+  ].sort();
+
+  const rated = tasks.filter((t) => t.rating !== null);
+  const ratedTasks = rated.length;
+  const usefulTasks = rated.filter((t) => t.rating === "pass" || t.rating === "partial").length;
+  const rescueRedo = rated.filter((t) => t.rating === "redo" || t.rating === "wrong").length;
+
+  // Unrated is NOT unuseful. With no ratings there is no rate — say so.
+  const usefulRate = ratedTasks > 0 ? usefulTasks / ratedTasks : null;
+
+  const durableHandoffs = tasks.filter((t) => t.durableHandoff).length;
+
+  const criteria: TrialCriterion[] = [
+    {
+      id: "substantive-tasks",
+      label: "Substantive tasks",
+      observed: substantiveTasks,
+      target: GATE_SUBSTANTIVE_TASKS,
+      unit: "tasks",
+      state: gateState(substantiveTasks, GATE_SUBSTANTIVE_TASKS),
+    },
+    {
+      id: "producers",
+      label: "Independent producers",
+      observed: producers.length,
+      target: GATE_PRODUCERS,
+      unit: "producers",
+      state: gateState(producers.length, GATE_PRODUCERS),
+    },
+    {
+      id: "useful-completion",
+      label: "Useful completion (pass or useful partial)",
+      // A rate over zero ratings is not 0% — it is unmeasured.
+      observed: usefulRate === null ? null : Math.round(usefulRate * 100),
+      target: Math.round(GATE_USEFUL_RATE * 100),
+      unit: "%",
+      state: usefulRate === null ? "not-instrumented" : gateState(Math.round(usefulRate * 100), 70),
+      note:
+        usefulRate === null
+          ? "No task has been rated yet — rate delegated tasks with hugin_rate, or this gate cannot be judged."
+          : `n=${ratedTasks} rated of ${substantiveTasks} tasks`,
+    },
+    {
+      id: "durable-handoff",
+      label: "Results collected after the initiating session ended",
+      observed: durableHandoffs,
+      target: GATE_DURABLE_HANDOFFS,
+      unit: "tasks",
+      state: gateState(durableHandoffs, GATE_DURABLE_HANDOFFS),
+      note:
+        "Conservative proxy: a terminal result collected by a DIFFERENT orchestrator " +
+        "session than the one that submitted it. Under-counts rather than over-counts.",
+    },
+    {
+      id: "rescue-redo",
+      label: "Human rescue / redo (lower is better)",
+      observed: rescueRedo,
+      target: 0,
+      unit: "tasks",
+      // Not a pass/fail gate — a tracked cost. Reported, never scored.
+      state: ratedTasks > 0 ? "met" : "not-instrumented",
+      note: ratedTasks > 0 ? `n=${ratedTasks} rated` : "No ratings yet.",
+    },
+    {
+      id: "maintenance-time",
+      label: "Maintenance time during trial (<2h)",
+      observed: null,
+      target: 2,
+      unit: "hours",
+      state: "not-instrumented",
+      note: "No maintenance-time tracking exists. Judge this manually at the 2026-08-22 decision.",
+    },
+    {
+      id: "incidents",
+      label: "Lost tasks / duplicate side effects / security failures",
+      observed: null,
+      target: 0,
+      unit: "incidents",
+      state: "not-instrumented",
+      note:
+        "No aggregate incident counter exists. Idempotency prevents duplicate submission, " +
+        "but occurrences are not counted — judge manually.",
+    },
+  ];
+
+  return {
+    substantiveTasks,
+    producers,
+    ratedTasks,
+    usefulTasks,
+    usefulRate,
+    durableHandoffs,
+    rescueRedo,
+    criteria,
+  };
+}
+
+function pct(rate: number | null): string {
+  return rate === null ? "—" : `${Math.round(rate * 100)}%`;
+}
+
+/**
+ * Render the two planes as Heimdall typed panels (`stat`/`table`/`status`).
+ *
+ * Typed panels carry DATA, never HTML, and Heimdall renders them with zero
+ * per-panel code — so this whole surface is a Hugin-only change, with no
+ * cross-repo dependency on the heimdall repo.
+ */
+export function buildLearningLoopPanels(input: {
+  capability: CapabilityPlane;
+  product: ProductPlane;
+  policy: RoutePolicy;
+}): TypedPanel[] {
+  const { capability, product, policy } = input;
+
+  // The real ledger carries ~100 rows. Rank by how much evidence a row actually
+  // has (verified samples, then attempts) and cap — but NEVER silently: a
+  // truncated table that doesn't say so reads as "this is everything".
+  const ranked = [...capability.rows].sort(
+    (a, b) => b.verifiedSamples - a.verifiedSamples || b.attempts - a.attempts
+  );
+  const shown = ranked.slice(0, MAX_CAPABILITY_ROWS);
+  const dropped = ranked.length - shown.length;
+
+  const capabilityRows: string[][] = capability.available
+    ? [
+        ...shown.map((r) => [
+          r.taskType,
+          r.modelId,
+          String(r.attempts),
+          String(r.verifiedSamples),
+          // No percentage without n.
+          r.qualityRate === null ? "— (unverified)" : pct(r.qualityRate),
+          r.maturity,
+          r.recommendation,
+        ]),
+        ...(dropped > 0
+          ? [[`… ${dropped} more row(s) with less evidence, not shown`, "", "", "", "", "", ""]]
+          : []),
+      ]
+    : [
+        [
+          "M5 ledger unreachable — no capability evidence available (not the same as zero)",
+          "", "", "", "", "", "",
+        ],
+      ];
+
+  const capabilityPanel: TypedPanel = {
+    id: "hugin-capability-evidence",
+    label: "M5 capability evidence (can the cell do the task?)",
+    kind: "table",
+    fullWidth: true,
+    refresh: 300,
+    cols: ["Task type", "Model", "Attempts", "Verified n", "Quality", "Maturity", "M5 recommends"],
+    rows: capabilityRows,
+  };
+
+  const gatePanel: TypedPanel = {
+    id: "hugin-trial-gate",
+    label: "Hugin product evidence — #165 trial gate (decides 2026-08-22)",
+    kind: "table",
+    fullWidth: true,
+    refresh: 300,
+    cols: ["Criterion", "Observed", "Target", "State"],
+    rows: product.criteria.map((c) => [
+      c.note ? `${c.label} — ${c.note}` : c.label,
+      c.observed === null ? "not instrumented" : `${c.observed} ${c.unit}`.trim(),
+      `${c.target} ${c.unit}`.trim(),
+      c.state,
+    ]),
+  };
+
+  const policyPanel: TypedPanel = {
+    id: "hugin-route-policy",
+    label: "Route policy",
+    kind: "status",
+    refresh: 300,
+    state: policy.evidenceDrivenRouteChange ? "pass" : "warn",
+    message:
+      policy.explanation +
+      (policy.priceCatalogVersion ? ` (price catalog ${policy.priceCatalogVersion})` : ""),
+  };
+
+  const handoffPanel: TypedPanel = {
+    id: "hugin-durable-handoffs",
+    label: `Durable handoffs (target ${GATE_DURABLE_HANDOFFS})`,
+    kind: "stat",
+    refresh: 300,
+    value: product.durableHandoffs,
+  };
+
+  return [capabilityPanel, gatePanel, policyPanel, handoffPanel];
+}

--- a/src/learning-loop-health.ts
+++ b/src/learning-loop-health.ts
@@ -76,7 +76,12 @@ export interface RoutePolicy {
   explanation: string;
 }
 
-export type TrialCriterionState = "met" | "not-met" | "not-instrumented";
+export type TrialCriterionState =
+  | "met"
+  | "not-met"
+  | "not-instrumented"
+  /** Tracked as a cost, not scored against a threshold (e.g. rescue/redo). */
+  | "informational";
 
 export interface TrialCriterion {
   id: string;
@@ -89,7 +94,19 @@ export interface TrialCriterion {
   note?: string;
 }
 
+/** Whether the corpus behind the product plane was actually readable. */
+export interface ProductSource {
+  /** False when the task corpus could not be read at all — unmeasured, not zero. */
+  available: boolean;
+  /** Per-task reads that failed: counts below are then a lower bound. */
+  readFailures?: number;
+  /** The corpus walk hit its cap: counts below are then a lower bound. */
+  truncated?: boolean;
+}
+
 export interface ProductPlane {
+  /** False ⇒ every count here is unmeasured. Never render them as zeroes. */
+  available: boolean;
   substantiveTasks: number;
   producers: string[];
   ratedTasks: number;
@@ -108,16 +125,31 @@ export interface ProductTaskEvidence {
   submitter: string | null;
   rating: "pass" | "partial" | "redo" | "wrong" | null;
   verificationOutcome: string | null;
-  /** A LATER session collected the terminal result (src/broker/await-observation.ts). */
+  /** A different MCP process collected the completed result. A PROXY — see the panel note. */
   durableHandoff: boolean;
+  /** For deterministic ordering of "most recent". */
+  updatedAt?: string;
   delegation?: {
     policyMode?: string;
     policyAction?: string;
     priceCatalogVersion?: string;
+    /** Needed to tie a route claim to the ledger row that backs it. */
+    modelId?: string;
+    taskType?: string;
   };
 }
 
-/** Heimdall's typed-panel kinds — rendered with zero Heimdall code. */
+/**
+ * Heimdall's typed-panel kinds — rendered with zero Heimdall code.
+ *
+ * `rows` MUST be an array of plain OBJECTS keyed by column name. Heimdall's
+ * normalizer (`src/contract/panel-data.js`, `isObj` = not-null, object, and
+ * NOT an array) silently FILTERS OUT array rows — a `string[][]` table renders
+ * completely empty on the dashboard while every local test still passes. Found
+ * by cross-checking the consumer contract, not by typechecking.
+ */
+export type TableRow = Record<string, string>;
+
 export interface TypedPanel {
   id: string;
   label: string;
@@ -133,8 +165,23 @@ const GATE_PRODUCERS = 2;
 const GATE_USEFUL_RATE = 0.7;
 const GATE_DURABLE_HANDOFFS = 5;
 
+/**
+ * A useful-completion rate is only meaningful over a decent slice of the corpus.
+ * Below this, the gate reports "not instrumented" rather than a rate inferred
+ * from a self-selected handful of ratings.
+ */
+const MIN_RATING_COVERAGE = 0.5;
+
 /** The live ledger carries ~100 rows; a dashboard table needs a ranked subset. */
 const MAX_CAPABILITY_ROWS = 15;
+
+/** Delegate-policy modes that actually change a route (vs merely observing). */
+const ENFORCING_POLICY_MODES: ReadonlySet<string> = new Set(["enforce", "enforcing", "active"]);
+
+/** A trustworthy count: a nonnegative safe integer, or null. */
+function countOrNull(v: unknown): number | null {
+  return typeof v === "number" && Number.isSafeInteger(v) && v >= 0 ? v : null;
+}
 
 export function computeCapabilityPlane(ledger: Ledger | null): CapabilityPlane {
   if (!ledger) {
@@ -149,19 +196,29 @@ export function computeCapabilityPlane(ledger: Ledger | null): CapabilityPlane {
     };
   }
 
-  const rows: CapabilityRow[] = ledger.report.map((r) => {
-    const passes = r.passes ?? 0;
-    const fails = r.fails ?? 0;
-    const attempts = r.attempts ?? 0;
-    const verifiedSamples = passes + fails;
+  const rows: CapabilityRow[] = [];
+  for (const r of ledger.report) {
+    // The ledger is another service's output — validate its numeric invariants
+    // rather than trusting them. A malformed row (attempts:0 but passes:1, or a
+    // fractional/negative count) would otherwise render as confident positive
+    // evidence — a false 100% quality rate is worse than no row at all.
+    const passes = countOrNull(r.passes);
+    const fails = countOrNull(r.fails);
+    const attempts = countOrNull(r.attempts);
+    const errors = countOrNull(r.errors);
+    if (passes === null || fails === null || attempts === null || errors === null) continue;
 
-    return {
+    const verifiedSamples = passes + fails;
+    // Verified outcomes cannot exceed attempts, and attempts must cover errors.
+    if (verifiedSamples > attempts || errors > attempts) continue;
+
+    rows.push({
       taskType: r.taskType,
       modelId: r.modelId,
       attempts,
       passes,
       fails,
-      errors: r.errors ?? 0,
+      errors,
       verifiedSamples,
       // Errors are infra, not model quality — excluded from the denominator.
       qualityRate: verifiedSamples > 0 ? passes / verifiedSamples : null,
@@ -169,8 +226,8 @@ export function computeCapabilityPlane(ledger: Ledger | null): CapabilityPlane {
         attempts === 0 ? "aspirational" : verifiedSamples > 0 ? "verified" : "unverified",
       recommendation: r.recommendation,
       frozen: r.frozen ?? false,
-    };
-  });
+    });
+  }
 
   const totalAttempts = rows.reduce((n, r) => n + r.attempts, 0);
   const totalVerifiedSamples = rows.reduce((n, r) => n + r.verifiedSamples, 0);
@@ -199,9 +256,13 @@ export function deriveRoutePolicy(
   tasks: ProductTaskEvidence[],
   capability: CapabilityPlane
 ): RoutePolicy {
-  // Most recent task carrying delegation provenance wins.
-  const withProvenance = tasks.filter((t) => t.delegation?.policyMode);
-  const latest = withProvenance[withProvenance.length - 1]?.delegation;
+  // Deterministic "most recent": explicitly by recorded time, not by the
+  // arbitrary order of a union of two Munin queries.
+  const withProvenance = tasks
+    .filter((t) => t.delegation?.policyMode)
+    .sort((a, b) => (a.updatedAt ?? "").localeCompare(b.updatedAt ?? ""));
+  const latestTask = withProvenance[withProvenance.length - 1];
+  const latest = latestTask?.delegation;
 
   const policyMode = latest?.policyMode ?? null;
   const policyAction = latest?.policyAction ?? null;
@@ -218,24 +279,33 @@ export function deriveRoutePolicy(
     };
   }
 
-  const isShadow = policyMode === "shadow";
-  const backedByVerifiedEvidence = capability.actionable;
-  const evidenceDrivenRouteChange = !isShadow && backedByVerifiedEvidence;
+  const isEnforcing = ENFORCING_POLICY_MODES.has(policyMode);
+
+  // A route change is "evidence-driven" only if the evidence in question is the
+  // evidence for THIS route. Any-verified-sample-anywhere would assert a causal
+  // link that was never established — the whole point of the criterion is to show
+  // that a specific route changed BECAUSE of specific verified evidence.
+  const backingRow = ledgerRowFor(capability, latest?.modelId, latest?.taskType);
+  const backedBySpecificEvidence =
+    backingRow !== undefined && backingRow.verifiedSamples > 0;
+  const evidenceDrivenRouteChange = isEnforcing && backedBySpecificEvidence;
 
   let explanation: string;
-  if (isShadow) {
+  if (!isEnforcing) {
     explanation =
       `Routing is still shadow/manual: the M5 delegate policy is in "${policyMode}" mode, ` +
       `so it observes and records evidence but does not change any route. ` +
       `No route change has been caused by verified evidence.`;
   } else if (evidenceDrivenRouteChange) {
     explanation =
-      `Route policy "${policyMode}" is enforcing action "${policyAction}" ` +
-      `backed by ${capability.totalVerifiedSamples} verified sample(s).`;
+      `Route policy "${policyMode}" is enforcing "${policyAction}" for ` +
+      `${latest?.taskType}×${latest?.modelId}, backed by ${backingRow!.verifiedSamples} ` +
+      `verified sample(s) for that exact pair (M5 recommends "${backingRow!.recommendation}").`;
   } else {
     explanation =
-      `Route policy "${policyMode}" reports action "${policyAction}", but no verified ` +
-      `evidence backs it yet — treat the route as manual, not evidence-driven.`;
+      `Route policy "${policyMode}" reports action "${policyAction}", but no verified ledger ` +
+      `evidence for that specific model × task type backs it — treat the route as manual, ` +
+      `not evidence-driven.`;
   }
 
   return {
@@ -252,73 +322,165 @@ function gateState(observed: number | null, target: number): TrialCriterionState
   return observed >= target ? "met" : "not-met";
 }
 
-export function computeProductPlane(tasks: ProductTaskEvidence[]): ProductPlane {
-  const substantiveTasks = tasks.length;
+/** Find the ledger row backing a specific (model × task type) claim. */
+function ledgerRowFor(
+  capability: CapabilityPlane,
+  modelId?: string,
+  taskType?: string
+): CapabilityRow | undefined {
+  if (!modelId || !taskType) return undefined;
+  return capability.rows.find((r) => r.modelId === modelId && r.taskType === taskType);
+}
+
+/**
+ * A `partial` is only USEFUL if the human actually used it. `partial` +
+ * `major_rewrite`/`discarded`/`escalated_to_claude` means the human had to
+ * rescue it — counting that as "useful completion" would inflate the gate with
+ * exactly the outcomes that prove the delegation didn't work.
+ */
+const USEFUL_PARTIAL_OUTCOMES: ReadonlySet<string> = new Set([
+  "accepted_unchanged",
+  "minor_edit",
+]);
+
+function isUseful(t: ProductTaskEvidence): boolean {
+  if (t.rating === "pass") return true;
+  if (t.rating !== "partial") return false;
+  // An unlabelled partial cannot be assumed useful.
+  return t.verificationOutcome !== null && USEFUL_PARTIAL_OUTCOMES.has(t.verificationOutcome);
+}
+
+function isRescue(t: ProductTaskEvidence): boolean {
+  if (t.rating === "redo" || t.rating === "wrong") return true;
+  return t.rating === "partial" && !isUseful(t);
+}
+
+/**
+ * Compute the #165 product gate.
+ *
+ * `available` distinguishes "we measured, and it is zero" from "we could not
+ * measure". They must never render the same: a failed Munin read that displays
+ * as `0 tasks` would let a broken collector masquerade as a failing trial (or,
+ * worse, an empty corpus masquerade as a measured one).
+ */
+export function computeProductPlane(
+  tasks: ProductTaskEvidence[],
+  source: ProductSource = { available: true }
+): ProductPlane {
+  // Only a COMPLETED task is a completed task. Pending/running/cancelled work
+  // is not evidence that Hugin delivered anything.
+  const completed = tasks.filter((t) => t.lifecycle === "completed");
+  const substantiveTasks = completed.length;
 
   const producers = [
-    ...new Set(tasks.map((t) => t.submitter).filter((s): s is string => !!s)),
+    ...new Set(completed.map((t) => t.submitter).filter((s): s is string => !!s)),
   ].sort();
 
-  const rated = tasks.filter((t) => t.rating !== null);
+  const rated = completed.filter((t) => t.rating !== null);
   const ratedTasks = rated.length;
-  const usefulTasks = rated.filter((t) => t.rating === "pass" || t.rating === "partial").length;
-  const rescueRedo = rated.filter((t) => t.rating === "redo" || t.rating === "wrong").length;
+  const usefulTasks = rated.filter(isUseful).length;
+  const rescueRedo = rated.filter(isRescue).length;
 
   // Unrated is NOT unuseful. With no ratings there is no rate — say so.
   const usefulRate = ratedTasks > 0 ? usefulTasks / ratedTasks : null;
+  const durableHandoffs = completed.filter((t) => t.durableHandoff).length;
 
-  const durableHandoffs = tasks.filter((t) => t.durableHandoff).length;
+  // A rate over a tiny slice of the corpus is not a rate for the corpus. Judging
+  // "70% useful" from 1 rated task out of 10 would be a lie of selection.
+  const coverage = substantiveTasks > 0 ? ratedTasks / substantiveTasks : 0;
+  const sufficientCoverage = ratedTasks > 0 && coverage >= MIN_RATING_COVERAGE;
+
+  // If the corpus itself could not be read, EVERY derived count is unmeasured.
+  const unavailable = !source.available;
+  const incomplete = source.truncated === true || (source.readFailures ?? 0) > 0;
+
+  const measured = <T>(value: T): T | null => (unavailable ? null : value);
+  const measuredState = (observed: number | null, target: number): TrialCriterionState =>
+    unavailable ? "not-instrumented" : gateState(observed, target);
+
+  const incompleteNote = incomplete
+    ? ` (corpus incomplete: ${source.readFailures ?? 0} read failure(s)${
+        source.truncated ? ", results truncated" : ""
+      } — counts are a LOWER BOUND)`
+    : "";
+  const unavailableNote =
+    "Task corpus could not be read — this is unmeasured, NOT zero.";
 
   const criteria: TrialCriterion[] = [
     {
       id: "substantive-tasks",
-      label: "Substantive tasks",
-      observed: substantiveTasks,
+      label: "Completed broker tasks",
+      observed: measured(substantiveTasks),
       target: GATE_SUBSTANTIVE_TASKS,
       unit: "tasks",
-      state: gateState(substantiveTasks, GATE_SUBSTANTIVE_TASKS),
+      state: measuredState(measured(substantiveTasks), GATE_SUBSTANTIVE_TASKS),
+      note: unavailable ? unavailableNote : `Completed only${incompleteNote}`,
     },
     {
       id: "producers",
       label: "Independent producers",
-      observed: producers.length,
+      observed: measured(producers.length),
       target: GATE_PRODUCERS,
       unit: "producers",
-      state: gateState(producers.length, GATE_PRODUCERS),
+      state: measuredState(measured(producers.length), GATE_PRODUCERS),
+      note: unavailable
+        ? unavailableNote
+        : `Distinct submitting principals — an identity label, not a verified identity${incompleteNote}`,
     },
     {
       id: "useful-completion",
-      label: "Useful completion (pass or useful partial)",
-      // A rate over zero ratings is not 0% — it is unmeasured.
-      observed: usefulRate === null ? null : Math.round(usefulRate * 100),
+      label: "Useful completion (pass, or partial the human actually used)",
+      observed: usefulRate === null || unavailable ? null : Math.round(usefulRate * 100),
       target: Math.round(GATE_USEFUL_RATE * 100),
       unit: "%",
-      state: usefulRate === null ? "not-instrumented" : gateState(Math.round(usefulRate * 100), 70),
-      note:
-        usefulRate === null
-          ? "No task has been rated yet — rate delegated tasks with hugin_rate, or this gate cannot be judged."
-          : `n=${ratedTasks} rated of ${substantiveTasks} tasks`,
+      // Unrated, under-covered, or unreadable ⇒ unmeasured. Never a zero, and
+      // never a "met" inferred from a flattering handful of ratings.
+      state:
+        unavailable || usefulRate === null || !sufficientCoverage
+          ? "not-instrumented"
+          : gateState(Math.round(usefulRate * 100), Math.round(GATE_USEFUL_RATE * 100)),
+      note: unavailable
+        ? unavailableNote
+        : ratedTasks === 0
+          ? "No completed task has been rated — rate them with hugin_rate or this gate cannot be judged."
+          : !sufficientCoverage
+            ? `Only ${ratedTasks} of ${substantiveTasks} completed tasks rated (${Math.round(
+                coverage * 100
+              )}% coverage; need ${Math.round(MIN_RATING_COVERAGE * 100)}%) — too few to judge the gate.`
+            : `n=${ratedTasks} rated of ${substantiveTasks} completed${incompleteNote}`,
     },
     {
       id: "durable-handoff",
-      label: "Results collected after the initiating session ended",
-      observed: durableHandoffs,
+      label: "Results collected by a later MCP process",
+      observed: measured(durableHandoffs),
       target: GATE_DURABLE_HANDOFFS,
       unit: "tasks",
-      state: gateState(durableHandoffs, GATE_DURABLE_HANDOFFS),
-      note:
-        "Conservative proxy: a terminal result collected by a DIFFERENT orchestrator " +
-        "session than the one that submitted it. Under-counts rather than over-counts.",
+      state: measuredState(measured(durableHandoffs), GATE_DURABLE_HANDOFFS),
+      // Say exactly what this measures, and where it can be WRONG. #165 asks for
+      // "completed after the initiating L1 session closed"; we cannot observe a
+      // session closing, and the session id is client-asserted and minted per
+      // MCP process — so an MCP restart inside a still-live session also trips
+      // this. It is a proxy in both directions, not a measurement.
+      note: unavailable
+        ? unavailableNote
+        : "PROXY: a completed result collected by a different orchestrator_session_id than " +
+          "submitted it. Session closure is not observable; the id is client-asserted and " +
+          "minted per MCP process, so an MCP restart within a live session also counts. " +
+          "Corroborate before relying on this at the 2026-08-22 decision.",
     },
     {
       id: "rescue-redo",
-      label: "Human rescue / redo (lower is better)",
-      observed: rescueRedo,
+      label: "Human rescue / redo (a cost, not a gate)",
+      observed: measured(rescueRedo),
       target: 0,
       unit: "tasks",
-      // Not a pass/fail gate — a tracked cost. Reported, never scored.
-      state: ratedTasks > 0 ? "met" : "not-instrumented",
-      note: ratedTasks > 0 ? `n=${ratedTasks} rated` : "No ratings yet.",
+      // Reported, never scored — a count with no threshold cannot be "met".
+      state: unavailable || ratedTasks === 0 ? "not-instrumented" : "informational",
+      note: unavailable
+        ? unavailableNote
+        : ratedTasks === 0
+          ? "No ratings yet."
+          : `n=${ratedTasks} rated; includes partials the human rewrote, discarded, or escalated`,
     },
     {
       id: "maintenance-time",
@@ -343,6 +505,7 @@ export function computeProductPlane(tasks: ProductTaskEvidence[]): ProductPlane 
   ];
 
   return {
+    available: source.available,
     substantiveTasks,
     producers,
     ratedTasks,
@@ -381,27 +544,40 @@ export function buildLearningLoopPanels(input: {
   const shown = ranked.slice(0, MAX_CAPABILITY_ROWS);
   const dropped = ranked.length - shown.length;
 
-  const capabilityRows: string[][] = capability.available
+  const CAP_COLS = [
+    "Task type", "Model", "Attempts", "Verified n", "Quality", "Maturity", "M5 recommends",
+  ] as const;
+  const emptyCapRow = Object.fromEntries(CAP_COLS.map((c) => [c, ""])) as TableRow;
+
+  const capabilityRows: TableRow[] = capability.available
     ? [
-        ...shown.map((r) => [
-          r.taskType,
-          r.modelId,
-          String(r.attempts),
-          String(r.verifiedSamples),
-          // No percentage without n.
-          r.qualityRate === null ? "— (unverified)" : pct(r.qualityRate),
-          r.maturity,
-          r.recommendation,
-        ]),
+        ...shown.map(
+          (r): TableRow => ({
+            "Task type": r.taskType,
+            Model: r.modelId,
+            Attempts: String(r.attempts),
+            "Verified n": String(r.verifiedSamples),
+            // No percentage without n.
+            Quality: r.qualityRate === null ? "— (unverified)" : pct(r.qualityRate),
+            Maturity: r.maturity,
+            "M5 recommends": r.recommendation,
+          })
+        ),
         ...(dropped > 0
-          ? [[`… ${dropped} more row(s) with less evidence, not shown`, "", "", "", "", "", ""]]
+          ? [
+              {
+                ...emptyCapRow,
+                "Task type": `… ${dropped} more row(s) with less evidence, not shown`,
+              },
+            ]
           : []),
       ]
     : [
-        [
-          "M5 ledger unreachable — no capability evidence available (not the same as zero)",
-          "", "", "", "", "", "",
-        ],
+        {
+          ...emptyCapRow,
+          "Task type":
+            "M5 ledger unreachable — no capability evidence available (not the same as zero)",
+        },
       ];
 
   const capabilityPanel: TypedPanel = {
@@ -410,7 +586,7 @@ export function buildLearningLoopPanels(input: {
     kind: "table",
     fullWidth: true,
     refresh: 300,
-    cols: ["Task type", "Model", "Attempts", "Verified n", "Quality", "Maturity", "M5 recommends"],
+    cols: [...CAP_COLS],
     rows: capabilityRows,
   };
 
@@ -420,13 +596,17 @@ export function buildLearningLoopPanels(input: {
     kind: "table",
     fullWidth: true,
     refresh: 300,
-    cols: ["Criterion", "Observed", "Target", "State"],
-    rows: product.criteria.map((c) => [
-      c.note ? `${c.label} — ${c.note}` : c.label,
-      c.observed === null ? "not instrumented" : `${c.observed} ${c.unit}`.trim(),
-      `${c.target} ${c.unit}`.trim(),
-      c.state,
-    ]),
+    cols: ["Criterion", "Observed", "Target", "State", "Note"],
+    rows: product.criteria.map(
+      (c): TableRow => ({
+        Criterion: c.label,
+        // An unmeasured criterion says so; it never renders as a zero.
+        Observed: c.observed === null ? "not measured" : `${c.observed} ${c.unit}`.trim(),
+        Target: `${c.target} ${c.unit}`.trim(),
+        State: c.state,
+        Note: c.note ?? "",
+      })
+    ),
   };
 
   const policyPanel: TypedPanel = {
@@ -440,12 +620,14 @@ export function buildLearningLoopPanels(input: {
       (policy.priceCatalogVersion ? ` (price catalog ${policy.priceCatalogVersion})` : ""),
   };
 
+  // A `0` here would read as "measured, and it's zero". When the corpus is
+  // unreadable it is neither — show a dash, not a number.
   const handoffPanel: TypedPanel = {
     id: "hugin-durable-handoffs",
-    label: `Durable handoffs (target ${GATE_DURABLE_HANDOFFS})`,
+    label: `Results collected by a later MCP process (proxy; target ${GATE_DURABLE_HANDOFFS})`,
     kind: "stat",
     refresh: 300,
-    value: product.durableHandoffs,
+    value: product.available ? product.durableHandoffs : "—",
   };
 
   return [capabilityPanel, gatePanel, policyPanel, handoffPanel];

--- a/src/mcp/broker-client.ts
+++ b/src/mcp/broker-client.ts
@@ -84,7 +84,11 @@ export class BrokerClient {
     return this.post("/v1/delegate/submit", payload);
   }
 
-  async await_(payload: { task_id: string; max_wait_s?: number }): Promise<unknown> {
+  async await_(payload: {
+    task_id: string;
+    max_wait_s?: number;
+    orchestrator_session_id?: string;
+  }): Promise<unknown> {
     return this.post("/v1/delegate/await", payload);
   }
 

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -279,7 +279,13 @@ export function buildTools(deps: ToolDeps): {
     handler: async (rawInput) => {
       try {
         const input = awaitInputSchema.parse(rawInput);
-        const response = await deps.broker.await_(input);
+        // Envelope autofill (#164): the awaiting session id is what lets the
+        // broker tell a durable handoff (a LATER session collecting a result)
+        // from an ordinary same-session poll. Callers never supply it.
+        const response = await deps.broker.await_({
+          ...input,
+          orchestrator_session_id: deps.sessionId,
+        });
         return asResult(response);
       } catch (err) {
         return asResult(errorPayload(err), true);

--- a/tests/broker/await-observation.test.ts
+++ b/tests/broker/await-observation.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveAwaitObservation,
+  type AwaitObservation,
+} from "../../src/broker/await-observation.js";
+
+const SUBMIT = "session-A";
+
+describe("deriveAwaitObservation", () => {
+  it("records the first await and marks it as a change worth persisting", () => {
+    const { next, changed } = deriveAwaitObservation(null, {
+      sessionId: SUBMIT,
+      at: "2026-07-12T10:00:00Z",
+      lifecycle: "running",
+      submitSessionId: SUBMIT,
+    });
+    expect(changed).toBe(true);
+    expect(next.submitSessionId).toBe(SUBMIT);
+    expect(next.awaitSessionIds).toEqual([SUBMIT]);
+    expect(next.firstAwaitAt).toBe("2026-07-12T10:00:00Z");
+    expect(next.terminalCollected).toBe(false);
+    expect(next.durableHandoff).toBe(false);
+  });
+
+  // The write path is fire-and-forget on a HOT path (every poll of hugin_await
+  // hits it). Re-polling from the same session with no state change must NOT
+  // trigger a Munin write, or a client polling every 2s would hammer the store.
+  it("does not report a change when the same session re-polls the same lifecycle", () => {
+    const first = deriveAwaitObservation(null, {
+      sessionId: SUBMIT, at: "2026-07-12T10:00:00Z", lifecycle: "running", submitSessionId: SUBMIT,
+    }).next;
+
+    const { next, changed } = deriveAwaitObservation(first, {
+      sessionId: SUBMIT, at: "2026-07-12T10:00:30Z", lifecycle: "running", submitSessionId: SUBMIT,
+    });
+    expect(changed).toBe(false);
+    // lastAwaitAt still advances in the derived value; it just isn't worth a write.
+    expect(next.lastAwaitAt).toBe("2026-07-12T10:00:30Z");
+  });
+
+  it("marks terminalCollected when an await observes a terminal lifecycle", () => {
+    const first = deriveAwaitObservation(null, {
+      sessionId: SUBMIT, at: "2026-07-12T10:00:00Z", lifecycle: "running", submitSessionId: SUBMIT,
+    }).next;
+
+    const { next, changed } = deriveAwaitObservation(first, {
+      sessionId: SUBMIT, at: "2026-07-12T10:05:00Z", lifecycle: "completed", submitSessionId: SUBMIT,
+    });
+    expect(changed).toBe(true);
+    expect(next.terminalCollected).toBe(true);
+    // Same session collected it — the submitting L1 session was still alive, so
+    // this does NOT evidence durable value.
+    expect(next.durableHandoff).toBe(false);
+  });
+
+  // THE #165 gate signal: a LATER session collected a terminal result the
+  // submitting session never saw. That is the durable macro-broker earning its
+  // keep — the work outlived the conductor that asked for it.
+  it("marks durableHandoff when a different session collects the terminal result", () => {
+    const first = deriveAwaitObservation(null, {
+      sessionId: SUBMIT, at: "2026-07-12T10:00:00Z", lifecycle: "running", submitSessionId: SUBMIT,
+    }).next;
+
+    const { next, changed } = deriveAwaitObservation(first, {
+      sessionId: "session-B", at: "2026-07-12T11:00:00Z", lifecycle: "completed", submitSessionId: SUBMIT,
+    });
+    expect(changed).toBe(true);
+    expect(next.durableHandoff).toBe(true);
+    expect(next.terminalCollected).toBe(true);
+    expect(next.awaitSessionIds).toEqual([SUBMIT, "session-B"]);
+  });
+
+  it("does not claim durableHandoff for a different session that only saw it running", () => {
+    const { next } = deriveAwaitObservation(null, {
+      sessionId: "session-B", at: "2026-07-12T11:00:00Z", lifecycle: "running", submitSessionId: SUBMIT,
+    });
+    // A second session peeked while it was still running — no terminal result
+    // was collected, so nothing is proven yet.
+    expect(next.durableHandoff).toBe(false);
+    expect(next.terminalCollected).toBe(false);
+  });
+
+  it("treats failed and cancelled as terminal collections too", () => {
+    for (const lifecycle of ["failed", "cancelled"] as const) {
+      const { next } = deriveAwaitObservation(null, {
+        sessionId: "session-B", at: "2026-07-12T11:00:00Z", lifecycle, submitSessionId: SUBMIT,
+      });
+      expect(next.terminalCollected).toBe(true);
+      expect(next.durableHandoff).toBe(true);
+    }
+  });
+
+  it("never un-sets durableHandoff once proven", () => {
+    const proven = deriveAwaitObservation(null, {
+      sessionId: "session-B", at: "2026-07-12T11:00:00Z", lifecycle: "completed", submitSessionId: SUBMIT,
+    }).next;
+
+    const { next, changed } = deriveAwaitObservation(proven, {
+      sessionId: SUBMIT, at: "2026-07-12T12:00:00Z", lifecycle: "completed", submitSessionId: SUBMIT,
+    });
+    expect(next.durableHandoff).toBe(true); // monotonic — evidence is not retracted
+    expect(changed).toBe(true); // a new session id was added to the set
+  });
+
+  it("caps the session-id set so a hostile client cannot grow the document unboundedly", () => {
+    let obs: AwaitObservation | null = null;
+    for (let i = 0; i < 50; i++) {
+      obs = deriveAwaitObservation(obs, {
+        sessionId: `session-${i}`, at: "2026-07-12T10:00:00Z", lifecycle: "running", submitSessionId: SUBMIT,
+      }).next;
+    }
+    expect(obs!.awaitSessionIds.length).toBeLessThanOrEqual(8);
+  });
+
+  it("tolerates a missing session id from a legacy client without claiming evidence", () => {
+    const { next } = deriveAwaitObservation(null, {
+      sessionId: null, at: "2026-07-12T10:00:00Z", lifecycle: "completed", submitSessionId: SUBMIT,
+    });
+    // An old hugin-mcp that sends no session id cannot prove a cross-session
+    // handoff. Record the collection, claim nothing.
+    expect(next.terminalCollected).toBe(true);
+    expect(next.durableHandoff).toBe(false);
+  });
+
+  it("claims nothing when the submitting session is unknown", () => {
+    const { next } = deriveAwaitObservation(null, {
+      sessionId: "session-B", at: "2026-07-12T10:00:00Z", lifecycle: "completed", submitSessionId: null,
+    });
+    expect(next.durableHandoff).toBe(false);
+  });
+});

--- a/tests/broker/await-observation.test.ts
+++ b/tests/broker/await-observation.test.ts
@@ -80,13 +80,17 @@ describe("deriveAwaitObservation", () => {
     expect(next.terminalCollected).toBe(false);
   });
 
-  it("treats failed and cancelled as terminal collections too", () => {
+  // Codex review: #165 asks for tasks that COMPLETE after the session closes. A
+  // failed or cancelled task collected later proves durability, but it is not a
+  // completion — counting it would pad the headline with work that delivered
+  // nothing.
+  it("does not count a failed or cancelled task as a completion", () => {
     for (const lifecycle of ["failed", "cancelled"] as const) {
       const { next } = deriveAwaitObservation(null, {
         sessionId: "session-B", at: "2026-07-12T11:00:00Z", lifecycle, submitSessionId: SUBMIT,
       });
-      expect(next.terminalCollected).toBe(true);
-      expect(next.durableHandoff).toBe(true);
+      expect(next.terminalCollected).toBe(false);
+      expect(next.durableHandoff).toBe(false);
     }
   });
 

--- a/tests/broker/handlers.test.ts
+++ b/tests/broker/handlers.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -458,6 +458,101 @@ describe("POST /v1/delegate/await", () => {
     const body = await res.json();
     expect(body.status).toBe("completed");
     expect(body.result.task_id).toBe("t1");
+  });
+
+  // Durable-handoff evidence (#164) — the #165 gate criterion that nothing
+  // recorded before: did a result outlive the session that asked for it?
+  it("records a durable handoff when a LATER session collects the terminal result", async () => {
+    const submit = await fetch(`${harness.url}/v1/delegate/submit`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify(validRequest({ orchestrator_session_id: "session-A" })),
+    });
+    const { task_id } = await submit.json();
+
+    const statusKey = `tasks/${task_id}/status`;
+    const stored = harness.munin.reads[statusKey] as { content: string };
+    harness.munin.reads[statusKey] = { ...stored, tags: ["completed", "broker:mcp-v2"] };
+    harness.munin.reads[`tasks/${task_id}/result-structured`] = {
+      content: JSON.stringify({ task_id, bodyText: "ok" }),
+    };
+
+    // A DIFFERENT MCP process collects the result: the original conductor is gone.
+    const res = await fetch(`${harness.url}/v1/delegate/await`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify({ task_id, orchestrator_session_id: "session-B" }),
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).status).toBe("completed");
+
+    // The write is fire-and-forget, so let the microtask queue drain.
+    await vi.waitFor(() => {
+      const obs = harness.munin.writes.find(
+        (w) => w.key === "await-observation" && w.namespace === `tasks/${task_id}`
+      );
+      expect(obs).toBeDefined();
+      const parsed = JSON.parse(obs!.content);
+      expect(parsed.durableHandoff).toBe(true);
+      expect(parsed.terminalCollected).toBe(true);
+      expect(parsed.submitSessionId).toBe("session-A");
+    });
+  });
+
+  it("does not claim a handoff when the submitting session collects its own result", async () => {
+    const submit = await fetch(`${harness.url}/v1/delegate/submit`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify(validRequest({ orchestrator_session_id: "session-A" })),
+    });
+    const { task_id } = await submit.json();
+    const statusKey = `tasks/${task_id}/status`;
+    const stored = harness.munin.reads[statusKey] as { content: string };
+    harness.munin.reads[statusKey] = { ...stored, tags: ["completed", "broker:mcp-v2"] };
+    harness.munin.reads[`tasks/${task_id}/result-structured`] = {
+      content: JSON.stringify({ task_id, bodyText: "ok" }),
+    };
+
+    await fetch(`${harness.url}/v1/delegate/await`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify({ task_id, orchestrator_session_id: "session-A" }),
+    });
+
+    await vi.waitFor(() => {
+      const obs = harness.munin.writes.find((w) => w.key === "await-observation");
+      expect(obs).toBeDefined();
+      const parsed = JSON.parse(obs!.content);
+      expect(parsed.terminalCollected).toBe(true);
+      expect(parsed.durableHandoff).toBe(false); // same session — nothing proven
+    });
+  });
+
+  // Evidence collection must never be able to break the thing it observes.
+  it("still answers the await when the observation write throws", async () => {
+    harness.munin.reads["tasks/t1/status"] = {
+      content: historicalBrokerStatus(),
+      tags: ["completed", ORCH_V1_TAG],
+      created_at: "ts",
+      updated_at: "ts",
+    };
+    harness.munin.reads["tasks/t1/result-structured"] = {
+      content: JSON.stringify({ task_id: "t1", result_schema_version: 1 }),
+    };
+    const originalWrite = harness.munin.write.bind(harness.munin);
+    harness.munin.write = vi.fn(async (ns: string, key: string, ...rest: unknown[]) => {
+      if (key === "await-observation") throw new Error("munin down");
+      return originalWrite(ns, key, ...(rest as [string, string[], unknown, unknown]));
+    }) as typeof harness.munin.write;
+
+    const res = await fetch(`${harness.url}/v1/delegate/await`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify({ task_id: "t1", orchestrator_session_id: "session-B" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).status).toBe("completed");
   });
 
   it("recovers ownership from a valid canonical envelope if old terminal tags lost the marker", async () => {

--- a/tests/broker/task-store.test.ts
+++ b/tests/broker/task-store.test.ts
@@ -267,3 +267,120 @@ describe("BrokerTaskStore.listInFlight", () => {
     expect(inflight.every((r) => r.namespace === "tasks/t1")).toBe(true);
   });
 });
+
+// Codex review of #164: the observation write is a read-modify-write. Without
+// CAS, two overlapping writers (a deploy/restart overlap, or concurrent polls)
+// can have a later writer holding a stale `durableHandoff:false` fold clobber an
+// earlier `true` — permanently ERASING proven trial evidence. The in-memory fold
+// is monotonic; persistence has to be too.
+describe("BrokerTaskStore.recordAwait — durable-handoff evidence (#164)", () => {
+  const ENVELOPE_CONTENT = `## Task\n\n### Broker envelope\n\`\`\`json\n${JSON.stringify({
+    envelope_version: 2,
+    orchestrator_submitter: "claude-code",
+    orchestrator_session_id: "session-A",
+    sensitivity: "internal",
+  })}\n\`\`\`\n`;
+
+  function makeMunin(overrides: Partial<Record<string, unknown>> = {}) {
+    const writes: WriteCall[] = [];
+    const store: Record<string, { content: string; updated_at: string }> = {};
+    const munin = {
+      writes,
+      store,
+      read: async (ns: string, key: string) => store[`${ns}/${key}`] ?? null,
+      write: async (
+        namespace: string,
+        key: string,
+        content: string,
+        tags?: string[],
+        expectedUpdatedAt?: string,
+      ) => {
+        const existing = store[`${namespace}/${key}`];
+        if (existing && existing.updated_at !== expectedUpdatedAt) {
+          throw new Error("CAS conflict: entry was modified");
+        }
+        writes.push({ namespace, key, content, tags, expectedUpdatedAt });
+        store[`${namespace}/${key}`] = {
+          content,
+          updated_at: `v${writes.length}`,
+        };
+        return { ok: true };
+      },
+      ...overrides,
+    };
+    return munin;
+  }
+
+  it("sends the CAS token so a concurrent writer cannot silently clobber evidence", async () => {
+    const munin = makeMunin();
+    munin.store["tasks/t1/status"] = { content: ENVELOPE_CONTENT, updated_at: "s1" };
+    const store = new BrokerTaskStore(munin as unknown as MuninClient);
+
+    // First await: same session, still running — records a baseline observation.
+    await store.recordAwait("t1", {
+      sessionId: "session-A", at: "2026-07-12T10:00:00Z", lifecycle: "running",
+    });
+    // Second await: a LATER session collects the completed result.
+    await store.recordAwait("t1", {
+      sessionId: "session-B", at: "2026-07-12T11:00:00Z", lifecycle: "completed",
+    });
+
+    const obs = munin.writes.filter((w) => w.key === "await-observation");
+    expect(obs).toHaveLength(2);
+    // The second write must be CAS-guarded against the first's version.
+    expect(obs[1]!.expectedUpdatedAt).toBe("v1");
+    expect(JSON.parse(obs[1]!.content).durableHandoff).toBe(true);
+  });
+
+  it("re-folds and preserves a proven handoff after losing a CAS race", async () => {
+    const munin = makeMunin();
+    munin.store["tasks/t1/status"] = { content: ENVELOPE_CONTENT, updated_at: "s1" };
+    const store = new BrokerTaskStore(munin as unknown as MuninClient);
+
+    // Another writer has already proven the handoff.
+    munin.store["tasks/t1/await-observation"] = {
+      content: JSON.stringify({
+        schemaVersion: 1, submitSessionId: "session-A", awaitSessionIds: ["session-B"],
+        firstAwaitAt: "x", lastAwaitAt: "x", terminalCollected: true, durableHandoff: true,
+      }),
+      updated_at: "v9",
+    };
+
+    let firstTry = true;
+    const realWrite = munin.write;
+    munin.write = async (...args: Parameters<typeof realWrite>) => {
+      if (firstTry && args[1] === "await-observation") {
+        firstTry = false;
+        // Simulate the doc moving under us mid-write.
+        munin.store["tasks/t1/await-observation"]!.updated_at = "v10";
+        throw new Error("CAS conflict: entry was modified");
+      }
+      return realWrite(...args);
+    };
+
+    // A different session polls; on its own it would prove nothing.
+    await store.recordAwait("t1", {
+      sessionId: "session-C", at: "2026-07-12T12:00:00Z", lifecycle: "running",
+    });
+
+    const obs = munin.writes.filter((w) => w.key === "await-observation");
+    expect(obs).toHaveLength(1);
+    // The retry re-read and re-folded: the earlier proof SURVIVES.
+    expect(JSON.parse(obs[0]!.content).durableHandoff).toBe(true);
+  });
+
+  it("skips the write entirely when a re-poll reveals nothing new (hot path)", async () => {
+    const munin = makeMunin();
+    munin.store["tasks/t1/status"] = { content: ENVELOPE_CONTENT, updated_at: "s1" };
+    const store = new BrokerTaskStore(munin as unknown as MuninClient);
+
+    for (let i = 0; i < 5; i++) {
+      await store.recordAwait("t1", {
+        sessionId: "session-A", at: `2026-07-12T10:0${i}:00Z`, lifecycle: "running",
+      });
+    }
+
+    // Five polls, ONE write: only the first carried new evidence.
+    expect(munin.writes.filter((w) => w.key === "await-observation")).toHaveLength(1);
+  });
+});

--- a/tests/learning-loop-collector.test.ts
+++ b/tests/learning-loop-collector.test.ts
@@ -56,7 +56,7 @@ describe("LearningLoopCollector", () => {
 
     const evidence = await new LearningLoopCollector({
       munin, ledgerClient: fakeLedgerClient(okLedger),
-    }).collect();
+    }).refresh();
 
     expect(evidence.tasks).toHaveLength(1);
     const t = evidence.tasks[0]!;
@@ -94,7 +94,7 @@ describe("LearningLoopCollector", () => {
 
     const evidence = await new LearningLoopCollector({
       munin, ledgerClient: fakeLedgerClient(null),
-    }).collect();
+    }).refresh();
 
     expect(evidence.tasks).toHaveLength(1);
     expect(evidence.tasks[0]!.taskId).toBe("mcp-m5-old");
@@ -115,7 +115,7 @@ describe("LearningLoopCollector", () => {
 
     const evidence = await new LearningLoopCollector({
       munin, ledgerClient: fakeLedgerClient(null),
-    }).collect();
+    }).refresh();
 
     // Product evidence is about the BROKER path under test (#165), not the
     // general dispatcher corpus.
@@ -132,9 +132,11 @@ describe("LearningLoopCollector", () => {
 
     const evidence = await new LearningLoopCollector({
       munin, ledgerClient: fakeLedgerClient(okLedger),
-    }).collect();
+    }).refresh();
 
     // /heimdall.json must never break because evidence collection failed.
+    // Codex review: a failed query must NOT read as a measured-empty corpus.
+    expect(evidence.available).toBe(false);
     expect(evidence.tasks).toEqual([]);
     expect(evidence.ledger).toEqual(okLedger); // the ledger half still works
   });
@@ -146,7 +148,7 @@ describe("LearningLoopCollector", () => {
     const evidence = await new LearningLoopCollector({
       munin,
       ledgerClient: { getLedger: vi.fn(async () => { throw new Error("gateway down"); }) },
-    }).collect();
+    }).refresh();
 
     expect(evidence.ledger).toBeNull(); // "unavailable", not a fabricated zero
     expect(evidence.tasks).toHaveLength(1);
@@ -160,11 +162,12 @@ describe("LearningLoopCollector", () => {
       munin, ledgerClient: fakeLedgerClient(okLedger), ttlMs: 300_000, now: () => 1000,
     });
 
-    await collector.collect();
-    await collector.collect();
-    await collector.collect();
+    await collector.refresh(); // prime the cache
+    collector.collect();
+    collector.collect();
+    collector.collect();
 
-    // One corpus walk (two queries: tagged + homeserver), not three.
+    // Cached reads do no further corpus walks (one walk = two queries).
     expect(munin.query).toHaveBeenCalledTimes(2);
   });
 
@@ -174,7 +177,7 @@ describe("LearningLoopCollector", () => {
     });
     const collector = new LearningLoopCollector({ munin, ledgerClient: fakeLedgerClient(okLedger) });
 
-    await Promise.all([collector.collect(), collector.collect(), collector.collect()]);
+    await Promise.all([collector.refresh(), collector.refresh(), collector.refresh()]);
 
     // One corpus walk (two queries), not three.
     expect(munin.query).toHaveBeenCalledTimes(2);
@@ -187,9 +190,65 @@ describe("LearningLoopCollector", () => {
     });
     const evidence = await new LearningLoopCollector({
       munin, ledgerClient: fakeLedgerClient(null),
-    }).collect();
+    }).refresh();
 
     expect(evidence.tasks).toHaveLength(1);
     expect(evidence.tasks[0]!.rating).toBeNull(); // one lost data point, not a crash
+  });
+
+  // Codex review: awaiting a cold corpus walk on /heimdall.json (up to 200 tasks
+  // × several serialized Munin reads) can hang the descriptor for ~a minute and
+  // blank Hugin's Heimdall page — the #135 regression, no exception needed.
+  it("returns immediately on a cold cache instead of blocking on the walk", () => {
+    const munin = {
+      query: vi.fn(() => new Promise(() => {})), // a walk that never resolves
+      read: vi.fn(() => new Promise(() => {})),
+    } as unknown as MuninClient;
+
+    const collector = new LearningLoopCollector({
+      munin, ledgerClient: { getLedger: () => new Promise(() => {}) },
+    });
+
+    // Synchronous — no await. Must not hang, and must say "unavailable" rather
+    // than invent an empty corpus.
+    const evidence = collector.collect();
+    expect(evidence.available).toBe(false);
+    expect(evidence.tasks).toEqual([]);
+  });
+
+  it("serves stale evidence rather than blocking while it refreshes", async () => {
+    let clock = 1000;
+    const munin = fakeMunin({
+      "tasks/mcp-m5-1/status": { content: ENVELOPE("claude-code"), tags: ["completed"] },
+    });
+    const collector = new LearningLoopCollector({
+      munin, ledgerClient: fakeLedgerClient(okLedger), ttlMs: 100, now: () => clock,
+    });
+
+    await collector.refresh();
+    clock += 10_000; // cache is now stale
+
+    const evidence = collector.collect(); // still instant, stale but honest
+    expect(evidence.available).toBe(true);
+    expect(evidence.tasks).toHaveLength(1);
+  });
+
+  it("does not cache a failed collection — the next tick retries", async () => {
+    let fail = true;
+    const munin = {
+      query: vi.fn(async () => {
+        if (fail) throw new Error("munin down");
+        return { results: [{ namespace: "tasks/mcp-m5-1", key: "status" }], total: 1 };
+      }),
+      read: vi.fn(async (_ns: string, key: string) =>
+        key === "status" ? { content: ENVELOPE("claude-code"), tags: ["completed"] } : null
+      ),
+    } as unknown as MuninClient;
+
+    const collector = new LearningLoopCollector({ munin, ledgerClient: fakeLedgerClient(null) });
+
+    expect((await collector.refresh()).available).toBe(false);
+    fail = false;
+    expect((await collector.refresh()).available).toBe(true); // recovers
   });
 });

--- a/tests/learning-loop-collector.test.ts
+++ b/tests/learning-loop-collector.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it, vi } from "vitest";
+import { LearningLoopCollector } from "../src/learning-loop-collector.js";
+import type { MuninClient } from "../src/munin-client.js";
+import type { Ledger, LedgerClientLike } from "../src/orchestrator/ledger-client.js";
+
+const ENVELOPE = (submitter: string) =>
+  `## Task\n\n### Broker envelope\n\`\`\`json\n${JSON.stringify({
+    envelope_version: 2,
+    orchestrator_submitter: submitter,
+    orchestrator_session_id: "session-A",
+  })}\n\`\`\`\n`;
+
+function fakeMunin(entries: Record<string, { content: string; tags?: string[] }>): MuninClient {
+  return {
+    query: vi.fn(async () => ({
+      results: Object.keys(entries)
+        .filter((k) => k.endsWith("/status"))
+        .map((k) => ({ namespace: k.replace(/\/status$/, ""), key: "status" })),
+      total: 0,
+    })),
+    read: vi.fn(async (ns: string, key: string) => entries[`${ns}/${key}`] ?? null),
+  } as unknown as MuninClient;
+}
+
+const okLedger: Ledger = {
+  report: [
+    {
+      taskType: "extract", modelId: "mellum", verdict: "viable", attempts: 10,
+      passes: 9, fails: 1, errors: 0, successRate: 0.9, frozen: false,
+      recommendation: "delegate-local",
+    },
+  ],
+};
+const fakeLedgerClient = (ledger: Ledger | null): LedgerClientLike => ({
+  getLedger: vi.fn(async () => ledger),
+});
+
+describe("LearningLoopCollector", () => {
+  it("collects rating, durable-handoff and route-policy provenance for a broker task", async () => {
+    const munin = fakeMunin({
+      "tasks/mcp-m5-1/status": { content: ENVELOPE("claude-code"), tags: ["completed", "broker:mcp-v2"] },
+      "tasks/mcp-m5-1/feedback": {
+        content: JSON.stringify({ rating: "pass", verification_outcome: "accepted_unchanged" }),
+      },
+      "tasks/mcp-m5-1/await-observation": {
+        content: JSON.stringify({ durableHandoff: true, terminalCollected: true }),
+      },
+      "tasks/mcp-m5-1/result-structured": {
+        content: JSON.stringify({
+          runtimeMetadata: {
+            delegation: { policyMode: "shadow", policyAction: "shadow", priceCatalogVersion: "2026-07-08" },
+          },
+        }),
+      },
+    });
+
+    const evidence = await new LearningLoopCollector({
+      munin, ledgerClient: fakeLedgerClient(okLedger),
+    }).collect();
+
+    expect(evidence.tasks).toHaveLength(1);
+    const t = evidence.tasks[0]!;
+    expect(t.taskId).toBe("mcp-m5-1");
+    expect(t.submitter).toBe("claude-code");
+    expect(t.rating).toBe("pass");
+    expect(t.durableHandoff).toBe(true);
+    expect(t.delegation?.policyMode).toBe("shadow");
+    expect(evidence.ledger).toEqual(okLedger);
+  });
+
+  // Caught against REAL production data: the one existing broker task predates
+  // PR #173, so its terminal status tags are ["completed","runtime:homeserver"]
+  // with NO `broker:mcp-v2` marker (that tag-dropping seam is exactly what #173
+  // fixed). Keying the corpus walk off the tag alone under-counts the trial —
+  // reporting 0 tasks when there is 1. The embedded broker envelope is the
+  // definitive marker, so identify tasks by envelope, not by tag.
+  it("finds a pre-#173 broker task whose status lost the broker:mcp-v2 tag", async () => {
+    const entries: Record<string, { content: string; tags?: string[] }> = {
+      "tasks/mcp-m5-old/status": {
+        content: ENVELOPE("claude-code"),
+        tags: ["completed", "runtime:homeserver"], // no broker:mcp-v2
+      },
+      "tasks/mcp-m5-old/feedback": { content: JSON.stringify({ rating: "pass" }) },
+    };
+    const munin = {
+      // The tag query only ever surfaces the explicitly-tagged feedback doc.
+      query: vi.fn(async (q: { tags?: string[] }) =>
+        q.tags?.includes("broker:mcp-v2")
+          ? { results: [{ namespace: "tasks/mcp-m5-old", key: "feedback" }], total: 1 }
+          : { results: [{ namespace: "tasks/mcp-m5-old", key: "status" }], total: 1 }
+      ),
+      read: vi.fn(async (ns: string, key: string) => entries[`${ns}/${key}`] ?? null),
+    } as unknown as MuninClient;
+
+    const evidence = await new LearningLoopCollector({
+      munin, ledgerClient: fakeLedgerClient(null),
+    }).collect();
+
+    expect(evidence.tasks).toHaveLength(1);
+    expect(evidence.tasks[0]!.taskId).toBe("mcp-m5-old");
+    expect(evidence.tasks[0]!.rating).toBe("pass");
+    expect(evidence.tasks[0]!.submitter).toBe("claude-code");
+  });
+
+  it("ignores a non-broker task that carries no envelope", async () => {
+    const munin = {
+      query: vi.fn(async () => ({
+        results: [{ namespace: "tasks/20260101-plain", key: "status" }],
+        total: 1,
+      })),
+      read: vi.fn(async (ns: string, key: string) =>
+        key === "status" ? { content: "## Task: ordinary\n\n### Prompt\nhi", tags: ["completed"] } : null
+      ),
+    } as unknown as MuninClient;
+
+    const evidence = await new LearningLoopCollector({
+      munin, ledgerClient: fakeLedgerClient(null),
+    }).collect();
+
+    // Product evidence is about the BROKER path under test (#165), not the
+    // general dispatcher corpus.
+    expect(evidence.tasks).toEqual([]);
+  });
+
+  it("degrades to no-evidence rather than throwing when Munin is down", async () => {
+    const munin = {
+      query: vi.fn(async () => {
+        throw new Error("munin down");
+      }),
+      read: vi.fn(async () => null),
+    } as unknown as MuninClient;
+
+    const evidence = await new LearningLoopCollector({
+      munin, ledgerClient: fakeLedgerClient(okLedger),
+    }).collect();
+
+    // /heimdall.json must never break because evidence collection failed.
+    expect(evidence.tasks).toEqual([]);
+    expect(evidence.ledger).toEqual(okLedger); // the ledger half still works
+  });
+
+  it("degrades to a null ledger when the gateway is unreachable", async () => {
+    const munin = fakeMunin({
+      "tasks/mcp-m5-1/status": { content: ENVELOPE("claude-code"), tags: ["completed"] },
+    });
+    const evidence = await new LearningLoopCollector({
+      munin,
+      ledgerClient: { getLedger: vi.fn(async () => { throw new Error("gateway down"); }) },
+    }).collect();
+
+    expect(evidence.ledger).toBeNull(); // "unavailable", not a fabricated zero
+    expect(evidence.tasks).toHaveLength(1);
+  });
+
+  it("caches — a 60s dashboard poll must not re-walk the corpus every time", async () => {
+    const munin = fakeMunin({
+      "tasks/mcp-m5-1/status": { content: ENVELOPE("claude-code"), tags: ["completed"] },
+    });
+    const collector = new LearningLoopCollector({
+      munin, ledgerClient: fakeLedgerClient(okLedger), ttlMs: 300_000, now: () => 1000,
+    });
+
+    await collector.collect();
+    await collector.collect();
+    await collector.collect();
+
+    // One corpus walk (two queries: tagged + homeserver), not three.
+    expect(munin.query).toHaveBeenCalledTimes(2);
+  });
+
+  it("coalesces concurrent collections into a single corpus walk", async () => {
+    const munin = fakeMunin({
+      "tasks/mcp-m5-1/status": { content: ENVELOPE("claude-code"), tags: ["completed"] },
+    });
+    const collector = new LearningLoopCollector({ munin, ledgerClient: fakeLedgerClient(okLedger) });
+
+    await Promise.all([collector.collect(), collector.collect(), collector.collect()]);
+
+    // One corpus walk (two queries), not three.
+    expect(munin.query).toHaveBeenCalledTimes(2);
+  });
+
+  it("survives a corrupt feedback document without losing the whole task", async () => {
+    const munin = fakeMunin({
+      "tasks/mcp-m5-1/status": { content: ENVELOPE("claude-code"), tags: ["completed"] },
+      "tasks/mcp-m5-1/feedback": { content: "{not json" },
+    });
+    const evidence = await new LearningLoopCollector({
+      munin, ledgerClient: fakeLedgerClient(null),
+    }).collect();
+
+    expect(evidence.tasks).toHaveLength(1);
+    expect(evidence.tasks[0]!.rating).toBeNull(); // one lost data point, not a crash
+  });
+});

--- a/tests/learning-loop-health.test.ts
+++ b/tests/learning-loop-health.test.ts
@@ -1,0 +1,230 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeCapabilityPlane,
+  computeProductPlane,
+  deriveRoutePolicy,
+  buildLearningLoopPanels,
+  type ProductTaskEvidence,
+} from "../src/learning-loop-health.js";
+import type { Ledger } from "../src/orchestrator/ledger-client.js";
+
+const ledger = (rows: Partial<Ledger["report"][number]>[]): Ledger => ({
+  report: rows.map((r) => ({
+    taskType: "extract", modelId: "mellum", verdict: "unknown",
+    attempts: 0, passes: 0, fails: 0, errors: 0, successRate: 0,
+    frozen: false, recommendation: "explore",
+    ...r,
+  })) as Ledger["report"],
+});
+
+const task = (o: Partial<ProductTaskEvidence> = {}): ProductTaskEvidence => ({
+  taskId: "t1", lifecycle: "completed", submitter: "claude-code",
+  rating: null, verificationOutcome: null, durableHandoff: false,
+  ...o,
+});
+
+describe("computeCapabilityPlane (M5 evidence)", () => {
+  it("reports no signal when the ledger is unreachable — never a fabricated zero", () => {
+    const plane = computeCapabilityPlane(null);
+    expect(plane.available).toBe(false);
+    expect(plane.evidenceArriving).toBe(false);
+    expect(plane.rows).toEqual([]);
+  });
+
+  // #164: "Show denominators and sample maturity; no percentage without n."
+  it("emits a null quality rate when there are no VERIFIED samples", () => {
+    const plane = computeCapabilityPlane(
+      ledger([{ taskType: "extract", modelId: "mellum", attempts: 12, passes: 0, fails: 0, errors: 0 }])
+    );
+    const row = plane.rows[0]!;
+    expect(row.attempts).toBe(12);
+    expect(row.verifiedSamples).toBe(0);
+    expect(row.qualityRate).toBeNull(); // 12 attempts, ZERO verified — no percentage
+    expect(row.maturity).toBe("unverified");
+    expect(plane.evidenceArriving).toBe(true); // calls are happening...
+    expect(plane.actionable).toBe(false); // ...but nothing is strong enough to act on
+  });
+
+  it("computes a quality rate only from verified pass/fail, excluding infra errors", () => {
+    const plane = computeCapabilityPlane(
+      ledger([{ attempts: 20, passes: 8, fails: 2, errors: 5 }])
+    );
+    const row = plane.rows[0]!;
+    expect(row.verifiedSamples).toBe(10); // 8 + 2 — errors are NOT quality signal
+    expect(row.qualityRate).toBe(0.8);
+    expect(row.maturity).toBe("verified");
+    expect(plane.actionable).toBe(true);
+  });
+
+  it("marks a never-attempted row aspirational, not failing", () => {
+    const plane = computeCapabilityPlane(ledger([{ attempts: 0 }]));
+    expect(plane.rows[0]!.maturity).toBe("aspirational");
+    expect(plane.evidenceArriving).toBe(false);
+  });
+});
+
+describe("deriveRoutePolicy", () => {
+  // #164: "Show at least one explainable route change caused by verified
+  // evidence, or explicitly state that routing is still shadow/manual."
+  it("states plainly that routing is shadow when the gateway policy is in shadow mode", () => {
+    const policy = deriveRoutePolicy(
+      [task({ delegation: { policyMode: "shadow", policyAction: "shadow", priceCatalogVersion: "2026-07-08" } })],
+      computeCapabilityPlane(ledger([{ attempts: 20, passes: 8, fails: 2 }]))
+    );
+    expect(policy.policyMode).toBe("shadow");
+    expect(policy.priceCatalogVersion).toBe("2026-07-08");
+    expect(policy.evidenceDrivenRouteChange).toBe(false);
+    expect(policy.explanation).toMatch(/shadow/i);
+  });
+
+  it("reports an evidence-driven route change once the policy actually enforces on verified evidence", () => {
+    const policy = deriveRoutePolicy(
+      [task({ delegation: { policyMode: "enforce", policyAction: "delegate-local" } })],
+      computeCapabilityPlane(ledger([{ attempts: 20, passes: 18, fails: 2, recommendation: "delegate-local" }]))
+    );
+    expect(policy.evidenceDrivenRouteChange).toBe(true);
+    expect(policy.explanation).toMatch(/delegate-local/);
+  });
+
+  it("does not claim an evidence-driven change when the policy enforces but no verified evidence backs it", () => {
+    const policy = deriveRoutePolicy(
+      [task({ delegation: { policyMode: "enforce", policyAction: "delegate-local" } })],
+      computeCapabilityPlane(ledger([{ attempts: 20, passes: 0, fails: 0 }])) // all unverified
+    );
+    expect(policy.evidenceDrivenRouteChange).toBe(false);
+  });
+
+  it("reports unknown policy rather than guessing when no task carries provenance", () => {
+    const policy = deriveRoutePolicy([task()], computeCapabilityPlane(null));
+    expect(policy.policyMode).toBeNull();
+    expect(policy.explanation).toMatch(/no route-policy provenance/i);
+  });
+});
+
+describe("computeProductPlane (#165 trial gate)", () => {
+  it("counts substantive tasks and distinct producers", () => {
+    const plane = computeProductPlane([
+      task({ taskId: "a", submitter: "claude-code" }),
+      task({ taskId: "b", submitter: "claude-code" }),
+      task({ taskId: "c", submitter: "codex-cli" }),
+    ]);
+    expect(plane.substantiveTasks).toBe(3);
+    expect(plane.producers).toEqual(["claude-code", "codex-cli"]);
+  });
+
+  it("emits a null useful rate when nothing has been rated — no percentage without n", () => {
+    const plane = computeProductPlane([task({ rating: null }), task({ taskId: "b", rating: null })]);
+    expect(plane.substantiveTasks).toBe(2);
+    expect(plane.ratedTasks).toBe(0);
+    expect(plane.usefulRate).toBeNull();
+    const useful = plane.criteria.find((c) => c.id === "useful-completion")!;
+    expect(useful.state).toBe("not-instrumented"); // unrated ≠ unuseful
+  });
+
+  it("treats pass and partial as useful, redo and wrong as rescue/redo", () => {
+    const plane = computeProductPlane([
+      task({ taskId: "a", rating: "pass" }),
+      task({ taskId: "b", rating: "partial" }),
+      task({ taskId: "c", rating: "redo" }),
+      task({ taskId: "d", rating: "wrong" }),
+    ]);
+    expect(plane.ratedTasks).toBe(4);
+    expect(plane.usefulTasks).toBe(2);
+    expect(plane.usefulRate).toBe(0.5);
+    expect(plane.rescueRedo).toBe(2);
+  });
+
+  it("counts durable handoffs — the criterion that proves the DURABLE broker earns its keep", () => {
+    const plane = computeProductPlane([
+      task({ taskId: "a", durableHandoff: true }),
+      task({ taskId: "b", durableHandoff: true }),
+      task({ taskId: "c", durableHandoff: false }),
+    ]);
+    expect(plane.durableHandoffs).toBe(2);
+    const c = plane.criteria.find((x) => x.id === "durable-handoff")!;
+    expect(c.observed).toBe(2);
+    expect(c.target).toBe(5);
+    expect(c.state).toBe("not-met"); // 2 < 5
+  });
+
+  it("marks the gate met once the thresholds are cleared", () => {
+    const tasks = Array.from({ length: 10 }, (_, i) =>
+      task({ taskId: `t${i}`, submitter: i % 2 ? "codex-cli" : "claude-code", rating: "pass", durableHandoff: i < 5 })
+    );
+    const plane = computeProductPlane(tasks);
+    const byId = Object.fromEntries(plane.criteria.map((c) => [c.id, c]));
+    expect(byId["substantive-tasks"]!.state).toBe("met"); // 10 >= 10
+    expect(byId["producers"]!.state).toBe("met"); // 2 >= 2
+    expect(byId["useful-completion"]!.state).toBe("met"); // 100% >= 70%
+    expect(byId["durable-handoff"]!.state).toBe("met"); // 5 >= 5
+  });
+
+  // The honesty requirement: metrics with no data source must say so, never
+  // render as a satisfied zero.
+  it("marks uninstrumented gate criteria explicitly instead of reporting a flattering zero", () => {
+    const plane = computeProductPlane([task()]);
+    const byId = Object.fromEntries(plane.criteria.map((c) => [c.id, c]));
+    for (const id of ["maintenance-time", "incidents"]) {
+      expect(byId[id]!.state).toBe("not-instrumented");
+      expect(byId[id]!.observed).toBeNull();
+      expect(byId[id]!.note).toBeTruthy();
+    }
+  });
+});
+
+describe("buildLearningLoopPanels", () => {
+  it("keeps the two evidence planes separate rather than collapsing them into one verdict", () => {
+    const panels = buildLearningLoopPanels({
+      capability: computeCapabilityPlane(ledger([{ attempts: 20, passes: 8, fails: 2 }])),
+      product: computeProductPlane([task({ rating: "pass", durableHandoff: true })]),
+      policy: deriveRoutePolicy([task({ delegation: { policyMode: "shadow" } })], computeCapabilityPlane(null)),
+    });
+    const ids = panels.map((p) => p.id);
+    expect(ids).toContain("hugin-capability-evidence");
+    expect(ids).toContain("hugin-trial-gate");
+    expect(ids).toContain("hugin-route-policy");
+    // No panel claims a single fused "learning loop is healthy" verdict.
+    expect(ids).not.toContain("hugin-learning-loop");
+  });
+
+  it("emits only Heimdall's typed-panel kinds, so no Heimdall code change is needed", () => {
+    const panels = buildLearningLoopPanels({
+      capability: computeCapabilityPlane(null),
+      product: computeProductPlane([]),
+      policy: deriveRoutePolicy([], computeCapabilityPlane(null)),
+    });
+    for (const p of panels) {
+      expect(["stat", "timeseries", "table", "status"]).toContain(p.kind);
+    }
+  });
+
+  // Real M5 ledger returns 106 rows — unusable on a dashboard. Cap it, but
+  // DISCLOSE the cap: a silently truncated table reads as "this is everything".
+  it("ranks and caps the capability table, disclosing what it dropped", () => {
+    const many = Array.from({ length: 40 }, (_, i) => ({
+      taskType: `type-${i}`, modelId: "m", attempts: i, passes: i, fails: 0,
+    }));
+    const panels = buildLearningLoopPanels({
+      capability: computeCapabilityPlane(ledger(many)),
+      product: computeProductPlane([]),
+      policy: deriveRoutePolicy([], computeCapabilityPlane(null)),
+    });
+    const table = panels.find((p) => p.id === "hugin-capability-evidence")!;
+    const rows = table.rows as string[][];
+    expect(rows.length).toBeLessThanOrEqual(16); // 15 rows + 1 disclosure row
+    // Ranked: the most-evidenced row leads, not an arbitrary one.
+    expect(rows[0]![0]).toBe("type-39");
+    // The drop is stated, not hidden.
+    expect(JSON.stringify(rows)).toMatch(/25 more/);
+  });
+
+  it("is content-blind — no prompt or result text can reach the panel", () => {
+    const panels = buildLearningLoopPanels({
+      capability: computeCapabilityPlane(ledger([{ attempts: 1, passes: 1 }])),
+      product: computeProductPlane([task({ rating: "pass" })]),
+      policy: deriveRoutePolicy([], computeCapabilityPlane(null)),
+    });
+    const serialized = JSON.stringify(panels);
+    expect(serialized).not.toMatch(/prompt|bodyText|secret/i);
+  });
+});

--- a/tests/learning-loop-health.test.ts
+++ b/tests/learning-loop-health.test.ts
@@ -77,21 +77,66 @@ describe("deriveRoutePolicy", () => {
     expect(policy.explanation).toMatch(/shadow/i);
   });
 
-  it("reports an evidence-driven route change once the policy actually enforces on verified evidence", () => {
+  it("reports an evidence-driven route change once the policy enforces on evidence for THAT pair", () => {
     const policy = deriveRoutePolicy(
-      [task({ delegation: { policyMode: "enforce", policyAction: "delegate-local" } })],
-      computeCapabilityPlane(ledger([{ attempts: 20, passes: 18, fails: 2, recommendation: "delegate-local" }]))
+      [task({
+        delegation: {
+          policyMode: "enforce", policyAction: "delegate-local",
+          modelId: "mellum", taskType: "extract",
+        },
+      })],
+      computeCapabilityPlane(
+        ledger([{ taskType: "extract", modelId: "mellum", attempts: 20, passes: 18, fails: 2, recommendation: "delegate-local" }])
+      )
     );
     expect(policy.evidenceDrivenRouteChange).toBe(true);
     expect(policy.explanation).toMatch(/delegate-local/);
+    expect(policy.explanation).toMatch(/extract×mellum/);
   });
 
-  it("does not claim an evidence-driven change when the policy enforces but no verified evidence backs it", () => {
+  // Codex review: "any verified sample anywhere in the ledger" asserts a causal
+  // link that was never established. The evidence must be evidence for THIS route.
+  it("does not claim causation from verified evidence about a DIFFERENT model or task type", () => {
     const policy = deriveRoutePolicy(
-      [task({ delegation: { policyMode: "enforce", policyAction: "delegate-local" } })],
-      computeCapabilityPlane(ledger([{ attempts: 20, passes: 0, fails: 0 }])) // all unverified
+      [task({
+        delegation: {
+          policyMode: "enforce", policyAction: "delegate-local",
+          modelId: "mellum", taskType: "extract",
+        },
+      })],
+      // Plenty of verified evidence — but all of it about a different pair.
+      computeCapabilityPlane(
+        ledger([{ taskType: "summarize", modelId: "gemma4", attempts: 50, passes: 50, fails: 0 }])
+      )
     );
     expect(policy.evidenceDrivenRouteChange).toBe(false);
+    expect(policy.explanation).toMatch(/no verified ledger evidence for that specific/i);
+  });
+
+  it("does not claim an evidence-driven change when the policy enforces but nothing is verified", () => {
+    const policy = deriveRoutePolicy(
+      [task({
+        delegation: {
+          policyMode: "enforce", policyAction: "delegate-local",
+          modelId: "mellum", taskType: "extract",
+        },
+      })],
+      computeCapabilityPlane(
+        ledger([{ taskType: "extract", modelId: "mellum", attempts: 20, passes: 0, fails: 0 }])
+      )
+    );
+    expect(policy.evidenceDrivenRouteChange).toBe(false);
+  });
+
+  it("picks the latest policy deterministically by time, not by array order", () => {
+    const policy = deriveRoutePolicy(
+      [
+        task({ taskId: "new", updatedAt: "2026-07-12T00:00:00Z", delegation: { policyMode: "enforce" } }),
+        task({ taskId: "old", updatedAt: "2026-01-01T00:00:00Z", delegation: { policyMode: "shadow" } }),
+      ],
+      computeCapabilityPlane(null)
+    );
+    expect(policy.policyMode).toBe("enforce"); // newest wins regardless of position
   });
 
   it("reports unknown policy rather than guessing when no task carries provenance", () => {
@@ -121,17 +166,72 @@ describe("computeProductPlane (#165 trial gate)", () => {
     expect(useful.state).toBe("not-instrumented"); // unrated ≠ unuseful
   });
 
-  it("treats pass and partial as useful, redo and wrong as rescue/redo", () => {
+  // Codex review: a `partial` the human had to REWRITE or DISCARD is not a
+  // useful completion — counting it as one would inflate the gate with exactly
+  // the outcomes that prove the delegation failed.
+  it("counts a partial as useful only when the human actually used it", () => {
     const plane = computeProductPlane([
       task({ taskId: "a", rating: "pass" }),
-      task({ taskId: "b", rating: "partial" }),
-      task({ taskId: "c", rating: "redo" }),
-      task({ taskId: "d", rating: "wrong" }),
+      task({ taskId: "b", rating: "partial", verificationOutcome: "minor_edit" }),
+      task({ taskId: "c", rating: "partial", verificationOutcome: "major_rewrite" }),
+      task({ taskId: "d", rating: "partial", verificationOutcome: "discarded" }),
+      task({ taskId: "e", rating: "partial", verificationOutcome: "escalated_to_claude" }),
+      task({ taskId: "f", rating: "redo" }),
+      task({ taskId: "g", rating: "wrong" }),
     ]);
-    expect(plane.ratedTasks).toBe(4);
-    expect(plane.usefulTasks).toBe(2);
-    expect(plane.usefulRate).toBe(0.5);
-    expect(plane.rescueRedo).toBe(2);
+    expect(plane.ratedTasks).toBe(7);
+    expect(plane.usefulTasks).toBe(2); // pass + minor_edit partial only
+    expect(plane.rescueRedo).toBe(5); // rewritten/discarded/escalated partials count as rescue
+  });
+
+  // Only a completed task is a completed task.
+  it("does not count pending, running or cancelled work as a completed task", () => {
+    const plane = computeProductPlane([
+      task({ taskId: "a", lifecycle: "completed" }),
+      task({ taskId: "b", lifecycle: "running" }),
+      task({ taskId: "c", lifecycle: "cancelled" }),
+      task({ taskId: "d", lifecycle: "failed" }),
+    ]);
+    expect(plane.substantiveTasks).toBe(1);
+  });
+
+  // Codex review: a rate over a self-selected handful is a lie of selection.
+  it("refuses to judge useful-completion from too thin a rating coverage", () => {
+    const tasks = Array.from({ length: 10 }, (_, i) =>
+      task({ taskId: `t${i}`, rating: i === 0 ? "pass" : null })
+    );
+    const plane = computeProductPlane(tasks);
+    const useful = plane.criteria.find((c) => c.id === "useful-completion")!;
+    // 1 rated pass out of 10 completed is NOT "100% useful, gate met".
+    expect(useful.state).toBe("not-instrumented");
+    expect(useful.note).toMatch(/coverage/i);
+  });
+
+  // Codex review: the corpus failing to load must not render as a measured zero.
+  it("reports every count as unmeasured when the task corpus could not be read", () => {
+    const plane = computeProductPlane([], { available: false });
+    expect(plane.available).toBe(false);
+    for (const c of plane.criteria) {
+      expect(c.observed).toBeNull();
+      expect(c.state).toBe("not-instrumented");
+    }
+    const subs = plane.criteria.find((c) => c.id === "substantive-tasks")!;
+    expect(subs.note).toMatch(/unmeasured, NOT zero/i);
+  });
+
+  it("flags a partially-read corpus as a lower bound rather than a fact", () => {
+    const plane = computeProductPlane([task()], {
+      available: true, readFailures: 3, truncated: true,
+    });
+    const subs = plane.criteria.find((c) => c.id === "substantive-tasks")!;
+    expect(subs.note).toMatch(/LOWER BOUND/);
+    expect(subs.note).toMatch(/3 read failure/);
+  });
+
+  it("reports rescue/redo as a cost, never as a satisfied gate", () => {
+    const plane = computeProductPlane([task({ rating: "pass" })]);
+    const rescue = plane.criteria.find((c) => c.id === "rescue-redo")!;
+    expect(rescue.state).toBe("informational"); // a count with no threshold cannot be "met"
   });
 
   it("counts durable handoffs — the criterion that proves the DURABLE broker earns its keep", () => {
@@ -187,6 +287,36 @@ describe("buildLearningLoopPanels", () => {
     expect(ids).not.toContain("hugin-learning-loop");
   });
 
+  // THE consumer-contract test. Heimdall's normalizer
+  // (heimdall src/contract/panel-data.js) keeps only rows passing
+  //   isObj = v != null && typeof v === 'object' && !Array.isArray(v)
+  // and SILENTLY DROPS the rest. An array-of-arrays table therefore renders
+  // completely empty on the real dashboard while every local test passes —
+  // which is exactly what happened until Codex cross-checked the consumer.
+  // Replicate Heimdall's rule here so the contract can never silently rot again.
+  it("emits table rows Heimdall will actually keep (objects, not arrays)", () => {
+    const isObj = (v: unknown) => v != null && typeof v === "object" && !Array.isArray(v);
+
+    const panels = buildLearningLoopPanels({
+      capability: computeCapabilityPlane(ledger([{ attempts: 5, passes: 4, fails: 1 }])),
+      product: computeProductPlane([task({ rating: "pass" })]),
+      policy: deriveRoutePolicy([], computeCapabilityPlane(null)),
+    });
+
+    for (const panel of panels.filter((p) => p.kind === "table")) {
+      const rows = panel.rows as unknown[];
+      expect(rows.length).toBeGreaterThan(0);
+      for (const row of rows) {
+        expect(isObj(row)).toBe(true); // an array row would be dropped by Heimdall
+      }
+      // Every row must key off the declared columns, or its cells vanish.
+      const cols = panel.cols as string[];
+      for (const row of rows as Record<string, string>[]) {
+        for (const key of Object.keys(row)) expect(cols).toContain(key);
+      }
+    }
+  });
+
   it("emits only Heimdall's typed-panel kinds, so no Heimdall code change is needed", () => {
     const panels = buildLearningLoopPanels({
       capability: computeCapabilityPlane(null),
@@ -210,10 +340,10 @@ describe("buildLearningLoopPanels", () => {
       policy: deriveRoutePolicy([], computeCapabilityPlane(null)),
     });
     const table = panels.find((p) => p.id === "hugin-capability-evidence")!;
-    const rows = table.rows as string[][];
+    const rows = table.rows as Record<string, string>[];
     expect(rows.length).toBeLessThanOrEqual(16); // 15 rows + 1 disclosure row
     // Ranked: the most-evidenced row leads, not an arbitrary one.
-    expect(rows[0]![0]).toBe("type-39");
+    expect(rows[0]!["Task type"]).toBe("type-39");
     // The drop is stated, not hidden.
     expect(JSON.stringify(rows)).toMatch(/25 more/);
   });

--- a/tests/mcp/tools.test.ts
+++ b/tests/mcp/tools.test.ts
@@ -316,7 +316,12 @@ describe("buildTools — hugin_await", () => {
 
     const result = await tools.await_.handler({ task_id: "t-123" });
 
-    expect(await_).toHaveBeenCalledWith({ task_id: "t-123" });
+    // #164: the awaiting session id is autofilled from the envelope, so the
+    // broker can distinguish a durable handoff from an ordinary same-session poll.
+    expect(await_).toHaveBeenCalledWith({
+      task_id: "t-123",
+      orchestrator_session_id: "sess",
+    });
     expect(parseResult(result)).toEqual({ state: "completed" });
   });
 });


### PR DESCRIPTION
Closes #164. **Stacked on #176** (`feat/163-m5-provenance`) — it needs #163's stored `policyMode` provenance to answer "is routing evidence-driven, or still shadow?". Merge #176 first; base retargets to `main` automatically.

## Why this is more than a panel

#164 asks for a surface that shows whether the learning loop is online and whether Hugin earns its place, to support the **#165 keep/reduce/remove decision on 2026-08-22**. Auditing the data first showed the panel *alone* would have rendered "not instrumented" for the criterion that matters most — so this closes that gap too.

**Durable-handoff instrumentation** (`src/broker/await-observation.ts`): the gate wants *"tasks that complete after the initiating L1 session closes"* — the criterion that proves a **durable** broker earns its keep rather than being a call the conductor could have made itself. Nothing recorded it: `/v1/delegate/await` only ever **read** state. Now each await folds into a durable per-task observation.

We cannot observe a session *closing*, so we record the positively-observable proxy: **a completed result collected by a different `orchestrator_session_id` than the one that submitted it**. It is documented as a proxy that errs in *both* directions (see below) — never presented as a measurement.

## The panel

Two evidence planes, deliberately **not** collapsed into one verdict:
1. **M5 capability** — "can the cell do the task?" Read from M5's ledger. M5 stays the sole capability authority.
2. **Hugin product** — "was durable delegation useful enough to keep?" The #165 gate.

Emitted as Heimdall **typed panels** (`stat`/`table`/`status`), which render with **zero Heimdall code** — so this is Hugin-only, no cross-repo ticket. (The `plugin`/`view` path would have required a renderer in the heimdall repo.)

**Honesty rules, enforced in code and tests:** no percentage without an `n`; an unmeasured metric reports `not-instrumented`, never a flattering zero; infra errors excluded from quality rates; a capped table discloses what it dropped.

## Bugs caught by checking reality, not the schema

**Against production Munin:** the one existing broker task predates PR #173, so its status tags lost the `broker:mcp-v2` marker. Keying the corpus walk off that tag reported **0 tasks against a Munin holding 1** — silently under-counting the very trial the panel measures. Broker tasks are now identified by their embedded envelope, which was never dropped.

**Against Heimdall's normalizer (Codex):** it keeps only rows passing `isObj = ... && !Array.isArray(v)` and **silently drops the rest**. Rows were `string[][]`, so **both tables would have rendered completely empty on the real dashboard** while every test passed — the tests asserted panel `kind`, never the consumer contract. Now objects keyed by column, with a test replicating Heimdall's exact rule. Verified live: **16/16 and 7/7 rows survive** normalization (previously 0/16, 0/7).

## Codex review: 9 mediums + 1 low, all real, all fixed

Several attacked the PR's own honesty thesis:
- A failed corpus read collapsed to `tasks: []` and rendered as a **measured zero**. Now `available`/`readFailures`/`truncated`; unreadable ⇒ "not measured", partial ⇒ labelled a **lower bound**.
- `durableHandoff` claimed to prove session closure and to "under-count rather than over-count". **Both false** — the session id is client-asserted and minted per MCP *process*, so an MCP restart inside a live session trips it. Now documented as a two-way proxy, in the panel where a reader sees it.
- `failed`/`cancelled` counted toward "tasks that **complete**", padding the headline with work that delivered nothing. Only a genuinely collected `completed` result counts.
- useful-completion could read **"met, 100%" from 1 rated pass out of 10 unrated** — a lie of selection. Now requires ≥50% rating coverage.
- A `partial` the human **rewrote/discarded/escalated** counted as *useful* — the outcomes proving failure were inflating the gate. Now rescue/redo.
- `deriveRoutePolicy` asserted causation from **any verified sample anywhere**. Now requires evidence for that exact model × task-type.
- `recordAwait` had **no CAS**: a stale writer could clobber a proven `durableHandoff:true`, permanently erasing evidence. Now CAS + re-fold retry, with a deterministic two-writer race test.
- The fire-and-forget write could **pile up unboundedly** under polling. Now bounded; five polls revealing nothing new cost **zero** writes.
- `/heimdall.json` **awaited a cold corpus walk** (~a minute) — enough to blank Hugin's page (#135) with no exception. Now synchronous stale-while-revalidate.
- Unvalidated ledger counters could yield a **false 100%** quality rate. Invariants now checked.

## What it says on real data

M5 capability is rich and verified (`source-distill`/Mellum **698/698** verified at 71%; `classify`/mellum 12/12, `delegate-local`). The #165 product gate is **nearly empty**: **1 completed task of 10, 1 producer of 2, 0 durable handoffs of 5**, with six weeks to go — and route policy is still **shadow**.

That is exactly the signal #164 was asked to surface: on current evidence the trial is not on track to be decidable, and two of its criteria (maintenance time, incidents) have no data source at all and say so.

## Verification
- Suite **95 files / 1612 tests** green; `tsc` clean; `git diff --check` clean.
- Panels rendered against the **live M5 ledger + real production task**, and checked against Heimdall's actual row filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)