### PR TITLE
fix(dispatcher): eliminate capped-window task starvation

### DIFF
--- a/src/broker/handlers.ts
+++ b/src/broker/handlers.ts
@@ -504,7 +504,8 @@ export function createListHandler(deps: BrokerHandlerDependencies) {
       if (parsed.alias && (row.alias ?? row.envelope?.alias_requested) !== parsed.alias) return false;
       if (parsed.since_ts) {
         const submittedAt = row.submitted_at ?? "";
-        if (submittedAt < parsed.since_ts) return false;
+        const submittedAtMs = Date.parse(submittedAt);
+        if (!Number.isFinite(submittedAtMs) || submittedAtMs < Date.parse(parsed.since_ts)) return false;
       }
       return true;
     });

--- a/src/broker/task-store.ts
+++ b/src/broker/task-store.ts
@@ -26,6 +26,9 @@ import { delegationEnvelopeSchema, delegationRequestSchema } from "./types.js";
 import { hashPayload } from "./idempotency.js";
 import { deriveAwaitObservation } from "./await-observation.js";
 import type { AwaitEvent, AwaitObservation } from "./await-observation.js";
+import { queryAllMuninEntries } from "../munin-pagination.js";
+
+export { MUNIN_QUERY_MAX } from "../munin-pagination.js";
 
 export interface DelegationResultLike {
   task_id: string;
@@ -39,10 +42,6 @@ export const RESULT_STRUCTURED_KEY = "result-structured";
 export const RESULT_ERROR_KEY = "result-error";
 /** Durable-handoff evidence for the #165 trial (#164). */
 export const AWAIT_OBSERVATION_KEY = "await-observation";
-/** Munin's memory_query tool documents a hard server-side cap of 50 results
- * per call regardless of the requested `limit` — see listCanonical (#181). */
-export const MUNIN_QUERY_MAX = 50;
-
 export interface TaskStoreConfig {
   munin: MuninClient;
 }
@@ -242,33 +241,24 @@ export class BrokerTaskStore {
    * unique namespace's `status` entry directly rather than relying on it
    * having survived inside the raw query window.
    *
-   * Always queries Munin at its real per-query cap (`MUNIN_QUERY_MAX`),
-   * independent of how many rows the caller ultimately wants — the final
-   * row count is enforced downstream by the handler's own slice(). A caller-
-   * requested small output limit narrowing this raw candidate window would
-   * reintroduce the same crowding-out risk this fix closes, just triggered
-   * by `?limit=1` instead of a rating event (caught in review of #181).
+   * Candidate discovery uses the shared capped-window paginator (#183). It
+   * selects Munin's temporally ordered filter-only mode, walks backward by
+   * updated_at, and probes exact timestamp boundaries so more than 50 tasks
+   * (including tasks owned by another principal) cannot crowd out matches.
+   * A same-millisecond bucket of 50+ remains explicitly `truncated` because
+   * Munin has no `(updated_at,id)` cursor with which to prove it complete.
    */
   async listCanonical(principal: string, sinceTs?: string): Promise<CanonicalListResult> {
     const baseOpts = {
-      query: "task",
       namespace: "tasks/",
       entry_type: "state" as const,
-      limit: MUNIN_QUERY_MAX,
       ...(sinceTs ? { since: sinceTs } : {}),
     };
     const [tagged, homeserver] = await Promise.all([
-      this.munin.query({ ...baseOpts, tags: ["broker:mcp-v2"] }),
-      this.munin.query({ ...baseOpts, tags: ["runtime:homeserver"] }),
+      queryAllMuninEntries(this.munin, { ...baseOpts, tags: ["broker:mcp-v2"] }),
+      queryAllMuninEntries(this.munin, { ...baseOpts, tags: ["runtime:homeserver"] }),
     ]);
-    // Munin exposes no cursor/offset and its `total` is only the number of
-    // formatted rows returned, not a pre-limit count. A result set at the
-    // server cap is therefore indistinguishable from an exactly-full set.
-    // Mark it conservatively: a timestamp walk-back is not safe because the
-    // ranked query is not guaranteed to expose every omitted row in time order.
-    const truncated =
-      tagged.results.length >= MUNIN_QUERY_MAX ||
-      homeserver.results.length >= MUNIN_QUERY_MAX;
+    const truncated = tagged.truncated || homeserver.truncated;
     const namespaces = new Set<string>();
     for (const result of [...tagged.results, ...homeserver.results]) {
       if (typeof result.namespace === "string") namespaces.add(result.namespace);

--- a/src/broker/types.ts
+++ b/src/broker/types.ts
@@ -204,7 +204,11 @@ export type SubmitResponse = z.infer<typeof submitResponseSchema>;
 
 export const listRequestSchema = z.object({
   limit: z.number().int().min(1).max(500).optional(),
-  since_ts: z.string().min(1).optional(),
+  // Pagination and the final historical-row filter both interpret this as an
+  // instant. Reject arbitrary non-empty strings up front so SQLite's lexical
+  // timestamp comparison and JavaScript's Date.parse cannot disagree about
+  // which rows belong in the response.
+  since_ts: z.string().datetime({ offset: true }).optional(),
   outcome: z.enum(["completed", "failed", "running", "any"]).optional(),
   alias: aliasSchema.optional(),
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import {
   type MuninReadResult,
 } from "./munin-client.js";
 import { getFoundBatchEntry, extractTaskId, pickEarliestTask, selectNextTask, checkoutTaskBranch, finalizeTaskBranch, shouldReapExpiredLease, decideStartupRecovery, decideDeliveryRetry, finalizeTaskCompletion, resolveContext, normalizeRoot, DEFAULT_REPOS_ROOT } from "./task-helpers.js";
+import { queryAllMuninEntries } from "./munin-pagination.js";
 import { executeSdkTask, type SdkExecutorResult, type SdkExecutorOptions, type SdkTaskConfig, type TaskPermissionProfile } from "./sdk-executor.js";
 import {
   classifyClaudeFailure,
@@ -3812,32 +3813,29 @@ async function emitHeartbeat(queueDepth: number, blockedTasks: number): Promise<
 
 // --- Poll loop ---
 
-/**
- * Given a batch of Munin query results, return the pending task with the
- * earliest created_at timestamp (FIFO ordering).  Only "status" entries are
- * considered — other keys are internal bookkeeping entries that the dispatcher
- * should not act on.
- *
- * ISO-8601 timestamps sort correctly as strings, so a plain lexicographic
- * compare is sufficient.
- */
+/** Enumerate the complete pending window and claim the oldest eligible task. */
 async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
-  const { results, total } = await munin.query({
-    query: "task",
-    tags: ["pending"],
-    namespace: "tasks/",
-    entry_type: "state",
-    limit: 10,
-  });
-
-  // Query running tasks to support group sequencing checks
-  const { results: runningResults } = await munin.query({
-    query: "task",
-    tags: ["running"],
-    namespace: "tasks/",
-    entry_type: "state",
-    limit: 50,
-  });
+  const [pendingPage, runningPage] = await Promise.all([
+    queryAllMuninEntries(munin, {
+      tags: ["pending"],
+      namespace: "tasks/",
+      entry_type: "state",
+    }),
+    // Query running tasks to support group sequencing checks.
+    queryAllMuninEntries(munin, {
+      tags: ["running"],
+      namespace: "tasks/",
+      entry_type: "state",
+    }),
+  ]);
+  const results = pendingPage.results;
+  const runningResults = runningPage.results;
+  if (pendingPage.truncated || runningPage.truncated) {
+    console.warn(
+      "Task queue enumeration contains a >=50-entry same-millisecond timestamp bucket; " +
+      "queue depth is a lower bound, but repeated claims remain starvation-free",
+    );
+  }
 
   // Orchestrator v1 tasks (broker-submitted, tagged "orch-v1") are dispatched
   // by the Pi-side broker, not by the legacy in-process poller. Filter them
@@ -3847,13 +3845,13 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
   const dispatchableResults = results.filter(
     (r) => !r.tags.includes("orch-v1"),
   );
+  const queueDepth = results.filter((result) => result.key === "status").length;
 
   // Select the next eligible task respecting Group/Sequence ordering (FIFO within eligible set)
   const taskResult = selectNextTask(dispatchableResults, runningResults);
-  if (!taskResult) return { hadTask: false, queueDepth: 0 };
+  if (!taskResult) return { hadTask: false, queueDepth };
 
   const taskNs = taskResult.namespace;
-  const queueDepth = total;
   const entry = await munin.read(taskNs, "status");
   if (!entry) return { hadTask: false, queueDepth };
 

--- a/src/munin-client.ts
+++ b/src/munin-client.ts
@@ -325,19 +325,27 @@ export class MuninClient {
   }
 
   async query(opts: {
-    query: string;
+    /**
+     * Omit for filter-only browsing. Munin orders filter-only results by
+     * updated_at DESC, which is the ordering required by the capped-window
+     * paginator. Supplying a search query switches to relevance ordering.
+     */
+    query?: string;
     tags?: string[];
     namespace?: string;
     limit?: number;
     entry_type?: string;
     since?: string;
+    until?: string;
   }): Promise<{ results: MuninQueryResult[]; total: number }> {
-    const args: Record<string, unknown> = { query: opts.query };
+    const args: Record<string, unknown> = {};
+    if (opts.query) args.query = opts.query;
     if (opts.tags) args.tags = opts.tags;
     if (opts.namespace) args.namespace = opts.namespace;
     if (opts.limit) args.limit = opts.limit;
     if (opts.entry_type) args.entry_type = opts.entry_type;
     if (opts.since) args.since = opts.since;
+    if (opts.until) args.until = opts.until;
     return (await this.callTool("memory_query", args)) as {
       results: MuninQueryResult[];
       total: number;

--- a/src/munin-pagination.ts
+++ b/src/munin-pagination.ts
@@ -1,0 +1,112 @@
+import type { MuninClient, MuninQueryResult } from "./munin-client.js";
+
+/** Munin's documented hard cap for one memory_query response. */
+export const MUNIN_QUERY_MAX = 50;
+
+export interface MuninFilterQueryOptions {
+  tags?: string[];
+  namespace?: string;
+  entry_type?: string;
+  since?: string;
+  until?: string;
+}
+
+export interface MuninPaginatedQueryResult {
+  results: MuninQueryResult[];
+  /**
+   * True only when an exact updated_at bucket itself reaches Munin's cap.
+   * Without a composite cursor, that bucket cannot be proven complete.
+   */
+  truncated: boolean;
+}
+
+function normalizeIsoTimestamp(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const epochMs = Date.parse(value);
+  return Number.isNaN(epochMs) ? value : new Date(epochMs).toISOString();
+}
+
+function resultIdentity(result: MuninQueryResult): string {
+  if (typeof result.id === "string" && result.id.length > 0) return result.id;
+  return [result.namespace, result.key ?? "", result.updated_at ?? ""].join("\0");
+}
+
+function addResults(
+  destination: Map<string, MuninQueryResult>,
+  results: MuninQueryResult[],
+): void {
+  for (const result of results) destination.set(resultIdentity(result), result);
+}
+
+/**
+ * Enumerate a tag/filter-scoped Munin corpus despite memory_query's 50-row cap.
+ *
+ * This deliberately omits `query`, selecting Munin's filter-only mode. That
+ * mode is ordered by `updated_at DESC`; query-based search is relevance-ranked
+ * and therefore cannot be paged safely with a timestamp cursor (#183).
+ *
+ * Each full page gets a second, exact-timestamp boundary probe. That probe
+ * recovers rows hidden behind the page boundary when several entries share the
+ * same millisecond. If the exact bucket itself reaches 50 rows, the API has no
+ * composite `(updated_at, id)` cursor with which to prove completeness, so the
+ * result stays useful but honestly reports `truncated: true`.
+ */
+export async function queryAllMuninEntries(
+  munin: Pick<MuninClient, "query">,
+  options: MuninFilterQueryOptions,
+): Promise<MuninPaginatedQueryResult> {
+  const since = normalizeIsoTimestamp(options.since);
+  let until = normalizeIsoTimestamp(options.until);
+  const unique = new Map<string, MuninQueryResult>();
+  let truncated = false;
+
+  while (true) {
+    const page = await munin.query({
+      tags: options.tags,
+      namespace: options.namespace,
+      entry_type: options.entry_type,
+      ...(since ? { since } : {}),
+      ...(until ? { until } : {}),
+      limit: MUNIN_QUERY_MAX,
+    });
+    addResults(unique, page.results);
+
+    if (page.results.length < MUNIN_QUERY_MAX) break;
+
+    const timestamps = page.results
+      .map((result) => normalizeIsoTimestamp(result.updated_at))
+      .filter((value): value is string => value !== undefined && !Number.isNaN(Date.parse(value)));
+    if (timestamps.length !== page.results.length) {
+      truncated = true;
+      break;
+    }
+
+    const boundary = timestamps.reduce((oldest, value) => value < oldest ? value : oldest);
+    const boundaryPage = await munin.query({
+      tags: options.tags,
+      namespace: options.namespace,
+      entry_type: options.entry_type,
+      since: boundary,
+      until: boundary,
+      limit: MUNIN_QUERY_MAX,
+    });
+    addResults(unique, boundaryPage.results);
+    if (boundaryPage.results.length >= MUNIN_QUERY_MAX) truncated = true;
+
+    const previousMillisecond = Date.parse(boundary) - 1;
+    if (!Number.isFinite(previousMillisecond)) {
+      truncated = true;
+      break;
+    }
+    if (since && previousMillisecond < Date.parse(since)) break;
+
+    const nextUntil = new Date(previousMillisecond).toISOString();
+    if (until && nextUntil >= until) {
+      truncated = true;
+      break;
+    }
+    until = nextUntil;
+  }
+
+  return { results: [...unique.values()], truncated };
+}

--- a/tests/broker/handlers.test.ts
+++ b/tests/broker/handlers.test.ts
@@ -16,6 +16,7 @@ const OTHER_SECRET = "b".repeat(64);
 class FakeMunin {
   writes: Array<{ namespace: string; key: string; content: string; tags?: string[] }> = [];
   reads: Record<string, unknown> = {};
+  queryCalls = 0;
   queryReturn: { results: unknown[]; total: number } = { results: [], total: 0 };
   async write(
     namespace: string,
@@ -37,6 +38,7 @@ class FakeMunin {
     return this.reads[`${namespace}/${key}`] ?? null;
   }
   async query(): Promise<{ results: unknown[]; total: number }> {
+    this.queryCalls += 1;
     return this.queryReturn;
   }
 }
@@ -839,6 +841,16 @@ describe("POST /v1/delegate/rate", () => {
 });
 
 describe("GET /v1/delegate/list", () => {
+  it("rejects a malformed since_ts instead of applying inconsistent time filters", async () => {
+    const res = await fetch(
+      `${harness.url}/v1/delegate/list?since_ts=not-a-timestamp`,
+      { headers: { authorization: `Bearer ${SECRET}` } },
+    );
+
+    expect(res.status).toBe(400);
+    expect(harness.munin.queryCalls).toBe(0);
+  });
+
   it("returns empty rows when journal is empty", async () => {
     const res = await fetch(`${harness.url}/v1/delegate/list`, {
       headers: { authorization: `Bearer ${SECRET}` },

--- a/tests/broker/task-store.test.ts
+++ b/tests/broker/task-store.test.ts
@@ -28,6 +28,9 @@ class FakeMunin {
   queries: Parameters<MuninClient["query"]>[0][] = [];
   readReturn: Record<string, unknown> = {};
   queryReturn: { results: unknown[]; total: number } = { results: [], total: 0 };
+  queryOverride?: (
+    opts: Parameters<MuninClient["query"]>[0],
+  ) => { results: unknown[]; total: number };
   /** Optional per-call override, keyed by the requested tags — lets a test
    * make the two tag-scoped queries in listCanonical diverge instead of
    * always sharing queryReturn. */
@@ -50,6 +53,7 @@ class FakeMunin {
   }
   async query(opts: Parameters<MuninClient["query"]>[0]) {
     this.queries.push(opts);
+    if (this.queryOverride) return this.queryOverride(opts);
     if (this.queryByTags) return this.queryByTags(opts.tags ?? []);
     return this.queryReturn;
   }
@@ -266,8 +270,53 @@ describe("BrokerTaskStore.listCanonical", () => {
 
     expect(munin.queries).toHaveLength(2);
     for (const query of munin.queries) {
-      expect(query).toHaveProperty("since", "2026-07-12T13:03:00Z");
+      expect(query).toHaveProperty("since", "2026-07-12T13:03:00.000Z");
     }
+  });
+
+  it("enumerates more than 100 namespaces before principal filtering", async () => {
+    const munin = new FakeMunin();
+    const rows = Array.from({ length: 130 }, (_, index) => {
+      const taskId = `principal-page-${index}`;
+      const timestamp = new Date(Date.UTC(2026, 6, 12, 12, 0, 0, index)).toISOString();
+      const taskEnvelope = envelope(taskId);
+      // The 65 target-principal tasks are oldest. A single newest-first page
+      // would contain only the other principal and falsely return zero rows.
+      taskEnvelope.broker_principal = index < 65 ? "claude-code" : "codex";
+      taskEnvelope.received_at = timestamp;
+      munin.readReturn[`tasks/${taskId}/status`] = {
+        content: serializeEnvelope(taskEnvelope),
+        tags: ["completed", "broker:mcp-v2", "runtime:homeserver"],
+      };
+      return {
+        id: `entry-${index}`,
+        namespace: `tasks/${taskId}`,
+        key: "status",
+        entry_type: "state",
+        content_preview: "task",
+        tags: ["completed", "broker:mcp-v2", "runtime:homeserver"],
+        created_at: timestamp,
+        updated_at: timestamp,
+      };
+    });
+    munin.queryOverride = (opts) => {
+      const filtered = rows
+        .filter((row) => (opts.tags ?? []).every((tag) => row.tags.includes(tag)))
+        .filter((row) => !opts.since || row.updated_at >= opts.since)
+        .filter((row) => !opts.until || row.updated_at <= opts.until)
+        .sort((a, b) => b.updated_at.localeCompare(a.updated_at))
+        .slice(0, opts.limit ?? 10);
+      return { results: filtered, total: filtered.length };
+    };
+
+    const result = await new BrokerTaskStore(munin as unknown as MuninClient)
+      .listCanonical("claude-code");
+
+    expect(result.rows).toHaveLength(65);
+    expect(result.rows.every((row) => row.task_id.startsWith("principal-page-"))).toBe(true);
+    expect(result.truncated).toBe(false);
+    expect(munin.queries.length).toBeGreaterThan(2);
+    expect(munin.queries.every((query) => query.query === undefined)).toBe(true);
   });
 
   // Codex review of #181/PR182: a caller-requested small output limit must

--- a/tests/munin-client.test.ts
+++ b/tests/munin-client.test.ts
@@ -121,6 +121,38 @@ describe("MuninClient", () => {
     });
   });
 
+  it("supports temporally bounded filter-only queries", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      rpcResponse({ results: [], total: 0 }),
+    );
+    const client = new MuninClient({
+      baseUrl: "http://munin.test",
+      apiKey: "test-key",
+      minRequestSpacingMs: 0,
+    });
+
+    await client.query({
+      tags: ["pending"],
+      namespace: "tasks/",
+      entry_type: "state",
+      since: "2026-07-12T12:00:00.000Z",
+      until: "2026-07-13T12:00:00.000Z",
+      limit: 50,
+    });
+
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const body = JSON.parse(String(request.body));
+    expect(body.params.arguments).toMatchObject({
+      tags: ["pending"],
+      namespace: "tasks/",
+      entry_type: "state",
+      since: "2026-07-12T12:00:00.000Z",
+      until: "2026-07-13T12:00:00.000Z",
+      limit: 50,
+    });
+    expect(body.params.arguments).not.toHaveProperty("query");
+  });
+
   it("passes classification through memory_write", async () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")

--- a/tests/munin-pagination.test.ts
+++ b/tests/munin-pagination.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import type { MuninClient, MuninQueryResult } from "../src/munin-client.js";
+import { queryAllMuninEntries } from "../src/munin-pagination.js";
+import { selectNextTask } from "../src/task-helpers.js";
+
+function makeTask(index: number, timestamp: string): MuninQueryResult {
+  return {
+    id: `entry-${index}`,
+    namespace: index === 0 ? "tasks/oldest" : `tasks/new-${index}`,
+    key: "status",
+    entry_type: "state",
+    content_preview: "**Runtime:** claude",
+    tags: ["pending"],
+    created_at: timestamp,
+    updated_at: timestamp,
+  };
+}
+
+class FilterOnlyMunin {
+  calls: Parameters<MuninClient["query"]>[0][] = [];
+
+  constructor(readonly rows: MuninQueryResult[]) {}
+
+  async query(opts: Parameters<MuninClient["query"]>[0]) {
+    this.calls.push(opts);
+    const results = this.rows
+      .filter((row) => (opts.tags ?? []).every((tag) => row.tags.includes(tag)))
+      .filter((row) => !opts.since || row.updated_at >= opts.since)
+      .filter((row) => !opts.until || row.updated_at <= opts.until)
+      .sort((a, b) => b.updated_at.localeCompare(a.updated_at))
+      .slice(0, opts.limit ?? 10);
+    return { results, total: results.length };
+  }
+}
+
+describe("queryAllMuninEntries", () => {
+  it("walks every capped page and recovers a corpus larger than 100 rows", async () => {
+    const base = Date.UTC(2026, 6, 12, 12, 0, 0);
+    const rows = Array.from({ length: 125 }, (_, index) =>
+      makeTask(index, new Date(base + index).toISOString()),
+    );
+    const munin = new FilterOnlyMunin(rows);
+
+    const result = await queryAllMuninEntries(munin as unknown as MuninClient, {
+      tags: ["pending"],
+      namespace: "tasks/",
+      entry_type: "state",
+    });
+
+    expect(result.results).toHaveLength(125);
+    expect(result.truncated).toBe(false);
+    expect(munin.calls.length).toBeGreaterThan(3);
+    expect(munin.calls.every((call) => call.query === undefined)).toBe(true);
+  });
+
+  it("keeps the oldest task claimable while newer tasks continuously refill the first page", async () => {
+    const base = Date.UTC(2026, 6, 12, 12, 0, 0);
+    const rows = Array.from({ length: 75 }, (_, index) =>
+      makeTask(index, new Date(base + index).toISOString()),
+    );
+    const munin = new FilterOnlyMunin(rows);
+
+    // A fresh batch arrives immediately before every poll. With the old
+    // relevance-ranked limit:10 query, this can keep the oldest task outside
+    // the candidate window forever. The paged filter query claims it in poll 1.
+    let claimed: MuninQueryResult | undefined;
+    let claimedOnPoll = 0;
+    for (let poll = 1; poll <= 3 && !claimed; poll += 1) {
+      for (let arrival = 0; arrival < 20; arrival += 1) {
+        const index = rows.length;
+        rows.push(makeTask(index, new Date(base + index).toISOString()));
+      }
+      const pending = await queryAllMuninEntries(munin as unknown as MuninClient, {
+        tags: ["pending"],
+        namespace: "tasks/",
+        entry_type: "state",
+      });
+      const candidate = selectNextTask(pending.results, []);
+      if (candidate?.namespace === "tasks/oldest") {
+        claimed = candidate;
+        claimedOnPoll = poll;
+      } else if (candidate) {
+        const index = rows.findIndex((row) => row.id === candidate.id);
+        if (index >= 0) rows.splice(index, 1);
+      }
+    }
+
+    expect(claimed?.namespace).toBe("tasks/oldest");
+    expect(claimedOnPoll).toBe(1);
+  });
+
+  it("reports an unpageable 50-row exact timestamp bucket as truncated", async () => {
+    const timestamp = "2026-07-12T12:00:00.000Z";
+    const rows = Array.from({ length: 60 }, (_, index) => makeTask(index, timestamp));
+    const munin = new FilterOnlyMunin(rows);
+
+    const result = await queryAllMuninEntries(munin as unknown as MuninClient, {
+      tags: ["pending"],
+      namespace: "tasks/",
+      entry_type: "state",
+    });
+
+    expect(result.truncated).toBe(true);
+    expect(result.results).toHaveLength(50);
+    expect(munin.calls).toContainEqual(expect.objectContaining({
+      since: timestamp,
+      until: timestamp,
+    }));
+  });
+});

--- a/tests/munin-pagination.test.ts
+++ b/tests/munin-pagination.test.ts
@@ -53,6 +53,34 @@ describe("queryAllMuninEntries", () => {
     expect(munin.calls.every((call) => call.query === undefined)).toBe(true);
   });
 
+  it("recovers every row when a page boundary splits a sub-cap timestamp bucket", async () => {
+    const base = Date.UTC(2026, 6, 12, 12, 0, 0);
+    const boundary = new Date(base).toISOString();
+    const newer = Array.from({ length: 30 }, (_, index) =>
+      makeTask(index, new Date(base + index + 1).toISOString()),
+    );
+    const boundaryRows = Array.from({ length: 30 }, (_, index) =>
+      makeTask(30 + index, boundary),
+    );
+    const older = Array.from({ length: 10 }, (_, index) =>
+      makeTask(60 + index, new Date(base - index - 1).toISOString()),
+    );
+    const munin = new FilterOnlyMunin([...newer, ...boundaryRows, ...older]);
+
+    const result = await queryAllMuninEntries(munin as unknown as MuninClient, {
+      tags: ["pending"],
+      namespace: "tasks/",
+      entry_type: "state",
+    });
+
+    expect(result.results).toHaveLength(70);
+    expect(result.truncated).toBe(false);
+    expect(munin.calls).toContainEqual(expect.objectContaining({
+      since: boundary,
+      until: boundary,
+    }));
+  });
+
   it("keeps the oldest task claimable while newer tasks continuously refill the first page", async () => {
     const base = Date.UTC(2026, 6, 12, 12, 0, 0);
     const rows = Array.from({ length: 75 }, (_, index) =>


### PR DESCRIPTION
## Summary

- replace the relevance-ranked, capped pending-task query with a shared filter-only paginator that walks every `updated_at` window
- probe exact timestamp boundaries so same-millisecond rows are recovered when possible and reported honestly when a 50-row bucket itself cannot be proven complete
- use the same pagination contract for dispatcher pending/running queues and canonical Broker task listing
- require offset-aware ISO timestamps and compare `since_ts` numerically, preventing SQLite/JavaScript time-filter disagreement

## Why

The dispatcher sorted only the relevance-ranked 10-row window it received. Sustained newer arrivals could therefore keep an old pending task outside the candidate window forever (#190). The same server-side 50-row ceiling could hide canonical Broker tasks before principal filtering (#183).

This change uses Munin's filter-only `updated_at DESC` ordering and a shared capped-window walker. A timestamp bucket containing 50 or more entries is the one case Munin's current API cannot fully enumerate without a composite cursor; the caller retains visible rows and reports/logs an explicit lower-bound signal.

## Review correction

Independent repo-agent review found that arbitrary non-empty `since_ts` values could make SQLite lexical filtering disagree with JavaScript date parsing. The final branch rejects malformed timestamps before any Munin query and adds a split-boundary timestamp-bucket regression. Parent Codex review found no remaining actionable defect.

## Verification

- `npm run build`
- `npm test` — 98 files / 1,664 tests passed
- focused pagination/client/store/handler suite — 90 tests passed
- `bash scripts/deploy-pi.test.sh`
- `bash scripts/lib/claude-config-bootstrap.test.sh`
- `git diff --check`
- GitHub CI rerun for the final head is in progress

Addresses #190 and the residual complete-enumeration gap documented in #183.