### PR TITLE
fix: distinguish missing vs broken claude-config checkout in deploy-pi (#153)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,5 @@ jobs:
       - run: npm run build
 
       - run: npm test
+
+      - run: bash scripts/lib/claude-config-bootstrap.test.sh

--- a/scripts/deploy-pi.sh
+++ b/scripts/deploy-pi.sh
@@ -130,8 +130,11 @@ echo "==> Refreshing Claude config on the Pi (claude-config bootstrap)..."
 # Config now lives in the versioned Magnus-Gille/claude-config repo (+ claude-skills,
 # skills-private), consumed via symlinks. Pull latest + re-run bootstrap instead of the
 # old rsync (which would clobber the symlinks with real dirs). See claude-config/README.md.
-ssh "$REMOTE" 'cd ~/repos/claude-config 2>/dev/null && git pull -q --ff-only && ./bootstrap.sh --no-plugins' \
-  || echo "  WARNING: claude-config bootstrap failed — clone ~/repos/claude-config on the Pi first, then re-run."
+# See scripts/lib/claude-config-bootstrap.sh (issue #153): missing checkout is optional
+# infra and informational, a broken existing checkout stays a real WARNING.
+# shellcheck source=lib/claude-config-bootstrap.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/lib/claude-config-bootstrap.sh"
+claude_config_bootstrap "$REMOTE"
 
 echo "==> Installing CLI update cron job..."
 CRON_CMD="0 4 * * * $REMOTE_DIR/scripts/update-cli.sh 2>&1 | logger -t hugin-update"

--- a/scripts/lib/claude-config-bootstrap.sh
+++ b/scripts/lib/claude-config-bootstrap.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# claude-config bootstrap helper for deploy-pi.sh (issue #153).
+#
+# claude-config is optional infra for a Hugin deploy — tracked separately as
+# claude-config#2, not a Hugin concern. A missing checkout is expected and
+# informational, not a deploy WARNING. An existing checkout that fails to
+# pull/bootstrap is a real problem (something broke), so that stays a
+# WARNING with its own distinct message.
+
+claude_config_bootstrap() {
+  local remote="$1"
+  if ssh "$remote" "test -d ~/repos/claude-config/.git"; then
+    ssh "$remote" 'cd ~/repos/claude-config && git pull -q --ff-only && ./bootstrap.sh --no-plugins' \
+      || echo "  WARNING: claude-config bootstrap failed (checkout exists but pull/bootstrap errored) — inspect ~/repos/claude-config on the Pi."
+  else
+    echo "  INFO: ~/repos/claude-config not found on the Pi — bootstrap is optional infra (tracked separately, see claude-config#2) and was skipped."
+    echo "  To enable it: ssh $remote 'git clone git@github.com:Magnus-Gille/claude-config.git ~/repos/claude-config && ~/repos/claude-config/bootstrap.sh --no-plugins'"
+  fi
+}

--- a/scripts/lib/claude-config-bootstrap.sh
+++ b/scripts/lib/claude-config-bootstrap.sh
@@ -3,17 +3,29 @@
 #
 # claude-config is optional infra for a Hugin deploy — tracked separately as
 # claude-config#2, not a Hugin concern. A missing checkout is expected and
-# informational, not a deploy WARNING. An existing checkout that fails to
-# pull/bootstrap is a real problem (something broke), so that stays a
-# WARNING with its own distinct message.
+# informational, not a deploy WARNING. An existing (or unprovable) checkout
+# is treated as a real problem: a broken pull/bootstrap AND an inconclusive
+# presence probe both stay a WARNING, each with its own distinct message.
+#
+# The presence probe relies on ssh's own exit-code convention: 0 means the
+# remote `test` ran and succeeded (checkout present), 1 means it ran and
+# failed (checkout genuinely absent), anything else means ssh itself could
+# not run the check at all (network/auth/timeout) — absence must never be
+# assumed in that case.
 
 claude_config_bootstrap() {
   local remote="$1"
-  if ssh "$remote" "test -d ~/repos/claude-config/.git"; then
+  local probe_rc=0
+
+  ssh "$remote" "test -d ~/repos/claude-config" || probe_rc=$?
+
+  if [ "$probe_rc" -eq 0 ]; then
     ssh "$remote" 'cd ~/repos/claude-config && git pull -q --ff-only && ./bootstrap.sh --no-plugins' \
       || echo "  WARNING: claude-config bootstrap failed (checkout exists but pull/bootstrap errored) — inspect ~/repos/claude-config on the Pi."
-  else
+  elif [ "$probe_rc" -eq 1 ]; then
     echo "  INFO: ~/repos/claude-config not found on the Pi — bootstrap is optional infra (tracked separately, see claude-config#2) and was skipped."
     echo "  To enable it: ssh $remote 'git clone git@github.com:Magnus-Gille/claude-config.git ~/repos/claude-config && ~/repos/claude-config/bootstrap.sh --no-plugins'"
+  else
+    echo "  WARNING: could not determine whether claude-config is checked out on the Pi (ssh probe exited $probe_rc) — check SSH connectivity, then inspect ~/repos/claude-config manually."
   fi
 }

--- a/scripts/lib/claude-config-bootstrap.test.sh
+++ b/scripts/lib/claude-config-bootstrap.test.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Bash-level test for claude-config-bootstrap.sh (issue #153).
+#
+# Stubs `ssh` so no network/remote access happens. Exercises the three
+# outcomes the deploy script must distinguish:
+#   1. checkout missing on the Pi  -> informational message, no WARNING
+#   2. checkout present, pull/bootstrap succeeds -> silent (no WARNING)
+#   3. checkout present, pull/bootstrap fails    -> WARNING
+#
+# Run: bash scripts/lib/claude-config-bootstrap.test.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FAKE_BIN_DIR="$(mktemp -d)"
+trap 'rm -rf "$FAKE_BIN_DIR"' EXIT
+
+cat >"$FAKE_BIN_DIR/ssh" <<'EOF'
+#!/usr/bin/env bash
+# Fake ssh for tests: never touches the network. Inspects the remote
+# command string to decide what the "remote" would have reported.
+remote="$1"
+shift
+cmd="$*"
+case "$cmd" in
+  *"test -d ~/repos/claude-config/.git"*)
+    [ "${MOCK_DIR_EXISTS:-0}" = "1" ]
+    ;;
+  *"git pull"*"bootstrap.sh"*)
+    [ "${MOCK_BOOTSTRAP_OK:-0}" = "1" ]
+    ;;
+  *)
+    echo "fake ssh: unexpected remote command: $cmd" >&2
+    exit 99
+    ;;
+esac
+EOF
+chmod +x "$FAKE_BIN_DIR/ssh"
+
+export PATH="$FAKE_BIN_DIR:$PATH"
+
+LIB_FILE="$SCRIPT_DIR/claude-config-bootstrap.sh"
+if [ ! -f "$LIB_FILE" ]; then
+  echo "FAIL: $LIB_FILE not found" >&2
+  exit 1
+fi
+# shellcheck source=claude-config-bootstrap.sh
+source "$LIB_FILE"
+
+failures=0
+
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "FAIL: $label — expected output to contain: $needle"
+    echo "--- actual output ---"
+    echo "$haystack"
+    echo "---------------------"
+    failures=$((failures + 1))
+  else
+    echo "PASS: $label"
+  fi
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "FAIL: $label — expected output NOT to contain: $needle"
+    echo "--- actual output ---"
+    echo "$haystack"
+    echo "---------------------"
+    failures=$((failures + 1))
+  else
+    echo "PASS: $label"
+  fi
+}
+
+# Case 1: missing checkout -> informational, not a WARNING, includes the
+# exact remediation command.
+out="$(MOCK_DIR_EXISTS=0 claude_config_bootstrap "magnus@testhost")"
+assert_not_contains "$out" "WARNING" "missing checkout: no WARNING"
+assert_contains "$out" "INFO" "missing checkout: informational message present"
+assert_contains "$out" "git clone" "missing checkout: remediation command present"
+assert_contains "$out" "magnus@testhost" "missing checkout: remediation command targets the right host"
+
+# Case 2: checkout present, pull/bootstrap succeeds -> no WARNING at all.
+out="$(MOCK_DIR_EXISTS=1 MOCK_BOOTSTRAP_OK=1 claude_config_bootstrap "magnus@testhost")"
+assert_not_contains "$out" "WARNING" "healthy checkout: no WARNING"
+
+# Case 3: checkout present but pull/bootstrap fails -> WARNING, distinct
+# wording from the "missing" case (this is a real problem, not optional).
+out="$(MOCK_DIR_EXISTS=1 MOCK_BOOTSTRAP_OK=0 claude_config_bootstrap "magnus@testhost")"
+assert_contains "$out" "WARNING" "broken checkout: WARNING present"
+assert_not_contains "$out" "git clone" "broken checkout: no clone remediation (checkout already exists)"
+
+if [ "$failures" -gt 0 ]; then
+  echo "$failures assertion(s) failed"
+  exit 1
+fi
+
+echo "All assertions passed"

--- a/scripts/lib/claude-config-bootstrap.test.sh
+++ b/scripts/lib/claude-config-bootstrap.test.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 # Bash-level test for claude-config-bootstrap.sh (issue #153).
 #
-# Stubs `ssh` so no network/remote access happens. Exercises the three
+# Stubs `ssh` so no network/remote access happens. Exercises the four
 # outcomes the deploy script must distinguish:
 #   1. checkout missing on the Pi  -> informational message, no WARNING
 #   2. checkout present, pull/bootstrap succeeds -> silent (no WARNING)
 #   3. checkout present, pull/bootstrap fails    -> WARNING
+#   4. presence probe itself inconclusive (ssh/network failure, not the
+#      remote `test` reporting "absent") -> WARNING, never INFO
 #
 # Run: bash scripts/lib/claude-config-bootstrap.test.sh
 
@@ -23,7 +25,10 @@ remote="$1"
 shift
 cmd="$*"
 case "$cmd" in
-  *"test -d ~/repos/claude-config/.git"*)
+  *"test -d ~/repos/claude-config"*)
+    if [ -n "${MOCK_PROBE_RC:-}" ]; then
+      exit "$MOCK_PROBE_RC"
+    fi
     [ "${MOCK_DIR_EXISTS:-0}" = "1" ]
     ;;
   *"git pull"*"bootstrap.sh"*)
@@ -92,6 +97,16 @@ assert_not_contains "$out" "WARNING" "healthy checkout: no WARNING"
 out="$(MOCK_DIR_EXISTS=1 MOCK_BOOTSTRAP_OK=0 claude_config_bootstrap "magnus@testhost")"
 assert_contains "$out" "WARNING" "broken checkout: WARNING present"
 assert_not_contains "$out" "git clone" "broken checkout: no clone remediation (checkout already exists)"
+
+# Case 4: the presence probe itself fails inconclusively (e.g. ssh exits 255
+# for a transport/auth/timeout failure) rather than the remote `test`
+# cleanly reporting "absent" (exit 1). Must NOT be reported as the optional
+# "missing" case — that would hide a real connectivity problem behind an
+# informational message.
+out="$(MOCK_PROBE_RC=255 claude_config_bootstrap "magnus@testhost")"
+assert_contains "$out" "WARNING" "inconclusive probe: WARNING present"
+assert_not_contains "$out" "INFO" "inconclusive probe: no INFO"
+assert_not_contains "$out" "git clone" "inconclusive probe: no clone remediation (absence unproven)"
 
 if [ "$failures" -gt 0 ]; then
   echo "$failures assertion(s) failed"


### PR DESCRIPTION
## Why

`scripts/deploy-pi.sh`'s claude-config bootstrap step printed the same
WARNING regardless of *why* it failed: whether `~/repos/claude-config` was
simply never cloned on the Pi (optional third-party config infra, unrelated
to Hugin's own health — tracked separately as claude-config#2) or an
existing checkout was actually broken (a real problem worth flagging). This
made routine, healthy Hugin deploys look like they had an unresolved issue.

Issue #153 asked for the script to tell apart "optional, not set up" from
"actually required and broken."

## What

Extracted the bootstrap logic into `scripts/lib/claude-config-bootstrap.sh`
(`claude_config_bootstrap()`), sourced by `deploy-pi.sh`:

- **Checkout missing** → prints an `INFO:` line (not a warning) explaining
  the step is optional and was skipped, plus the exact `git clone` command
  to enable it.
- **Checkout present but `git pull`/`bootstrap.sh --no-plugins` fails** →
  still prints a `WARNING:` — something is genuinely broken and needs
  inspecting.
- **Checkout present and healthy** → silent, as before.

Kept the diff surgical: no behavior change to the rest of `deploy-pi.sh`,
no auto-clone (a private repo clone from inside the deploy script isn't
"trivially safe" — it would need credentials/agent forwarding the script
can't assume), just a clearer signal.

## Test plan

- [x] New bash-level test `scripts/lib/claude-config-bootstrap.test.sh`
      stubs `ssh` (no network/remote access) and asserts all three code
      paths (missing / healthy / broken checkout). Written and confirmed
      failing (red) before the implementation existed, then green after.
- [x] `shellcheck` on both changed/new files — no new findings; only the
      same pre-existing info-level `SC2029` notes already present elsewhere
      in `deploy-pi.sh`.
- [x] `bash -n` syntax check on all three files.
- [x] Full test suite: `npm run build` + `npm test` — 95 files / 1612 tests
      pass (this change is bash-only and doesn't touch the TS suite).
- [x] Did **not** execute the actual deploy or ssh anywhere, per scope.

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)