### PR TITLE
fix(broker): disclose truncated task listings

### DIFF
--- a/src/broker/handlers.ts
+++ b/src/broker/handlers.ts
@@ -492,9 +492,9 @@ export function createListHandler(deps: BrokerHandlerDependencies) {
     const canonical = await deps.taskStore.listCanonical(principal, parsed.since_ts);
     const historical = Array.from(projectDelegations(await deps.journal.readAll()).values())
       .filter((row) => row.envelope?.broker_principal === principal);
-    const canonicalIds = new Set(canonical.map((row) => row.task_id));
+    const canonicalIds = new Set(canonical.rows.map((row) => row.task_id));
     const combined: Array<Record<string, any>> = [
-      ...canonical,
+      ...canonical.rows,
       ...historical.filter((row) => !canonicalIds.has(row.task_id)),
     ];
     const rows = combined.filter((row) => {
@@ -511,7 +511,11 @@ export function createListHandler(deps: BrokerHandlerDependencies) {
     rows.sort((a, b) =>
       (b.submitted_at ?? "").localeCompare(a.submitted_at ?? ""),
     );
-    res.status(200).json({ rows: rows.slice(0, parsed.limit ?? 50), total: rows.length });
+    res.status(200).json({
+      rows: rows.slice(0, parsed.limit ?? 50),
+      total: rows.length,
+      truncated: canonical.truncated,
+    });
   };
 }
 

--- a/src/broker/task-store.ts
+++ b/src/broker/task-store.ts
@@ -56,7 +56,7 @@ export interface CanonicalListRow {
 
 export interface CanonicalListResult {
   rows: CanonicalListRow[];
-  /** True when at least one Munin query matched more entries than it returned. */
+  /** True when at least one Munin query hit its cap and may have omitted matches. */
   truncated: boolean;
 }
 
@@ -261,13 +261,14 @@ export class BrokerTaskStore {
       this.munin.query({ ...baseOpts, tags: ["broker:mcp-v2"] }),
       this.munin.query({ ...baseOpts, tags: ["runtime:homeserver"] }),
     ]);
-    // Munin exposes no cursor/offset and orders these results lexically rather
-    // than temporally. A timestamp walk-back could therefore skip omitted
-    // newer rows. Disclose the incomplete candidate set instead of presenting
-    // the discovered row count as exact (#183).
+    // Munin exposes no cursor/offset and its `total` is only the number of
+    // formatted rows returned, not a pre-limit count. A result set at the
+    // server cap is therefore indistinguishable from an exactly-full set.
+    // Mark it conservatively: a timestamp walk-back is not safe because the
+    // ranked query is not guaranteed to expose every omitted row in time order.
     const truncated =
-      tagged.total > tagged.results.length ||
-      homeserver.total > homeserver.results.length;
+      tagged.results.length >= MUNIN_QUERY_MAX ||
+      homeserver.results.length >= MUNIN_QUERY_MAX;
     const namespaces = new Set<string>();
     for (const result of [...tagged.results, ...homeserver.results]) {
       if (typeof result.namespace === "string") namespaces.add(result.namespace);

--- a/src/broker/task-store.ts
+++ b/src/broker/task-store.ts
@@ -47,6 +47,19 @@ export interface TaskStoreConfig {
   munin: MuninClient;
 }
 
+export interface CanonicalListRow {
+  task_id: string;
+  submitted_at: string;
+  outcome: "completed" | "failed" | "cancelled" | "running";
+  alias: DelegationEnvelope["alias_requested"];
+}
+
+export interface CanonicalListResult {
+  rows: CanonicalListRow[];
+  /** True when at least one Munin query matched more entries than it returned. */
+  truncated: boolean;
+}
+
 /**
  * Generate a stable principal-scoped task id. Persisting the request at this
  * namespace is the restart-safe idempotency record; the raw key is never tagged.
@@ -236,12 +249,7 @@ export class BrokerTaskStore {
    * reintroduce the same crowding-out risk this fix closes, just triggered
    * by `?limit=1` instead of a rating event (caught in review of #181).
    */
-  async listCanonical(principal: string, sinceTs?: string): Promise<Array<{
-    task_id: string;
-    submitted_at: string;
-    outcome: "completed" | "failed" | "cancelled" | "running";
-    alias: DelegationEnvelope["alias_requested"];
-  }>> {
+  async listCanonical(principal: string, sinceTs?: string): Promise<CanonicalListResult> {
     const baseOpts = {
       query: "task",
       namespace: "tasks/",
@@ -253,6 +261,13 @@ export class BrokerTaskStore {
       this.munin.query({ ...baseOpts, tags: ["broker:mcp-v2"] }),
       this.munin.query({ ...baseOpts, tags: ["runtime:homeserver"] }),
     ]);
+    // Munin exposes no cursor/offset and orders these results lexically rather
+    // than temporally. A timestamp walk-back could therefore skip omitted
+    // newer rows. Disclose the incomplete candidate set instead of presenting
+    // the discovered row count as exact (#183).
+    const truncated =
+      tagged.total > tagged.results.length ||
+      homeserver.total > homeserver.results.length;
     const namespaces = new Set<string>();
     for (const result of [...tagged.results, ...homeserver.results]) {
       if (typeof result.namespace === "string") namespaces.add(result.namespace);
@@ -283,7 +298,7 @@ export class BrokerTaskStore {
       });
     }
     rows.sort((a, b) => b.submitted_at.localeCompare(a.submitted_at));
-    return rows;
+    return { rows, truncated };
   }
 
   /**

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -314,7 +314,7 @@ export function buildTools(deps: ToolDeps): {
     name: "hugin_list",
     title: "List recent delegated tasks",
     description:
-      "List this authenticated principal's recent canonical Munin tasks, plus its read-only historical orch-v1 rows.",
+      "List this authenticated principal's recent canonical Munin tasks, plus its read-only historical orch-v1 rows. A true truncated field means Munin capped candidate discovery, so total is only a lower bound.",
     inputShape: listInputShape,
     handler: async (rawInput) => {
       try {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -314,7 +314,7 @@ export function buildTools(deps: ToolDeps): {
     name: "hugin_list",
     title: "List recent delegated tasks",
     description:
-      "List this authenticated principal's recent canonical Munin tasks, plus its read-only historical orch-v1 rows. A true truncated field means Munin capped candidate discovery, so total is only a lower bound.",
+      "List this authenticated principal's recent canonical Munin tasks, plus its read-only historical orch-v1 rows. A true truncated field means a Munin query hit its result cap and may have omitted tasks, so total is only a lower bound.",
     inputShape: listInputShape,
     handler: async (rawInput) => {
       try {

--- a/tests/broker/handlers.test.ts
+++ b/tests/broker/handlers.test.ts
@@ -869,16 +869,29 @@ describe("GET /v1/delegate/list", () => {
     expect(body.rows[0].alias).toBe("m5");
   });
 
-  it("marks the returned total as truncated when Munin capped candidate discovery", async () => {
+  it("marks the returned total as truncated when Munin candidate discovery hits its cap", async () => {
     await fetch(`${harness.url}/v1/delegate/submit`, {
       method: "POST",
       headers: authHeader(),
       body: JSON.stringify(validRequest()),
     });
     const submitted = harness.munin.writes.find((write) => write.key === "status")!;
+    const rawResults = Array.from({ length: 50 }, (_, index) => {
+      const namespace = `tasks/capped-${index}`;
+      harness.munin.reads[`${namespace}/status`] = {
+        namespace,
+        key: "status",
+        content: submitted.content,
+        tags: submitted.tags ?? [],
+        created_at: "2026-07-11T12:00:00.000Z",
+        updated_at: "2026-07-11T12:00:00.000Z",
+      };
+      return { namespace, key: "status", tags: submitted.tags };
+    });
     harness.munin.queryReturn = {
-      results: [{ namespace: submitted.namespace, key: "status", tags: submitted.tags }],
-      total: 101,
+      results: rawResults,
+      // Munin reports the number of formatted rows, not matches before LIMIT.
+      total: rawResults.length,
     };
 
     const res = await fetch(`${harness.url}/v1/delegate/list`, {
@@ -886,8 +899,8 @@ describe("GET /v1/delegate/list", () => {
     });
     const body = await res.json();
 
-    expect(body.rows).toHaveLength(1);
-    expect(body.total).toBe(1);
+    expect(body.rows).toHaveLength(50);
+    expect(body.total).toBe(50);
     expect(body.truncated).toBe(true);
   });
 

--- a/tests/broker/handlers.test.ts
+++ b/tests/broker/handlers.test.ts
@@ -865,7 +865,30 @@ describe("GET /v1/delegate/list", () => {
     const body = await res.json();
     expect(body.rows).toHaveLength(1);
     expect(body.total).toBe(1);
+    expect(body.truncated).toBe(false);
     expect(body.rows[0].alias).toBe("m5");
+  });
+
+  it("marks the returned total as truncated when Munin capped candidate discovery", async () => {
+    await fetch(`${harness.url}/v1/delegate/submit`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify(validRequest()),
+    });
+    const submitted = harness.munin.writes.find((write) => write.key === "status")!;
+    harness.munin.queryReturn = {
+      results: [{ namespace: submitted.namespace, key: "status", tags: submitted.tags }],
+      total: 101,
+    };
+
+    const res = await fetch(`${harness.url}/v1/delegate/list`, {
+      headers: { authorization: `Bearer ${SECRET}` },
+    });
+    const body = await res.json();
+
+    expect(body.rows).toHaveLength(1);
+    expect(body.total).toBe(1);
+    expect(body.truncated).toBe(true);
   });
 
   it("lists only canonical tasks owned by the authenticated principal", async () => {

--- a/tests/broker/task-store.test.ts
+++ b/tests/broker/task-store.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   BrokerTaskStore,
+  MUNIN_QUERY_MAX,
   ORCH_V1_TAG,
   buildSubmitTags,
   flipLifecycleTags,
@@ -198,9 +199,12 @@ describe("BrokerTaskStore.listCanonical", () => {
       content: serializeEnvelope(envelope("t1")),
       tags: ["cancelled", "broker:mcp-v2"],
     };
-    const rows = await new BrokerTaskStore(munin as unknown as MuninClient)
+    const result = await new BrokerTaskStore(munin as unknown as MuninClient)
       .listCanonical("claude-code");
-    expect(rows).toEqual([expect.objectContaining({ task_id: "t1", outcome: "cancelled" })]);
+    expect(result).toEqual({
+      rows: [expect.objectContaining({ task_id: "t1", outcome: "cancelled" })],
+      truncated: false,
+    });
   });
 
   // #181: hugin_list under-counted real broker tasks. A tag-scoped Munin query
@@ -226,9 +230,12 @@ describe("BrokerTaskStore.listCanonical", () => {
       results: [{ namespace: "tasks/t1", key: "feedback", tags: ["broker:mcp-v2", "feedback"] }],
       total: 1,
     };
-    const rows = await new BrokerTaskStore(munin as unknown as MuninClient)
+    const result = await new BrokerTaskStore(munin as unknown as MuninClient)
       .listCanonical("claude-code");
-    expect(rows).toEqual([expect.objectContaining({ task_id: "t1", outcome: "completed" })]);
+    expect(result.rows).toEqual([
+      expect.objectContaining({ task_id: "t1", outcome: "completed" }),
+    ]);
+    expect(result.truncated).toBe(false);
   });
 
   it("still lists a task whose status entry is crowded out by an await-observation entry", async () => {
@@ -243,9 +250,12 @@ describe("BrokerTaskStore.listCanonical", () => {
       ],
       total: 1,
     };
-    const rows = await new BrokerTaskStore(munin as unknown as MuninClient)
+    const result = await new BrokerTaskStore(munin as unknown as MuninClient)
       .listCanonical("claude-code");
-    expect(rows).toEqual([expect.objectContaining({ task_id: "t2", outcome: "running" })]);
+    expect(result.rows).toEqual([
+      expect.objectContaining({ task_id: "t2", outcome: "running" }),
+    ]);
+    expect(result.truncated).toBe(false);
   });
 
   it("forwards sinceTs as the since field on both munin.query calls", async () => {
@@ -278,6 +288,53 @@ describe("BrokerTaskStore.listCanonical", () => {
     }
   });
 
+  it("discloses when Munin capped either candidate query", async () => {
+    const munin = new FakeMunin();
+    const rawResults = Array.from({ length: MUNIN_QUERY_MAX }, (_, index) => ({
+      namespace: `tasks/t${index}`,
+      key: "status",
+    }));
+    munin.queryByTags = (tags) => ({
+      results: rawResults,
+      total: tags.includes("broker:mcp-v2")
+        ? MUNIN_QUERY_MAX + 51
+        : MUNIN_QUERY_MAX,
+    });
+    for (let index = 0; index < MUNIN_QUERY_MAX; index += 1) {
+      munin.readReturn[`tasks/t${index}/status`] = {
+        content: serializeEnvelope(envelope(`t${index}`)),
+        tags: ["completed", "broker:mcp-v2", "runtime:homeserver"],
+      };
+    }
+
+    const result = await new BrokerTaskStore(munin as unknown as MuninClient)
+      .listCanonical("claude-code");
+
+    expect(result.rows).toHaveLength(MUNIN_QUERY_MAX);
+    expect(result.truncated).toBe(true);
+  });
+
+  it("does not report truncation at the exact Munin result boundary", async () => {
+    const munin = new FakeMunin();
+    const rawResults = Array.from({ length: MUNIN_QUERY_MAX }, (_, index) => ({
+      namespace: `tasks/boundary-${index}`,
+      key: "status",
+    }));
+    munin.queryReturn = { results: rawResults, total: MUNIN_QUERY_MAX };
+    for (let index = 0; index < MUNIN_QUERY_MAX; index += 1) {
+      munin.readReturn[`tasks/boundary-${index}/status`] = {
+        content: serializeEnvelope(envelope(`boundary-${index}`)),
+        tags: ["completed", "broker:mcp-v2", "runtime:homeserver"],
+      };
+    }
+
+    const result = await new BrokerTaskStore(munin as unknown as MuninClient)
+      .listCanonical("claude-code");
+
+    expect(result.rows).toHaveLength(MUNIN_QUERY_MAX);
+    expect(result.truncated).toBe(false);
+  });
+
   // Codex review of #181/PR182: the earlier crowd-out tests above share one
   // `queryReturn` fixture for both tag queries, so they cannot distinguish
   // "found via the broker:mcp-v2 channel" from "found via the runtime:homeserver
@@ -296,9 +353,12 @@ describe("BrokerTaskStore.listCanonical", () => {
         ? { results: [{ namespace: "tasks/unrelated-1", key: "feedback" }, { namespace: "tasks/unrelated-2", key: "await-observation" }], total: 2 }
         : { results: [{ namespace: "tasks/t3", key: "status" }], total: 1 };
 
-    const rows = await new BrokerTaskStore(munin as unknown as MuninClient)
+    const result = await new BrokerTaskStore(munin as unknown as MuninClient)
       .listCanonical("claude-code");
-    expect(rows).toEqual([expect.objectContaining({ task_id: "t3", outcome: "completed" })]);
+    expect(result.rows).toEqual([
+      expect.objectContaining({ task_id: "t3", outcome: "completed" }),
+    ]);
+    expect(result.truncated).toBe(false);
   });
 });
 

--- a/tests/broker/task-store.test.ts
+++ b/tests/broker/task-store.test.ts
@@ -288,18 +288,20 @@ describe("BrokerTaskStore.listCanonical", () => {
     }
   });
 
-  it("discloses when Munin capped either candidate query", async () => {
+  it("discloses when either Munin candidate query hits its result cap", async () => {
     const munin = new FakeMunin();
     const rawResults = Array.from({ length: MUNIN_QUERY_MAX }, (_, index) => ({
       namespace: `tasks/t${index}`,
       key: "status",
     }));
-    munin.queryByTags = (tags) => ({
-      results: rawResults,
-      total: tags.includes("broker:mcp-v2")
-        ? MUNIN_QUERY_MAX + 51
-        : MUNIN_QUERY_MAX,
-    });
+    munin.queryByTags = (tags) => {
+      const results = tags.includes("broker:mcp-v2")
+        ? rawResults
+        : rawResults.slice(0, MUNIN_QUERY_MAX - 1);
+      // Munin's real memory_query contract reports the formatted row count,
+      // so total cannot reveal whether a full 50-row page omitted matches.
+      return { results, total: results.length };
+    };
     for (let index = 0; index < MUNIN_QUERY_MAX; index += 1) {
       munin.readReturn[`tasks/t${index}/status`] = {
         content: serializeEnvelope(envelope(`t${index}`)),
@@ -314,14 +316,14 @@ describe("BrokerTaskStore.listCanonical", () => {
     expect(result.truncated).toBe(true);
   });
 
-  it("does not report truncation at the exact Munin result boundary", async () => {
+  it("does not report truncation below the Munin result boundary", async () => {
     const munin = new FakeMunin();
-    const rawResults = Array.from({ length: MUNIN_QUERY_MAX }, (_, index) => ({
+    const rawResults = Array.from({ length: MUNIN_QUERY_MAX - 1 }, (_, index) => ({
       namespace: `tasks/boundary-${index}`,
       key: "status",
     }));
-    munin.queryReturn = { results: rawResults, total: MUNIN_QUERY_MAX };
-    for (let index = 0; index < MUNIN_QUERY_MAX; index += 1) {
+    munin.queryReturn = { results: rawResults, total: rawResults.length };
+    for (let index = 0; index < rawResults.length; index += 1) {
       munin.readReturn[`tasks/boundary-${index}/status`] = {
         content: serializeEnvelope(envelope(`boundary-${index}`)),
         tags: ["completed", "broker:mcp-v2", "runtime:homeserver"],
@@ -331,7 +333,7 @@ describe("BrokerTaskStore.listCanonical", () => {
     const result = await new BrokerTaskStore(munin as unknown as MuninClient)
       .listCanonical("claude-code");
 
-    expect(result.rows).toHaveLength(MUNIN_QUERY_MAX);
+    expect(result.rows).toHaveLength(MUNIN_QUERY_MAX - 1);
     expect(result.truncated).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

- surface `truncated` from canonical Broker discovery when either Munin query returns the full 50-row server cap
- preserve the current namespace union, direct status reads, principal filtering, sorting, and caller limit
- document in `hugin_list` that `total` is only a lower bound when `truncated` is true
- add capped, below-boundary, and HTTP propagation regressions

This is the safe Hugin-side honesty mitigation for #183. Munin `memory_query.total` is only the formatted row count, not a pre-limit match count, and the current ranked query has no cursor. A full 50-row page is therefore conservatively marked as possibly truncated. This PR does not claim to recover omitted rows and does not close #183.

CODEX: implemented and independently reviewed against Hugin plus Munin’s real query implementation; one high-severity total-semantics finding was fixed before handoff.
DELEGATIONS: 6 submitted/6 rated — mcp-m5-e2022918f83326f3deb753fd research-plan=wrong(discarded), mcp-m5-23918b73a0ae0c8e4c9ac333 data-transform=redo(discarded), mcp-m5-8cbb9a18c901c438b95fb520 data-transform=pass(accepted_unchanged), mcp-m5-3a44823db10b6c549b1f6bb2 extract=pass(accepted_unchanged), mcp-m5-3311c3e008568b6149719821 code-implement=partial(major_rewrite), mcp-m5-748c9135106a86067d7d705c unit-test-gen=wrong(discarded)
UNCERTAINTIES: `truncated` discloses possible incomplete candidate discovery but cannot recover omitted principal-owned rows without a cursor or a separately proven safe pagination strategy.

## Validation

- `npm run build`
- `npm test` — 97 files / 1,657 tests
- `git diff --check`
- GitHub `build-test` check passed