### PR TITLE
fix(deploy): reject symlinked node_modules before sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,4 +26,6 @@ jobs:
 
       - run: npm test
 
+      - run: bash scripts/deploy-pi.test.sh
+
       - run: bash scripts/lib/claude-config-bootstrap.test.sh

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,30 @@
 # Hugin — Status
 
+**Latest session:** 2026-07-12 (Codex: deploy source hardening, issue #187)
+**Branch:** `codex/hugin-187-node-modules-symlink` from `main@565f9e6`; PR pending.
+
+## Latest — `node_modules` worktree symlinks rejected before deploy mutation (#187)
+
+- `scripts/deploy-pi.sh` now fails before build, rsync, or SSH when the local
+  `node_modules` entry is a symlink, with remediation to replace it with worktree-local
+  dependencies via `npm ci`.
+- Rsync now excludes both the `node_modules` entry and `node_modules/` contents. This is
+  defence in depth against the incident where a worktree symlink bypassed the trailing-slash
+  exclusion and rsync partially deleted the Pi dependency tree before exiting 23.
+- New `scripts/deploy-pi.test.sh`, wired into CI, proves the preflight invokes none of npm,
+  rsync, or SSH for a symlinked source; checks all prior deployment exclusions remain; and
+  uses real local rsync to prove a source symlink cannot replace or delete a destination's
+  real dependency directory.
+- Validation: red/green shell regression, Bash syntax checks, TypeScript build, full suite
+  (97 files / 1,657 tests), both shell test suites, and `git diff --check` are green.
+- No production action was taken. After review/merge, deploy from a clean `main` checkout with
+  real local dependencies using `./scripts/deploy-pi.sh`, then verify the user service is
+  active/enabled and Pi loopback `/health` reports `status:"ok"`, `polling:true`, queue depth 0.
+  Rollback is `git revert` of the merged #187 commit followed by the same deploy; the change has
+  no data migration or configuration impact.
+
+**Next:** independent PR review, green GitHub CI, merge, then deploy and verify from clean `main`.
+
 **Last session:** 2026-07-12 (Claude) — M5 provenance (#163) + learning-loop health panel (#164)
 **Branch:** `main` @ `287d473`; deployed to Hugin-Munin on 2026-07-12, health `ok` / `polling:true` / queue 0.
 

--- a/scripts/deploy-pi.sh
+++ b/scripts/deploy-pi.sh
@@ -17,11 +17,24 @@ DEPLOY_USER="${DEPLOY_USER:-magnus}"
 REMOTE="$DEPLOY_USER@$PI_HOST"
 REMOTE_DIR="/home/$DEPLOY_USER/repos/hugin"
 
+echo "==> Checking deploy source..."
+# rsync distinguishes a directory from a symlink to a directory. The trailing-
+# slash node_modules exclusion below therefore does not match the common
+# worktree optimization where node_modules links to another checkout. Reject
+# that source shape before any build, sync, or remote mutation can happen.
+if [ -L node_modules ]; then
+  echo "ERROR: local node_modules is a symlink; refusing to deploy." >&2
+  echo "Replace it with worktree-local dependencies, for example:" >&2
+  echo "  unlink node_modules && npm ci" >&2
+  exit 1
+fi
+
 echo "==> Building locally..."
 npm run build
 
 echo "==> Syncing to $REMOTE:$REMOTE_DIR..."
 rsync -av --delete \
+  --exclude='node_modules' \
   --exclude='node_modules/' \
   --exclude='.git' \
   --exclude='.git/' \

--- a/scripts/deploy-pi.test.sh
+++ b/scripts/deploy-pi.test.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# Regression coverage for deploy-pi.sh source-tree safety (issue #187).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEPLOY_SCRIPT="$SCRIPT_DIR/deploy-pi.sh"
+ORIGINAL_PATH="$PATH"
+REAL_RSYNC="$(command -v rsync)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+FAKE_BIN="$TMP_DIR/bin"
+CALL_LOG="$TMP_DIR/calls.log"
+mkdir -p "$FAKE_BIN"
+: >"$CALL_LOG"
+
+cat >"$FAKE_BIN/npm" <<'EOF'
+#!/usr/bin/env bash
+printf 'npm %s\n' "$*" >>"$CALL_LOG"
+EOF
+
+cat >"$FAKE_BIN/rsync" <<'EOF'
+#!/usr/bin/env bash
+printf 'rsync %s\n' "$*" >>"$CALL_LOG"
+# Stop a normal-source run immediately after capturing the sync arguments.
+exit 42
+EOF
+
+cat >"$FAKE_BIN/ssh" <<'EOF'
+#!/usr/bin/env bash
+printf 'ssh %s\n' "$*" >>"$CALL_LOG"
+exit 99
+EOF
+
+chmod +x "$FAKE_BIN/npm" "$FAKE_BIN/rsync" "$FAKE_BIN/ssh"
+export PATH="$FAKE_BIN:$PATH"
+export CALL_LOG
+
+failures=0
+
+fail() {
+  echo "FAIL: $1" >&2
+  failures=$((failures + 1))
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  [[ "$haystack" == *"$needle"* ]] || fail "$label (missing: $needle)"
+}
+
+# A worktree commonly links dependencies from its owning checkout. The deploy
+# must reject that shape before build, rsync, or any remote command can run.
+SYMLINK_SOURCE="$TMP_DIR/symlink-source"
+mkdir -p "$SYMLINK_SOURCE" "$TMP_DIR/shared-node-modules"
+ln -s "$TMP_DIR/shared-node-modules" "$SYMLINK_SOURCE/node_modules"
+
+set +e
+symlink_output="$(cd "$SYMLINK_SOURCE" && bash "$DEPLOY_SCRIPT" testhost 2>&1)"
+symlink_rc=$?
+set -e
+
+[[ "$symlink_rc" -ne 0 ]] || fail "symlinked node_modules must fail deployment"
+assert_contains "$symlink_output" "node_modules is a symlink" "symlink failure explains the unsafe source"
+assert_contains "$symlink_output" "npm ci" "symlink failure gives a safe remediation"
+[[ ! -s "$CALL_LOG" ]] || fail "symlink preflight must run before npm, rsync, or ssh"
+
+# Defence in depth: a normal source reaches rsync with exclusions for both the
+# symlink entry and directory contents, while retaining all existing excludes.
+NORMAL_SOURCE="$TMP_DIR/normal-source"
+mkdir -p "$NORMAL_SOURCE/node_modules"
+: >"$CALL_LOG"
+
+set +e
+(cd "$NORMAL_SOURCE" && bash "$DEPLOY_SCRIPT" testhost >/dev/null 2>&1)
+normal_rc=$?
+set -e
+
+[[ "$normal_rc" -eq 42 ]] || fail "normal source should reach the rsync stub"
+calls="$(cat "$CALL_LOG")"
+assert_contains "$calls" "npm run build" "normal source still builds first"
+assert_contains "$calls" "--exclude=node_modules --exclude=node_modules/" "rsync excludes the node_modules entry (including symlinks)"
+assert_contains "$calls" "--exclude=node_modules/" "rsync retains the node_modules directory exclusion"
+assert_contains "$calls" "--exclude=.git" "rsync retains the .git entry exclusion"
+assert_contains "$calls" "--exclude=.git/" "rsync retains the .git directory exclusion"
+assert_contains "$calls" "--exclude=.env" "rsync retains the .env exclusion"
+assert_contains "$calls" "--exclude=tests/" "rsync retains the tests exclusion"
+assert_contains "$calls" "--exclude=.DS_Store" "rsync retains the .DS_Store exclusion"
+[[ "$calls" != *"ssh "* ]] || fail "rsync failure must stop before any remote command"
+
+# Prove the exclusion semantics themselves against a real rsync: even if the
+# preflight is accidentally bypassed in a future refactor, the local symlink
+# must not replace or delete an existing remote dependency directory.
+DEFENCE_SOURCE="$TMP_DIR/defence-source"
+DEFENCE_REMOTE="$TMP_DIR/defence-remote"
+mkdir -p "$DEFENCE_SOURCE" "$DEFENCE_REMOTE/node_modules" "$TMP_DIR/defence-shared"
+ln -s "$TMP_DIR/defence-shared" "$DEFENCE_SOURCE/node_modules"
+printf 'preserve me\n' >"$DEFENCE_REMOTE/node_modules/marker.txt"
+
+PATH="$ORIGINAL_PATH" "$REAL_RSYNC" -a --delete \
+  --exclude='node_modules' \
+  --exclude='node_modules/' \
+  "$DEFENCE_SOURCE/" "$DEFENCE_REMOTE/"
+
+[[ -d "$DEFENCE_REMOTE/node_modules" ]] || fail "rsync exclusions must preserve the remote dependency directory"
+[[ ! -L "$DEFENCE_REMOTE/node_modules" ]] || fail "rsync exclusions must not replace remote dependencies with a symlink"
+[[ "$(cat "$DEFENCE_REMOTE/node_modules/marker.txt")" == "preserve me" ]] || fail "rsync exclusions must not delete remote dependencies"
+
+if [[ "$failures" -gt 0 ]]; then
+  echo "$failures assertion(s) failed" >&2
+  exit 1
+fi
+
+echo "All assertions passed"


### PR DESCRIPTION
Closes #187

## Root cause

`rsync --exclude=node_modules/` matches a directory but not a symlink with that basename. A worktree-level `node_modules` symlink therefore entered the `--delete` sync, attempted to replace the Pi's real dependency directory, and partially deleted remote packages before rsync exited 23.

## Fix

- fail locally when `node_modules` is a symlink, before build, rsync, SSH, or any remote mutation
- provide a clear `unlink node_modules && npm ci` remediation
- exclude both the `node_modules` entry and `node_modules/` contents as defence in depth
- retain the existing `.git`, `.env`, `tests/`, and `.DS_Store` exclusions
- add the deploy shell regression to CI

## Validation

- red/green `bash scripts/deploy-pi.test.sh`
  - proves a symlinked source calls none of npm, rsync, or SSH
  - proves all deployment exclusions remain present
  - uses real local rsync to prove a source symlink cannot replace or delete a destination's real `node_modules` directory
- `bash -n scripts/deploy-pi.sh scripts/deploy-pi.test.sh`
- `bash scripts/lib/claude-config-bootstrap.test.sh`
- `npm run build`
- `npm test` — 97 files / 1,657 tests
- `git diff --check`

## Deploy and verification

No production action was taken from this branch. After merge, deploy from a clean `main` checkout with real local dependencies:

```bash
npm ci
./scripts/deploy-pi.sh
```

Then verify on the Pi:

```bash
ssh huginmunin.local 'XDG_RUNTIME_DIR=/run/user/1000 systemctl --user is-active hugin.service && XDG_RUNTIME_DIR=/run/user/1000 systemctl --user is-enabled hugin.service && curl -fsS http://127.0.0.1:3032/health'
```

Expected: service `active`, `enabled`, and health reports `status:"ok"`, `polling:true`, queue depth 0.

## Rollback

`git revert` the merged commit on `main`, then run the same deploy command. There is no data migration or configuration change. Restoring the old deploy script also restores the original symlink risk, so only roll back if the preflight itself causes an unexpected regression.