### PR TITLE
feat(broker): soft-require a verifier or rubric for judgment task types (#184)

### DIFF
--- a/src/broker/handlers.ts
+++ b/src/broker/handlers.ts
@@ -40,6 +40,7 @@ import {
 } from "./types.js";
 import type { AwaitLifecycle } from "./await-observation.js";
 import type { AuthenticatedRequest } from "./auth.js";
+import { computeSubmitWarnings } from "./submit-warnings.js";
 
 export interface BrokerHandlerDependencies {
   taskStore: BrokerTaskStore;
@@ -109,6 +110,9 @@ export function createSubmitHandler(deps: BrokerHandlerDependencies) {
       respondZodError(res, err);
       return;
     }
+    // #184: same request payload on every success path below (fresh accept
+    // or any idempotent reuse), so computed once and reused verbatim.
+    const submitWarnings = computeSubmitWarnings(request);
 
     if (request.envelope_version !== 2) {
       res.status(400).json({
@@ -217,6 +221,7 @@ export function createSubmitHandler(deps: BrokerHandlerDependencies) {
         task_id: taskId,
         received_at: persistedEnvelope.received_at,
         reused_idempotency: true,
+        ...(submitWarnings.length > 0 ? { warnings: submitWarnings } : {}),
       });
       return;
     }
@@ -228,6 +233,7 @@ export function createSubmitHandler(deps: BrokerHandlerDependencies) {
         task_id: idemOutcome.task_id,
         received_at: nowFn(deps)().toISOString(),
         reused_idempotency: true,
+        ...(submitWarnings.length > 0 ? { warnings: submitWarnings } : {}),
       });
       return;
     }
@@ -274,6 +280,7 @@ export function createSubmitHandler(deps: BrokerHandlerDependencies) {
       task_id: taskId,
       received_at: envelope.received_at,
       reused_idempotency: false,
+      ...(submitWarnings.length > 0 ? { warnings: submitWarnings } : {}),
     });
   };
 }

--- a/src/broker/submit-warnings.ts
+++ b/src/broker/submit-warnings.ts
@@ -1,0 +1,46 @@
+/**
+ * Non-blocking submit-time warnings (issue #184).
+ *
+ * Judgment-flavored task types (classify, qa-factual, triage,
+ * memory-decision, claim-verify) have no mechanical acceptance check to
+ * fall back on — with the default `l1_review` acceptance and no rubric in
+ * the prompt, the resulting pass/fail grade is pure L1 subjectivity, and
+ * the m5h harvest evidence it produces is weak. This never rejects a task;
+ * it only surfaces advice in the submit response.
+ */
+
+import type { DelegationRequest, TaskType } from "./types.js";
+
+export const JUDGMENT_TASK_TYPES: readonly TaskType[] = [
+  "classify",
+  "qa-factual",
+  "triage",
+  "memory-decision",
+  "claim-verify",
+];
+
+export const NO_RUBRIC_WARNING =
+  "judgment-type task submitted without verifier or rubric — capability evidence will be weak";
+
+/**
+ * Deliberately dumb, no NLP: a case-insensitive substring match for
+ * "rubric" or "grading criteria" anywhere in the prompt. False negatives
+ * (a rubric phrased some other way) are expected and fine — this only
+ * gates an advisory warning, never the task itself.
+ */
+const RUBRIC_PATTERN = /rubric|grading criteria/i;
+
+export function promptHasRubric(prompt: string): boolean {
+  return RUBRIC_PATTERN.test(prompt);
+}
+
+export function computeSubmitWarnings(
+  request: Pick<DelegationRequest, "task_type" | "acceptance" | "prompt">,
+): string[] {
+  const isJudgmentType = (JUDGMENT_TASK_TYPES as readonly string[]).includes(request.task_type);
+  const isDefaultAcceptance = request.acceptance.mode === "l1_review";
+  if (isJudgmentType && isDefaultAcceptance && !promptHasRubric(request.prompt)) {
+    return [NO_RUBRIC_WARNING];
+  }
+  return [];
+}

--- a/src/broker/types.ts
+++ b/src/broker/types.ts
@@ -195,6 +195,10 @@ export const submitResponseSchema = z.object({
   task_id: z.string().min(1),
   received_at: z.string().min(1),
   reused_idempotency: z.boolean(),
+  // Non-blocking submit-time advice (#184), e.g. a judgment-flavored
+  // task_type submitted with the default l1_review acceptance and no
+  // rubric in the prompt. Never causes rejection — see submit-warnings.ts.
+  warnings: z.array(z.string()).optional(),
 });
 export type SubmitResponse = z.infer<typeof submitResponseSchema>;
 

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -231,7 +231,7 @@ export function buildTools(deps: ToolDeps): {
     name: "hugin_submit",
     title: "Submit a delegation task to Hugin",
     description:
-      "Persist one bounded task in Hugin's durable lifecycle and execute it as one M5 `/delegate` leaf. M5 chooses the model and owns capability evidence; Hugin owns lifecycle and delivery. Returns the task_id and idempotency_key — reuse that key only to retry the same logical request.",
+      "Persist one bounded task in Hugin's durable lifecycle and execute it as one M5 `/delegate` leaf. M5 chooses the model and owns capability evidence; Hugin owns lifecycle and delivery. Returns the task_id and idempotency_key — reuse that key only to retry the same logical request. For judgment-flavored task_type values (classify, qa-factual, triage, memory-decision, claim-verify) submitted with the default `l1_review` acceptance and a prompt with no rubric, the response carries a non-blocking `warnings` array — the task still runs, but attach a mechanical `acceptance.verifier` or add a rubric/grading-criteria section to the prompt for stronger capability evidence.",
     inputShape: activeSubmitInputShape,
     handler: async (rawInput) => {
       let idempotencyKey: string | undefined;

--- a/tests/broker/handlers.test.ts
+++ b/tests/broker/handlers.test.ts
@@ -182,6 +182,62 @@ describe("POST /v1/delegate/submit", () => {
     expect(harness.munin.writes).toHaveLength(1);
   });
 
+  it("includes a warnings array for a judgment task_type submitted with default l1_review and no rubric (#184)", async () => {
+    const res = await fetch(`${harness.url}/v1/delegate/submit`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify(validRequest({
+        task_type: "classify",
+        prompt: "Classify this ticket as bug or feature.",
+      })),
+    });
+    expect(res.status).toBe(202);
+    const body = await res.json();
+    expect(body.warnings).toEqual([
+      "judgment-type task submitted without verifier or rubric — capability evidence will be weak",
+    ]);
+  });
+
+  it("omits warnings when a judgment task_type carries an explicit verifier (#184)", async () => {
+    const res = await fetch(`${harness.url}/v1/delegate/submit`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify(validRequest({
+        task_type: "classify",
+        prompt: "Classify this ticket as bug or feature.",
+        acceptance: { mode: "verifier", verifier: { type: "nonEmpty" } },
+      })),
+    });
+    expect(res.status).toBe(202);
+    const body = await res.json();
+    expect(body.warnings).toBeUndefined();
+  });
+
+  it("omits warnings when a judgment task_type's prompt has a rubric section (#184)", async () => {
+    const res = await fetch(`${harness.url}/v1/delegate/submit`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify(validRequest({
+        task_type: "triage",
+        prompt: "Triage this issue.\n\n## Rubric\n- p0: data loss\n- p1: broken feature",
+      })),
+    });
+    expect(res.status).toBe(202);
+    const body = await res.json();
+    expect(body.warnings).toBeUndefined();
+  });
+
+  it("never warns for a non-judgment task_type (#184)", async () => {
+    const res = await fetch(`${harness.url}/v1/delegate/submit`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify(validRequest({ task_type: "summarize", prompt: "Summarize the README." })),
+    });
+    expect(res.status).toBe(202);
+    const body = await res.json();
+    expect(body.warnings).toBeUndefined();
+  });
+
   it("reuses the persisted task after a fresh Broker instance and ignores MCP session rotation", async () => {
     const first = validRequest();
     const firstResponse = await fetch(`${harness.url}/v1/delegate/submit`, {

--- a/tests/broker/handlers.test.ts
+++ b/tests/broker/handlers.test.ts
@@ -182,6 +182,35 @@ describe("POST /v1/delegate/submit", () => {
     expect(harness.munin.writes).toHaveLength(1);
   });
 
+  it("propagates warnings on the in-memory idempotency retry path (#184)", async () => {
+    const req = validRequest({
+      task_type: "classify",
+      prompt: "Classify this ticket as bug or feature.",
+    });
+    const r1 = await fetch(`${harness.url}/v1/delegate/submit`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify(req),
+    });
+    expect(r1.status).toBe(202);
+    const b1 = await r1.json();
+    expect(b1.warnings).toEqual([
+      "judgment-type task submitted without verifier or rubric — capability evidence will be weak",
+    ]);
+
+    const r2 = await fetch(`${harness.url}/v1/delegate/submit`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify(req),
+    });
+    expect(r2.status).toBe(200);
+    const b2 = await r2.json();
+    expect(b2.reused_idempotency).toBe(true);
+    expect(b2.warnings).toEqual([
+      "judgment-type task submitted without verifier or rubric — capability evidence will be weak",
+    ]);
+  });
+
   it("includes a warnings array for a judgment task_type submitted with default l1_review and no rubric (#184)", async () => {
     const res = await fetch(`${harness.url}/v1/delegate/submit`, {
       method: "POST",
@@ -276,6 +305,47 @@ describe("POST /v1/delegate/submit", () => {
         body: JSON.stringify(validRequest({ prompt: "different", orchestrator_session_id: "third" })),
       });
       expect(collision.status).toBe(409);
+    } finally {
+      await restarted.close();
+    }
+  });
+
+  it("propagates warnings on the persisted-envelope reuse path after a fresh Broker instance (#184)", async () => {
+    const first = validRequest({
+      task_type: "triage",
+      prompt: "Triage this issue and assign a severity.",
+    });
+    const firstResponse = await fetch(`${harness.url}/v1/delegate/submit`, {
+      method: "POST", headers: authHeader(), body: JSON.stringify(first),
+    });
+    expect((await firstResponse.json()).warnings).toEqual([
+      "judgment-type task submitted without verifier or rubric — capability evidence will be weak",
+    ]);
+
+    const restarted = await startBroker({
+      host: "127.0.0.1",
+      port: 0,
+      keys: { "claude-code": SECRET },
+      deps: {
+        taskStore: new BrokerTaskStore(harness.munin as unknown as MuninClient),
+        journal: harness.journal,
+        idempotency: new IdempotencyIndex(),
+        executorCapabilities: brokerExecutorCapabilities({ homeserverEnabled: true }),
+      },
+    });
+    try {
+      const addr = restarted.server.address() as AddressInfo;
+      const res = await fetch(`http://127.0.0.1:${addr.port}/v1/delegate/submit`, {
+        method: "POST",
+        headers: authHeader(),
+        body: JSON.stringify(first),
+      });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.reused_idempotency).toBe(true);
+      expect(body.warnings).toEqual([
+        "judgment-type task submitted without verifier or rubric — capability evidence will be weak",
+      ]);
     } finally {
       await restarted.close();
     }

--- a/tests/broker/submit-warnings.test.ts
+++ b/tests/broker/submit-warnings.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  JUDGMENT_TASK_TYPES,
+  NO_RUBRIC_WARNING,
+  computeSubmitWarnings,
+  promptHasRubric,
+} from "../../src/broker/submit-warnings.js";
+
+function req(overrides: {
+  task_type?: string;
+  acceptance?: { mode: "l1_review" } | { mode: "verifier"; verifier: unknown };
+  prompt?: string;
+} = {}) {
+  return {
+    task_type: overrides.task_type ?? "classify",
+    acceptance: overrides.acceptance ?? { mode: "l1_review" as const },
+    prompt: overrides.prompt ?? "Classify this ticket as bug or feature.",
+  } as Parameters<typeof computeSubmitWarnings>[0];
+}
+
+describe("computeSubmitWarnings (#184)", () => {
+  it("warns for a judgment-flavored task_type with default l1_review acceptance and no rubric", () => {
+    expect(computeSubmitWarnings(req())).toEqual([NO_RUBRIC_WARNING]);
+  });
+
+  it.each(JUDGMENT_TASK_TYPES)("warns for every judgment task_type: %s", (taskType) => {
+    expect(computeSubmitWarnings(req({ task_type: taskType }))).toEqual([NO_RUBRIC_WARNING]);
+  });
+
+  it("does not warn when acceptance is an explicit verifier", () => {
+    const warnings = computeSubmitWarnings(
+      req({ acceptance: { mode: "verifier", verifier: { type: "nonEmpty" } } }),
+    );
+    expect(warnings).toEqual([]);
+  });
+
+  it("does not warn when the prompt has a Rubric heading (case-insensitive)", () => {
+    const warnings = computeSubmitWarnings(
+      req({ prompt: "Classify this.\n\n## RUBRIC\n- bug: mentions a defect\n- feature: mentions new capability" }),
+    );
+    expect(warnings).toEqual([]);
+  });
+
+  it("does not warn when the prompt mentions grading criteria", () => {
+    const warnings = computeSubmitWarnings(
+      req({ prompt: "Triage this issue.\nGrading criteria: correct severity + correct owner." }),
+    );
+    expect(warnings).toEqual([]);
+  });
+
+  it("does not warn for a non-judgment task_type even without a rubric", () => {
+    const warnings = computeSubmitWarnings(req({ task_type: "summarize", prompt: "Summarize the README." }));
+    expect(warnings).toEqual([]);
+  });
+
+  describe("promptHasRubric", () => {
+    it("is case-insensitive and dumb (no NLP) — substring match only", () => {
+      expect(promptHasRubric("See the RuBrIc below.")).toBe(true);
+      expect(promptHasRubric("Grading Criteria: must be exact.")).toBe(true);
+      expect(promptHasRubric("No structured criteria here.")).toBe(false);
+    });
+  });
+});

--- a/tests/mcp/tools.test.ts
+++ b/tests/mcp/tools.test.ts
@@ -166,6 +166,35 @@ describe("buildTools — hugin_submit", () => {
     });
   });
 
+  it("passes through a judgment-task warnings array from the broker response unchanged (#184)", async () => {
+    const submit = vi.fn(async () => ({
+      task_id: "t1",
+      warnings: [
+        "judgment-type task submitted without verifier or rubric — capability evidence will be weak",
+      ],
+    }));
+    const broker = fakeBroker({ submit });
+    const tools = buildTools({
+      broker,
+      sessionId: "sess",
+      submitter: "claude-code",
+      newId: () => "44444444-4444-4444-8444-444444444444",
+    });
+
+    const result = await tools.submit.handler({
+      task_type: "classify",
+      prompt: "Classify this ticket.",
+      alias_requested: "m5",
+    });
+
+    expect(parseResult(result)).toMatchObject({
+      task_id: "t1",
+      warnings: [
+        "judgment-type task submitted without verifier or rubric — capability evidence will be weak",
+      ],
+    });
+  });
+
   it("uses the caller-supplied idempotency_key when provided", async () => {
     const submit = vi.fn(async () => ({ task_id: "t2" }));
     const broker = fakeBroker({ submit });


### PR DESCRIPTION
## Summary

`hugin_submit` now returns a non-blocking `warnings` array in the submit response when all three conditions hold: `task_type` is judgment-flavored (`classify`, `qa-factual`, `triage`, `memory-decision`, `claim-verify`), `acceptance` is the default `l1_review`, and the prompt lacks a rubric section. The warning text is: `"judgment-type task submitted without verifier or rubric — capability evidence will be weak"`. This is purely advisory and never rejects tasks, addressing grader-noise issues in internal harvest projects (see #184).

*(Summary paragraph above was drafted by an M5-delegated `rewrite` task against my longer draft, reviewed and used as-is — see the delegation campaign note at the bottom.)*

## Implementation

- **`src/broker/submit-warnings.ts`** (new) — pure `computeSubmitWarnings()`.
  Rubric detection is deliberately dumb per the issue's ask: a
  case-insensitive substring match for `rubric` or `grading criteria`,
  no NLP.
- **`src/broker/types.ts`** — additive optional `warnings: string[]` field
  on `submitResponseSchema`. No existing field changed.
- **`src/broker/handlers.ts`** — `createSubmitHandler` computes the warning
  once per request (same payload backs all three success paths: fresh 202,
  and both idempotent-reuse 200s) and attaches it only when non-empty.
- **`src/mcp/tools.ts`** — `hugin_submit`'s tool description documents the
  rule so a delegating agent sees it at tool-selection time. No code change
  was needed for pass-through: the MCP submit handler already relays the
  broker's JSON response verbatim (`withIdempotencyKey` spreads the existing
  object), so `warnings` flows to the calling agent unmodified — verified
  with a dedicated test.

Deliberately out of scope (issue marks it "Optional"): counting rubric-less
judgment submissions in the learning-loop health panel (#164). Left for a
follow-up if the discipline needs to be observable on the dashboard.

## Test plan

Red/green TDD — all new tests were written first and confirmed failing
before implementation:

- [x] `tests/broker/submit-warnings.test.ts` (new, 11 tests) — pure-function
      coverage: warns for each of the 5 judgment types; no warning with an
      explicit verifier; no warning with a `## Rubric` heading; no warning
      with a "grading criteria" mention; no warning for a non-judgment
      `task_type`; case-insensitivity of the dumb matcher.
- [x] `tests/broker/handlers.test.ts` (+6 tests) — full HTTP-level
      `POST /v1/delegate/submit` coverage for the same four scenarios
      through the real Express app + Zod schema, plus two tests (added
      after self-review, see below) proving `warnings` also propagates on
      both idempotent-reuse 200 paths, not just the fresh 202.
- [x] `tests/mcp/tools.test.ts` (+1 test) — confirms `hugin_submit`'s
      handler passes a broker-returned `warnings` array through unchanged.
- [x] Full suite: `npx vitest run` → **1654/1654 passing** (97 files).
- [x] `npx tsc --noEmit` and `npm run build` clean.

## Review

Codex CLI was unavailable locally (missing `code-mode-host` binary — a
broken install, not a credits issue), so this PR went through an
adversarial self-review instead (see PR comment below for the full
writeup). One confirmed medium finding — missing coverage on the two
idempotent-reuse 200 paths — was fixed test-first; two low/informational
findings were declined with rationale. Flagging for a real Codex pass once
the local install is fixed.

## Delegation campaign note

Several sub-tasks on this ticket (classify the issue, extract its
acceptance criteria, a factual Q&A against the actual Zod schema, a
data-transform over the task-type taxonomy, a regex derivation, a summary,
this PR-body rewrite, a unit-test-gen pass, an independent `code-implement`
of `computeSubmitWarnings`/`promptHasRubric` from a blind spec, and a
`code-review` of the full diff) were routed through the M5 local-inference
box via `hugin_submit`/`hugin_await`/`hugin_rate` as part of an ongoing
harvest of local-model capability evidence, each independently verified and
rated. The blind-spec `code-implement` output was verified to pass all 11
of this PR's own unit tests; it wasn't merged in favor of the version
already written here, but it's strong capability evidence.

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)
