### PR TITLE
Add continuous M5 harness learning loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,20 +113,28 @@ hugin/
 │   ├── mcp-server.ts             # hugin-mcp stdio entrypoint (orchestrator-side, on the laptop)
 │   ├── mcp/                      # hugin-mcp internals (broker client + tool definitions)
 │   │   ├── broker-client.ts      # HTTP client for /v1/delegate/* (bearer auth, AbortController timeout)
-│   │   └── tools.ts              # 5 MCP tools (hugin_submit/await/rate/list/models) with envelope autofill
-│   └── broker/                   # MCP durable-delegation API (Tailscale-only HTTP, /v1/delegate/*)
-│       ├── server.ts             # Express app + opt-in startup (HUGIN_BROKER_KEYS)
-│       ├── handlers.ts           # submit/await/rate/list/models endpoint handlers
-│       ├── executor-capabilities.ts # Live executor truth shared by submit/models/worker
-│       ├── orch-worker.ts        # RETIRED historical orch-v1 worker; never started
-│       ├── openrouter-executor.ts # OpenRouter one-shot delegation runner
-│       ├── reconciliation.ts     # RETIRED historical journal reconciler; never started
-│       └── task-store.ts         # Munin operations: submit / read / two-phase complete
+│   │   └── tools.ts              # 5 delegation + 5 learning-loop MCP tools
+│   ├── broker/                   # MCP durable-delegation API (Tailscale-only HTTP, /v1/delegate/*)
+│   │   ├── server.ts             # Express app + opt-in startup (HUGIN_BROKER_KEYS)
+│   │   ├── handlers.ts           # submit/await/rate/list/models endpoint handlers
+│   │   ├── executor-capabilities.ts # Live executor truth shared by submit/models/worker
+│   │   ├── orch-worker.ts        # RETIRED historical orch-v1 worker; never started
+│   │   ├── openrouter-executor.ts # OpenRouter one-shot delegation runner
+│   │   ├── reconciliation.ts     # RETIRED historical journal reconciler; never started
+│   │   └── task-store.ts         # Munin operations: submit / read / two-phase complete
+│   └── learning/                 # Versioned champion/challenger experiments + monotonic promotion gate
+│       ├── experiment-schema.ts  # Content-blind config/run/evaluation contracts
+│       ├── experiment-evaluator.ts # Pure matched-pair promotion/rejection logic
+│       ├── experiment-store.ts   # Principal-isolated Munin state + CAS/idempotency
+│       ├── experiment-handlers.ts # Authenticated Broker learning endpoints
+│       ├── m5-code-loop-adapter.ts # Honest M5 result → content-blind observation mapping
+│       └── m5-code-loop-client.ts  # Owner-gated async code_loop JSON-RPC client
 ├── tests/
 │   ├── dispatcher.test.ts
 │   └── sdk-executor.test.ts
 └── scripts/
     ├── deploy-pi.sh
+    ├── run-m5-code-loop-experiment.ts # Resumable matched Gate D experiment runner
     ├── submit-daily-analysis.sh  # Submit daily journal analysis as ollama task
     ├── sync-claude-config.sh     # DEPRECATED — config now lives in the claude-config repo (bootstrap.sh)
     └── update-cli.sh             # Auto-update CLI tools (daily cron)

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,8 +1,9 @@
 # Hugin — Status
 
 **Latest session (2026-07-13, Codex) — continuous Hugin/M5 improvement loop + Gate D adapter
-implemented locally.** Branch `codex/continuous-harness-learning-loop` from `main@d589449`;
-changes are currently uncommitted, not published, and not deployed.
+published for review.** Draft PR [#196](https://github.com/Magnus-Gille/hugin/pull/196) from
+`codex/continuous-harness-learning-loop`; implementation commit `916b689`, reconciled with
+`origin/main@8b1bfdd`. Not merged or deployed.
 
 Hugin now has a durable, principal-isolated champion/challenger experiment ledger under
 `experiments/hugin/*`, exposed through five authenticated Broker/MCP operations: create, observe,
@@ -37,17 +38,19 @@ existing ten-case Gate D battery. The owning M5 work (phase telemetry, immutable
 metadata, and optional edit-deadline policy) is filed as gille-inference #247 and added to the
 Grimnir Roadmap with the exact wire contract.
 
-Validation: `npm run build`, standalone runner typecheck, focused integration/unit suite (103 tests
-after the last adapter hardening), full `npm test` (**101 files / 1,693 tests**), and
-`git diff --check` are green. No production state or M5 configuration was changed. A live run was
+Validation after merging current `origin/main`: `npm run build`, standalone runner typecheck,
+focused integration/unit suite (103 tests after the last adapter hardening), full `npm test`
+(**102 files / 1,700 tests**), and `git diff --check` are green. No production state or M5
+configuration was changed. A live run was
 not started: #247 is not implemented/deployed, this Hugin branch is not deployed, and this laptop's
 `m5-auth` helper reports no owner token in Keychain. The credential boundary was not bypassed.
 
-**Next:** publish/review/merge this Hugin branch; implement/review/deploy gille-inference #247;
-provision the M5 owner key via `m5-auth` (Keychain, never a file); deploy Hugin; generate and
-dry-run the ten-case Gate D manifest with two predeclared holdouts; then run current 13-turn champion
-versus the identical turn-6 edit-deadline challenger. Collect product ratings and keep the champion
-unless every paired protected-check, coverage, and non-regression gate passes.
+**Next:** review/merge PR #196; implement/review/deploy
+[gille-inference #247](https://github.com/Magnus-Gille/gille-inference/issues/247); provision the
+M5 owner key via `m5-auth` (Keychain, never a file); deploy Hugin; generate and dry-run the ten-case
+Gate D manifest with two predeclared holdouts; then run current 13-turn champion versus the identical
+turn-6 edit-deadline challenger. Collect product ratings and keep the champion unless every paired
+protected-check, coverage, and non-regression gate passes.
 
 **Latest session:** 2026-07-13 (Claude) — **M5-harvest campaign (`m5h-2026-07`): 9 tickets, 10 PRs, ~92 graded delegations, shadow lane live**
 **Branch:** `main` @ `977e851` + this handoff; hugin deployed to Pi (health `ok`, polling, queue 0).

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,54 @@
 # Hugin — Status
 
+**Latest session (2026-07-13, Codex) — continuous Hugin/M5 improvement loop + Gate D adapter
+implemented locally.** Branch `codex/continuous-harness-learning-loop` from `main@d589449`;
+changes are currently uncommitted, not published, and not deployed.
+
+Hugin now has a durable, principal-isolated champion/challenger experiment ledger under
+`experiments/hugin/*`, exposed through five authenticated Broker/MCP operations: create, observe,
+rate, status, and explicit reviewed promotion. Automated observations may be enriched exactly once
+from `unrated` to a human/downstream product outcome; existing ratings cannot be overwritten.
+Experiments are content-blind but version logging, test
+harness/corpus/oracle/holdout, agent prompt, agent harness/budgets, model identity/configuration,
+and routing. Hugin recomputes configuration fingerprints and permits exactly one changed semantic
+axis per iteration. Evidence is idempotent, configuration-bound, matched by sample, and records
+independent verification, product usefulness, latency/cost/review time, time-to-edit,
+inspect/edit/check timing, test state, and failure signals.
+
+The pure evaluator requires matched/holdout evidence, independent-verifier and product-rating
+coverage, and paired scalar measurements. It rejects correctness/usefulness/rescue/infra/latency/
+cost regressions; a challenger must also clear its predeclared primary-improvement threshold.
+Judge-only evidence never counts as verified. A reviewed promotion advances a CAS-guarded per-scope
+champion pointer with an applied repo/config ref; future experiments must start from that exact
+fingerprint, and crash recovery handles a pointer write that lands before the experiment-state
+write. Heimdall now shows experiment state, sample maturity, normalized primary improvement, and
+the evidence-derived next action. Full design: `docs/continuous-learning-loop.md`.
+
+The Hugin-side M5 adapter/client and resumable `scripts/run-m5-code-loop-experiment.ts` runner are
+also present. The runner hashes every Gate D task/verifier asset, refuses config-fingerprint drift,
+requires M5 to report effective model/harness/caps, counterbalances arm order, applies each returned
+diff to a pristine local seed, runs Gate D's hidden-oracle/typecheck/anti-cheat `check.sh`, and sends
+only content-blind evidence to Hugin. Old M5 results remain recordable but edit timing stays
+explicitly unmeasured.
+
+Correction discovered during live preparation: there is no Wave 5 code-loop corpus, and
+gille-inference #201 is an unrelated chat-replay issue. The reproducible matched corpus is the
+existing ten-case Gate D battery. The owning M5 work (phase telemetry, immutable effective-execution
+metadata, and optional edit-deadline policy) is filed as gille-inference #247 and added to the
+Grimnir Roadmap with the exact wire contract.
+
+Validation: `npm run build`, standalone runner typecheck, focused integration/unit suite (103 tests
+after the last adapter hardening), full `npm test` (**101 files / 1,693 tests**), and
+`git diff --check` are green. No production state or M5 configuration was changed. A live run was
+not started: #247 is not implemented/deployed, this Hugin branch is not deployed, and this laptop's
+`m5-auth` helper reports no owner token in Keychain. The credential boundary was not bypassed.
+
+**Next:** publish/review/merge this Hugin branch; implement/review/deploy gille-inference #247;
+provision the M5 owner key via `m5-auth` (Keychain, never a file); deploy Hugin; generate and
+dry-run the ten-case Gate D manifest with two predeclared holdouts; then run current 13-turn champion
+versus the identical turn-6 edit-deadline challenger. Collect product ratings and keep the champion
+unless every paired protected-check, coverage, and non-regression gate passes.
+
 **Latest session:** 2026-07-13 (Claude) — **M5-harvest campaign (`m5h-2026-07`): 9 tickets, 10 PRs, ~92 graded delegations, shadow lane live**
 **Branch:** `main` @ `977e851` + this handoff; hugin deployed to Pi (health `ok`, polling, queue 0).
 

--- a/docs/continuous-learning-loop.md
+++ b/docs/continuous-learning-loop.md
@@ -1,0 +1,161 @@
+# Continuous Hugin/M5 learning loop
+
+**Status:** first production-safe slice (2026-07-13)
+
+## Goal
+
+Every real or replayed task should improve either the production baseline or the evidence used to
+choose the next experiment. A failed challenger is useful negative evidence, but it must never
+silently replace the current champion.
+
+The loop is:
+
+```text
+versioned champion
+  → matched champion/challenger runs
+  → independent verification + product rating
+  → monotonic gates
+  → promotion-ready OR reject-and-diagnose
+  → next one-axis experiment
+```
+
+This slice gives Hugin a durable experiment ledger, evaluation state machine, and per-scope
+champion lineage. It does **not** let Hugin edit or deploy M5 configuration. `promotion-ready`
+means the owning configuration repo may apply the reviewed challenger. The operator then records
+that applied commit/config reference, advances the champion pointer, and uses it as the mandatory
+baseline for the next experiment.
+
+## What is versioned
+
+Each arm records a content-blind configuration fingerprint plus exact references for:
+
+- logging schema and required-field contract;
+- test harness, corpus, oracle, and holdout revision;
+- agent prompt version and SHA-256;
+- agent harness version/configuration, turn and timeout budgets, edit deadline, context strategy,
+  and tool-policy version;
+- model identity, provider/runtime, quantization, context/output limits, sampling, reasoning, and
+  prompt-template version;
+- routing policy version.
+
+Prompt text and fixture contents remain in their owning repositories. Hugin stores only versions
+and hashes, so experiment evidence cannot become a second sensitive-content archive.
+
+Exactly one semantic axis may differ between champion and challenger. Hugin rejects an experiment
+that claims to test a prompt while also changing the model, harness, or corpus.
+
+## Evidence contract
+
+An observation identifies an experiment, run, matched `sample_id`, arm, holdout status, and exact
+configuration fingerprint. It may record:
+
+- independently verified `pass` / `fail`, `unverified`, or `infra-error`;
+- product outcome: accepted unchanged, minor edit, major rewrite, discarded, or unrated;
+- latency, local cost, human-review time, and time-to-first-edit;
+- observability coverage and verifier score;
+- whether an edit occurred, tests ran/passed, and inspect/edit/check phase timing;
+- failure kind plus task, M5-ledger, and code-loop work identifiers.
+
+A judge model is advisory. A judge-only verdict never contributes verified quality evidence.
+Duplicate `run_id` submissions are idempotent; conflicting duplicates, a second arm result for the
+same sample, or a configuration fingerprint outside the experiment contract are rejected.
+
+## Promotion rule
+
+The evaluator uses matched pairs only. Before it can decide, it requires the experiment's minimum
+pair count, holdout count, independent-verification coverage, rating coverage, and a measured
+primary metric.
+
+The challenger is rejected if it exceeds any configured regression limit for correctness, useful
+completion, human rescue, infrastructure failures, latency, or cost. If every guard passes, it
+must still clear the predeclared primary improvement threshold. Otherwise the champion remains.
+
+Every evaluation returns dominant challenger failure signals and a concrete next action. Common
+signals are `no-edit`, `tests-not-run`, `tests-failed`, `unverified-output`, `infra-error`, and the
+explicit failure kind supplied by the harness.
+
+## API and MCP tools
+
+The authenticated Broker exposes:
+
+- `POST /v1/learning/experiments/create`
+- `POST /v1/learning/experiments/observe`
+- `POST /v1/learning/experiments/rate`
+- `POST /v1/learning/experiments/status`
+- `POST /v1/learning/experiments/promote`
+
+`hugin-mcp` mirrors them as:
+
+- `hugin_experiment_create`
+- `hugin_experiment_observe`
+- `hugin_experiment_rate`
+- `hugin_experiment_status`
+- `hugin_experiment_promote`
+
+State is principal-isolated and stored under `experiments/hugin/*` in Munin with CAS-guarded
+updates. Each scope also has a champion pointer. A new experiment whose champion fingerprint does
+not match that pointer is rejected, preventing an iteration from silently restarting at an
+obsolete baseline. Promotion requires the exact evaluated challenger fingerprint and an applied
+repository/config reference; it is idempotent and reconciles a crash between the champion-pointer
+and experiment-state writes. Experiment writes use a dedicated Munin client so a large evidence
+upload cannot queue behind task claims, leases, or terminal checkpoints.
+
+Heimdall's Hugin page shows experiment state, matched/holdout counts, primary improvement, and the
+next action. An unavailable ledger renders as unavailable, never as zero experiments.
+
+Automated runners normally record `product_outcome: unrated` as soon as protected checks finish.
+`hugin_experiment_rate` later enriches that exact run with a human/downstream usefulness outcome
+and optional review time. This is a one-way, audited transition: an existing rating cannot be
+overwritten. An experiment that requires product coverage therefore remains in `gathering` until
+enough runs have been rated.
+
+## First M5 iteration
+
+The original draft incorrectly referred to a "Wave 5" corpus and gille-inference #201. That issue
+is about chat-replay scoring and no such code-loop corpus exists. The reproducible baseline is the
+existing ten-case Gate D battery. The first controlled experiment should change only
+`agent-harness`:
+
+- champion: current 13-turn code-loop configuration;
+- challenger: identical configuration with inspect/edit/check timing plus an edit-deadline rule;
+- matched corpus: all ten Gate D code-edit cases on both arms;
+- holdout: two predeclared Gate D cases not used to design the rule;
+- independent oracle: protected local check;
+- primary metric: `edit-start-ms`;
+- non-regression: zero correctness/usefulness/rescue regression, bounded latency, identical local
+  cost.
+
+The M5/gille-inference code-loop owner must emit the phase timing and work id. That owning-repo
+work is tracked by [gille-inference #247](https://github.com/Magnus-Gille/gille-inference/issues/247).
+Until it is deployed, Hugin records final diff/check facts but deliberately leaves edit timing
+unmeasured, so this experiment remains `gathering` instead of manufacturing a conclusion.
+
+## Running the Gate D loop
+
+`scripts/run-m5-code-loop-experiment.ts` is the resumable Hugin-side adapter. Its JSON manifest
+contains the fully versioned experiment contract, both arms' effective caps, and paths to each
+sample's instruction/seed directory/check. Before any remote mutation it:
+
+1. validates exactly one changed configuration axis;
+2. hashes every instruction, seed file, check command, holdout flag, and protected path and compares
+   the result with the declared corpus SHA-256;
+3. verifies that M5 advertises #247's `edit_deadline_turn` contract;
+4. idempotently creates or resumes the Hugin experiment;
+5. runs matched pairs sequentially, counterbalancing which arm runs first;
+6. records only content-blind observations—never diffs, prompts, check output, or seed contents.
+
+Credentials stay in environment variables. Use the Keychain helper and tailnet path; never put
+tokens in the manifest:
+
+```bash
+eval "$(m5-auth --env --tailnet)"
+HUGIN_BROKER_URL=http://huginmunin.<tailnet>.ts.net:3035 \
+HUGIN_BROKER_TOKEN=<keychain-or-env-token> \
+npm run experiment:m5-code-loop -- /path/to/gate-d-wave.json --dry-run
+
+# Remove --dry-run only after gille-inference #247 and this Hugin branch are deployed.
+```
+
+After mechanical collection, rate each run through `hugin_experiment_rate`. Do not promote while
+the evaluator reports missing rating coverage, missing paired edit timing, or any non-regression
+failure.

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "friction-report": "node scripts/friction-report.mjs",
     "build:pii-fixtures": "tsx scripts/build-pii-fixtures.ts",
     "eval:pii": "tsx scripts/run-pii-eval.ts",
+    "experiment:m5-code-loop": "tsx scripts/run-m5-code-loop-experiment.ts",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/scripts/run-m5-code-loop-experiment.ts
+++ b/scripts/run-m5-code-loop-experiment.ts
@@ -1,0 +1,426 @@
+#!/usr/bin/env tsx
+/**
+ * Resumable Gate-D-style champion/challenger runner.
+ *
+ * Credentials are environment-only. Recommended invocation:
+ *   eval "$(m5-auth --env --tailnet)"
+ *   HUGIN_BROKER_URL=... HUGIN_BROKER_TOKEN=... \
+ *     npm run experiment:m5-code-loop -- ./wave.json
+ */
+
+import { createHash } from "node:crypto";
+import {
+  cpSync,
+  lstatSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, isAbsolute, join, relative, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { z } from "zod";
+import { BrokerClient, BrokerHttpError } from "../src/mcp/broker-client.js";
+import {
+  learningExperimentCreateSchema,
+  type LearningExperimentCreate,
+  type LearningExperimentState,
+} from "../src/learning/experiment-schema.js";
+import {
+  observationFromM5CodeLoop,
+  type M5CodeLoopResult,
+} from "../src/learning/m5-code-loop-adapter.js";
+import {
+  M5CodeLoopClient,
+  type M5CodeLoopRequest,
+} from "../src/learning/m5-code-loop-client.js";
+
+const capsSchema = z.object({
+  wall_s: z.number().int().positive().max(900),
+  turns: z.number().int().positive().max(40),
+  completion_tokens: z.number().int().positive().max(120_000),
+  edit_deadline_turn: z.number().int().positive().max(40).optional(),
+}).strict().superRefine((value, ctx) => {
+  if (value.edit_deadline_turn !== undefined && value.edit_deadline_turn > value.turns) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["edit_deadline_turn"],
+      message: "edit deadline must not exceed the turn cap",
+    });
+  }
+});
+
+const sampleSchema = z.object({
+  id: z.string().min(1).max(120),
+  holdout: z.boolean(),
+  instruction_file: z.string().min(1),
+  task_dir: z.string().min(1),
+  seed_dir: z.string().min(1),
+  m5_check_cmd: z.string().min(1).optional(),
+  protected: z.array(z.string().min(1)).default([]),
+}).strict();
+
+const manifestSchema = z.object({
+  schema_version: z.literal(1),
+  experiment: learningExperimentCreateSchema,
+  arms: z.object({
+    champion: z.object({ caps: capsSchema }).strict(),
+    challenger: z.object({ caps: capsSchema }).strict(),
+  }).strict(),
+  verifier: z.object({
+    script: z.string().min(1),
+    version: z.string().min(1).max(120),
+    sha256: z.string().regex(/^[a-f0-9]{64}$/),
+    node_modules_dir: z.string().min(1),
+  }).strict(),
+  samples: z.array(sampleSchema).min(2).max(100),
+  poll_ms: z.number().int().min(250).max(30_000).default(5_000),
+  result_deadline_s: z.number().int().min(60).max(3_600).default(900),
+}).strict().superRefine((value, ctx) => {
+  const ids = new Set<string>();
+  for (const [index, sample] of value.samples.entries()) {
+    if (ids.has(sample.id)) {
+      ctx.addIssue({ code: "custom", path: ["samples", index, "id"], message: "duplicate sample id" });
+    }
+    ids.add(sample.id);
+  }
+  const holdouts = value.samples.filter((sample) => sample.holdout).length;
+  if (holdouts < value.experiment.gates.minHoldoutPairs) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["samples"],
+      message: `manifest needs at least ${value.experiment.gates.minHoldoutPairs} holdout samples`,
+    });
+  }
+  for (const arm of ["champion", "challenger"] as const) {
+    const config = value.experiment[arm].harness;
+    const caps = value.arms[arm].caps;
+    if (config.maxTurns !== caps.turns) {
+      ctx.addIssue({ code: "custom", path: ["arms", arm, "caps", "turns"], message: "turn cap differs from the versioned harness config" });
+    }
+    if (config.editDeadlineTurn !== caps.edit_deadline_turn) {
+      ctx.addIssue({ code: "custom", path: ["arms", arm, "caps", "edit_deadline_turn"], message: "edit deadline differs from the versioned harness config" });
+    }
+  }
+});
+
+type Manifest = z.infer<typeof manifestSchema>;
+type LoadedSample = z.infer<typeof sampleSchema> & {
+  instruction: string;
+  files: Array<{ path: string; content: string }>;
+  taskDir: string;
+  taskFiles: Array<{ path: string; content: string }>;
+};
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value || value.trim() === "") throw new Error(`missing required environment variable ${name}`);
+  return value;
+}
+
+function m5McpEndpoint(): string {
+  const explicit = process.env.M5_MCP_URL;
+  if (explicit) return explicit;
+  const base = requiredEnv("M5_BASE_URL");
+  const url = new URL(base);
+  url.pathname = "/mcp";
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+}
+
+function filesUnder(
+  rootInput: string,
+  enforceM5Caps = true,
+): Array<{ path: string; content: string }> {
+  const root = resolve(rootInput);
+  if (!lstatSync(root).isDirectory()) throw new Error(`seed_dir is not a directory: ${root}`);
+  const output: Array<{ path: string; content: string }> = [];
+  const walk = (dir: string): void => {
+    for (const name of readdirSync(dir).sort()) {
+      const path = resolve(dir, name);
+      const stat = lstatSync(path);
+      if (stat.isSymbolicLink()) throw new Error(`seed corpus contains a symlink: ${path}`);
+      if (stat.isDirectory()) {
+        walk(path);
+        continue;
+      }
+      if (!stat.isFile()) continue;
+      const rel = relative(root, path);
+      if (rel.startsWith("..") || isAbsolute(rel)) throw new Error(`seed file escaped root: ${path}`);
+      output.push({ path: rel, content: readFileSync(path, "utf8") });
+    }
+  };
+  walk(root);
+  if (output.length === 0) throw new Error(`seed_dir has no files: ${root}`);
+  if (enforceM5Caps && output.length > 64) throw new Error(`seed_dir exceeds M5's 64-file cap: ${root}`);
+  const bytes = output.reduce((sum, file) => sum + Buffer.byteLength(file.content), 0);
+  if (enforceM5Caps && bytes > 2 * 1024 * 1024) throw new Error(`seed_dir exceeds M5's 2 MiB cap: ${root}`);
+  return output;
+}
+
+function loadSamples(manifest: Manifest, manifestDir: string): LoadedSample[] {
+  return manifest.samples.map((sample) => {
+    const taskDir = resolve(manifestDir, sample.task_dir);
+    const meta = JSON.parse(readFileSync(join(taskDir, "meta.json"), "utf8")) as {
+      oracleFiles?: unknown;
+    };
+    const oracleFiles = Array.isArray(meta.oracleFiles)
+      ? meta.oracleFiles.filter((value): value is string => typeof value === "string")
+      : [];
+    const missingProtection = oracleFiles.filter((path) => !sample.protected.includes(path));
+    if (missingProtection.length > 0) {
+      throw new Error(
+        `sample ${sample.id} does not protect Gate D oracle file(s): ${missingProtection.join(", ")}`,
+      );
+    }
+    return {
+      ...sample,
+      instruction: readFileSync(resolve(manifestDir, sample.instruction_file), "utf8"),
+      files: filesUnder(resolve(manifestDir, sample.seed_dir)),
+      taskDir,
+      taskFiles: filesUnder(taskDir, false),
+    };
+  });
+}
+
+function stable(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stable).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, child]) => `${JSON.stringify(key)}:${stable(child)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function gateDCorpusFingerprint(
+  samples: LoadedSample[],
+  verifier: { version: string; sha256: string },
+): string {
+  const contentBlindManifest = {
+    verifier,
+    samples: samples.map((sample) => ({
+    id: sample.id,
+    holdout: sample.holdout,
+    instructionSha256: createHash("sha256").update(sample.instruction).digest("hex"),
+    files: sample.files.map((file) => ({
+      path: file.path,
+      sha256: createHash("sha256").update(file.content).digest("hex"),
+    })),
+    taskFiles: sample.taskFiles.map((file) => ({
+      path: file.path,
+      sha256: createHash("sha256").update(file.content).digest("hex"),
+    })),
+    m5CheckCmdSha256: sample.m5_check_cmd
+      ? createHash("sha256").update(sample.m5_check_cmd).digest("hex")
+      : null,
+    protected: [...sample.protected].sort(),
+    })),
+  };
+  return createHash("sha256").update(stable(contentBlindManifest)).digest("hex");
+}
+
+function verifyGateD(
+  result: M5CodeLoopResult,
+  sample: LoadedSample,
+  verifier: Manifest["verifier"],
+  manifestDir: string,
+): { ran: true; passed: boolean; testsRan: boolean; id: string; version: string; durationMs: number } {
+  const started = Date.now();
+  const workRoot = mkdtempSync(join(tmpdir(), `hugin-gate-d-${sample.id}-`));
+  const work = join(workRoot, "repo");
+  try {
+    cpSync(resolve(manifestDir, sample.seed_dir), work, { recursive: true });
+    const nodeModules = resolve(manifestDir, verifier.node_modules_dir);
+    symlinkSync(nodeModules, join(work, "node_modules"), "dir");
+    const applied = spawnSync(
+      "git",
+      ["apply", "--whitespace=nowarn", "-"],
+      { cwd: work, input: result.diff, encoding: "utf8", timeout: 60_000 },
+    );
+    if (applied.status !== 0) {
+      return {
+        ran: true,
+        passed: false,
+        testsRan: false,
+        id: "gate-d-check",
+        version: verifier.version,
+        durationMs: Date.now() - started,
+      };
+    }
+    const checked = spawnSync(
+      "bash",
+      [resolve(manifestDir, verifier.script), sample.taskDir, work],
+      { encoding: "utf8", timeout: 300_000 },
+    );
+    return {
+      ran: true,
+      passed: checked.status === 0,
+      testsRan: true,
+      id: "gate-d-check",
+      version: verifier.version,
+      durationMs: Date.now() - started,
+    };
+  } finally {
+    rmSync(workRoot, { recursive: true, force: true });
+  }
+}
+
+function supportsIssue247(tools: Array<Record<string, unknown>>): boolean {
+  const start = tools.find((tool) => tool.name === "code_loop_start");
+  return !!start && JSON.stringify(start).includes("edit_deadline_turn");
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+}
+
+async function readOrCreate(
+  broker: BrokerClient,
+  experiment: LearningExperimentCreate,
+): Promise<LearningExperimentState> {
+  try {
+    const response = await broker.experimentStatus({ experiment_id: experiment.experiment_id }) as { state: LearningExperimentState };
+    return response.state;
+  } catch (err) {
+    if (!(err instanceof BrokerHttpError) || err.httpStatus !== 404) throw err;
+  }
+  const response = await broker.experimentCreate(experiment) as { state: LearningExperimentState };
+  return response.state;
+}
+
+async function runArm(input: {
+  m5: M5CodeLoopClient;
+  broker: BrokerClient;
+  manifest: Manifest;
+  sample: LoadedSample;
+  arm: "champion" | "challenger";
+  manifestDir: string;
+}): Promise<void> {
+  const { m5, broker, manifest, sample, arm, manifestDir } = input;
+  const config = manifest.experiment[arm];
+  const runId = `${manifest.experiment.experiment_id}:${sample.id}:${arm}:${config.fingerprint.slice(0, 12)}`;
+  const request: M5CodeLoopRequest = {
+    instruction: sample.instruction,
+    files: sample.files,
+    check_cmd: sample.m5_check_cmd,
+    protected: sample.protected,
+    task_type: manifest.experiment.task_type,
+    caps: manifest.arms[arm].caps,
+  };
+  process.stdout.write(`[${sample.id}/${arm}] starting\n`);
+  const started = await m5.start(request);
+  const deadline = Date.now() + manifest.result_deadline_s * 1_000;
+  for (;;) {
+    await sleep(manifest.poll_ms);
+    const status = await m5.status(started.work_id);
+    if (status.status !== "running") break;
+    if (Date.now() >= deadline) {
+      throw new Error(`[${sample.id}/${arm}] result deadline exceeded for ${started.work_id}`);
+    }
+  }
+  const result = await m5.result(started.work_id);
+  const externalVerification = verifyGateD(
+    result,
+    sample,
+    manifest.verifier,
+    manifestDir,
+  );
+  const observation = observationFromM5CodeLoop(result, {
+    experimentId: manifest.experiment.experiment_id,
+    runId,
+    sampleId: sample.id,
+    arm,
+    holdout: sample.holdout,
+    configurationFingerprint: config.fingerprint,
+    expectedExecution: {
+      model: config.model.id,
+      harnessVersion: config.harness.version,
+      caps: manifest.arms[arm].caps,
+    },
+    externalVerification,
+  });
+  await broker.experimentObserve(observation);
+  process.stdout.write(
+    `[${sample.id}/${arm}] ${observation.quality_outcome}; edit=${observation.edit_start_ms ?? "unmeasured"}ms; work=${result.work_id}\n`,
+  );
+}
+
+async function main(): Promise<void> {
+  const manifestArg = process.argv[2];
+  if (!manifestArg) throw new Error("usage: run-m5-code-loop-experiment.ts <manifest.json> [--dry-run]");
+  const manifestPath = resolve(manifestArg);
+  const manifestDir = dirname(manifestPath);
+  const manifest = manifestSchema.parse(JSON.parse(readFileSync(manifestPath, "utf8")));
+  const samples = loadSamples(manifest, manifestDir);
+  const verifierSha256 = createHash("sha256")
+    .update(readFileSync(resolve(manifestDir, manifest.verifier.script)))
+    .digest("hex");
+  if (verifierSha256 !== manifest.verifier.sha256) {
+    throw new Error(
+      `verifier fingerprint mismatch: manifest=${manifest.verifier.sha256} actual=${verifierSha256}`,
+    );
+  }
+  const corpusFingerprint = gateDCorpusFingerprint(samples, {
+    version: manifest.verifier.version,
+    sha256: verifierSha256,
+  });
+  if (corpusFingerprint !== manifest.experiment.champion.testHarness.corpusSha256) {
+    throw new Error(
+      `corpus fingerprint mismatch: manifest=${manifest.experiment.champion.testHarness.corpusSha256} actual=${corpusFingerprint}`,
+    );
+  }
+  process.stdout.write(
+    `validated ${samples.length} matched samples (${samples.filter((sample) => sample.holdout).length} holdouts), corpus ${corpusFingerprint}\n`,
+  );
+  if (process.argv.includes("--dry-run")) return;
+
+  const m5 = new M5CodeLoopClient({
+    endpoint: m5McpEndpoint(),
+    bearerToken: requiredEnv("M5_API_KEY"),
+  });
+  const broker = new BrokerClient({
+    baseUrl: requiredEnv("HUGIN_BROKER_URL"),
+    bearerToken: requiredEnv("HUGIN_BROKER_TOKEN"),
+  });
+  if (!supportsIssue247(await m5.toolDefinitions())) {
+    throw new Error("M5 code_loop does not advertise edit_deadline_turn; deploy gille-inference #247 before creating the experiment");
+  }
+
+  let state = await readOrCreate(broker, manifest.experiment);
+  if (state.status !== "running") {
+    process.stdout.write(`experiment already ${state.status}: ${state.evaluation.nextAction}\n`);
+    return;
+  }
+  const recorded = new Set(state.observations.map((observation) => observation.run_id));
+  for (const [index, sample] of samples.entries()) {
+    // Counterbalance first-arm order so warmth/time does not always favor one arm.
+    const order: Array<"champion" | "challenger"> =
+      index % 2 === 0 ? ["champion", "challenger"] : ["challenger", "champion"];
+    for (const arm of order) {
+      const config = manifest.experiment[arm];
+      const runId = `${manifest.experiment.experiment_id}:${sample.id}:${arm}:${config.fingerprint.slice(0, 12)}`;
+      if (recorded.has(runId)) {
+        process.stdout.write(`[${sample.id}/${arm}] already recorded; skipping\n`);
+        continue;
+      }
+      await runArm({ m5, broker, manifest, sample, arm, manifestDir });
+      recorded.add(runId);
+    }
+  }
+  state = (await broker.experimentStatus({
+    experiment_id: manifest.experiment.experiment_id,
+  }) as { state: LearningExperimentState }).state;
+  process.stdout.write(
+    `experiment ${state.status}: ${state.evaluation.reason}\nnext: ${state.evaluation.nextAction}\n`,
+  );
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/src/broker/server.ts
+++ b/src/broker/server.ts
@@ -1,8 +1,8 @@
 /**
  * Broker HTTP server (orchestrator v1).
  *
- * Mounts the five `/v1/delegate/*` handlers behind the bearer-token
- * middleware on a separate Express app. The default bind is loopback only;
+ * Mounts the five `/v1/delegate/*` handlers and optional versioned-learning
+ * handlers behind the bearer-token middleware on a separate Express app. The default bind is loopback only;
  * production deployments override `HUGIN_BROKER_HOST` to the Tailscale
  * interface IP. Health is unauthenticated; everything else requires a
  * known principal.
@@ -29,12 +29,21 @@ import {
   createSubmitHandler,
   type BrokerHandlerDependencies,
 } from "./handlers.js";
+import {
+  createLearningExperimentHandler,
+  createLearningExperimentPromoteHandler,
+  createLearningExperimentRateHandler,
+  createLearningExperimentStatusHandler,
+  createLearningObservationHandler,
+} from "../learning/experiment-handlers.js";
+import type { LearningExperimentStore } from "../learning/experiment-store.js";
 
 export interface BrokerServerConfig {
   host: string;
   port: number;
   keys: BrokerKeyStore;
   deps: BrokerHandlerDependencies;
+  learningStore?: LearningExperimentStore;
 }
 
 export function buildBrokerApp(config: BrokerServerConfig): Express {
@@ -60,6 +69,33 @@ export function buildBrokerApp(config: BrokerServerConfig): Express {
     auth,
     createModelsHandler(config.deps.executorCapabilities),
   );
+  if (config.learningStore) {
+    app.post(
+      "/v1/learning/experiments/create",
+      auth,
+      createLearningExperimentHandler(config.learningStore),
+    );
+    app.post(
+      "/v1/learning/experiments/observe",
+      auth,
+      createLearningObservationHandler(config.learningStore),
+    );
+    app.post(
+      "/v1/learning/experiments/rate",
+      auth,
+      createLearningExperimentRateHandler(config.learningStore),
+    );
+    app.post(
+      "/v1/learning/experiments/status",
+      auth,
+      createLearningExperimentStatusHandler(config.learningStore),
+    );
+    app.post(
+      "/v1/learning/experiments/promote",
+      auth,
+      createLearningExperimentPromoteHandler(config.learningStore),
+    );
+  }
 
   return app;
 }

--- a/src/heimdall-descriptor.ts
+++ b/src/heimdall-descriptor.ts
@@ -65,11 +65,29 @@ export function buildLearningLoopHealthPanels(
   // Synchronous by design: `collect()` is stale-while-revalidate and returns
   // immediately. The descriptor must never wait on a cold corpus walk — hanging
   // /heimdall.json blanks Hugin's whole Heimdall page (#135).
-  const { ledger, tasks, available, readFailures, truncated } = collector.collect();
+  const {
+    ledger,
+    tasks,
+    available,
+    readFailures,
+    truncated,
+    experiments,
+    experimentsAvailable,
+    experimentsTruncated,
+  } = collector.collect();
   const capability = computeCapabilityPlane(ledger);
   const product = computeProductPlane(tasks, { available, readFailures, truncated });
   const policy = deriveRoutePolicy(tasks, capability);
-  return buildLearningLoopPanels({ capability, product, policy });
+  return buildLearningLoopPanels({
+    capability,
+    product,
+    policy,
+    experiments: {
+      available: experimentsAvailable,
+      states: experiments,
+      truncated: experimentsTruncated,
+    },
+  });
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,6 +103,7 @@ import {
   getPersistentStatusTags,
 } from "./task-status-tags.js";
 import { LearningLoopCollector } from "./learning-loop-collector.js";
+import { LearningExperimentStore } from "./learning/experiment-store.js";
 import { sanitizeProviderTokenCount } from "./m5-provenance.js";
 import {
   buildStructuredTaskResult,
@@ -584,6 +585,10 @@ const reaperMunin = createMuninClient();
 // queue behind — or be queued behind by — task-completion writes on the main
 // client's serial request slot.
 const orchVerdictMunin = createMuninClient();
+// Champion/challenger observations are operator-plane writes. Keep them off the
+// dispatcher's serial Munin request slot so an experiment upload cannot delay a
+// task claim, completion checkpoint, or lease renewal.
+const learningExperimentMunin = createMuninClient();
 
 // Verdict layer (docs/orchestrator-verdict-layer.md, V4/V7). Gated on a
 // single master switch (HUGIN_ORCH_VERDICT_STORE, default "on") — when
@@ -5863,6 +5868,7 @@ if (brokerEnv.enabled) {
   const brokerHome = path.join(HUGIN_HOME, "delegation-events.jsonl");
   const journal = new DelegationJournal({ path: brokerHome });
   const taskStore = new BrokerTaskStore(munin);
+  const learningStore = new LearningExperimentStore(learningExperimentMunin);
   const idempotency = new IdempotencyIndex();
   const homeserverReady = loadHomeserverGatewayConfig(process.env) !== null;
   const executorCapabilities = brokerExecutorCapabilities({
@@ -5872,6 +5878,7 @@ if (brokerEnv.enabled) {
     host: brokerEnv.host,
     port: brokerEnv.port,
     keys: brokerEnv.keys,
+    learningStore,
     deps: { taskStore, journal, idempotency, executorCapabilities },
   })
     .then((rb) => {

--- a/src/learning-loop-collector.ts
+++ b/src/learning-loop-collector.ts
@@ -23,6 +23,10 @@ import type { Ledger } from "./orchestrator/ledger-client.js";
 import type { ProductTaskEvidence } from "./learning-loop-health.js";
 import { parseStoredEnvelope } from "./broker/task-store.js";
 import type { AwaitObservation } from "./broker/await-observation.js";
+import {
+  learningExperimentStateSchema,
+  type LearningExperimentState,
+} from "./learning/experiment-schema.js";
 
 /** Dashboard-facing data: refresh a few times an hour, not every 60s poll. */
 export const DEFAULT_COLLECT_TTL_MS = 300_000;
@@ -49,6 +53,9 @@ export interface LearningLoopEvidence {
   readFailures: number;
   /** The corpus walk hit its cap — counts derived from this are a lower bound. */
   truncated: boolean;
+  experiments: LearningExperimentState[];
+  experimentsAvailable: boolean;
+  experimentsTruncated: boolean;
 }
 
 const UNAVAILABLE: LearningLoopEvidence = {
@@ -57,6 +64,9 @@ const UNAVAILABLE: LearningLoopEvidence = {
   available: false,
   readFailures: 0,
   truncated: false,
+  experiments: [],
+  experimentsAvailable: false,
+  experimentsTruncated: false,
 };
 
 interface CorpusResult {
@@ -135,13 +145,66 @@ export class LearningLoopCollector {
   }
 
   private async collectUncached(): Promise<LearningLoopEvidence> {
-    const [ledger, corpus] = await Promise.all([
+    const [ledger, corpus, experiments] = await Promise.all([
       this.ledgerClient.getLedger().catch(() => null),
       this.collectTasks().catch(
         (): CorpusResult => ({ tasks: [], available: false, readFailures: 0, truncated: false })
       ),
+      this.collectExperiments().catch(() => ({
+        states: [] as LearningExperimentState[],
+        available: false,
+        truncated: false,
+      })),
     ]);
-    return { ledger, ...corpus };
+    return {
+      ledger,
+      ...corpus,
+      experiments: experiments.states,
+      experimentsAvailable: experiments.available,
+      experimentsTruncated: experiments.truncated,
+    };
+  }
+
+  private async collectExperiments(): Promise<{
+    states: LearningExperimentState[];
+    available: boolean;
+    truncated: boolean;
+  }> {
+    const result = await this.munin.query({
+      // JSON state carries the exact key `experimentId`; query by that lexical
+      // token rather than the looser "experiment", which FTS tokenizers need
+      // not derive from camelCase.
+      query: "experimentId",
+      tags: ["learning:experiment"],
+      namespace: "experiments/hugin/",
+      entry_type: "state",
+      limit: 50,
+    });
+    const namespaces = [
+      ...new Set(
+        result.results
+          .map((entry) => entry.namespace)
+          .filter((namespace): namespace is string => typeof namespace === "string"),
+      ),
+    ];
+    const states: LearningExperimentState[] = [];
+    for (const namespace of namespaces) {
+      const entry = await this.munin.read(namespace, "state").catch(() => null);
+      if (!entry) continue;
+      try {
+        states.push(learningExperimentStateSchema.parse(JSON.parse(entry.content)));
+      } catch {
+        // One corrupt experiment is omitted; it must not blank the dashboard.
+      }
+    }
+    states.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+    return {
+      states,
+      available: true,
+      // Munin exposes no query cursor; an exactly-full result is conservatively
+      // treated as truncated rather than pretending it is complete.
+      truncated: result.results.length >= 50,
+    };
   }
 
   /**

--- a/src/learning-loop-health.ts
+++ b/src/learning-loop-health.ts
@@ -27,6 +27,7 @@
  */
 
 import type { Ledger } from "./orchestrator/ledger-client.js";
+import type { LearningExperimentState } from "./learning/experiment-schema.js";
 
 /** How much can be concluded from a row's evidence. */
 export type EvidenceMaturity =
@@ -532,6 +533,11 @@ export function buildLearningLoopPanels(input: {
   capability: CapabilityPlane;
   product: ProductPlane;
   policy: RoutePolicy;
+  experiments?: {
+    available: boolean;
+    states: LearningExperimentState[];
+    truncated?: boolean;
+  };
 }): TypedPanel[] {
   const { capability, product, policy } = input;
 
@@ -630,5 +636,73 @@ export function buildLearningLoopPanels(input: {
     value: product.available ? product.durableHandoffs : "—",
   };
 
-  return [capabilityPanel, gatePanel, policyPanel, handoffPanel];
+  const experimentPanel: TypedPanel | null = input.experiments
+    ? {
+        id: "hugin-learning-experiments",
+        label: "Continuous improvement experiments",
+        kind: "table",
+        fullWidth: true,
+        refresh: 300,
+        cols: ["Experiment", "Scope", "Axis", "State", "Matched", "Primary", "Next"],
+        rows: input.experiments.available
+          ? input.experiments.states.length > 0
+            ? [
+                ...input.experiments.states.slice(0, 15).map(
+                  (state): TableRow => ({
+                    Experiment: state.experimentId,
+                    Scope: `${state.taskType} / ${state.scope}`,
+                    Axis: state.changeAxis,
+                    State: state.status,
+                    Matched: `${state.evaluation.matchedPairs} (${state.evaluation.holdoutPairs} holdout)`,
+                    Primary:
+                      state.evaluation.primaryImprovement === null
+                        ? `${state.evaluation.primaryMetric}: not measured`
+                        : `${state.evaluation.primaryMetric}: ${Math.round(
+                            state.evaluation.primaryImprovement * 1_000,
+                          ) / 10}% normalized improvement`,
+                    Next: state.evaluation.nextAction,
+                  }),
+                ),
+                ...(input.experiments.truncated || input.experiments.states.length > 15
+                  ? [{
+                      Experiment: "… more experiments not shown",
+                      Scope: "",
+                      Axis: "",
+                      State: "",
+                      Matched: "",
+                      Primary: "",
+                      Next: input.experiments.truncated
+                        ? "Munin query reached its cap; this table is incomplete."
+                        : `${input.experiments.states.length - 15} lower-ranked row(s) omitted.`,
+                    }]
+                  : []),
+              ]
+            : [{
+                Experiment: "No versioned experiment recorded yet",
+                Scope: "",
+                Axis: "",
+                State: "gathering",
+                Matched: "0",
+                Primary: "not measured",
+                Next: "Create the first matched champion/challenger experiment through hugin-mcp.",
+              }]
+          : [{
+              Experiment: "Experiment ledger unavailable",
+              Scope: "",
+              Axis: "",
+              State: "unavailable",
+              Matched: "not measured",
+              Primary: "not measured",
+              Next: "Retry after Munin is reachable; this is not evidence of zero experiments.",
+            }],
+      }
+    : null;
+
+  return [
+    capabilityPanel,
+    gatePanel,
+    policyPanel,
+    handoffPanel,
+    ...(experimentPanel ? [experimentPanel] : []),
+  ];
 }

--- a/src/learning/experiment-evaluator.ts
+++ b/src/learning/experiment-evaluator.ts
@@ -1,0 +1,398 @@
+/** Pure, deterministic monotonic-promotion gate for learning experiments. */
+
+import type {
+  LearningArmSummary,
+  LearningExperimentEvaluation,
+  LearningExperimentGates,
+  LearningPrimaryMetric,
+  RecordedLearningObservation,
+} from "./experiment-schema.js";
+
+function mean(values: Array<number | undefined>): number | null {
+  const measured = values.filter((value): value is number => value !== undefined);
+  if (measured.length === 0) return null;
+  return measured.reduce((sum, value) => sum + value, 0) / measured.length;
+}
+
+function isAuthoritative(observation: RecordedLearningObservation): boolean {
+  return (
+    observation.verifier.independent &&
+    (observation.verifier.kind === "mechanical" || observation.verifier.kind === "human")
+  );
+}
+
+function summarize(observations: RecordedLearningObservation[]): LearningArmSummary {
+  const samples = observations.length;
+  const verified = observations.filter(
+    (observation) =>
+      isAuthoritative(observation) &&
+      (observation.quality_outcome === "pass" || observation.quality_outcome === "fail"),
+  );
+  const passes = verified.filter((observation) => observation.quality_outcome === "pass").length;
+  const rated = observations.filter((observation) => observation.product_outcome !== "unrated");
+  const useful = rated.filter(
+    (observation) =>
+      observation.product_outcome === "accepted-unchanged" ||
+      observation.product_outcome === "minor-edit",
+  ).length;
+  const rescue = rated.filter(
+    (observation) =>
+      observation.product_outcome === "major-rewrite" ||
+      observation.product_outcome === "discarded",
+  ).length;
+  const infra = observations.filter(
+    (observation) => observation.quality_outcome === "infra-error",
+  ).length;
+
+  return {
+    samples,
+    verifiedSamples: verified.length,
+    verifiedCoverage: samples > 0 ? verified.length / samples : 0,
+    qualityRate: verified.length > 0 ? passes / verified.length : null,
+    ratedSamples: rated.length,
+    ratedCoverage: samples > 0 ? rated.length / samples : 0,
+    usefulRate: rated.length > 0 ? useful / rated.length : null,
+    rescueRate: rated.length > 0 ? rescue / rated.length : null,
+    infraRate: samples > 0 ? infra / samples : 0,
+    latencyMeanMs: mean(observations.map((observation) => observation.latency_ms)),
+    costMeanUsd: mean(observations.map((observation) => observation.cost_usd)),
+    humanReviewMeanSeconds: mean(
+      observations.map((observation) => observation.human_review_seconds),
+    ),
+    editStartMeanMs: mean(observations.map((observation) => observation.edit_start_ms)),
+    observabilityCoverageMean: mean(
+      observations.map((observation) => observation.observability_coverage),
+    ),
+    verifierScoreMean: mean(
+      observations.map((observation) => observation.verifier_score),
+    ),
+  };
+}
+
+function metricValue(summary: LearningArmSummary, metric: LearningPrimaryMetric): number | null {
+  switch (metric) {
+    case "quality-rate": return summary.qualityRate;
+    case "useful-rate": return summary.usefulRate;
+    case "rescue-rate": return summary.rescueRate;
+    case "latency-ms": return summary.latencyMeanMs;
+    case "cost-usd": return summary.costMeanUsd;
+    case "human-review-seconds": return summary.humanReviewMeanSeconds;
+    case "edit-start-ms": return summary.editStartMeanMs;
+    case "observability-coverage": return summary.observabilityCoverageMean;
+    case "verifier-score": return summary.verifierScoreMean;
+  }
+}
+
+const HIGHER_IS_BETTER: ReadonlySet<LearningPrimaryMetric> = new Set([
+  "quality-rate",
+  "useful-rate",
+  "observability-coverage",
+  "verifier-score",
+]);
+
+type ObservationPair = Record<
+  "champion" | "challenger",
+  RecordedLearningObservation
+>;
+
+const SCALAR_METRICS: ReadonlySet<LearningPrimaryMetric> = new Set([
+  "latency-ms",
+  "cost-usd",
+  "human-review-seconds",
+  "edit-start-ms",
+  "observability-coverage",
+  "verifier-score",
+]);
+
+function scalarObservationValue(
+  observation: RecordedLearningObservation,
+  metric: LearningPrimaryMetric,
+): number | undefined {
+  switch (metric) {
+    case "latency-ms": return observation.latency_ms;
+    case "cost-usd": return observation.cost_usd;
+    case "human-review-seconds": return observation.human_review_seconds;
+    case "edit-start-ms": return observation.edit_start_ms;
+    case "observability-coverage": return observation.observability_coverage;
+    case "verifier-score": return observation.verifier_score;
+    case "quality-rate":
+    case "useful-rate":
+    case "rescue-rate":
+      return undefined;
+  }
+}
+
+function pairedScalar(
+  pairs: ObservationPair[],
+  metric: LearningPrimaryMetric,
+): { champion: number | null; challenger: number | null; count: number } {
+  const measured = pairs.flatMap((pair) => {
+    const champion = scalarObservationValue(pair.champion, metric);
+    const challenger = scalarObservationValue(pair.challenger, metric);
+    return champion === undefined || challenger === undefined
+      ? []
+      : [{ champion, challenger }];
+  });
+  return {
+    champion: mean(measured.map((pair) => pair.champion)),
+    challenger: mean(measured.map((pair) => pair.challenger)),
+    count: measured.length,
+  };
+}
+
+function primaryImprovement(
+  metric: LearningPrimaryMetric,
+  champion: number | null,
+  challenger: number | null,
+): number | null {
+  if (champion === null || challenger === null) return null;
+  if (HIGHER_IS_BETTER.has(metric)) return challenger - champion;
+  if (champion === 0) return challenger === 0 ? 0 : -1;
+  return (champion - challenger) / champion;
+}
+
+function collectFailureSignals(
+  observations: RecordedLearningObservation[],
+): Array<{ signal: string; count: number }> {
+  const counts = new Map<string, number>();
+  const add = (signal: string) => counts.set(signal, (counts.get(signal) ?? 0) + 1);
+
+  for (const observation of observations) {
+    if (observation.failure_kind) add(observation.failure_kind);
+    if (observation.quality_outcome === "infra-error") add("infra-error");
+    if (observation.quality_outcome === "unverified") add("unverified-output");
+    if (observation.quality_outcome === "fail" && !observation.failure_kind) add("quality-fail");
+    if (observation.edited === false) add("no-edit");
+    if (observation.edited === true && observation.tests_run === false) add("tests-not-run");
+    if (observation.tests_run === true && observation.tests_passed === false) add("tests-failed");
+    if (observation.edit_start_ms === undefined && observation.phase_ms?.inspect !== undefined) {
+      add("edit-start-unobserved");
+    }
+  }
+
+  return [...counts.entries()]
+    .map(([signal, count]) => ({ signal, count }))
+    .sort((a, b) => b.count - a.count || a.signal.localeCompare(b.signal));
+}
+
+function addCoverageRequirements(
+  missing: string[],
+  champion: LearningArmSummary,
+  challenger: LearningArmSummary,
+  gates: LearningExperimentGates,
+): void {
+  if (
+    champion.verifiedCoverage < gates.minVerifiedCoverage ||
+    challenger.verifiedCoverage < gates.minVerifiedCoverage
+  ) {
+    missing.push(
+      `verified coverage must be >= ${gates.minVerifiedCoverage} on both arms`,
+    );
+  }
+  if (
+    champion.ratedCoverage < gates.minRatedCoverage ||
+    challenger.ratedCoverage < gates.minRatedCoverage
+  ) {
+    missing.push(`rated coverage must be >= ${gates.minRatedCoverage} on both arms`);
+  }
+}
+
+function addGuardFailures(
+  failures: string[],
+  champion: LearningArmSummary,
+  challenger: LearningArmSummary,
+  gates: LearningExperimentGates,
+): void {
+  if (
+    champion.qualityRate !== null &&
+    challenger.qualityRate !== null &&
+    challenger.qualityRate + gates.maxQualityRegression < champion.qualityRate
+  ) {
+    failures.push("quality regression exceeded the configured tolerance");
+  }
+  if (
+    champion.usefulRate !== null &&
+    challenger.usefulRate !== null &&
+    challenger.usefulRate + gates.maxUsefulRegression < champion.usefulRate
+  ) {
+    failures.push("useful-completion regression exceeded the configured tolerance");
+  }
+  if (
+    champion.rescueRate !== null &&
+    challenger.rescueRate !== null &&
+    challenger.rescueRate > champion.rescueRate + gates.maxRescueRateIncrease
+  ) {
+    failures.push("human rescue rate increased beyond the configured tolerance");
+  }
+  if (challenger.infraRate > champion.infraRate + gates.maxInfraRateIncrease) {
+    failures.push("infrastructure failure rate increased beyond the configured tolerance");
+  }
+  if (
+    gates.maxLatencyRatio !== null &&
+    champion.latencyMeanMs !== null &&
+    challenger.latencyMeanMs !== null &&
+    challenger.latencyMeanMs > champion.latencyMeanMs * gates.maxLatencyRatio
+  ) {
+    failures.push("latency exceeded the configured ratio guard");
+  }
+  if (
+    gates.maxCostRatio !== null &&
+    champion.costMeanUsd !== null &&
+    challenger.costMeanUsd !== null &&
+    challenger.costMeanUsd > champion.costMeanUsd * gates.maxCostRatio
+  ) {
+    failures.push("cost exceeded the configured ratio guard");
+  }
+}
+
+export function evaluateLearningExperiment(input: {
+  observations: RecordedLearningObservation[];
+  gates: LearningExperimentGates;
+  now?: () => Date;
+}): LearningExperimentEvaluation {
+  const now = input.now ?? (() => new Date());
+  const bySample = new Map<
+    string,
+    Partial<Record<"champion" | "challenger", RecordedLearningObservation>>
+  >();
+  for (const observation of input.observations) {
+    const pair = bySample.get(observation.sample_id) ?? {};
+    pair[observation.arm] = observation;
+    bySample.set(observation.sample_id, pair);
+  }
+
+  const pairs = [...bySample.values()].filter(
+    (pair): pair is Record<"champion" | "challenger", RecordedLearningObservation> =>
+      pair.champion !== undefined && pair.challenger !== undefined,
+  );
+  const championObservations = pairs.map((pair) => pair.champion);
+  const challengerObservations = pairs.map((pair) => pair.challenger);
+  const champion = summarize(championObservations);
+  const challenger = summarize(challengerObservations);
+  // Scalar comparisons are paired too: never compare champion latency from
+  // one subset with challenger latency from another subset merely because both
+  // arms supplied at least one number somewhere.
+  const scalarPairs = {
+    latency: pairedScalar(pairs, "latency-ms"),
+    cost: pairedScalar(pairs, "cost-usd"),
+    review: pairedScalar(pairs, "human-review-seconds"),
+    editStart: pairedScalar(pairs, "edit-start-ms"),
+    observability: pairedScalar(pairs, "observability-coverage"),
+    verifier: pairedScalar(pairs, "verifier-score"),
+  };
+  champion.latencyMeanMs = scalarPairs.latency.champion;
+  challenger.latencyMeanMs = scalarPairs.latency.challenger;
+  champion.costMeanUsd = scalarPairs.cost.champion;
+  challenger.costMeanUsd = scalarPairs.cost.challenger;
+  champion.humanReviewMeanSeconds = scalarPairs.review.champion;
+  challenger.humanReviewMeanSeconds = scalarPairs.review.challenger;
+  champion.editStartMeanMs = scalarPairs.editStart.champion;
+  challenger.editStartMeanMs = scalarPairs.editStart.challenger;
+  champion.observabilityCoverageMean = scalarPairs.observability.champion;
+  challenger.observabilityCoverageMean = scalarPairs.observability.challenger;
+  champion.verifierScoreMean = scalarPairs.verifier.champion;
+  challenger.verifierScoreMean = scalarPairs.verifier.challenger;
+  const holdoutPairs = pairs.filter(
+    (pair) => pair.champion.holdout && pair.challenger.holdout,
+  ).length;
+  const unmatchedObservations = input.observations.length - pairs.length * 2;
+  const missingRequirements: string[] = [];
+  if (pairs.length < input.gates.minMatchedPairs) {
+    missingRequirements.push(
+      `need ${input.gates.minMatchedPairs - pairs.length} more matched pair(s)`,
+    );
+  }
+  if (holdoutPairs < input.gates.minHoldoutPairs) {
+    missingRequirements.push(
+      `need ${input.gates.minHoldoutPairs - holdoutPairs} more holdout pair(s)`,
+    );
+  }
+  addCoverageRequirements(missingRequirements, champion, challenger, input.gates);
+  if (
+    input.gates.maxLatencyRatio !== null &&
+    scalarPairs.latency.count < input.gates.minMatchedPairs
+  ) {
+    missingRequirements.push(
+      `latency guard needs ${input.gates.minMatchedPairs} paired measurement(s)`,
+    );
+  }
+  if (
+    input.gates.maxCostRatio !== null &&
+    scalarPairs.cost.count < input.gates.minMatchedPairs
+  ) {
+    missingRequirements.push(
+      `cost guard needs ${input.gates.minMatchedPairs} paired measurement(s)`,
+    );
+  }
+
+  const primaryChampion = metricValue(champion, input.gates.primaryMetric);
+  const primaryChallenger = metricValue(challenger, input.gates.primaryMetric);
+  const improvement = primaryImprovement(
+    input.gates.primaryMetric,
+    primaryChampion,
+    primaryChallenger,
+  );
+  if (SCALAR_METRICS.has(input.gates.primaryMetric)) {
+    const primaryPairs = pairedScalar(pairs, input.gates.primaryMetric);
+    if (primaryPairs.count < input.gates.minMatchedPairs) {
+      missingRequirements.push(
+        `primary metric ${input.gates.primaryMetric} needs ` +
+        `${input.gates.minMatchedPairs} paired measurement(s)`,
+      );
+    }
+  }
+  if (primaryChampion === null || primaryChallenger === null) {
+    missingRequirements.push(`primary metric ${input.gates.primaryMetric} is not measured on both arms`);
+  }
+
+  const guardFailures: string[] = [];
+  addGuardFailures(guardFailures, champion, challenger, input.gates);
+  const failureSignals = collectFailureSignals(challengerObservations);
+
+  let decision: LearningExperimentEvaluation["decision"];
+  let reason: string;
+  let nextAction: string;
+  if (missingRequirements.length > 0) {
+    decision = "gathering";
+    reason = "The experiment cannot be judged yet because required evidence is missing.";
+    nextAction = `Collect matched evidence: ${missingRequirements.join("; ")}.`;
+  } else if (guardFailures.length > 0) {
+    decision = "reject";
+    reason = "The challenger violated at least one monotonic production guard.";
+    nextAction =
+      `Keep the champion. The next experiment should address ${failureSignals[0]?.signal ?? "the failed guard"} ` +
+      "and change only one declared axis.";
+  } else if (improvement === null || improvement < input.gates.minPrimaryImprovement) {
+    decision = "reject";
+    reason =
+      `The challenger did not clear the predeclared ${input.gates.primaryMetric} improvement threshold.`;
+    nextAction =
+      `Keep the champion and use ${failureSignals[0]?.signal ?? "the measured primary-metric gap"} ` +
+      "as the hypothesis source for the next iteration.";
+  } else {
+    decision = "promotion-ready";
+    reason = "The challenger improved the primary metric and passed every non-regression guard.";
+    nextAction =
+      "Review the evidence and promote the challenger through the owning configuration repository; " +
+      "then seed the next experiment from that committed version.";
+  }
+
+  return {
+    decision,
+    reason,
+    evaluatedAt: now().toISOString(),
+    matchedPairs: pairs.length,
+    holdoutPairs,
+    unmatchedObservations,
+    champion,
+    challenger,
+    primaryMetric: input.gates.primaryMetric,
+    primaryChampion,
+    primaryChallenger,
+    primaryImprovement: improvement,
+    guardFailures,
+    missingRequirements,
+    failureSignals,
+    nextAction,
+  };
+}

--- a/src/learning/experiment-handlers.ts
+++ b/src/learning/experiment-handlers.ts
@@ -1,0 +1,118 @@
+/** Authenticated Broker HTTP handlers for the durable learning loop. */
+
+import type { Response } from "express";
+import { ZodError } from "zod";
+import type { AuthenticatedRequest } from "../broker/auth.js";
+import {
+  learningExperimentCreateSchema,
+  learningExperimentPromoteSchema,
+  learningExperimentRateSchema,
+  learningExperimentStatusSchema,
+  learningObservationSchema,
+} from "./experiment-schema.js";
+import { LearningStoreError, type LearningExperimentStore } from "./experiment-store.js";
+
+function principalOr500(req: AuthenticatedRequest, res: Response): string | null {
+  if (!req.brokerPrincipal) {
+    res.status(500).json({ error: "internal", message: "principal missing" });
+    return null;
+  }
+  return req.brokerPrincipal;
+}
+
+function respondError(res: Response, err: unknown): void {
+  if (err instanceof ZodError) {
+    res.status(400).json({
+      error: "input_validation",
+      message: "learning-loop input failed validation",
+      issues: err.issues,
+    });
+    return;
+  }
+  if (err instanceof LearningStoreError) {
+    const status =
+      err.code === "not-found"
+        ? 404
+        : err.code === "forbidden"
+          ? 403
+          : err.code === "conflict" || err.code === "invalid-state" || err.code === "capacity"
+            ? 409
+            : 500;
+    res.status(status).json({ error: err.code, message: err.message });
+    return;
+  }
+  res.status(500).json({
+    error: "internal",
+    message: err instanceof Error ? err.message : String(err),
+  });
+}
+
+export function createLearningExperimentHandler(store: LearningExperimentStore) {
+  return async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    const principal = principalOr500(req, res);
+    if (!principal) return;
+    try {
+      const input = learningExperimentCreateSchema.parse(req.body);
+      const result = await store.create(principal, input);
+      res.status(result.reused ? 200 : 201).json(result);
+    } catch (err) {
+      respondError(res, err);
+    }
+  };
+}
+
+export function createLearningObservationHandler(store: LearningExperimentStore) {
+  return async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    const principal = principalOr500(req, res);
+    if (!principal) return;
+    try {
+      const input = learningObservationSchema.parse(req.body);
+      const result = await store.observe(principal, input);
+      res.status(200).json(result);
+    } catch (err) {
+      respondError(res, err);
+    }
+  };
+}
+
+export function createLearningExperimentRateHandler(store: LearningExperimentStore) {
+  return async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    const principal = principalOr500(req, res);
+    if (!principal) return;
+    try {
+      const input = learningExperimentRateSchema.parse(req.body);
+      const result = await store.rate(principal, input);
+      res.status(200).json(result);
+    } catch (err) {
+      respondError(res, err);
+    }
+  };
+}
+
+export function createLearningExperimentStatusHandler(store: LearningExperimentStore) {
+  return async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    const principal = principalOr500(req, res);
+    if (!principal) return;
+    try {
+      const input = learningExperimentStatusSchema.parse(req.body);
+      const state = await store.read(principal, input.experiment_id);
+      res.status(200).json({ state });
+    } catch (err) {
+      respondError(res, err);
+    }
+  };
+}
+
+export function createLearningExperimentPromoteHandler(store: LearningExperimentStore) {
+  return async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    const principal = principalOr500(req, res);
+    if (!principal) return;
+    try {
+      const input = learningExperimentPromoteSchema.parse(req.body);
+      const result = await store.promote(principal, input);
+      res.status(200).json(result);
+    } catch (err) {
+      respondError(res, err);
+    }
+  };
+}

--- a/src/learning/experiment-schema.ts
+++ b/src/learning/experiment-schema.ts
@@ -1,0 +1,399 @@
+/**
+ * Durable champion/challenger experiment contract for the Hugin/M5 learning loop.
+ *
+ * The contract is deliberately content-blind. Prompts, test fixtures, and
+ * arbitrary model configuration blobs stay in their owning repositories; Hugin
+ * records immutable versions and SHA-256 fingerprints so a run can be reproduced
+ * without copying potentially sensitive task content into the experiment ledger.
+ */
+
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import { taskTypeSchema } from "../broker/types.js";
+
+export const sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
+const versionSchema = z.string().min(1).max(120);
+const slugSchema = z.string().regex(/^[a-z0-9][a-z0-9-]{1,79}$/);
+
+export const learningChangeAxisSchema = z.enum([
+  "logging",
+  "test-harness",
+  "agent-prompt",
+  "agent-harness",
+  "model",
+  "model-config",
+  "routing",
+]);
+export type LearningChangeAxis = z.infer<typeof learningChangeAxisSchema>;
+
+export const promptRefSchema = z.object({
+  id: slugSchema,
+  version: versionSchema,
+  sha256: sha256Schema,
+}).strict();
+
+export const harnessRefSchema = z.object({
+  id: slugSchema,
+  version: versionSchema,
+  configSha256: sha256Schema,
+  maxTurns: z.number().int().positive().max(1_000).optional(),
+  timeoutMs: z.number().int().positive().max(3_600_000).optional(),
+  editDeadlineTurn: z.number().int().positive().max(1_000).optional(),
+  contextStrategy: versionSchema.optional(),
+  toolPolicyVersion: versionSchema.optional(),
+}).strict();
+
+export const modelConfigSchema = z.object({
+  quantization: versionSchema.optional(),
+  contextWindow: z.number().int().positive().max(10_000_000).optional(),
+  maxOutputTokens: z.number().int().positive().max(1_000_000).optional(),
+  temperature: z.number().min(0).max(2).optional(),
+  topP: z.number().min(0).max(1).optional(),
+  topK: z.number().int().nonnegative().optional(),
+  seed: z.number().int().optional(),
+  reasoning: z.enum(["off", "low", "medium", "high"]).optional(),
+  templateVersion: versionSchema.optional(),
+  extraConfigSha256: sha256Schema.optional(),
+}).strict();
+
+export const modelRefSchema = z.object({
+  id: versionSchema,
+  provider: versionSchema,
+  runtime: versionSchema,
+  config: modelConfigSchema,
+}).strict();
+
+export const loggingRefSchema = z.object({
+  schemaVersion: versionSchema,
+  requiredFieldsSha256: sha256Schema,
+}).strict();
+
+export const testHarnessRefSchema = z.object({
+  id: slugSchema,
+  version: versionSchema,
+  corpusSha256: sha256Schema,
+  oracleVersion: versionSchema,
+  holdoutRevision: versionSchema,
+}).strict();
+
+export const routingRefSchema = z.object({
+  policyId: slugSchema,
+  version: versionSchema,
+  configSha256: sha256Schema,
+}).strict();
+
+const learningConfigurationPayloadSchema = z.object({
+  prompt: promptRefSchema,
+  harness: harnessRefSchema,
+  model: modelRefSchema,
+  logging: loggingRefSchema,
+  testHarness: testHarnessRefSchema,
+  routing: routingRefSchema,
+}).strict();
+export const learningConfigurationSchema = learningConfigurationPayloadSchema.extend({
+  fingerprint: sha256Schema,
+}).strict().superRefine((value, ctx) => {
+  const expected = computeConfigurationFingerprint(value);
+  if (value.fingerprint !== expected) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["fingerprint"],
+      message: `configuration fingerprint mismatch; expected ${expected}`,
+    });
+  }
+});
+export type LearningConfiguration = z.infer<typeof learningConfigurationSchema>;
+
+function stable(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stable).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, child]) => `${JSON.stringify(key)}:${stable(child)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function computeConfigurationFingerprint(
+  configuration: Omit<LearningConfiguration, "fingerprint"> | LearningConfiguration,
+): string {
+  const { fingerprint: _fingerprint, ...payload } = configuration as LearningConfiguration;
+  return createHash("sha256").update(stable(payload)).digest("hex");
+}
+
+/** Return the semantic axes that differ between two versioned configurations. */
+export function configurationChangedAxes(
+  champion: LearningConfiguration,
+  challenger: LearningConfiguration,
+): LearningChangeAxis[] {
+  const changed: LearningChangeAxis[] = [];
+  if (stable(champion.logging) !== stable(challenger.logging)) changed.push("logging");
+  if (stable(champion.testHarness) !== stable(challenger.testHarness)) changed.push("test-harness");
+  if (stable(champion.prompt) !== stable(challenger.prompt)) changed.push("agent-prompt");
+  if (stable(champion.harness) !== stable(challenger.harness)) changed.push("agent-harness");
+  const championModelIdentity = {
+    id: champion.model.id,
+    provider: champion.model.provider,
+    runtime: champion.model.runtime,
+  };
+  const challengerModelIdentity = {
+    id: challenger.model.id,
+    provider: challenger.model.provider,
+    runtime: challenger.model.runtime,
+  };
+  if (stable(championModelIdentity) !== stable(challengerModelIdentity)) changed.push("model");
+  if (stable(champion.model.config) !== stable(challenger.model.config)) changed.push("model-config");
+  if (stable(champion.routing) !== stable(challenger.routing)) changed.push("routing");
+  return changed;
+}
+
+export const learningPrimaryMetricSchema = z.enum([
+  "quality-rate",
+  "useful-rate",
+  "rescue-rate",
+  "latency-ms",
+  "cost-usd",
+  "human-review-seconds",
+  "edit-start-ms",
+  "observability-coverage",
+  "verifier-score",
+]);
+export type LearningPrimaryMetric = z.infer<typeof learningPrimaryMetricSchema>;
+
+export const learningExperimentGatesSchema = z.object({
+  minMatchedPairs: z.number().int().min(2).max(200).default(6),
+  minHoldoutPairs: z.number().int().min(1).max(100).default(2),
+  minVerifiedCoverage: z.number().min(0).max(1).default(0.8),
+  minRatedCoverage: z.number().min(0).max(1).default(0.5),
+  maxQualityRegression: z.number().min(0).max(1).default(0),
+  maxUsefulRegression: z.number().min(0).max(1).default(0),
+  maxRescueRateIncrease: z.number().min(0).max(1).default(0),
+  maxInfraRateIncrease: z.number().min(0).max(1).default(0.05),
+  maxLatencyRatio: z.number().min(1).max(100).nullable().default(1.25),
+  maxCostRatio: z.number().min(1).max(100).nullable().default(1.25),
+  primaryMetric: learningPrimaryMetricSchema,
+  /** Absolute delta for rates; relative reduction for lower-is-better scalar metrics. */
+  minPrimaryImprovement: z.number().min(0).max(1).default(0.05),
+}).strict();
+export type LearningExperimentGates = z.infer<typeof learningExperimentGatesSchema>;
+
+export const learningExperimentCreateInputShape = {
+  experiment_id: slugSchema,
+  scope: slugSchema,
+  task_type: taskTypeSchema,
+  hypothesis: z.string().min(1).max(2_000),
+  change_axis: learningChangeAxisSchema,
+  champion: learningConfigurationSchema,
+  challenger: learningConfigurationSchema,
+  gates: learningExperimentGatesSchema,
+};
+
+export const learningExperimentCreateSchema = z.object(
+  learningExperimentCreateInputShape,
+).strict().superRefine((value, ctx) => {
+  if (value.champion.fingerprint === value.challenger.fingerprint) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["challenger", "fingerprint"],
+      message: "challenger fingerprint must differ from champion",
+    });
+  }
+  const changed = configurationChangedAxes(value.champion, value.challenger);
+  if (changed.length !== 1 || changed[0] !== value.change_axis) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["change_axis"],
+      message:
+        `exactly one declared axis may change; declared ${value.change_axis}, ` +
+        `observed ${changed.length > 0 ? changed.join(", ") : "none"}`,
+    });
+  }
+});
+export type LearningExperimentCreate = z.infer<typeof learningExperimentCreateSchema>;
+
+export const learningQualityOutcomeSchema = z.enum([
+  "pass",
+  "fail",
+  "unverified",
+  "infra-error",
+]);
+
+export const learningProductOutcomeSchema = z.enum([
+  "accepted-unchanged",
+  "minor-edit",
+  "major-rewrite",
+  "discarded",
+  "unrated",
+]);
+
+export const learningVerifierSchema = z.object({
+  kind: z.enum(["mechanical", "human", "judge", "none"]),
+  independent: z.boolean(),
+  id: versionSchema.optional(),
+  version: versionSchema.optional(),
+}).strict();
+
+export const learningObservationInputShape = {
+  experiment_id: slugSchema,
+  run_id: z.string().min(1).max(200),
+  sample_id: z.string().min(1).max(200),
+  arm: z.enum(["champion", "challenger"]),
+  holdout: z.boolean(),
+  configuration_fingerprint: sha256Schema,
+  quality_outcome: learningQualityOutcomeSchema,
+  product_outcome: learningProductOutcomeSchema.default("unrated"),
+  verifier: learningVerifierSchema,
+  latency_ms: z.number().int().nonnegative().optional(),
+  cost_usd: z.number().nonnegative().optional(),
+  human_review_seconds: z.number().nonnegative().optional(),
+  edit_start_ms: z.number().int().nonnegative().optional(),
+  observability_coverage: z.number().min(0).max(1).optional(),
+  verifier_score: z.number().min(0).max(1).optional(),
+  edited: z.boolean().optional(),
+  tests_run: z.boolean().optional(),
+  tests_passed: z.boolean().optional(),
+  phase_ms: z.object({
+    inspect: z.number().int().nonnegative().optional(),
+    edit: z.number().int().nonnegative().optional(),
+    check: z.number().int().nonnegative().optional(),
+  }).strict().optional(),
+  failure_kind: z.string().min(1).max(120).optional(),
+  task_id: z.string().min(1).max(200).optional(),
+  ledger_id: z.string().min(1).max(200).optional(),
+  work_id: z.string().min(1).max(200).optional(),
+};
+
+export const learningObservationSchema = z.object(learningObservationInputShape).strict();
+export type LearningObservationInput = z.infer<typeof learningObservationSchema>;
+
+export const recordedLearningObservationSchema = learningObservationSchema.extend({
+  recorded_at: z.string().min(1),
+  recorded_by: z.string().min(1),
+  product_rated_at: z.string().min(1).optional(),
+  product_rated_by: z.string().min(1).optional(),
+}).strict();
+export type RecordedLearningObservation = z.infer<typeof recordedLearningObservationSchema>;
+
+const ratedProductOutcomeSchema = z.enum([
+  "accepted-unchanged",
+  "minor-edit",
+  "major-rewrite",
+  "discarded",
+]);
+
+/**
+ * Product usefulness is intentionally enriched after mechanical collection.
+ * Automated runners can record `unrated` immediately; a later human/downstream
+ * review may move that observation to exactly one terminal product outcome.
+ */
+export const learningExperimentRateInputShape = {
+  experiment_id: slugSchema,
+  run_id: z.string().min(1).max(200),
+  product_outcome: ratedProductOutcomeSchema,
+  human_review_seconds: z.number().nonnegative().optional(),
+};
+export const learningExperimentRateSchema = z.object(
+  learningExperimentRateInputShape,
+).strict();
+export type LearningExperimentRate = z.infer<typeof learningExperimentRateSchema>;
+
+export const failureSignalSchema = z.object({
+  signal: z.string().min(1),
+  count: z.number().int().nonnegative(),
+}).strict();
+
+export const learningArmSummarySchema = z.object({
+  samples: z.number().int().nonnegative(),
+  verifiedSamples: z.number().int().nonnegative(),
+  verifiedCoverage: z.number().min(0).max(1),
+  qualityRate: z.number().min(0).max(1).nullable(),
+  ratedSamples: z.number().int().nonnegative(),
+  ratedCoverage: z.number().min(0).max(1),
+  usefulRate: z.number().min(0).max(1).nullable(),
+  rescueRate: z.number().min(0).max(1).nullable(),
+  infraRate: z.number().min(0).max(1),
+  latencyMeanMs: z.number().nonnegative().nullable(),
+  costMeanUsd: z.number().nonnegative().nullable(),
+  humanReviewMeanSeconds: z.number().nonnegative().nullable(),
+  editStartMeanMs: z.number().nonnegative().nullable(),
+  observabilityCoverageMean: z.number().min(0).max(1).nullable(),
+  verifierScoreMean: z.number().min(0).max(1).nullable(),
+}).strict();
+export type LearningArmSummary = z.infer<typeof learningArmSummarySchema>;
+
+export const learningExperimentEvaluationSchema = z.object({
+  decision: z.enum(["gathering", "promotion-ready", "reject"]),
+  reason: z.string().min(1),
+  evaluatedAt: z.string().min(1),
+  matchedPairs: z.number().int().nonnegative(),
+  holdoutPairs: z.number().int().nonnegative(),
+  unmatchedObservations: z.number().int().nonnegative(),
+  champion: learningArmSummarySchema,
+  challenger: learningArmSummarySchema,
+  primaryMetric: learningPrimaryMetricSchema,
+  primaryChampion: z.number().nullable(),
+  primaryChallenger: z.number().nullable(),
+  primaryImprovement: z.number().nullable(),
+  guardFailures: z.array(z.string()),
+  missingRequirements: z.array(z.string()),
+  failureSignals: z.array(failureSignalSchema),
+  nextAction: z.string().min(1),
+}).strict();
+export type LearningExperimentEvaluation = z.infer<
+  typeof learningExperimentEvaluationSchema
+>;
+
+export const learningExperimentStateSchema = z.object({
+  schemaVersion: z.literal(1),
+  experimentId: slugSchema,
+  scope: slugSchema,
+  taskType: taskTypeSchema,
+  ownerPrincipal: z.string().min(1),
+  hypothesis: z.string().min(1).max(2_000),
+  changeAxis: learningChangeAxisSchema,
+  champion: learningConfigurationSchema,
+  challenger: learningConfigurationSchema,
+  gates: learningExperimentGatesSchema,
+  status: z.enum(["running", "promotion-ready", "rejected", "promoted"]),
+  revision: z.number().int().positive(),
+  createdAt: z.string().min(1),
+  updatedAt: z.string().min(1),
+  observations: z.array(recordedLearningObservationSchema).max(400),
+  evaluation: learningExperimentEvaluationSchema,
+  promotion: z.object({
+    appliedRef: z.string().min(1).max(500),
+    promotedAt: z.string().min(1),
+    promotedBy: z.string().min(1),
+  }).strict().optional(),
+}).strict();
+export type LearningExperimentState = z.infer<typeof learningExperimentStateSchema>;
+
+export const learningExperimentStatusInputShape = {
+  experiment_id: slugSchema,
+};
+export const learningExperimentStatusSchema = z.object(
+  learningExperimentStatusInputShape,
+).strict();
+
+export const learningExperimentPromoteInputShape = {
+  experiment_id: slugSchema,
+  configuration_fingerprint: sha256Schema,
+  applied_ref: z.string().regex(/^[A-Za-z0-9._/-]+@[A-Za-z0-9._-]{1,120}$/),
+};
+export const learningExperimentPromoteSchema = z.object(
+  learningExperimentPromoteInputShape,
+).strict();
+export type LearningExperimentPromote = z.infer<typeof learningExperimentPromoteSchema>;
+
+export const learningChampionStateSchema = z.object({
+  schemaVersion: z.literal(1),
+  scope: slugSchema,
+  ownerPrincipal: z.string().min(1),
+  configuration: learningConfigurationSchema,
+  sourceExperimentId: slugSchema.nullable(),
+  appliedRef: z.string().min(1).max(500),
+  promotedAt: z.string().min(1),
+  promotedBy: z.string().min(1),
+}).strict();
+export type LearningChampionState = z.infer<typeof learningChampionStateSchema>;

--- a/src/learning/experiment-store.ts
+++ b/src/learning/experiment-store.ts
@@ -1,0 +1,583 @@
+/** Munin-backed durable store for champion/challenger learning experiments. */
+
+import { createHash } from "node:crypto";
+import type { MuninClient } from "../munin-client.js";
+import { evaluateLearningExperiment } from "./experiment-evaluator.js";
+import {
+  learningExperimentCreateSchema,
+  learningExperimentPromoteSchema,
+  learningExperimentRateSchema,
+  learningExperimentStateSchema,
+  learningChampionStateSchema,
+  learningObservationSchema,
+  type LearningExperimentCreate,
+  type LearningExperimentPromote,
+  type LearningExperimentRate,
+  type LearningExperimentState,
+  type LearningChampionState,
+  type LearningObservationInput,
+  type RecordedLearningObservation,
+} from "./experiment-schema.js";
+
+const STATE_KEY = "state";
+const MAX_MUTATION_ATTEMPTS = 3;
+
+export type LearningStoreErrorCode =
+  | "not-found"
+  | "forbidden"
+  | "conflict"
+  | "invalid-state"
+  | "capacity";
+
+export class LearningStoreError extends Error {
+  constructor(
+    public readonly code: LearningStoreErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "LearningStoreError";
+  }
+}
+
+function namespaceFor(principal: string, experimentId: string): string {
+  const principalHash = createHash("sha256").update(principal).digest("hex").slice(0, 12);
+  return `experiments/hugin/${experimentId}-${principalHash}`;
+}
+
+function championNamespaceFor(principal: string, scope: string): string {
+  const principalHash = createHash("sha256").update(principal).digest("hex").slice(0, 12);
+  return `experiments/hugin/champions/${scope}-${principalHash}`;
+}
+
+function stable(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stable).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, child]) => `${JSON.stringify(key)}:${stable(child)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sameInput(state: LearningExperimentState, input: LearningExperimentCreate): boolean {
+  return stable({
+    experiment_id: state.experimentId,
+    scope: state.scope,
+    task_type: state.taskType,
+    hypothesis: state.hypothesis,
+    change_axis: state.changeAxis,
+    champion: state.champion,
+    challenger: state.challenger,
+    gates: state.gates,
+  }) === stable(input);
+}
+
+function statusTags(state: LearningExperimentState): string[] {
+  return [
+    "learning:experiment",
+    `learning:${state.status}`,
+    `axis:${state.changeAxis}`,
+    `type:${state.taskType}`,
+  ];
+}
+
+function parseState(content: string): LearningExperimentState {
+  try {
+    return learningExperimentStateSchema.parse(JSON.parse(content));
+  } catch (err) {
+    throw new LearningStoreError(
+      "invalid-state",
+      `stored experiment state is invalid: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+function parseChampion(content: string): LearningChampionState {
+  try {
+    return learningChampionStateSchema.parse(JSON.parse(content));
+  } catch (err) {
+    throw new LearningStoreError(
+      "invalid-state",
+      `stored champion state is invalid: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+export interface LearningExperimentStoreOptions {
+  now?: () => Date;
+}
+
+export class LearningExperimentStore {
+  private readonly now: () => Date;
+  /** Serialize same-process updates; cross-process races are still guarded by Munin CAS. */
+  private readonly locks = new Map<string, Promise<void>>();
+
+  constructor(
+    private readonly munin: MuninClient,
+    options: LearningExperimentStoreOptions = {},
+  ) {
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async create(
+    principal: string,
+    rawInput: LearningExperimentCreate,
+  ): Promise<{ state: LearningExperimentState; reused: boolean }> {
+    const input = learningExperimentCreateSchema.parse(rawInput);
+    const namespace = namespaceFor(principal, input.experiment_id);
+    return this.withLock(championNamespaceFor(principal, input.scope), async () => {
+      const existing = await this.munin.read(namespace, STATE_KEY);
+      if (existing) {
+        const state = parseState(existing.content);
+        this.assertOwner(state, principal);
+        if (!sameInput(state, input)) {
+          throw new LearningStoreError(
+            "conflict",
+            `experiment ${input.experiment_id} already exists with a different contract`,
+          );
+        }
+        return { state, reused: true };
+      }
+
+      await this.ensureChampionBaseline(principal, input);
+
+      const timestamp = this.now().toISOString();
+      const evaluation = evaluateLearningExperiment({
+        observations: [],
+        gates: input.gates,
+        now: this.now,
+      });
+      const state = learningExperimentStateSchema.parse({
+        schemaVersion: 1,
+        experimentId: input.experiment_id,
+        scope: input.scope,
+        taskType: input.task_type,
+        ownerPrincipal: principal,
+        hypothesis: input.hypothesis,
+        changeAxis: input.change_axis,
+        champion: input.champion,
+        challenger: input.challenger,
+        gates: input.gates,
+        status: "running",
+        revision: 1,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        observations: [],
+        evaluation,
+      });
+      await this.munin.write(
+        namespace,
+        STATE_KEY,
+        JSON.stringify(state),
+        statusTags(state),
+        undefined,
+        "internal",
+      );
+      return { state, reused: false };
+    });
+  }
+
+  async read(principal: string, experimentId: string): Promise<LearningExperimentState> {
+    const entry = await this.munin.read(namespaceFor(principal, experimentId), STATE_KEY);
+    if (!entry) {
+      throw new LearningStoreError("not-found", `experiment ${experimentId} not found`);
+    }
+    const state = parseState(entry.content);
+    this.assertOwner(state, principal);
+    return state;
+  }
+
+  async readChampion(principal: string, scope: string): Promise<LearningChampionState | null> {
+    const entry = await this.munin.read(championNamespaceFor(principal, scope), STATE_KEY);
+    if (!entry) return null;
+    const champion = parseChampion(entry.content);
+    if (champion.ownerPrincipal !== principal) {
+      throw new LearningStoreError("forbidden", "champion belongs to another principal");
+    }
+    return champion;
+  }
+
+  async observe(
+    principal: string,
+    rawObservation: LearningObservationInput,
+  ): Promise<{ state: LearningExperimentState; reused: boolean }> {
+    const observation = learningObservationSchema.parse(rawObservation);
+    const namespace = namespaceFor(principal, observation.experiment_id);
+    return this.withLock(namespace, async () => {
+      for (let attempt = 0; attempt < MAX_MUTATION_ATTEMPTS; attempt++) {
+        const entry = await this.munin.read(namespace, STATE_KEY);
+        if (!entry) {
+          throw new LearningStoreError(
+            "not-found",
+            `experiment ${observation.experiment_id} not found`,
+          );
+        }
+        const current = parseState(entry.content);
+        this.assertOwner(current, principal);
+        if (current.status !== "running") {
+          throw new LearningStoreError(
+            "invalid-state",
+            `experiment is ${current.status}; terminal evidence cannot be rewritten`,
+          );
+        }
+
+        const existingRun = current.observations.find(
+          (candidate) => candidate.run_id === observation.run_id,
+        );
+        if (existingRun) {
+          const {
+            recorded_at: _recordedAt,
+            recorded_by: _recordedBy,
+            ...comparable
+          } = existingRun;
+          if (stable(comparable) !== stable(observation)) {
+            throw new LearningStoreError(
+              "conflict",
+              `run_id ${observation.run_id} already exists with different evidence`,
+            );
+          }
+          return { state: current, reused: true };
+        }
+        if (
+          current.observations.some(
+            (candidate) =>
+              candidate.sample_id === observation.sample_id && candidate.arm === observation.arm,
+          )
+        ) {
+          throw new LearningStoreError(
+            "conflict",
+            `sample ${observation.sample_id} already has a ${observation.arm} observation`,
+          );
+        }
+        if (current.observations.length >= 400) {
+          throw new LearningStoreError("capacity", "experiment reached the 400-observation cap");
+        }
+
+        const expectedFingerprint =
+          observation.arm === "champion"
+            ? current.champion.fingerprint
+            : current.challenger.fingerprint;
+        if (observation.configuration_fingerprint !== expectedFingerprint) {
+          throw new LearningStoreError(
+            "conflict",
+            `${observation.arm} observation fingerprint does not match the experiment contract`,
+          );
+        }
+
+        const timestamp = this.now().toISOString();
+        const recorded: RecordedLearningObservation = {
+          ...observation,
+          recorded_at: timestamp,
+          recorded_by: principal,
+        };
+        const observations = [...current.observations, recorded];
+        const evaluation = evaluateLearningExperiment({
+          observations,
+          gates: current.gates,
+          now: this.now,
+        });
+        const status: LearningExperimentState["status"] =
+          evaluation.decision === "promotion-ready"
+            ? "promotion-ready"
+            : evaluation.decision === "reject"
+              ? "rejected"
+              : "running";
+        const next = learningExperimentStateSchema.parse({
+          ...current,
+          status,
+          revision: current.revision + 1,
+          updatedAt: timestamp,
+          observations,
+          evaluation,
+        });
+
+        try {
+          await this.munin.write(
+            namespace,
+            STATE_KEY,
+            JSON.stringify(next),
+            statusTags(next),
+            entry.updated_at,
+            "internal",
+          );
+          return { state: next, reused: false };
+        } catch (err) {
+          if (attempt === MAX_MUTATION_ATTEMPTS - 1) throw err;
+          // A competing writer won the CAS. Re-read and fold once more.
+        }
+      }
+      throw new LearningStoreError("conflict", "experiment update lost repeated CAS races");
+    });
+  }
+
+  async rate(
+    principal: string,
+    rawRating: LearningExperimentRate,
+  ): Promise<{ state: LearningExperimentState; reused: boolean }> {
+    const rating = learningExperimentRateSchema.parse(rawRating);
+    const namespace = namespaceFor(principal, rating.experiment_id);
+    return this.withLock(namespace, async () => {
+      for (let attempt = 0; attempt < MAX_MUTATION_ATTEMPTS; attempt++) {
+        const entry = await this.munin.read(namespace, STATE_KEY);
+        if (!entry) {
+          throw new LearningStoreError(
+            "not-found",
+            `experiment ${rating.experiment_id} not found`,
+          );
+        }
+        const current = parseState(entry.content);
+        this.assertOwner(current, principal);
+        if (current.status !== "running") {
+          throw new LearningStoreError(
+            "invalid-state",
+            `experiment is ${current.status}; terminal evidence cannot be rewritten`,
+          );
+        }
+
+        const index = current.observations.findIndex(
+          (candidate) => candidate.run_id === rating.run_id,
+        );
+        if (index === -1) {
+          throw new LearningStoreError(
+            "not-found",
+            `run_id ${rating.run_id} is not recorded in experiment ${rating.experiment_id}`,
+          );
+        }
+        const existing = current.observations[index]!;
+        if (existing.product_outcome !== "unrated") {
+          const effectiveReviewSeconds =
+            rating.human_review_seconds ?? existing.human_review_seconds;
+          if (
+            existing.product_outcome === rating.product_outcome &&
+            existing.human_review_seconds === effectiveReviewSeconds
+          ) {
+            return { state: current, reused: true };
+          }
+          throw new LearningStoreError(
+            "conflict",
+            `run_id ${rating.run_id} already has a different product rating`,
+          );
+        }
+
+        const timestamp = this.now().toISOString();
+        const rated: RecordedLearningObservation = {
+          ...existing,
+          product_outcome: rating.product_outcome,
+          ...(rating.human_review_seconds !== undefined
+            ? { human_review_seconds: rating.human_review_seconds }
+            : {}),
+          product_rated_at: timestamp,
+          product_rated_by: principal,
+        };
+        const observations = [...current.observations];
+        observations[index] = rated;
+        const evaluation = evaluateLearningExperiment({
+          observations,
+          gates: current.gates,
+          now: this.now,
+        });
+        const status: LearningExperimentState["status"] =
+          evaluation.decision === "promotion-ready"
+            ? "promotion-ready"
+            : evaluation.decision === "reject"
+              ? "rejected"
+              : "running";
+        const next = learningExperimentStateSchema.parse({
+          ...current,
+          status,
+          revision: current.revision + 1,
+          updatedAt: timestamp,
+          observations,
+          evaluation,
+        });
+
+        try {
+          await this.munin.write(
+            namespace,
+            STATE_KEY,
+            JSON.stringify(next),
+            statusTags(next),
+            entry.updated_at,
+            "internal",
+          );
+          return { state: next, reused: false };
+        } catch (err) {
+          if (attempt === MAX_MUTATION_ATTEMPTS - 1) throw err;
+        }
+      }
+      throw new LearningStoreError("conflict", "experiment rating lost repeated CAS races");
+    });
+  }
+
+  async promote(
+    principal: string,
+    rawPromotion: LearningExperimentPromote,
+  ): Promise<{ state: LearningExperimentState; champion: LearningChampionState; reused: boolean }> {
+    const promotion = learningExperimentPromoteSchema.parse(rawPromotion);
+    const namespace = namespaceFor(principal, promotion.experiment_id);
+    return this.withLock(namespace, async () => {
+      const entry = await this.munin.read(namespace, STATE_KEY);
+      if (!entry) {
+        throw new LearningStoreError(
+          "not-found",
+          `experiment ${promotion.experiment_id} not found`,
+        );
+      }
+      const current = parseState(entry.content);
+      this.assertOwner(current, principal);
+      if (promotion.configuration_fingerprint !== current.challenger.fingerprint) {
+        throw new LearningStoreError(
+          "conflict",
+          "promotion fingerprint does not match the evaluated challenger",
+        );
+      }
+      if (current.status === "promoted") {
+        if (current.promotion?.appliedRef !== promotion.applied_ref) {
+          throw new LearningStoreError(
+            "conflict",
+            "experiment was already promoted with a different applied_ref",
+          );
+        }
+        const champion = await this.readChampion(principal, current.scope);
+        if (!champion) {
+          throw new LearningStoreError("invalid-state", "promoted experiment has no champion pointer");
+        }
+        return { state: current, champion, reused: true };
+      }
+      if (current.status !== "promotion-ready") {
+        throw new LearningStoreError(
+          "invalid-state",
+          `experiment is ${current.status}; only promotion-ready evidence can be promoted`,
+        );
+      }
+
+      const championNamespace = championNamespaceFor(principal, current.scope);
+      const championEntry = await this.munin.read(championNamespace, STATE_KEY);
+      if (!championEntry) {
+        throw new LearningStoreError("invalid-state", "experiment scope has no champion pointer");
+      }
+      const previousChampion = parseChampion(championEntry.content);
+      let nextChampion: LearningChampionState;
+      const timestamp = this.now().toISOString();
+      if (previousChampion.configuration.fingerprint === current.champion.fingerprint) {
+        nextChampion = learningChampionStateSchema.parse({
+          schemaVersion: 1,
+          scope: current.scope,
+          ownerPrincipal: principal,
+          configuration: current.challenger,
+          sourceExperimentId: current.experimentId,
+          appliedRef: promotion.applied_ref,
+          promotedAt: timestamp,
+          promotedBy: principal,
+        });
+        await this.munin.write(
+          championNamespace,
+          STATE_KEY,
+          JSON.stringify(nextChampion),
+          ["learning:champion", `type:${current.taskType}`],
+          championEntry.updated_at,
+          "internal",
+        );
+      } else if (
+        previousChampion.configuration.fingerprint === current.challenger.fingerprint &&
+        previousChampion.sourceExperimentId === current.experimentId
+      ) {
+        // Recovery after a crash/CAS loss between champion-pointer and
+        // experiment-state writes: the monotonic move already happened.
+        nextChampion = previousChampion;
+      } else {
+        throw new LearningStoreError(
+          "conflict",
+          "scope champion changed since this experiment started; refusing stale promotion",
+        );
+      }
+
+      const next = learningExperimentStateSchema.parse({
+        ...current,
+        status: "promoted",
+        revision: current.revision + 1,
+        updatedAt: timestamp,
+        promotion: {
+          appliedRef: promotion.applied_ref,
+          promotedAt: timestamp,
+          promotedBy: principal,
+        },
+      });
+      await this.munin.write(
+        namespace,
+        STATE_KEY,
+        JSON.stringify(next),
+        statusTags(next),
+        entry.updated_at,
+        "internal",
+      );
+      return { state: next, champion: nextChampion, reused: false };
+    });
+  }
+
+  private async ensureChampionBaseline(
+    principal: string,
+    input: LearningExperimentCreate,
+  ): Promise<void> {
+    const namespace = championNamespaceFor(principal, input.scope);
+    const existing = await this.munin.read(namespace, STATE_KEY);
+    if (existing) {
+      const champion = parseChampion(existing.content);
+      if (champion.ownerPrincipal !== principal) {
+        throw new LearningStoreError("forbidden", "champion belongs to another principal");
+      }
+      if (champion.configuration.fingerprint !== input.champion.fingerprint) {
+        throw new LearningStoreError(
+          "conflict",
+          "experiment champion does not match the current champion for this scope",
+        );
+      }
+      return;
+    }
+    const timestamp = this.now().toISOString();
+    const champion = learningChampionStateSchema.parse({
+      schemaVersion: 1,
+      scope: input.scope,
+      ownerPrincipal: principal,
+      configuration: input.champion,
+      sourceExperimentId: null,
+      appliedRef: `seed:${input.champion.fingerprint}`,
+      promotedAt: timestamp,
+      promotedBy: principal,
+    });
+    await this.munin.write(
+      namespace,
+      STATE_KEY,
+      JSON.stringify(champion),
+      ["learning:champion", `type:${input.task_type}`],
+      undefined,
+      "internal",
+    );
+  }
+
+  private assertOwner(state: LearningExperimentState, principal: string): void {
+    if (state.ownerPrincipal !== principal) {
+      // Principal-scoped namespaces make this unreachable without corrupt state,
+      // but preserve the explicit authorization boundary in case storage moves.
+      throw new LearningStoreError("forbidden", "experiment belongs to another principal");
+    }
+  }
+
+  private async withLock<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const previous = this.locks.get(key) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const queued = previous.then(() => current);
+    this.locks.set(key, queued);
+    await previous;
+    try {
+      return await fn();
+    } finally {
+      release();
+      if (this.locks.get(key) === queued) this.locks.delete(key);
+    }
+  }
+}

--- a/src/learning/m5-code-loop-adapter.ts
+++ b/src/learning/m5-code-loop-adapter.ts
@@ -1,0 +1,238 @@
+/**
+ * Translate the owner-only M5 code_loop result into Hugin's content-blind
+ * experiment observation. The M5 response is untrusted input: validate it,
+ * preserve missing telemetry as missing, and never infer edit timing from a
+ * final git diff.
+ */
+
+import { z } from "zod";
+import {
+  learningObservationSchema,
+  sha256Schema,
+  type LearningObservationInput,
+} from "./experiment-schema.js";
+
+const codeLoopStatusSchema = z.enum([
+  "completed",
+  "cap-exceeded",
+  "degenerate",
+  "arm-error",
+  "orphaned",
+]);
+
+const phaseMsSchema = z.object({
+  inspect: z.number().int().nonnegative().optional(),
+  edit: z.number().int().nonnegative().optional(),
+  check: z.number().int().nonnegative().optional(),
+}).strict();
+
+/** Proposed gille-inference #247 telemetry. Optional for old deployed gateways. */
+export const m5CodeLoopTelemetrySchema = z.object({
+  schema_version: z.literal(1),
+  first_edit_turn: z.number().int().positive().optional(),
+  edit_start_ms: z.number().int().nonnegative().optional(),
+  phase_ms: phaseMsSchema,
+  mutation_evidence: z.enum(["tool-call", "diff-only", "none"]),
+  observability_coverage: z.number().min(0).max(1),
+  failure_kind: z.string().min(1).max(120).optional(),
+}).strict().superRefine((value, ctx) => {
+  if (value.mutation_evidence !== "tool-call" && value.edit_start_ms !== undefined) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["edit_start_ms"],
+      message: "edit_start_ms requires tool-call mutation evidence",
+    });
+  }
+  if (value.mutation_evidence !== "tool-call" && value.first_edit_turn !== undefined) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["first_edit_turn"],
+      message: "first_edit_turn requires tool-call mutation evidence",
+    });
+  }
+});
+
+export const m5CodeLoopResultSchema = z.object({
+  status: codeLoopStatusSchema,
+  diff: z.string(),
+  diff_truncated: z.boolean().default(false),
+  changed_files: z.array(z.string()),
+  protected_violations: z.array(z.string()),
+  summary: z.string(),
+  check: z.object({
+    ran: z.boolean(),
+    exit_code: z.number().int().nullable(),
+    output_tail: z.string(),
+    duration_ms: z.number().int().nonnegative().optional(),
+  }).strict(),
+  usage: z.object({
+    turns: z.number().int().nonnegative(),
+    wall_ms: z.number().int().nonnegative(),
+    prompt_tokens: z.number().int().nonnegative(),
+    completion_tokens: z.number().int().nonnegative(),
+  }).strict(),
+  work_id: z.string().min(1).max(200),
+  detail: z.string(),
+  execution: z.object({
+    schema_version: z.literal(1),
+    model: z.string().min(1),
+    engine: z.string().min(1),
+    harness_version: z.string().min(1),
+    effective_caps: z.object({
+      wall_s: z.number().int().positive(),
+      turns: z.number().int().positive(),
+      completion_tokens: z.number().int().positive(),
+      edit_deadline_turn: z.number().int().positive().optional(),
+    }).strict(),
+  }).strict().optional(),
+  telemetry: m5CodeLoopTelemetrySchema.optional(),
+}).strict();
+export type M5CodeLoopResult = z.infer<typeof m5CodeLoopResultSchema>;
+
+export interface M5CodeLoopObservationContext {
+  experimentId: string;
+  runId: string;
+  sampleId: string;
+  arm: "champion" | "challenger";
+  holdout: boolean;
+  configurationFingerprint: string;
+  taskId?: string;
+  ledgerId?: string;
+  expectedExecution?: {
+    model: string;
+    harnessVersion: string;
+    caps: {
+      wall_s: number;
+      turns: number;
+      completion_tokens: number;
+      edit_deadline_turn?: number;
+    };
+  };
+  externalVerification?: {
+    ran: boolean;
+    passed: boolean;
+    testsRan: boolean;
+    id: string;
+    version: string;
+    durationMs: number;
+  };
+}
+
+function qualityOf(
+  result: M5CodeLoopResult,
+  external: M5CodeLoopObservationContext["externalVerification"],
+): LearningObservationInput["quality_outcome"] {
+  if (
+    result.status === "degenerate" ||
+    result.status === "arm-error" ||
+    result.status === "orphaned"
+  ) {
+    return "infra-error";
+  }
+  if (result.status === "cap-exceeded" || result.protected_violations.length > 0) {
+    if (result.protected_violations.length > 0) return "fail";
+  }
+  if (external?.ran) return external.passed ? "pass" : "fail";
+  if (result.status === "cap-exceeded") return "fail";
+  if (!result.check.ran) return "unverified";
+  return result.check.exit_code === 0 ? "pass" : "fail";
+}
+
+function failureKindOf(
+  result: M5CodeLoopResult,
+  external: M5CodeLoopObservationContext["externalVerification"],
+): string | undefined {
+  if (result.telemetry?.failure_kind) return result.telemetry.failure_kind;
+  if (result.protected_violations.length > 0) return "protected-file-modified";
+  if (external?.ran && !external.passed) return "protected-check-failed";
+  if (result.status === "completed" && result.check.ran && result.check.exit_code !== 0) {
+    return "protected-check-failed";
+  }
+  return result.status === "completed" ? undefined : result.status;
+}
+
+function assertExecutionBinding(
+  result: M5CodeLoopResult,
+  expected: M5CodeLoopObservationContext["expectedExecution"],
+): void {
+  if (!expected) return;
+  if (!result.execution) {
+    throw new Error("M5 result omitted effective execution metadata required by the experiment");
+  }
+  if (result.execution.model !== expected.model) {
+    throw new Error(
+      `M5 effective model ${result.execution.model} does not match declared ${expected.model}`,
+    );
+  }
+  if (result.execution.harness_version !== expected.harnessVersion) {
+    throw new Error(
+      `M5 harness version ${result.execution.harness_version} does not match declared ${expected.harnessVersion}`,
+    );
+  }
+  const actual = result.execution.effective_caps;
+  const fields = ["wall_s", "turns", "completion_tokens", "edit_deadline_turn"] as const;
+  for (const field of fields) {
+    if (actual[field] !== expected.caps[field]) {
+      throw new Error(`M5 effective cap ${field} does not match the declared experiment arm`);
+    }
+  }
+}
+
+export function observationFromM5CodeLoop(
+  rawResult: unknown,
+  context: M5CodeLoopObservationContext,
+): LearningObservationInput {
+  const result = m5CodeLoopResultSchema.parse(rawResult);
+  assertExecutionBinding(result, context.expectedExecution);
+  const fingerprint = sha256Schema.parse(context.configurationFingerprint);
+  const external = context.externalVerification;
+  const authoritativeCheck =
+    result.protected_violations.length === 0 &&
+    (external?.ran === true || result.check.ran);
+  const m5CheckMs = result.telemetry?.phase_ms.check ?? result.check.duration_ms ?? 0;
+  const checkMs = m5CheckMs + (external?.durationMs ?? 0);
+  const latencyMs = result.usage.wall_ms + (checkMs ?? 0);
+  const rawPhase = result.telemetry?.phase_ms;
+  const phase = rawPhase || checkMs > 0
+    ? { ...rawPhase, ...(checkMs > 0 ? { check: checkMs } : {}) }
+    : undefined;
+
+  return learningObservationSchema.parse({
+    experiment_id: context.experimentId,
+    run_id: context.runId,
+    sample_id: context.sampleId,
+    arm: context.arm,
+    holdout: context.holdout,
+    configuration_fingerprint: fingerprint,
+    quality_outcome: qualityOf(result, external),
+    product_outcome: "unrated",
+    verifier: authoritativeCheck
+      ? {
+          kind: "mechanical",
+          independent: true,
+          id: external?.ran ? external.id : "m5-check-cmd",
+          version: external?.ran ? external.version : "1",
+        }
+      : { kind: "none", independent: false },
+    latency_ms: latencyMs,
+    cost_usd: 0,
+    edit_start_ms: result.telemetry?.edit_start_ms,
+    observability_coverage: result.telemetry?.observability_coverage ?? 0,
+    edited: result.changed_files.length > 0,
+    tests_run: external?.ran ? external.testsRan : result.check.ran,
+    tests_passed: external?.ran && external.testsRan
+      ? external.passed
+      : external?.ran
+        ? undefined
+        : result.check.ran
+        ? result.check.exit_code === 0
+        : undefined,
+    phase_ms: phase && Object.values(phase).some((value) => value !== undefined)
+      ? phase
+      : undefined,
+    failure_kind: failureKindOf(result, external),
+    task_id: context.taskId,
+    ledger_id: context.ledgerId,
+    work_id: result.work_id,
+  });
+}

--- a/src/learning/m5-code-loop-client.ts
+++ b/src/learning/m5-code-loop-client.ts
@@ -1,0 +1,176 @@
+/** Minimal owner-authenticated JSON-RPC client for M5's async code_loop tools. */
+
+import { z } from "zod";
+import {
+  m5CodeLoopResultSchema,
+  type M5CodeLoopResult,
+} from "./m5-code-loop-adapter.js";
+
+export interface M5CodeLoopClientConfig {
+  endpoint: string;
+  bearerToken: string;
+  requestTimeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}
+
+export interface M5CodeLoopRequest {
+  instruction: string;
+  files: Array<{ path: string; content: string }>;
+  check_cmd?: string;
+  protected?: string[];
+  task_type?: string;
+  caps?: {
+    wall_s?: number;
+    turns?: number;
+    completion_tokens?: number;
+    /** Proposed in gille-inference #247. */
+    edit_deadline_turn?: number;
+  };
+}
+
+const startSchema = z.object({
+  work_id: z.string().min(1),
+  status: z.literal("running"),
+}).strict();
+
+const statusSchema = z.object({
+  status: z.enum([
+    "running",
+    "completed",
+    "cap-exceeded",
+    "degenerate",
+    "arm-error",
+    "orphaned",
+  ]),
+  usage: z.object({
+    turns: z.number().int().nonnegative(),
+    wall_ms: z.number().int().nonnegative(),
+    prompt_tokens: z.number().int().nonnegative(),
+    completion_tokens: z.number().int().nonnegative(),
+  }).strict(),
+}).strict();
+
+export class M5CodeLoopError extends Error {
+  constructor(message: string, public readonly detail?: unknown) {
+    super(message);
+    this.name = "M5CodeLoopError";
+  }
+}
+
+export class M5CodeLoopClient {
+  private readonly endpoint: string;
+  private readonly token: string;
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: typeof fetch;
+  private nextId = 1;
+
+  constructor(config: M5CodeLoopClientConfig) {
+    const endpoint = new URL(config.endpoint);
+    if (endpoint.protocol !== "http:" && endpoint.protocol !== "https:") {
+      throw new Error("M5 code-loop endpoint must use http(s)");
+    }
+    if (endpoint.username || endpoint.password || endpoint.search || endpoint.hash) {
+      throw new Error("M5 code-loop endpoint must not contain credentials, query, or fragment");
+    }
+    if (endpoint.pathname !== "/mcp") {
+      throw new Error(`M5 code-loop endpoint path must be /mcp; got ${endpoint.pathname}`);
+    }
+    if (config.bearerToken.trim() === "") throw new Error("M5 bearer token is required");
+    this.endpoint = endpoint.toString();
+    this.token = config.bearerToken;
+    this.timeoutMs = config.requestTimeoutMs ?? 30_000;
+    this.fetchImpl = config.fetchImpl ?? fetch;
+  }
+
+  async start(request: M5CodeLoopRequest): Promise<{ work_id: string; status: "running" }> {
+    return startSchema.parse(
+      await this.call("code_loop_start", { ...request }),
+    );
+  }
+
+  async status(workId: string): Promise<z.infer<typeof statusSchema>> {
+    return statusSchema.parse(await this.call("code_loop_status", { work_id: workId }));
+  }
+
+  async result(workId: string): Promise<M5CodeLoopResult> {
+    return m5CodeLoopResultSchema.parse(
+      await this.call("code_loop_result", { work_id: workId }),
+    );
+  }
+
+  async toolDefinitions(): Promise<Array<Record<string, unknown>>> {
+    const response = await this.rpc("tools/list", {});
+    if (!response || typeof response !== "object" || !Array.isArray((response as { tools?: unknown }).tools)) {
+      throw new M5CodeLoopError("M5 tools/list returned an invalid payload");
+    }
+    return (response as { tools: Array<Record<string, unknown>> }).tools;
+  }
+
+  private async call(name: string, args: Record<string, unknown>): Promise<unknown> {
+    const response = await this.rpc("tools/call", { name, arguments: args });
+    if (!response || typeof response !== "object") {
+      throw new M5CodeLoopError(`M5 ${name} returned an invalid result`);
+    }
+    const result = response as { isError?: unknown; content?: unknown };
+    if (!Array.isArray(result.content)) {
+      throw new M5CodeLoopError(`M5 ${name} returned no content`);
+    }
+    const text = result.content.find(
+      (item): item is { type: "text"; text: string } =>
+        !!item && typeof item === "object" &&
+        (item as { type?: unknown }).type === "text" &&
+        typeof (item as { text?: unknown }).text === "string",
+    )?.text;
+    if (text === undefined) throw new M5CodeLoopError(`M5 ${name} returned no text content`);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      throw new M5CodeLoopError(`M5 ${name} returned non-JSON text`);
+    }
+    if (result.isError === true) {
+      throw new M5CodeLoopError(`M5 ${name} refused or failed`, parsed);
+    }
+    return parsed;
+  }
+
+  private async rpc(method: string, params: Record<string, unknown>): Promise<unknown> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const response = await this.fetchImpl(this.endpoint, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${this.token}`,
+          "content-type": "application/json",
+          accept: "application/json",
+        },
+        body: JSON.stringify({ jsonrpc: "2.0", id: this.nextId++, method, params }),
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new M5CodeLoopError(`M5 JSON-RPC returned HTTP ${response.status}`);
+      }
+      const body = await response.json() as {
+        error?: { code?: unknown; message?: unknown };
+        result?: unknown;
+      };
+      if (body.error) {
+        throw new M5CodeLoopError(
+          `M5 JSON-RPC error ${String(body.error.code ?? "unknown")}: ${String(body.error.message ?? "unknown")}`,
+        );
+      }
+      return body.result;
+    } catch (err) {
+      if (err instanceof M5CodeLoopError) throw err;
+      if (err instanceof Error && err.name === "AbortError") {
+        throw new M5CodeLoopError(`M5 JSON-RPC timed out after ${this.timeoutMs}ms`);
+      }
+      throw new M5CodeLoopError(
+        `M5 JSON-RPC request failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 /**
  * hugin-mcp — stdio MCP server that exposes the Pi-side broker's
- * `/v1/delegate/*` endpoints to a local Claude Code or Claude Desktop
- * session.
+ * delegation and versioned-learning endpoints to a local Claude Code or
+ * Claude Desktop session.
  *
  * Wiring:
  *   stdio  ↔  McpServer  ↔  buildTools()  ↔  BrokerClient  ↔  HTTP /v1/delegate
@@ -131,6 +131,11 @@ export async function main(): Promise<void> {
     tools.rate as HuginTool<Record<string, unknown>>,
     tools.list as HuginTool<Record<string, unknown>>,
     tools.models as HuginTool<Record<string, unknown>>,
+    tools.experimentCreate as HuginTool<Record<string, unknown>>,
+    tools.experimentObserve as HuginTool<Record<string, unknown>>,
+    tools.experimentRate as HuginTool<Record<string, unknown>>,
+    tools.experimentStatus as HuginTool<Record<string, unknown>>,
+    tools.experimentPromote as HuginTool<Record<string, unknown>>,
   ];
   for (const tool of allTools) {
     server.registerTool(

--- a/src/mcp/broker-client.ts
+++ b/src/mcp/broker-client.ts
@@ -1,8 +1,8 @@
 /**
  * HTTP client for the Pi-side orchestrator broker.
  *
- * Used by the hugin-mcp server (laptop-side). Wraps the five
- * `/v1/delegate/*` endpoints with typed methods, bearer-token auth,
+ * Used by the hugin-mcp server (laptop-side). Wraps the delegation and
+ * learning-loop endpoints with typed methods, bearer-token auth,
  * and bounded timeouts.
  *
  * The broker is exposed only on the Tailscale interface (per
@@ -102,6 +102,26 @@ export class BrokerClient {
 
   async models(): Promise<unknown> {
     return this.get("/v1/delegate/models");
+  }
+
+  async experimentCreate(payload: Record<string, unknown>): Promise<unknown> {
+    return this.post("/v1/learning/experiments/create", payload);
+  }
+
+  async experimentObserve(payload: Record<string, unknown>): Promise<unknown> {
+    return this.post("/v1/learning/experiments/observe", payload);
+  }
+
+  async experimentRate(payload: Record<string, unknown>): Promise<unknown> {
+    return this.post("/v1/learning/experiments/rate", payload);
+  }
+
+  async experimentStatus(payload: Record<string, unknown>): Promise<unknown> {
+    return this.post("/v1/learning/experiments/status", payload);
+  }
+
+  async experimentPromote(payload: Record<string, unknown>): Promise<unknown> {
+    return this.post("/v1/learning/experiments/promote", payload);
   }
 
   private async post(path: string, body: unknown): Promise<unknown> {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,8 +1,11 @@
 /**
  * Tool definitions for hugin-mcp.
  *
- * Five tools mirror the broker's `/v1/delegate/*` endpoints:
+ * Five delegation tools mirror the broker's `/v1/delegate/*` endpoints:
  *   hugin_submit, hugin_await, hugin_rate, hugin_list, hugin_models.
+ * Five learning tools expose the durable champion/challenger loop:
+ *   hugin_experiment_create, hugin_experiment_observe,
+ *   hugin_experiment_rate, hugin_experiment_status, hugin_experiment_promote.
  *
  * The MCP layer is the only place that fills in protocol envelope
  * fields (`envelope_version`, `alias_map_version`, `idempotency_key`,
@@ -28,6 +31,18 @@ import {
   BrokerNetworkError,
   type BrokerClient,
 } from "./broker-client.js";
+import {
+  learningExperimentCreateInputShape,
+  learningExperimentCreateSchema,
+  learningExperimentPromoteInputShape,
+  learningExperimentPromoteSchema,
+  learningExperimentRateInputShape,
+  learningExperimentRateSchema,
+  learningExperimentStatusInputShape,
+  learningExperimentStatusSchema,
+  learningObservationInputShape,
+  learningObservationSchema,
+} from "../learning/experiment-schema.js";
 
 export const ALIAS_MAP_VERSION = 2;
 export const ENVELOPE_VERSION = 2 as const;
@@ -141,6 +156,11 @@ const listInputSchema = z.object(listInputShape);
 export const modelsInputShape = {};
 const modelsInputSchema = z.object(modelsInputShape);
 
+export const experimentCreateInputShape = learningExperimentCreateInputShape;
+export const experimentObserveInputShape = learningObservationInputShape;
+export const experimentStatusInputShape = learningExperimentStatusInputShape;
+export const experimentPromoteInputShape = learningExperimentPromoteInputShape;
+
 export interface HuginTool<I extends Record<string, unknown>> {
   name: string;
   title: string;
@@ -211,6 +231,11 @@ export function buildTools(deps: ToolDeps): {
   rate: HuginTool<z.infer<typeof rateInputSchema>>;
   list: HuginTool<z.infer<typeof listInputSchema>>;
   models: HuginTool<z.infer<typeof modelsInputSchema>>;
+  experimentCreate: HuginTool<z.infer<typeof learningExperimentCreateSchema>>;
+  experimentObserve: HuginTool<z.infer<typeof learningObservationSchema>>;
+  experimentRate: HuginTool<z.infer<typeof learningExperimentRateSchema>>;
+  experimentStatus: HuginTool<z.infer<typeof learningExperimentStatusSchema>>;
+  experimentPromote: HuginTool<z.infer<typeof learningExperimentPromoteSchema>>;
 } {
   const newId = deps.newId ?? randomUUID;
   const executableAliases = deps.executableAliases ?? ["m5"];
@@ -343,5 +368,96 @@ export function buildTools(deps: ToolDeps): {
     },
   };
 
-  return { submit, await_, rate, list, models };
+  const experimentCreate: HuginTool<z.infer<typeof learningExperimentCreateSchema>> = {
+    name: "hugin_experiment_create",
+    title: "Create a versioned learning experiment",
+    description:
+      "Create or idempotently reopen one content-blind champion/challenger experiment. Exactly one logging, test-harness, prompt, harness, model, model-config, or routing axis may differ. Prompts and fixtures stay in their owning repos; only versions and SHA-256 fingerprints are stored.",
+    inputShape: experimentCreateInputShape,
+    handler: async (rawInput) => {
+      try {
+        const input = learningExperimentCreateSchema.parse(rawInput);
+        return asResult(await deps.broker.experimentCreate(input));
+      } catch (err) {
+        return asResult(errorPayload(err), true);
+      }
+    },
+  };
+
+  const experimentObserve: HuginTool<z.infer<typeof learningObservationSchema>> = {
+    name: "hugin_experiment_observe",
+    title: "Record one experiment-arm observation",
+    description:
+      "Append idempotent evidence for one champion or challenger run. Matching uses sample_id; promotion is evaluated only from matched pairs, requires holdout and independent verification coverage, and automatically rejects measured regressions.",
+    inputShape: experimentObserveInputShape,
+    handler: async (rawInput) => {
+      try {
+        const input = learningObservationSchema.parse(rawInput);
+        return asResult(await deps.broker.experimentObserve(input));
+      } catch (err) {
+        return asResult(errorPayload(err), true);
+      }
+    },
+  };
+
+  const experimentRate: HuginTool<z.infer<typeof learningExperimentRateSchema>> = {
+    name: "hugin_experiment_rate",
+    title: "Add a product rating to an experiment run",
+    description:
+      "Enrich one already-recorded unrated run with its human/downstream usefulness outcome and optional review time. The transition is one-way and idempotent; an existing rating can never be overwritten.",
+    inputShape: learningExperimentRateInputShape,
+    handler: async (rawInput) => {
+      try {
+        const input = learningExperimentRateSchema.parse(rawInput);
+        return asResult(await deps.broker.experimentRate(input));
+      } catch (err) {
+        return asResult(errorPayload(err), true);
+      }
+    },
+  };
+
+  const experimentStatus: HuginTool<z.infer<typeof learningExperimentStatusSchema>> = {
+    name: "hugin_experiment_status",
+    title: "Read a learning experiment and its promotion gate",
+    description:
+      "Read the durable experiment state, matched-pair metrics, guard failures, dominant failure signals, and next action. A promotion-ready state is evidence for operator review, never an uncontrolled production mutation.",
+    inputShape: experimentStatusInputShape,
+    handler: async (rawInput) => {
+      try {
+        const input = learningExperimentStatusSchema.parse(rawInput);
+        return asResult(await deps.broker.experimentStatus(input));
+      } catch (err) {
+        return asResult(errorPayload(err), true);
+      }
+    },
+  };
+
+  const experimentPromote: HuginTool<z.infer<typeof learningExperimentPromoteSchema>> = {
+    name: "hugin_experiment_promote",
+    title: "Record reviewed promotion of a winning challenger",
+    description:
+      "After the owning configuration repository has applied and reviewed a promotion-ready challenger, advance the scope's durable champion pointer. Requires the exact evaluated fingerprint and an applied commit/config reference. Future experiments for the scope must start from this champion.",
+    inputShape: experimentPromoteInputShape,
+    handler: async (rawInput) => {
+      try {
+        const input = learningExperimentPromoteSchema.parse(rawInput);
+        return asResult(await deps.broker.experimentPromote(input));
+      } catch (err) {
+        return asResult(errorPayload(err), true);
+      }
+    },
+  };
+
+  return {
+    submit,
+    await_,
+    rate,
+    list,
+    models,
+    experimentCreate,
+    experimentObserve,
+    experimentRate,
+    experimentStatus,
+    experimentPromote,
+  };
 }

--- a/tests/fixtures/learning.ts
+++ b/tests/fixtures/learning.ts
@@ -1,0 +1,141 @@
+import {
+  learningExperimentCreateSchema,
+  learningObservationSchema,
+  computeConfigurationFingerprint,
+  type LearningConfiguration,
+  type LearningExperimentCreate,
+  type LearningObservationInput,
+} from "../../src/learning/experiment-schema.js";
+
+const hash = (char: string) => char.repeat(64);
+
+export function makeLearningConfig(
+  arm: "champion" | "challenger",
+  axis: LearningExperimentCreate["change_axis"] = "agent-harness",
+): LearningConfiguration {
+  const changed = arm === "challenger";
+  const base: LearningConfiguration = {
+    fingerprint: changed ? hash("b") : hash("a"),
+    prompt: { id: "code-worker", version: "1", sha256: hash("c") },
+    harness: {
+      id: "pi-code-loop",
+      version: "1",
+      configSha256: hash("d"),
+      maxTurns: 13,
+      timeoutMs: 600_000,
+    },
+    model: {
+      id: "qwen3-coder-next-80b",
+      provider: "m5",
+      runtime: "llama-swap",
+      config: {
+        quantization: "q4-k-m",
+        contextWindow: 131_072,
+        maxOutputTokens: 16_384,
+        temperature: 0.2,
+      },
+    },
+    logging: { schemaVersion: "1", requiredFieldsSha256: hash("e") },
+    testHarness: {
+      id: "wave-five",
+      version: "1",
+      corpusSha256: hash("f"),
+      oracleVersion: "protected-check-v1",
+      holdoutRevision: "holdout-1",
+    },
+    routing: { policyId: "m5-shadow", version: "1", configSha256: hash("1") },
+  };
+  if (!changed) {
+    base.fingerprint = computeConfigurationFingerprint(base);
+    return base;
+  }
+
+  switch (axis) {
+    case "logging":
+      base.logging = { schemaVersion: "2", requiredFieldsSha256: hash("2") };
+      break;
+    case "test-harness":
+      base.testHarness = { ...base.testHarness, version: "2", corpusSha256: hash("2") };
+      break;
+    case "agent-prompt":
+      base.prompt = { ...base.prompt, version: "2", sha256: hash("2") };
+      break;
+    case "agent-harness":
+      base.harness = {
+        ...base.harness,
+        version: "2",
+        configSha256: hash("2"),
+        editDeadlineTurn: 6,
+      };
+      break;
+    case "model":
+      base.model = { ...base.model, id: "candidate-coder-80b" };
+      break;
+    case "model-config":
+      base.model = { ...base.model, config: { ...base.model.config, temperature: 0.1 } };
+      break;
+    case "routing":
+      base.routing = { policyId: "m5-canary", version: "2", configSha256: hash("2") };
+      break;
+  }
+  base.fingerprint = computeConfigurationFingerprint(base);
+  return base;
+}
+
+export function makeExperimentInput(
+  overrides: Partial<LearningExperimentCreate> = {},
+): LearningExperimentCreate {
+  const axis = overrides.change_axis ?? "agent-harness";
+  return learningExperimentCreateSchema.parse({
+    experiment_id: "wave-six-edit-deadline",
+    scope: "m5-code-edit",
+    task_type: "code-edit",
+    hypothesis: "An edit deadline makes the harness edit before exhausting its turn budget.",
+    change_axis: axis,
+    champion: makeLearningConfig("champion", axis),
+    challenger: makeLearningConfig("challenger", axis),
+    gates: {
+      minMatchedPairs: 2,
+      minHoldoutPairs: 1,
+      minVerifiedCoverage: 1,
+      minRatedCoverage: 1,
+      maxQualityRegression: 0,
+      maxUsefulRegression: 0,
+      maxRescueRateIncrease: 0,
+      maxInfraRateIncrease: 0,
+      maxLatencyRatio: 1.25,
+      maxCostRatio: 1.25,
+      primaryMetric: "edit-start-ms",
+      minPrimaryImprovement: 0.1,
+    },
+    ...overrides,
+  });
+}
+
+export function makeObservation(
+  sample: string,
+  arm: "champion" | "challenger",
+  overrides: Partial<LearningObservationInput> = {},
+): LearningObservationInput {
+  return learningObservationSchema.parse({
+    experiment_id: "wave-six-edit-deadline",
+    run_id: `${sample}-${arm}`,
+    sample_id: sample,
+    arm,
+    holdout: sample === "case-2",
+    configuration_fingerprint: makeLearningConfig(arm).fingerprint,
+    quality_outcome: "pass",
+    product_outcome: "accepted-unchanged",
+    verifier: { kind: "mechanical", independent: true, id: "protected-check", version: "1" },
+    latency_ms: arm === "champion" ? 100_000 : 90_000,
+    cost_usd: 0,
+    human_review_seconds: arm === "champion" ? 60 : 50,
+    edit_start_ms: arm === "champion" ? 60_000 : 40_000,
+    observability_coverage: 1,
+    verifier_score: 1,
+    edited: true,
+    tests_run: true,
+    tests_passed: true,
+    ...overrides,
+  });
+}

--- a/tests/learning-experiment-http.test.ts
+++ b/tests/learning-experiment-http.test.ts
@@ -1,0 +1,188 @@
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildBrokerApp } from "../src/broker/server.js";
+import { brokerExecutorCapabilities } from "../src/broker/executor-capabilities.js";
+import type { BrokerTaskStore } from "../src/broker/task-store.js";
+import type { DelegationJournal } from "../src/broker/journal.js";
+import type { IdempotencyIndex } from "../src/broker/idempotency.js";
+import type { MuninClient, MuninEntry } from "../src/munin-client.js";
+import { LearningExperimentStore } from "../src/learning/experiment-store.js";
+import { makeExperimentInput, makeObservation } from "./fixtures/learning.js";
+
+const CODEX_TOKEN = "a".repeat(64);
+const CLAUDE_TOKEN = "b".repeat(64);
+
+class FakeMunin {
+  entries = new Map<string, MuninEntry & { found: true }>();
+  revision = 0;
+
+  async read(namespace: string, key: string) {
+    return this.entries.get(`${namespace}/${key}`) ?? null;
+  }
+
+  async write(
+    namespace: string,
+    key: string,
+    content: string,
+    tags?: string[],
+    expectedUpdatedAt?: string,
+    classification?: string,
+  ): Promise<Record<string, unknown>> {
+    const id = `${namespace}/${key}`;
+    const existing = this.entries.get(id);
+    if (expectedUpdatedAt && existing?.updated_at !== expectedUpdatedAt) {
+      throw new Error("CAS conflict");
+    }
+    const timestamp = `2026-07-13T12:00:${String(++this.revision).padStart(2, "0")}.000Z`;
+    this.entries.set(id, {
+      id,
+      namespace,
+      key,
+      content,
+      tags: tags ?? [],
+      classification,
+      created_at: existing?.created_at ?? timestamp,
+      updated_at: timestamp,
+      found: true,
+    });
+    return { ok: true };
+  }
+}
+
+let baseUrl = "";
+let closeServer: (() => Promise<void>) | null = null;
+
+beforeEach(async () => {
+  const munin = new FakeMunin();
+  const app = buildBrokerApp({
+    host: "127.0.0.1",
+    port: 0,
+    keys: { codex: CODEX_TOKEN, "claude-code": CLAUDE_TOKEN },
+    learningStore: new LearningExperimentStore(munin as unknown as MuninClient),
+    deps: {
+      taskStore: {} as BrokerTaskStore,
+      journal: {} as DelegationJournal,
+      idempotency: {} as IdempotencyIndex,
+      executorCapabilities: brokerExecutorCapabilities({ homeserverEnabled: true }),
+    },
+  });
+  const server = createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  closeServer = () => new Promise<void>((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+});
+
+afterEach(async () => {
+  await closeServer?.();
+  closeServer = null;
+});
+
+function headers(token = CODEX_TOKEN): Record<string, string> {
+  return {
+    authorization: `Bearer ${token}`,
+    "content-type": "application/json",
+  };
+}
+
+async function post(path: string, body: unknown, token = CODEX_TOKEN): Promise<Response> {
+  return fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: headers(token),
+    body: JSON.stringify(body),
+  });
+}
+
+describe("Broker continuous-learning HTTP API", () => {
+  it("requires Broker authentication", async () => {
+    const response = await fetch(`${baseUrl}/v1/learning/experiments/status`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ experiment_id: "wave-six-edit-deadline" }),
+    });
+    expect(response.status).toBe(401);
+  });
+
+  it("runs a matched experiment through to a promotion-ready decision", async () => {
+    const experiment = makeExperimentInput();
+    const created = await post("/v1/learning/experiments/create", experiment);
+    expect(created.status).toBe(201);
+
+    for (const sample of ["case-1", "case-2"]) {
+      for (const arm of ["champion", "challenger"] as const) {
+        const observed = await post(
+          "/v1/learning/experiments/observe",
+          makeObservation(sample, arm),
+        );
+        expect(observed.status).toBe(200);
+      }
+    }
+
+    const status = await post("/v1/learning/experiments/status", {
+      experiment_id: "wave-six-edit-deadline",
+    });
+    expect(status.status).toBe(200);
+    const body = await status.json() as {
+      state: { status: string; evaluation: { decision: string; matchedPairs: number } };
+    };
+    expect(body.state.status).toBe("promotion-ready");
+    expect(body.state.evaluation).toMatchObject({
+      decision: "promotion-ready",
+      matchedPairs: 2,
+    });
+
+    const promoted = await post("/v1/learning/experiments/promote", {
+      experiment_id: "wave-six-edit-deadline",
+      configuration_fingerprint: experiment.challenger.fingerprint,
+      applied_ref: "gille-inference@abc123",
+    });
+    expect(promoted.status).toBe(200);
+    expect(await promoted.json()).toMatchObject({
+      state: { status: "promoted" },
+      champion: {
+        sourceExperimentId: "wave-six-edit-deadline",
+        appliedRef: "gille-inference@abc123",
+      },
+    });
+  });
+
+  it("isolates experiment state by authenticated principal", async () => {
+    expect((await post("/v1/learning/experiments/create", makeExperimentInput())).status).toBe(201);
+    const other = await post(
+      "/v1/learning/experiments/status",
+      { experiment_id: "wave-six-edit-deadline" },
+      CLAUDE_TOKEN,
+    );
+    expect(other.status).toBe(404);
+  });
+
+  it("adds a later product rating through a dedicated authenticated endpoint", async () => {
+    expect((await post("/v1/learning/experiments/create", makeExperimentInput())).status).toBe(201);
+    const observation = makeObservation("case-1", "champion", {
+      product_outcome: "unrated",
+      human_review_seconds: undefined,
+    });
+    expect((await post("/v1/learning/experiments/observe", observation)).status).toBe(200);
+
+    const rated = await post("/v1/learning/experiments/rate", {
+      experiment_id: observation.experiment_id,
+      run_id: observation.run_id,
+      product_outcome: "accepted-unchanged",
+      human_review_seconds: 15,
+    });
+    expect(rated.status).toBe(200);
+    expect(await rated.json()).toMatchObject({
+      reused: false,
+      state: {
+        observations: [{
+          run_id: observation.run_id,
+          product_outcome: "accepted-unchanged",
+          human_review_seconds: 15,
+          product_rated_by: "codex",
+        }],
+      },
+    });
+  });
+});

--- a/tests/learning-experiment.test.ts
+++ b/tests/learning-experiment.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, it } from "vitest";
+import type { MuninClient, MuninEntry } from "../src/munin-client.js";
+import { evaluateLearningExperiment } from "../src/learning/experiment-evaluator.js";
+import {
+  computeConfigurationFingerprint,
+  learningExperimentCreateSchema,
+  type RecordedLearningObservation,
+} from "../src/learning/experiment-schema.js";
+import {
+  LearningExperimentStore,
+  LearningStoreError,
+} from "../src/learning/experiment-store.js";
+import {
+  makeExperimentInput,
+  makeLearningConfig,
+  makeObservation,
+} from "./fixtures/learning.js";
+
+function recorded(
+  input: ReturnType<typeof makeObservation>,
+): RecordedLearningObservation {
+  return { ...input, recorded_at: "2026-07-13T12:00:00.000Z", recorded_by: "codex" };
+}
+
+describe("learning experiment schema", () => {
+  it("accepts a single declared change axis", () => {
+    expect(makeExperimentInput().change_axis).toBe("agent-harness");
+  });
+
+  it("rejects a challenger that changes more than the declared axis", () => {
+    const challenger = makeLearningConfig("challenger", "agent-harness");
+    challenger.model.config.temperature = 0.8;
+    const parsed = learningExperimentCreateSchema.safeParse({
+      ...makeExperimentInput(),
+      challenger,
+    });
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) expect(parsed.error.message).toMatch(/exactly one declared axis/);
+  });
+
+  it("rejects a stale top-level fingerprint after configuration changes", () => {
+    const config = makeLearningConfig("challenger", "agent-harness");
+    config.harness.maxTurns = 99;
+    expect(learningExperimentCreateSchema.safeParse({
+      ...makeExperimentInput(),
+      challenger: config,
+    }).success).toBe(false);
+  });
+});
+
+describe("evaluateLearningExperiment", () => {
+  it("stays in gathering until matched, independently verified holdout evidence exists", () => {
+    const input = makeExperimentInput();
+    const evaluation = evaluateLearningExperiment({
+      observations: [recorded(makeObservation("case-1", "champion"))],
+      gates: input.gates,
+      now: () => new Date("2026-07-13T12:00:00.000Z"),
+    });
+    expect(evaluation.decision).toBe("gathering");
+    expect(evaluation.matchedPairs).toBe(0);
+    expect(evaluation.missingRequirements.join(" ")).toMatch(/matched pair/);
+  });
+
+  it("marks a faster non-regressing challenger promotion-ready", () => {
+    const input = makeExperimentInput();
+    const observations = ["case-1", "case-2"].flatMap((sample) => [
+      recorded(makeObservation(sample, "champion")),
+      recorded(makeObservation(sample, "challenger")),
+    ]);
+    const evaluation = evaluateLearningExperiment({ observations, gates: input.gates });
+    expect(evaluation.decision).toBe("promotion-ready");
+    expect(evaluation.primaryImprovement).toBeCloseTo(1 / 3);
+    expect(evaluation.guardFailures).toEqual([]);
+  });
+
+  it("rejects a faster challenger when correctness regresses", () => {
+    const input = makeExperimentInput();
+    const observations = ["case-1", "case-2"].flatMap((sample) => [
+      recorded(makeObservation(sample, "champion")),
+      recorded(makeObservation(sample, "challenger", {
+        quality_outcome: sample === "case-1" ? "fail" : "pass",
+        product_outcome: sample === "case-1" ? "discarded" : "accepted-unchanged",
+        failure_kind: sample === "case-1" ? "tests-failed" : undefined,
+      })),
+    ]);
+    const evaluation = evaluateLearningExperiment({ observations, gates: input.gates });
+    expect(evaluation.decision).toBe("reject");
+    expect(evaluation.guardFailures.join(" ")).toMatch(/quality regression/);
+    expect(evaluation.failureSignals[0]).toMatchObject({ signal: "tests-failed" });
+  });
+
+  it("does not count a judge-only verdict as verified quality evidence", () => {
+    const input = makeExperimentInput();
+    const observations = ["case-1", "case-2"].flatMap((sample) => [
+      recorded(makeObservation(sample, "champion", {
+        verifier: { kind: "judge", independent: true },
+      })),
+      recorded(makeObservation(sample, "challenger", {
+        verifier: { kind: "judge", independent: true },
+      })),
+    ]);
+    const evaluation = evaluateLearningExperiment({ observations, gates: input.gates });
+    expect(evaluation.decision).toBe("gathering");
+    expect(evaluation.champion.verifiedSamples).toBe(0);
+    expect(evaluation.missingRequirements.join(" ")).toMatch(/verified coverage/);
+  });
+
+  it("requires scalar primary measurements from the same matched samples", () => {
+    const input = makeExperimentInput();
+    const observations = [
+      recorded(makeObservation("case-1", "champion", { edit_start_ms: 50_000 })),
+      recorded(makeObservation("case-1", "challenger", { edit_start_ms: undefined })),
+      recorded(makeObservation("case-2", "champion", { edit_start_ms: undefined })),
+      recorded(makeObservation("case-2", "challenger", { edit_start_ms: 30_000 })),
+    ];
+    const evaluation = evaluateLearningExperiment({ observations, gates: input.gates });
+    expect(evaluation.decision).toBe("gathering");
+    expect(evaluation.primaryChampion).toBeNull();
+    expect(evaluation.primaryChallenger).toBeNull();
+    expect(evaluation.missingRequirements.join(" ")).toMatch(/paired measurement/);
+  });
+});
+
+class FakeMunin {
+  entries = new Map<string, MuninEntry & { found: true }>();
+  revision = 0;
+
+  async read(namespace: string, key: string) {
+    return this.entries.get(`${namespace}/${key}`) ?? null;
+  }
+
+  async write(
+    namespace: string,
+    key: string,
+    content: string,
+    tags?: string[],
+    expectedUpdatedAt?: string,
+    classification?: string,
+  ): Promise<Record<string, unknown>> {
+    const id = `${namespace}/${key}`;
+    const existing = this.entries.get(id);
+    if (expectedUpdatedAt && existing?.updated_at !== expectedUpdatedAt) {
+      throw new Error("CAS conflict");
+    }
+    const now = `2026-07-13T12:00:${String(++this.revision).padStart(2, "0")}.000Z`;
+    this.entries.set(id, {
+      id,
+      namespace,
+      key,
+      content,
+      tags: tags ?? [],
+      classification,
+      created_at: existing?.created_at ?? now,
+      updated_at: now,
+      found: true,
+    });
+    return { ok: true };
+  }
+}
+
+describe("LearningExperimentStore", () => {
+  it("persists observations idempotently and closes a winning experiment", async () => {
+    const munin = new FakeMunin();
+    let tick = 0;
+    const store = new LearningExperimentStore(munin as unknown as MuninClient, {
+      now: () => new Date(1_720_872_000_000 + tick++ * 1_000),
+    });
+    const created = await store.create("codex", makeExperimentInput());
+    expect(created.reused).toBe(false);
+    expect(created.state.status).toBe("running");
+
+    for (const sample of ["case-1", "case-2"]) {
+      await store.observe("codex", makeObservation(sample, "champion"));
+      await store.observe("codex", makeObservation(sample, "challenger"));
+    }
+    const state = await store.read("codex", "wave-six-edit-deadline");
+    expect(state.status).toBe("promotion-ready");
+    expect(state.evaluation.decision).toBe("promotion-ready");
+    expect(state.observations).toHaveLength(4);
+
+    await expect(
+      store.observe("codex", makeObservation("case-3", "challenger")),
+    ).rejects.toMatchObject({ code: "invalid-state" });
+
+    const promoted = await store.promote("codex", {
+      experiment_id: "wave-six-edit-deadline",
+      configuration_fingerprint: created.state.challenger.fingerprint,
+      applied_ref: "gille-inference@abc123",
+    });
+    expect(promoted.state.status).toBe("promoted");
+    expect(promoted.champion.configuration.fingerprint).toBe(
+      created.state.challenger.fingerprint,
+    );
+    expect((await store.promote("codex", {
+      experiment_id: "wave-six-edit-deadline",
+      configuration_fingerprint: created.state.challenger.fingerprint,
+      applied_ref: "gille-inference@abc123",
+    })).reused).toBe(true);
+  });
+
+  it("reuses an identical run_id but rejects conflicting evidence", async () => {
+    const store = new LearningExperimentStore(new FakeMunin() as unknown as MuninClient);
+    await store.create("codex", makeExperimentInput());
+    const observation = makeObservation("case-1", "champion");
+    expect((await store.observe("codex", observation)).reused).toBe(false);
+    expect((await store.observe("codex", observation)).reused).toBe(true);
+    await expect(
+      store.observe("codex", { ...observation, latency_ms: 999 }),
+    ).rejects.toBeInstanceOf(LearningStoreError);
+  });
+
+  it("enriches an unrated observation exactly once without weakening idempotency", async () => {
+    const store = new LearningExperimentStore(new FakeMunin() as unknown as MuninClient, {
+      now: () => new Date("2026-07-13T12:00:00.000Z"),
+    });
+    await store.create("codex", makeExperimentInput());
+    const observation = makeObservation("case-1", "champion", {
+      product_outcome: "unrated",
+      human_review_seconds: undefined,
+    });
+    await store.observe("codex", observation);
+
+    const rated = await store.rate("codex", {
+      experiment_id: observation.experiment_id,
+      run_id: observation.run_id,
+      product_outcome: "minor-edit",
+      human_review_seconds: 42,
+    });
+    expect(rated.reused).toBe(false);
+    expect(rated.state.observations[0]).toMatchObject({
+      product_outcome: "minor-edit",
+      human_review_seconds: 42,
+      product_rated_by: "codex",
+    });
+
+    expect((await store.rate("codex", {
+      experiment_id: observation.experiment_id,
+      run_id: observation.run_id,
+      product_outcome: "minor-edit",
+      human_review_seconds: 42,
+    })).reused).toBe(true);
+    await expect(store.rate("codex", {
+      experiment_id: observation.experiment_id,
+      run_id: observation.run_id,
+      product_outcome: "discarded",
+      human_review_seconds: 42,
+    })).rejects.toMatchObject({ code: "conflict" });
+  });
+
+  it("rejects rating an unknown run", async () => {
+    const store = new LearningExperimentStore(new FakeMunin() as unknown as MuninClient);
+    await store.create("codex", makeExperimentInput());
+    await expect(store.rate("codex", {
+      experiment_id: "wave-six-edit-deadline",
+      run_id: "missing",
+      product_outcome: "accepted-unchanged",
+    })).rejects.toMatchObject({ code: "not-found" });
+  });
+
+  it("rejects evidence produced by a configuration outside the experiment contract", async () => {
+    const store = new LearningExperimentStore(new FakeMunin() as unknown as MuninClient);
+    await store.create("codex", makeExperimentInput());
+    await expect(
+      store.observe("codex", {
+        ...makeObservation("case-1", "challenger"),
+        configuration_fingerprint: "f".repeat(64),
+      }),
+    ).rejects.toMatchObject({ code: "conflict" });
+  });
+
+  it("requires the next iteration to start from the promoted scope champion", async () => {
+    const store = new LearningExperimentStore(new FakeMunin() as unknown as MuninClient);
+    const first = makeExperimentInput();
+    await store.create("codex", first);
+    for (const sample of ["case-1", "case-2"]) {
+      await store.observe("codex", makeObservation(sample, "champion"));
+      await store.observe("codex", makeObservation(sample, "challenger"));
+    }
+    await store.promote("codex", {
+      experiment_id: first.experiment_id,
+      configuration_fingerprint: first.challenger.fingerprint,
+      applied_ref: "gille-inference@abc123",
+    });
+
+    await expect(
+      store.create("codex", makeExperimentInput({ experiment_id: "obsolete-baseline" })),
+    ).rejects.toMatchObject({ code: "conflict" });
+
+    const nextChallenger = structuredClone(first.challenger);
+    nextChallenger.fingerprint = "3".repeat(64);
+    nextChallenger.harness = {
+      ...nextChallenger.harness,
+      version: "3",
+      configSha256: "3".repeat(64),
+      editDeadlineTurn: 5,
+    };
+    nextChallenger.fingerprint = computeConfigurationFingerprint(nextChallenger);
+    const next = makeExperimentInput({
+      experiment_id: "wave-seven-earlier-edit",
+      champion: first.challenger,
+      challenger: nextChallenger,
+    });
+    expect((await store.create("codex", next)).state.status).toBe("running");
+  });
+});

--- a/tests/learning-loop-collector.test.ts
+++ b/tests/learning-loop-collector.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 import { LearningLoopCollector } from "../src/learning-loop-collector.js";
 import type { MuninClient } from "../src/munin-client.js";
 import type { Ledger, LedgerClientLike } from "../src/orchestrator/ledger-client.js";
+import { evaluateLearningExperiment } from "../src/learning/experiment-evaluator.js";
+import { makeExperimentInput } from "./fixtures/learning.js";
 
 const ENVELOPE = (submitter: string) =>
   `## Task\n\n### Broker envelope\n\`\`\`json\n${JSON.stringify({
@@ -36,6 +38,52 @@ const fakeLedgerClient = (ledger: Ledger | null): LedgerClientLike => ({
 });
 
 describe("LearningLoopCollector", () => {
+  it("collects versioned experiment decisions for the operator panel", async () => {
+    const input = makeExperimentInput();
+    const state = {
+      schemaVersion: 1 as const,
+      experimentId: input.experiment_id,
+      scope: input.scope,
+      taskType: input.task_type,
+      ownerPrincipal: "codex",
+      hypothesis: input.hypothesis,
+      changeAxis: input.change_axis,
+      champion: input.champion,
+      challenger: input.challenger,
+      gates: input.gates,
+      status: "running" as const,
+      revision: 1,
+      createdAt: "2026-07-13T12:00:00.000Z",
+      updatedAt: "2026-07-13T12:00:00.000Z",
+      observations: [],
+      evaluation: evaluateLearningExperiment({ observations: [], gates: input.gates }),
+    };
+    const munin = {
+      query: vi.fn(async (query: { tags?: string[] }) =>
+        query.tags?.includes("learning:experiment")
+          ? {
+              results: [{ namespace: "experiments/hugin/wave-six-abc", key: "state" }],
+              total: 1,
+            }
+          : { results: [], total: 0 },
+      ),
+      read: vi.fn(async (namespace: string, key: string) =>
+        namespace === "experiments/hugin/wave-six-abc" && key === "state"
+          ? { content: JSON.stringify(state), tags: ["learning:experiment"] }
+          : null,
+      ),
+    } as unknown as MuninClient;
+
+    const evidence = await new LearningLoopCollector({
+      munin,
+      ledgerClient: fakeLedgerClient(null),
+    }).refresh();
+
+    expect(evidence.experimentsAvailable).toBe(true);
+    expect(evidence.experiments).toHaveLength(1);
+    expect(evidence.experiments[0]!.experimentId).toBe("wave-six-edit-deadline");
+  });
+
   it("collects rating, durable-handoff and route-policy provenance for a broker task", async () => {
     const munin = fakeMunin({
       "tasks/mcp-m5-1/status": { content: ENVELOPE("claude-code"), tags: ["completed", "broker:mcp-v2"] },
@@ -204,8 +252,8 @@ describe("LearningLoopCollector", () => {
     collector.collect();
     collector.collect();
 
-    // Cached reads do no further corpus walks (one walk = two queries).
-    expect(munin.query).toHaveBeenCalledTimes(2);
+    // Cached reads do no further walks (two task queries + one experiment query).
+    expect(munin.query).toHaveBeenCalledTimes(3);
   });
 
   it("coalesces concurrent collections into a single corpus walk", async () => {
@@ -216,8 +264,8 @@ describe("LearningLoopCollector", () => {
 
     await Promise.all([collector.refresh(), collector.refresh(), collector.refresh()]);
 
-    // One corpus walk (two queries), not three.
-    expect(munin.query).toHaveBeenCalledTimes(2);
+    // One collection (two task queries + one experiment query), not three collections.
+    expect(munin.query).toHaveBeenCalledTimes(3);
   });
 
   it("survives a corrupt feedback document without losing the whole task", async () => {

--- a/tests/learning-loop-health.test.ts
+++ b/tests/learning-loop-health.test.ts
@@ -7,6 +7,8 @@ import {
   type ProductTaskEvidence,
 } from "../src/learning-loop-health.js";
 import type { Ledger } from "../src/orchestrator/ledger-client.js";
+import { evaluateLearningExperiment } from "../src/learning/experiment-evaluator.js";
+import { makeExperimentInput } from "./fixtures/learning.js";
 
 const ledger = (rows: Partial<Ledger["report"][number]>[]): Ledger => ({
   report: rows.map((r) => ({
@@ -273,6 +275,42 @@ describe("computeProductPlane (#165 trial gate)", () => {
 });
 
 describe("buildLearningLoopPanels", () => {
+  it("surfaces the current experiment decision without claiming automatic promotion", () => {
+    const input = makeExperimentInput();
+    const evaluation = evaluateLearningExperiment({ observations: [], gates: input.gates });
+    const panels = buildLearningLoopPanels({
+      capability: computeCapabilityPlane(null),
+      product: computeProductPlane([]),
+      policy: deriveRoutePolicy([], computeCapabilityPlane(null)),
+      experiments: {
+        available: true,
+        states: [{
+          schemaVersion: 1,
+          experimentId: input.experiment_id,
+          scope: input.scope,
+          taskType: input.task_type,
+          ownerPrincipal: "codex",
+          hypothesis: input.hypothesis,
+          changeAxis: input.change_axis,
+          champion: input.champion,
+          challenger: input.challenger,
+          gates: input.gates,
+          status: "running",
+          revision: 1,
+          createdAt: evaluation.evaluatedAt,
+          updatedAt: evaluation.evaluatedAt,
+          observations: [],
+          evaluation,
+        }],
+      },
+    });
+    const panel = panels.find((candidate) => candidate.id === "hugin-learning-experiments")!;
+    expect(panel.kind).toBe("table");
+    expect(panel.rows).toEqual(expect.arrayContaining([
+      expect.objectContaining({ Experiment: input.experiment_id, State: "running" }),
+    ]));
+  });
+
   it("keeps the two evidence planes separate rather than collapsing them into one verdict", () => {
     const panels = buildLearningLoopPanels({
       capability: computeCapabilityPlane(ledger([{ attempts: 20, passes: 8, fails: 2 }])),

--- a/tests/m5-code-loop-adapter.test.ts
+++ b/tests/m5-code-loop-adapter.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import {
+  m5CodeLoopTelemetrySchema,
+  observationFromM5CodeLoop,
+} from "../src/learning/m5-code-loop-adapter.js";
+
+const context = {
+  experimentId: "gate-d-edit-deadline",
+  runId: "01-champion",
+  sampleId: "01",
+  arm: "champion" as const,
+  holdout: false,
+  configurationFingerprint: "a".repeat(64),
+};
+
+function result(overrides: Record<string, unknown> = {}) {
+  return {
+    status: "completed",
+    diff: "diff --git a/a.ts b/a.ts",
+    diff_truncated: false,
+    changed_files: ["a.ts"],
+    protected_violations: [],
+    summary: "done",
+    check: { ran: true, exit_code: 0, output_tail: "ok" },
+    usage: {
+      turns: 4,
+      wall_ms: 10_000,
+      prompt_tokens: 100,
+      completion_tokens: 50,
+    },
+    work_id: "cl-20260713-abcdef12",
+    detail: "",
+    ...overrides,
+  };
+}
+
+describe("M5 code-loop experiment adapter", () => {
+  it("maps protected-check success and phase telemetry without copying content", () => {
+    const observation = observationFromM5CodeLoop(result({
+      telemetry: {
+        schema_version: 1,
+        first_edit_turn: 2,
+        edit_start_ms: 3_000,
+        phase_ms: { inspect: 3_000, edit: 7_000, check: 500 },
+        mutation_evidence: "tool-call",
+        observability_coverage: 1,
+      },
+    }), context);
+
+    expect(observation).toMatchObject({
+      quality_outcome: "pass",
+      product_outcome: "unrated",
+      verifier: { kind: "mechanical", independent: true },
+      latency_ms: 10_500,
+      edit_start_ms: 3_000,
+      edited: true,
+      tests_run: true,
+      tests_passed: true,
+      work_id: "cl-20260713-abcdef12",
+      phase_ms: { inspect: 3_000, edit: 7_000, check: 500 },
+    });
+    expect(JSON.stringify(observation)).not.toContain("diff --git");
+    expect(JSON.stringify(observation)).not.toContain("done");
+  });
+
+  it("keeps old gateway results honest by leaving edit timing unmeasured", () => {
+    const observation = observationFromM5CodeLoop(result(), context);
+    expect(observation.edited).toBe(true);
+    expect(observation.edit_start_ms).toBeUndefined();
+    expect(observation.phase_ms).toBeUndefined();
+    expect(observation.observability_coverage).toBe(0);
+  });
+
+  it("does not fabricate edit time for diff-only mutation evidence", () => {
+    const parsed = m5CodeLoopTelemetrySchema.safeParse({
+      schema_version: 1,
+      first_edit_turn: 2,
+      edit_start_ms: 3_000,
+      phase_ms: { inspect: 3_000 },
+      mutation_evidence: "diff-only",
+      observability_coverage: 0.5,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("classifies serving failures as infra and deadline caps as quality failures", () => {
+    expect(observationFromM5CodeLoop(result({
+      status: "arm-error",
+      changed_files: [],
+      check: { ran: false, exit_code: null, output_tail: "" },
+    }), context)).toMatchObject({
+      quality_outcome: "infra-error",
+      failure_kind: "arm-error",
+      edited: false,
+    });
+    expect(observationFromM5CodeLoop(result({
+      status: "cap-exceeded",
+      changed_files: [],
+      check: { ran: false, exit_code: null, output_tail: "" },
+      telemetry: {
+        schema_version: 1,
+        phase_ms: { inspect: 8_000 },
+        mutation_evidence: "none",
+        observability_coverage: 1,
+        failure_kind: "edit-deadline",
+      },
+    }), context)).toMatchObject({
+      quality_outcome: "fail",
+      failure_kind: "edit-deadline",
+    });
+  });
+
+  it("disqualifies a protected-file violation even when check reports success", () => {
+    const observation = observationFromM5CodeLoop(result({
+      protected_violations: ["test/oracle.ts"],
+    }), context);
+    expect(observation.quality_outcome).toBe("fail");
+    expect(observation.verifier).toEqual({ kind: "none", independent: false });
+    expect(observation.failure_kind).toBe("protected-file-modified");
+  });
+
+  it("binds the recorded fingerprint to M5's effective model and caps", () => {
+    const execution = {
+      schema_version: 1 as const,
+      model: "qwen3-coder-next-80b",
+      engine: "pi",
+      harness_version: "1",
+      effective_caps: { wall_s: 600, turns: 13, completion_tokens: 60_000 },
+    };
+    expect(() => observationFromM5CodeLoop(result({ execution }), {
+      ...context,
+      expectedExecution: {
+        model: "another-model",
+        harnessVersion: execution.harness_version,
+        caps: execution.effective_caps,
+      },
+    })).toThrow(/effective model/);
+    expect(observationFromM5CodeLoop(result({ execution }), {
+      ...context,
+      expectedExecution: {
+        model: execution.model,
+        harnessVersion: execution.harness_version,
+        caps: execution.effective_caps,
+      },
+    }).configuration_fingerprint).toBe("a".repeat(64));
+  });
+
+  it("uses an external protected verifier without trusting an M5 self-check", () => {
+    const observation = observationFromM5CodeLoop(result({
+      status: "cap-exceeded",
+      check: { ran: false, exit_code: null, output_tail: "" },
+    }), {
+      ...context,
+      externalVerification: {
+        ran: true,
+        passed: true,
+        testsRan: true,
+        id: "gate-d-check",
+        version: "sha256:abc",
+        durationMs: 800,
+      },
+    });
+    expect(observation).toMatchObject({
+      quality_outcome: "pass",
+      verifier: { id: "gate-d-check", version: "sha256:abc" },
+      latency_ms: 10_800,
+      tests_run: true,
+      tests_passed: true,
+      phase_ms: { check: 800 },
+    });
+  });
+});

--- a/tests/m5-code-loop-client.test.ts
+++ b/tests/m5-code-loop-client.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { M5CodeLoopClient, M5CodeLoopError } from "../src/learning/m5-code-loop-client.js";
+
+function rpcResult(value: unknown, isError = false): Response {
+  return new Response(JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    result: {
+      content: [{ type: "text", text: JSON.stringify(value) }],
+      ...(isError ? { isError: true } : {}),
+    },
+  }), { status: 200, headers: { "content-type": "application/json" } });
+}
+
+describe("M5CodeLoopClient", () => {
+  it("calls the owner-gated tool without leaking the token into the body", async () => {
+    const fetchImpl = vi.fn(async () => rpcResult({ work_id: "cl-1", status: "running" }));
+    const client = new M5CodeLoopClient({
+      endpoint: "http://m5.test:8080/mcp",
+      bearerToken: "owner-secret",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    expect(await client.start({ instruction: "fix", files: [{ path: "a.ts", content: "x" }] }))
+      .toEqual({ work_id: "cl-1", status: "running" });
+    const [, init] = fetchImpl.mock.calls[0]!;
+    expect((init?.headers as Record<string, string>).authorization).toBe("Bearer owner-secret");
+    expect(String(init?.body)).not.toContain("owner-secret");
+    expect(JSON.parse(String(init?.body))).toMatchObject({
+      method: "tools/call",
+      params: { name: "code_loop_start" },
+    });
+  });
+
+  it("surfaces structured tool refusals without credential content", async () => {
+    const client = new M5CodeLoopClient({
+      endpoint: "http://m5.test:8080/mcp",
+      bearerToken: "owner-secret",
+      fetchImpl: (async () => rpcResult({ refusal: "busy" }, true)) as typeof fetch,
+    });
+    await expect(client.start({ instruction: "fix", files: [{ path: "a", content: "b" }] }))
+      .rejects.toMatchObject({ name: "M5CodeLoopError", detail: { refusal: "busy" } });
+  });
+
+  it("rejects unsafe or wrong-path endpoints", () => {
+    expect(() => new M5CodeLoopClient({
+      endpoint: "http://secret@m5.test:8080/mcp",
+      bearerToken: "x",
+    })).toThrow(/credentials/);
+    expect(() => new M5CodeLoopClient({
+      endpoint: "http://m5.test:8080/v1",
+      bearerToken: "x",
+    })).toThrow(/\/mcp/);
+  });
+
+  it("uses a typed error for malformed tool content", async () => {
+    const client = new M5CodeLoopClient({
+      endpoint: "http://m5.test:8080/mcp",
+      bearerToken: "x",
+      fetchImpl: (async () => new Response(JSON.stringify({
+        jsonrpc: "2.0", id: 1, result: { content: [] },
+      }), { status: 200 })) as typeof fetch,
+    });
+    await expect(client.status("cl-1")).rejects.toBeInstanceOf(M5CodeLoopError);
+  });
+});

--- a/tests/mcp/broker-client.test.ts
+++ b/tests/mcp/broker-client.test.ts
@@ -57,6 +57,30 @@ describe("BrokerClient", () => {
     expect(init?.body).toBeUndefined();
   });
 
+  it("posts learning-loop operations to their authenticated endpoints", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ ok: true }));
+    const client = new BrokerClient({
+      baseUrl: "http://broker.test:3033",
+      bearerToken: "tk",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await client.experimentCreate({ experiment_id: "exp-1" });
+    await client.experimentObserve({ experiment_id: "exp-1", run_id: "r1" });
+    await client.experimentRate({ experiment_id: "exp-1", run_id: "r1" });
+    await client.experimentStatus({ experiment_id: "exp-1" });
+    await client.experimentPromote({ experiment_id: "exp-1" });
+
+    expect(fetchImpl.mock.calls.map(([url]) => url)).toEqual([
+      "http://broker.test:3033/v1/learning/experiments/create",
+      "http://broker.test:3033/v1/learning/experiments/observe",
+      "http://broker.test:3033/v1/learning/experiments/rate",
+      "http://broker.test:3033/v1/learning/experiments/status",
+      "http://broker.test:3033/v1/learning/experiments/promote",
+    ]);
+    for (const [, init] of fetchImpl.mock.calls) expect(init?.method).toBe("POST");
+  });
+
   it("returns {} for 204 No Content", async () => {
     const fetchImpl = vi.fn(
       async () => new Response(null, { status: 204 }),

--- a/tests/mcp/tools.test.ts
+++ b/tests/mcp/tools.test.ts
@@ -9,6 +9,7 @@ import {
   BrokerNetworkError,
   type BrokerClient,
 } from "../../src/mcp/broker-client.js";
+import { makeExperimentInput, makeObservation } from "../fixtures/learning.js";
 
 function fakeBroker(overrides: Partial<BrokerClient> = {}): BrokerClient {
   const noop = vi.fn(async () => ({}));
@@ -18,6 +19,11 @@ function fakeBroker(overrides: Partial<BrokerClient> = {}): BrokerClient {
     rate: noop,
     list: noop,
     models: noop,
+    experimentCreate: noop,
+    experimentObserve: noop,
+    experimentRate: noop,
+    experimentStatus: noop,
+    experimentPromote: noop,
     ...overrides,
   } as unknown as BrokerClient;
 }
@@ -404,5 +410,83 @@ describe("buildTools — hugin_models", () => {
       alias_map: { tiny: "ollama-pi" },
       runtimes: [],
     });
+  });
+});
+
+describe("buildTools — continuous learning loop", () => {
+  it("forwards a validated one-axis experiment contract", async () => {
+    const experimentCreate = vi.fn(async () => ({ state: { status: "running" } }));
+    const tools = buildTools({
+      broker: fakeBroker({ experimentCreate }),
+      sessionId: "sess",
+      submitter: "codex",
+    });
+    const input = makeExperimentInput();
+
+    const result = await tools.experimentCreate.handler(input);
+
+    expect(result.isError).toBeUndefined();
+    expect(experimentCreate).toHaveBeenCalledWith(input);
+  });
+
+  it("forwards observations and reads the resulting promotion state", async () => {
+    const experimentObserve = vi.fn(async () => ({ state: { status: "running" } }));
+    const experimentStatus = vi.fn(async () => ({ state: { status: "promotion-ready" } }));
+    const tools = buildTools({
+      broker: fakeBroker({ experimentObserve, experimentStatus }),
+      sessionId: "sess",
+      submitter: "codex",
+    });
+    const observation = makeObservation("case-1", "challenger");
+
+    await tools.experimentObserve.handler(observation);
+    const status = await tools.experimentStatus.handler({
+      experiment_id: "wave-six-edit-deadline",
+    });
+
+    expect(experimentObserve).toHaveBeenCalledWith(observation);
+    expect(experimentStatus).toHaveBeenCalledWith({
+      experiment_id: "wave-six-edit-deadline",
+    });
+    expect(parseResult(status)).toMatchObject({ state: { status: "promotion-ready" } });
+  });
+
+  it("forwards one-way product rating enrichment", async () => {
+    const experimentRate = vi.fn(async () => ({ state: { status: "running" } }));
+    const tools = buildTools({
+      broker: fakeBroker({ experimentRate }),
+      sessionId: "sess",
+      submitter: "codex",
+    });
+    const input = {
+      experiment_id: "wave-six-edit-deadline",
+      run_id: "case-1-champion",
+      product_outcome: "minor-edit" as const,
+      human_review_seconds: 30,
+    };
+
+    const result = await tools.experimentRate.handler(input);
+
+    expect(result.isError).toBeUndefined();
+    expect(experimentRate).toHaveBeenCalledWith(input);
+  });
+
+  it("forwards an explicit reviewed promotion reference", async () => {
+    const experimentPromote = vi.fn(async () => ({ state: { status: "promoted" } }));
+    const tools = buildTools({
+      broker: fakeBroker({ experimentPromote }),
+      sessionId: "sess",
+      submitter: "codex",
+    });
+    const input = {
+      experiment_id: "wave-six-edit-deadline",
+      configuration_fingerprint: "b".repeat(64),
+      applied_ref: "gille-inference@abc123",
+    };
+
+    const result = await tools.experimentPromote.handler(input);
+
+    expect(result.isError).toBeUndefined();
+    expect(experimentPromote).toHaveBeenCalledWith(input);
   });
 });


### PR DESCRIPTION
## What changed

- add a principal-isolated, CAS-guarded champion/challenger experiment ledger with versioned configuration fingerprints and exactly-one-axis experiments
- evaluate matched pairs and holdouts with independent-verifier, product-rating, latency, cost, rescue, infrastructure, and primary-improvement gates
- expose authenticated create/observe/rate/status/promote Broker endpoints and MCP tools
- make product rating a one-way post-run enrichment so automated observations can be collected immediately without making usefulness evidence immutable as `unrated`
- surface experiment maturity, normalized improvement, failure signals, and next action in Heimdall
- add a strict M5 `code_loop` result adapter/client and resumable ten-case Gate D runner
- hash all corpus/verifier assets, bind observations to M5's reported effective model/harness/caps, counterbalance arm order, and use Gate D's existing hidden-oracle/typecheck/anti-cheat verifier outside the model sandbox
- document the contract, correction, operational recipe, and promotion boundary

## Why

The system had capability/product telemetry, but no durable controlled loop for comparing prompts, harnesses, models, or configuration without confounding changes. The first implementation also revealed a concrete product-evidence gap: an automated `unrated` observation could never receive its later human rating without violating run idempotency.

Preparation for the first live run also corrected stale handoff text: there is no Wave 5 code-loop corpus, and gille-inference #201 is unrelated. The reproducible corpus is Gate D. The required M5 phase telemetry and edit-deadline policy are now tracked in Magnus-Gille/gille-inference#247 with the exact wire contract.

## Impact and safety

Every iteration may add knowledge, but production changes remain monotonic: only a matched, independently verified, non-regressing challenger can become promotion-ready, and an operator must still apply/review the owning-repo change before recording promotion.

Prompts, diffs, fixtures, check output, and seed contents never enter the Hugin experiment ledger. Missing M5 telemetry remains missing; a final diff never manufactures a time-to-first-edit measurement.

This PR does not merge, deploy, change M5 configuration, provision credentials, run the experiment, or promote a challenger.

## Validation

After merging current `main@8b1bfdd`:

- `npm run build`
- standalone strict TypeScript check for `scripts/run-m5-code-loop-experiment.ts`
- focused learning/MCP/HTTP/dashboard suite: 8 files, 103 tests
- full `npm test`: 102 files, 1,700 tests
- `git diff --check`

## Before the first live Gate D run

1. review/merge/deploy this Hugin PR
2. implement/review/deploy gille-inference #247
3. provision the M5 owner token through `m5-auth`/Keychain (never a file)
4. dry-run the ten-case manifest with two predeclared holdouts
5. collect both mechanical evidence and later product ratings
6. keep the champion unless every configured gate passes