### PR TITLE
fix: harden dispatcher operations and alert lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Content format:
 - **Context:** repo:heimdall
 - **Working dir:** /home/magnus/workspace
 - **Timeout:** 300000
+- **Max output tokens:** 4096
 - **Submitted by:** Codex-desktop
 - **Submitted at:** 2026-03-14T10:00:00Z
 - **Reply-to:** telegram:12345678
@@ -61,7 +62,7 @@ Content format:
 <the actual prompt for the AI runtime>
 ```
 
-**Context resolution:** `Context:` takes priority over `Working dir:` for determining the working directory. Supported aliases:
+**Context resolution:** `Context:` takes priority over `Working dir:` for determining the working directory. Both fields use the same path guard; relative paths and normalized paths outside `/home/magnus/` fall back to the configured workspace. Supported aliases:
 - `repo:<name>` → `<HUGIN_REPOS_ROOT>/<name>` (default `/home/magnus/repos/<name>`; see `HUGIN_REPOS_ROOT` in the env table — point it at an isolated tree to keep tasks off production checkouts, #139)
 - `scratch` → `/home/magnus/scratch` (non-code tasks)
 - `files` → `/home/magnus/mimir`
@@ -76,7 +77,9 @@ Content format:
 - `Reasoning:` — `true` to force `think:true` via native `/api/chat`, `false` to force `think:false`. Omit to auto: reasoning-model families (qwen3/3.5, deepseek-r1, magistral) default to `think:false` via `/api/chat`; other models use the OpenAI-compatible endpoint unchanged. `gpt-oss` uses level-based reasoning and is not auto-routed.
 - `Fallback:` — `claude` to fall back to claude on infra failures (host unreachable, 5xx); `none` (default) to fail without fallback. Semantic failure (model responds but poorly) is never retried — that's experiment data.
 - `Context-refs:` — comma-separated Munin references (`namespace/key`) to fetch and inject into the prompt. Hugin enforces Munin classification against the task/runtime trust boundary before injecting them.
-- `Context-budget:` — max characters for injected context (default 8000). Truncated from end if exceeded.
+- `Context-budget:` — max characters for injected context (default 8000, hard cap 100000). At most 50 refs are read; excess content/refs are reported as truncated.
+- `Max output tokens:` — hard generation cap for ollama and homeserver tasks (maximum 32768).
+- `Timeout:` — positive milliseconds, clamped to a 12-hour dispatcher ceiling (Broker envelopes retain their stricter 15-minute schema cap).
 
 **Type tags:** Tags matching `type:*` (e.g., `type:research`, `type:email`) are carried forward through the task lifecycle (pending → running → completed/failed).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ Content format:
 - **Context:** repo:heimdall
 - **Working dir:** /home/magnus/workspace
 - **Timeout:** 300000
+- **Max output tokens:** 4096
 - **Submitted by:** Codex-desktop
 - **Submitted at:** 2026-03-14T10:00:00Z
 - **Reply-to:** telegram:12345678
@@ -65,7 +66,7 @@ Content format:
 <the actual prompt for the AI runtime>
 ```
 
-**Context resolution:** `Context:` takes priority over `Working dir:` for determining the working directory. Supported aliases:
+**Context resolution:** `Context:` takes priority over `Working dir:` for determining the working directory. Both fields use the same path guard; relative paths and normalized paths outside `/home/magnus/` fall back to the configured workspace. Supported aliases:
 - `repo:<name>` → `<HUGIN_REPOS_ROOT>/<name>` (default `/home/magnus/repos/<name>`; see `HUGIN_REPOS_ROOT` in the env table — point it at an isolated tree to keep tasks off production checkouts, #139)
 - `scratch` → `/home/magnus/scratch` (non-code tasks)
 - `files` → `/home/magnus/mimir`
@@ -80,7 +81,9 @@ Content format:
 - `Reasoning:` — `true` to force `think:true` via native `/api/chat`, `false` to force `think:false`. Omit to auto: reasoning-model families (qwen3/3.5, deepseek-r1, magistral) default to `think:false` via `/api/chat`; other models use the OpenAI-compatible endpoint unchanged. `gpt-oss` uses level-based reasoning (`low`/`medium`/`high`) and is not auto-routed — set `Reasoning:` explicitly only once Hugin supports levels.
 - `Fallback:` — `claude` to fall back to Claude on infra failures (host unreachable, 5xx); `none` (default) to fail without fallback. Semantic failure (model responds but poorly) is never retried — that's experiment data.
 - `Context-refs:` — comma-separated Munin references (`namespace/key`) to fetch and inject into the prompt. Hugin enforces Munin classification against the task/runtime trust boundary before injecting them.
-- `Context-budget:` — max characters for injected context (default 8000). Truncated from end if exceeded.
+- `Context-budget:` — max characters for injected context (default 8000, hard cap 100000). At most 50 refs are read; excess content/refs are reported as truncated.
+- `Max output tokens:` — hard generation cap for ollama and homeserver tasks (maximum 32768).
+- `Timeout:` — positive milliseconds, clamped to a 12-hour dispatcher ceiling (Broker envelopes retain their stricter 15-minute schema cap).
 
 **Type tags:** Tags matching `type:*` (e.g., `type:research`, `type:email`) are carried forward through the task lifecycle (pending → running → completed/failed).
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,9 +1,57 @@
 # Hugin — Status
 
-**Latest session (2026-07-13, Codex) — continuous Hugin/M5 improvement loop + Gate D adapter
-published for review.** Draft PR [#196](https://github.com/Magnus-Gille/hugin/pull/196) from
-`codex/continuous-harness-learning-loop`; implementation commit `916b689`, reconciled with
-`origin/main@8b1bfdd`. Not merged or deployed.
+**Latest session:** 2026-07-13 (Codex) — **general hardening implementation complete locally; awaiting parent review/publish/deploy**
+**Branch:** `codex/hugin-hardening-20260713` rebased onto `origin/main@bb66fcd` (includes merged starvation/pagination fix #193 and continuous M5 harness #196).
+
+## Latest — bounded operations, honest alert lifecycle, and Daily Analysis reliability
+
+- Recovery/control scans now paginate past Munin's 50-row cap under a 200-entry
+  per-pass budget and retain a timestamp continuation so repeated sweeps rotate
+  through old work. Canonical Broker history is capped at 1,000 candidates per
+  discovery channel, reads status with concurrency 25, and reports truncation.
+- `Working dir` now uses the same normalized `/home/magnus` path guard as
+  `Context`; task timeout/output-token/env settings and context ref/character
+  fan-out have hard ceilings.
+- Daily Analysis no longer sends raw 24-hour JSONL to the Pi model. A streaming
+  deterministic pre-aggregation keeps the evidence below 5,000 characters even
+  for the 2,000-row regression fixture, and the existing Ollama task is capped
+  at 192 output tokens. Malformed/non-object journal rows and invalid, negative,
+  or overflowing duration/cost samples are ignored without aborting or emitting
+  misleading JSON `null` aggregates. Production evidence motivating this:
+  2026-07-13 had 116 rows / 46,091 prompt characters and timed out before output;
+  2026-07-12 also timed out at 5,675 prompt characters while streaming an
+  overlong answer.
+- Ratatoskr/Heimdall alert lifecycle now resolves the existing exact dedup keys:
+  confirmed auth recovery resolves `hugin-claude-auth`; expiry resolves only on
+  known-safe expiry or refresh-token N/A evidence (never unknown null); version
+  drift resolves only from persisted prior-process firing state after a fresh
+  startup baseline. Resolution state commits only after Ratatoskr delivery; the
+  drift path additionally retries until state persistence succeeds.
+- Heimdall usefulness was checked against the live descriptor: Tasks and Task
+  history remain the concrete operational views; capability evidence discloses
+  verified n and omitted rows; the trial gate shows targets/state/notes; route
+  policy is explicitly warn/shadow; uninstrumented metrics say so. No Hugin view
+  should be removed. The misleading relative descriptor links to `/health` and
+  `/heimdall.json` were removed because Heimdall resolved them against itself;
+  the unambiguous repository link remains. Resolution events prevent stale
+  auth/drift incidents from degrading that at-a-glance signal.
+- Compatible lockfile updates clear Hono, qs, Vitest/Vite, and esbuild advisories.
+  Final validation after rebasing onto `bb66fcd`: clean `npm ci`; TypeScript
+  build; standalone Gate D runner typecheck; 103 files / 1,721 tests; both CI
+  shell suites; Bash/Node syntax; `git diff --check`; and full plus
+  production-only `npm audit` (0 vulnerabilities).
+
+**Next:** parent agent publishes the local commit as a PR, obtains independent
+review, merges only with green CI, deploys from clean `main`, and verifies Pi
+health plus alert-resolution delivery. No live alerts, Munin writes, deploy, or
+production mutation occurred in this implementation session.
+
+---
+
+**Previous session (2026-07-13, Codex) — continuous Hugin/M5 improvement loop + Gate D adapter,
+merged as [#196](https://github.com/Magnus-Gille/hugin/pull/196) in `bb66fcd`.** Implementation
+commit `916b689` was originally reconciled with `origin/main@8b1bfdd`; it was not deployed during
+that session.
 
 Hugin now has a durable, principal-isolated champion/challenger experiment ledger under
 `experiments/hugin/*`, exposed through five authenticated Broker/MCP operations: create, observe,
@@ -38,19 +86,12 @@ existing ten-case Gate D battery. The owning M5 work (phase telemetry, immutable
 metadata, and optional edit-deadline policy) is filed as gille-inference #247 and added to the
 Grimnir Roadmap with the exact wire contract.
 
-Validation after merging current `origin/main`: `npm run build`, standalone runner typecheck,
-focused integration/unit suite (103 tests after the last adapter hardening), full `npm test`
-(**102 files / 1,700 tests**), and `git diff --check` are green. No production state or M5
-configuration was changed. A live run was
-not started: #247 is not implemented/deployed, this Hugin branch is not deployed, and this laptop's
-`m5-auth` helper reports no owner token in Keychain. The credential boundary was not bypassed.
+The first live Gate D run remains blocked on #247 and an owner key provisioned through `m5-auth`;
+neither boundary was bypassed. After those prerequisites and Hugin deployment, dry-run the ten-case
+Gate D manifest with two holdouts, then compare the current 13-turn champion against the identical
+turn-6 edit-deadline challenger. Keep the champion unless every protected paired gate passes.
 
-**Next:** review/merge PR #196; implement/review/deploy
-[gille-inference #247](https://github.com/Magnus-Gille/gille-inference/issues/247); provision the
-M5 owner key via `m5-auth` (Keychain, never a file); deploy Hugin; generate and dry-run the ten-case
-Gate D manifest with two predeclared holdouts; then run current 13-turn champion versus the identical
-turn-6 edit-deadline challenger. Collect product ratings and keep the champion unless every paired
-protected-check, coverage, and non-regression gate passes.
+---
 
 **Latest session:** 2026-07-13 (Claude) — **M5-harvest campaign (`m5h-2026-07`): 9 tickets, 10 PRs, ~92 graded delegations, shadow lane live**
 **Branch:** `main` @ `977e851` + this handoff; hugin deployed to Pi (health `ok`, polling, queue 0).

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,9 +53,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
-      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -70,9 +70,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
-      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -87,9 +87,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
-      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -104,9 +104,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
-      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -121,9 +121,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
-      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -138,9 +138,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
-      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -155,9 +155,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -172,9 +172,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
-      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -189,9 +189,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
-      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -206,9 +206,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
-      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -223,9 +223,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
-      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -240,9 +240,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
-      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -257,9 +257,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
-      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -274,9 +274,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
-      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -291,9 +291,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
-      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -308,9 +308,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
-      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -325,9 +325,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
-      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -342,9 +342,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -359,9 +359,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -376,9 +376,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -393,9 +393,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -410,9 +410,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
-      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -427,9 +427,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
-      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -444,9 +444,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
-      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -461,9 +461,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
-      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -478,9 +478,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
-      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -1331,15 +1331,15 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
         "chai": "^5.2.0",
         "tinyrainbow": "^2.0.0"
       },
@@ -1348,13 +1348,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.4",
+        "@vitest/spy": "3.2.7",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.17"
       },
@@ -1375,9 +1375,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1388,13 +1388,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
+        "@vitest/utils": "3.2.7",
         "pathe": "^2.0.3",
         "strip-literal": "^3.0.0"
       },
@@ -1403,13 +1403,13 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.7",
         "magic-string": "^0.30.17",
         "pathe": "^2.0.3"
       },
@@ -1418,9 +1418,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1431,13 +1431,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
+        "@vitest/pretty-format": "3.2.7",
         "loupe": "^3.1.4",
         "tinyrainbow": "^2.0.0"
       },
@@ -1762,9 +1762,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -1774,9 +1774,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
-      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1787,32 +1787,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.4",
-        "@esbuild/android-arm": "0.27.4",
-        "@esbuild/android-arm64": "0.27.4",
-        "@esbuild/android-x64": "0.27.4",
-        "@esbuild/darwin-arm64": "0.27.4",
-        "@esbuild/darwin-x64": "0.27.4",
-        "@esbuild/freebsd-arm64": "0.27.4",
-        "@esbuild/freebsd-x64": "0.27.4",
-        "@esbuild/linux-arm": "0.27.4",
-        "@esbuild/linux-arm64": "0.27.4",
-        "@esbuild/linux-ia32": "0.27.4",
-        "@esbuild/linux-loong64": "0.27.4",
-        "@esbuild/linux-mips64el": "0.27.4",
-        "@esbuild/linux-ppc64": "0.27.4",
-        "@esbuild/linux-riscv64": "0.27.4",
-        "@esbuild/linux-s390x": "0.27.4",
-        "@esbuild/linux-x64": "0.27.4",
-        "@esbuild/netbsd-arm64": "0.27.4",
-        "@esbuild/netbsd-x64": "0.27.4",
-        "@esbuild/openbsd-arm64": "0.27.4",
-        "@esbuild/openbsd-x64": "0.27.4",
-        "@esbuild/openharmony-arm64": "0.27.4",
-        "@esbuild/sunos-x64": "0.27.4",
-        "@esbuild/win32-arm64": "0.27.4",
-        "@esbuild/win32-ia32": "0.27.4",
-        "@esbuild/win32-x64": "0.27.4"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escape-html": {
@@ -2072,19 +2072,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/get-tsconfig": {
-      "version": "4.13.6",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
-      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2110,9 +2097,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2122,9 +2109,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.19",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.19.tgz",
-      "integrity": "sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==",
+      "version": "4.12.30",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.30.tgz",
+      "integrity": "sha512-emn+JoJjrN9YTpRDS5it/UI2SO9BAE37T6I3d963RxcZ81G9A4pr2SZTEiiaiKbzx+NKRg5BZ89fCL7gCJCUog==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2495,12 +2482,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -2540,16 +2528,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/rollup": {
@@ -2692,14 +2670,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -2711,13 +2689,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2887,14 +2865,13 @@
       }
     },
     "node_modules/tsx": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
+        "esbuild": "~0.28.0"
       },
       "bin": {
         "tsx": "dist/cli.mjs"
@@ -2960,13 +2937,13 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
-      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "fdir": "^6.5.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.6",
@@ -3058,20 +3035,20 @@
       }
     },
     "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
         "chai": "^5.2.0",
         "debug": "^4.4.1",
         "expect-type": "^1.2.1",
@@ -3101,8 +3078,8 @@
         "@edge-runtime/vm": "*",
         "@types/debug": "^4.1.12",
         "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
         "happy-dom": "*",
         "jsdom": "*"
       },

--- a/scripts/build-daily-analysis-input.mjs
+++ b/scripts/build-daily-analysis-input.mjs
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+
+import { createReadStream } from "node:fs";
+import { createInterface } from "node:readline";
+
+const journalPath = process.argv[2];
+const nowMs = process.argv[3] ? Date.parse(process.argv[3]) : Date.now();
+if (!journalPath || !Number.isFinite(nowMs)) {
+  console.error("usage: build-daily-analysis-input.mjs JOURNAL_PATH [NOW_ISO]");
+  process.exit(2);
+}
+
+const sinceMs = nowMs - 24 * 60 * 60 * 1_000;
+const runtimeNames = [
+  "claude",
+  "codex",
+  "ollama",
+  "homeserver",
+  "opencode",
+  "orchestrator",
+  "other",
+];
+const runtimes = Object.fromEntries(
+  runtimeNames.map((name) => [
+    name,
+    {
+      tasks: 0,
+      succeeded: 0,
+      failed: 0,
+      timed_out: 0,
+      duration_samples: 0,
+      duration_sum_s: 0,
+      max_duration_s: 0,
+    },
+  ]),
+);
+const quota = {
+  q5: { first: null, last: null, min: null, max: null },
+  q7: { first: null, last: null, min: null, max: null },
+};
+const longest = [];
+let entries = 0;
+let invalidLines = 0;
+let succeeded = 0;
+let failed = 0;
+let timedOut = 0;
+let totalCostUsd = 0;
+let costSamples = 0;
+
+function finiteNumber(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function nonNegativeFiniteNumber(value) {
+  const numeric = finiteNumber(value);
+  return numeric !== null && numeric >= 0 ? numeric : null;
+}
+
+function roundFinite(value, digits) {
+  return Number(value.toFixed(digits));
+}
+
+function observeQuota(name, value) {
+  const numeric = finiteNumber(value);
+  if (numeric === null) return;
+  const target = quota[name];
+  if (target.first === null) target.first = numeric;
+  target.last = numeric;
+  target.min = target.min === null ? numeric : Math.min(target.min, numeric);
+  target.max = target.max === null ? numeric : Math.max(target.max, numeric);
+}
+
+function observeLongest(event, durationS, outcome) {
+  longest.push({
+    task_id: String(event.task_id ?? "unknown").slice(0, 120),
+    runtime: String(event.runtime ?? "unknown").slice(0, 40),
+    duration_s: durationS,
+    outcome,
+  });
+  longest.sort((a, b) => b.duration_s - a.duration_s);
+  if (longest.length > 5) longest.length = 5;
+}
+
+const lines = createInterface({
+  input: createReadStream(journalPath, { encoding: "utf8" }),
+  crlfDelay: Infinity,
+});
+
+for await (const line of lines) {
+  if (!line.trim()) continue;
+  let event;
+  try {
+    event = JSON.parse(line);
+  } catch {
+    invalidLines += 1;
+    continue;
+  }
+  if (event === null || typeof event !== "object" || Array.isArray(event)) {
+    invalidLines += 1;
+    continue;
+  }
+  const tsMs = Date.parse(event.ts);
+  if (!Number.isFinite(tsMs) || tsMs <= sinceMs || tsMs > nowMs) continue;
+
+  entries += 1;
+  const runtime = runtimeNames.includes(event.runtime) ? event.runtime : "other";
+  const row = runtimes[runtime];
+  row.tasks += 1;
+
+  const timeout = event.exit_code === "TIMEOUT";
+  const success = event.exit_code === 0;
+  const outcome = timeout ? "timed_out" : success ? "succeeded" : "failed";
+  if (timeout) {
+    timedOut += 1;
+    row.timed_out += 1;
+  } else if (success) {
+    succeeded += 1;
+    row.succeeded += 1;
+  } else {
+    failed += 1;
+    row.failed += 1;
+  }
+
+  const durationS = nonNegativeFiniteNumber(event.duration_s);
+  if (durationS !== null) {
+    const durationSum = row.duration_sum_s + durationS;
+    if (Number.isFinite(durationSum)) {
+      row.duration_samples += 1;
+      row.duration_sum_s = durationSum;
+      row.max_duration_s = Math.max(row.max_duration_s, durationS);
+      observeLongest(event, durationS, outcome);
+    }
+  }
+
+  const cost = nonNegativeFiniteNumber(event.cost_usd);
+  if (cost !== null) {
+    const costTotal = totalCostUsd + cost;
+    if (Number.isFinite(costTotal)) {
+      totalCostUsd = costTotal;
+      costSamples += 1;
+    }
+  }
+  observeQuota("q5", event.quota_before?.q5);
+  observeQuota("q5", event.quota_after?.q5);
+  observeQuota("q7", event.quota_before?.q7);
+  observeQuota("q7", event.quota_after?.q7);
+}
+
+const byRuntime = {};
+for (const [name, row] of Object.entries(runtimes)) {
+  if (row.tasks === 0) continue;
+  byRuntime[name] = {
+    tasks: row.tasks,
+    succeeded: row.succeeded,
+    failed: row.failed,
+    timed_out: row.timed_out,
+    average_duration_s: row.duration_samples === 0
+      ? null
+      : roundFinite(row.duration_sum_s / row.duration_samples, 1),
+    max_duration_s: row.duration_samples === 0 ? null : row.max_duration_s,
+  };
+}
+
+const rate = (count) => entries === 0 ? null : Math.round((count / entries) * 10_000) / 100;
+process.stdout.write(JSON.stringify({
+  window: {
+    since: new Date(sinceMs).toISOString(),
+    until: new Date(nowMs).toISOString(),
+  },
+  entries,
+  invalid_lines: invalidLines,
+  outcomes: {
+    succeeded,
+    failed,
+    timed_out: timedOut,
+    success_rate_pct: rate(succeeded),
+    failure_rate_pct: rate(failed + timedOut),
+  },
+  by_runtime: byRuntime,
+  cost: {
+    total_usd: roundFinite(totalCostUsd, 6),
+    samples: costSamples,
+    missing: entries - costSamples,
+  },
+  quota,
+  longest_tasks: longest,
+}, null, 2));

--- a/scripts/submit-daily-analysis.sh
+++ b/scripts/submit-daily-analysis.sh
@@ -2,12 +2,13 @@
 # Submit a daily invocation journal analysis task to Hugin via Munin.
 # Intended to run via systemd timer at 07:00 daily.
 #
-# Reads the last 24 hours of journal entries and submits them as an
-# ollama task with fallback to Claude.
+# Deterministically summarizes the last 24 hours into bounded evidence and
+# submits that evidence as an ollama task with fallback to Claude.
 
 set -euo pipefail
 
-JOURNAL_FILE="${HOME}/.hugin/invocation-journal.jsonl"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+JOURNAL_FILE="${HUGIN_JOURNAL_FILE:-${HOME}/.hugin/invocation-journal.jsonl}"
 MUNIN_URL="${MUNIN_URL:-http://localhost:3030}"
 MUNIN_API_KEY="${MUNIN_API_KEY:?MUNIN_API_KEY is required}"
 
@@ -15,26 +16,17 @@ MUNIN_API_KEY="${MUNIN_API_KEY:?MUNIN_API_KEY is required}"
 TASK_ID="$(date -u +%Y%m%d-%H%M%S)-daily-analysis"
 TASK_NS="tasks/${TASK_ID}"
 
-# Read last 24 hours of journal entries
-CUTOFF=$(date -u -d '24 hours ago' +%Y-%m-%dT%H:%M:%S 2>/dev/null || date -u -v-24H +%Y-%m-%dT%H:%M:%S)
-
-JOURNAL_DATA=""
-if [ -f "$JOURNAL_FILE" ]; then
-  # Filter entries from last 24h (ts field is ISO 8601)
-  JOURNAL_DATA=$(while IFS= read -r line; do
-    ts=$(echo "$line" | python3 -c "import sys,json; print(json.load(sys.stdin).get('ts',''))" 2>/dev/null || echo "")
-    if [ -n "$ts" ] && [ "$ts" \> "$CUTOFF" ]; then
-      echo "$line"
-    fi
-  done < "$JOURNAL_FILE")
-fi
-
-if [ -z "$JOURNAL_DATA" ]; then
+if [ ! -f "$JOURNAL_FILE" ]; then
   echo "No journal entries in last 24 hours, skipping submission"
   exit 0
 fi
 
-ENTRY_COUNT=$(echo "$JOURNAL_DATA" | wc -l | tr -d ' ')
+ANALYSIS_INPUT="$(node "${SCRIPT_DIR}/build-daily-analysis-input.mjs" "$JOURNAL_FILE")"
+ENTRY_COUNT="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["entries"])' <<< "$ANALYSIS_INPUT")"
+if [ "$ENTRY_COUNT" -eq 0 ]; then
+  echo "No journal entries in last 24 hours, skipping submission"
+  exit 0
+fi
 echo "Found ${ENTRY_COUNT} journal entries from last 24 hours"
 
 # Build the task content
@@ -46,11 +38,13 @@ TASK_CONTENT=$(cat <<TASK_EOF
 - **Model:** qwen2.5:3b
 - **Fallback:** claude
 - **Timeout:** 300000
+- **Max output tokens:** 192
 - **Submitted by:** hugin
 - **Submitted at:** $(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 ### Prompt
-Analyze the following Hugin invocation journal entries from the last 24 hours.
+Turn the following precomputed Hugin invocation evidence into a concise operator report.
+The aggregation is authoritative: do not recalculate or invent missing values.
 
 Report:
 1. Total tasks executed, success rate, failure rate
@@ -59,10 +53,10 @@ Report:
 4. Any anomalies (unusually long tasks, repeated failures, timeout patterns)
 5. Quota utilization trend (if quota_before/quota_after data present)
 
-Use markdown tables where appropriate. Be concise.
+Use markdown tables where appropriate. Keep the entire answer under 160 words.
 
-\`\`\`jsonl
-${JOURNAL_DATA}
+\`\`\`json
+${ANALYSIS_INPUT}
 \`\`\`
 TASK_EOF
 )

--- a/src/auth-alarm.ts
+++ b/src/auth-alarm.ts
@@ -17,20 +17,49 @@
 /** Result of a credential probe. `unknown` = transient/inconclusive (fail-open). */
 export type AuthProbeState = "ok" | "unauthorized" | "unknown";
 
-/** Matches Ratatoskr's AlertEnvelope contract (ratatoskr/src/alert.ts, #16). */
-export interface AlertEnvelope {
+interface AlertEnvelopeFields {
   severity?: "info" | "warn" | "error" | "critical";
   source?: string;
-  title: string;
   body?: string;
-  dedup_key?: string;
   ts?: string;
+}
+
+/** Matches Ratatoskr's firing/resolved AlertEnvelope contract. */
+export interface FiringAlertEnvelope extends AlertEnvelopeFields {
+  state?: "firing";
+  title: string;
+  dedup_key?: string;
+}
+
+export interface ResolvedAlertEnvelope extends AlertEnvelopeFields {
+  state: "resolved";
+  title?: string;
+  dedup_key: string;
+}
+
+export type AlertEnvelope = FiringAlertEnvelope | ResolvedAlertEnvelope;
+
+export type AlertDeliveryStatus = "delivered" | "skipped" | "failed";
+
+/** Resolutions mutate external alert state and therefore require a real 2xx. */
+export function alertDeliveryCommitsTransition(
+  alert: AlertEnvelope,
+  status: AlertDeliveryStatus,
+): boolean {
+  if (alert.state === "resolved") return status === "delivered";
+  return status !== "failed";
 }
 
 export interface AuthProbeReading {
   auth: AuthProbeState;
   /** Token expiry (epoch ms) from the credential file, or null if unavailable. */
   expiresAtMs: number | null;
+  /**
+   * `not-applicable` is positive evidence that a refresh token can renew the
+   * short-lived access token. `unknown` must never clear a firing warning.
+   * Omitted readings retain the legacy safe default: numeric=known, null=unknown.
+   */
+  expiryEvidence?: "known" | "not-applicable" | "unknown";
 }
 
 /** Persisted between ticks so the alarm is edge-triggered, not repeated. */
@@ -79,10 +108,7 @@ function invalidAlert(): AlertEnvelope {
 
 function recoveredAlert(): AlertEnvelope {
   return {
-    severity: "info",
-    source: "hugin",
-    title: "Pi Claude auth restored",
-    body: "The Pi's Claude Code credential authenticates again — autonomous tasks can run.",
+    state: "resolved",
     dedup_key: AUTH_ALARM_DEDUP_KEY,
   };
 }
@@ -99,27 +125,28 @@ function expiryAlert(hoursLeft: number): AlertEnvelope {
   };
 }
 
+function expiryRecoveredAlert(): AlertEnvelope {
+  return {
+    state: "resolved",
+    dedup_key: AUTH_EXPIRY_DEDUP_KEY,
+  };
+}
+
 /**
  * Decide, purely, what alert(s) a fresh probe reading warrants.
  *
  * Edge-triggered: an alert fires only on a *transition*, never every tick.
  * - `→ unauthorized` (from ok or first reading): one `error` alert.
- * - `unauthorized → ok`: one `info` recovery alert.
+ * - `unauthorized → ok`: resolve the auth dedup key.
  * - `ok` with `expiresAtMs` inside the warn window: one `warn` alert, once per
- *   token (re-armed when a fresh token pushes expiry back beyond the window).
- * - `unknown`: no alert, state untouched — a transient probe glitch must never
- *   flip the alarm or spam a recovery/failure notice.
+ *   token; resolve only on known-safe expiry or refresh-token N/A evidence.
+ * - Unknown auth/expiry evidence leaves that dimension untouched.
  */
 export function decideAuthAlarm(
   state: AuthAlarmState,
   reading: AuthProbeReading,
   opts: AuthAlarmDecideOptions,
 ): AuthAlarmDecision {
-  // Fail-open: an inconclusive probe leaves the alarm exactly as it was.
-  if (reading.auth === "unknown") {
-    return { alerts: [], nextState: state };
-  }
-
   const alerts: AlertEnvelope[] = [];
   const nextState: AuthAlarmState = { ...state };
 
@@ -128,18 +155,20 @@ export function decideAuthAlarm(
       alerts.push(invalidAlert());
     }
     nextState.lastAuth = "unauthorized";
-    // Leave expiryWarned as-is: a dead token has nothing to pre-warn about, and
-    // preserving the flag avoids a spurious re-warn if it briefly recovers.
-    return { alerts, nextState };
+  } else if (reading.auth === "ok") {
+    if (state.lastAuth === "unauthorized") {
+      alerts.push(recoveredAlert());
+    }
+    nextState.lastAuth = "ok";
   }
 
-  // reading.auth === "ok"
-  if (state.lastAuth === "unauthorized") {
-    alerts.push(recoveredAlert());
-  }
-  nextState.lastAuth = "ok";
-
-  if (reading.expiresAtMs !== null) {
+  const expiryEvidence = reading.expiryEvidence ?? (
+    reading.expiresAtMs === null ? "unknown" : "known"
+  );
+  if (expiryEvidence === "not-applicable") {
+    if (state.expiryWarned) alerts.push(expiryRecoveredAlert());
+    nextState.expiryWarned = false;
+  } else if (expiryEvidence === "known" && reading.expiresAtMs !== null) {
     const msLeft = reading.expiresAtMs - opts.nowMs;
     if (msLeft > 0 && msLeft <= opts.expiryWarnMs) {
       if (!state.expiryWarned) {
@@ -148,8 +177,7 @@ export function decideAuthAlarm(
         nextState.expiryWarned = true;
       }
     } else if (msLeft > opts.expiryWarnMs) {
-      // A freshly-refreshed token pushed expiry back beyond the window — re-arm
-      // so the next approach to expiry warns again.
+      if (state.expiryWarned) alerts.push(expiryRecoveredAlert());
       nextState.expiryWarned = false;
     }
   }

--- a/src/broker/task-store.ts
+++ b/src/broker/task-store.ts
@@ -42,6 +42,8 @@ export const RESULT_STRUCTURED_KEY = "result-structured";
 export const RESULT_ERROR_KEY = "result-error";
 /** Durable-handoff evidence for the #165 trial (#164). */
 export const AWAIT_OBSERVATION_KEY = "await-observation";
+const CANONICAL_HISTORY_SCAN_BUDGET = { maxPages: 20, maxResults: 1_000 } as const;
+const CANONICAL_HISTORY_READ_CONCURRENCY = 25;
 export interface TaskStoreConfig {
   munin: MuninClient;
 }
@@ -55,7 +57,7 @@ export interface CanonicalListRow {
 
 export interface CanonicalListResult {
   rows: CanonicalListRow[];
-  /** True when at least one Munin query hit its cap and may have omitted matches. */
+  /** True when a Munin ambiguity or the bounded history budget may omit matches. */
   truncated: boolean;
 }
 
@@ -255,8 +257,16 @@ export class BrokerTaskStore {
       ...(sinceTs ? { since: sinceTs } : {}),
     };
     const [tagged, homeserver] = await Promise.all([
-      queryAllMuninEntries(this.munin, { ...baseOpts, tags: ["broker:mcp-v2"] }),
-      queryAllMuninEntries(this.munin, { ...baseOpts, tags: ["runtime:homeserver"] }),
+      queryAllMuninEntries(
+        this.munin,
+        { ...baseOpts, tags: ["broker:mcp-v2"] },
+        CANONICAL_HISTORY_SCAN_BUDGET,
+      ),
+      queryAllMuninEntries(
+        this.munin,
+        { ...baseOpts, tags: ["runtime:homeserver"] },
+        CANONICAL_HISTORY_SCAN_BUDGET,
+      ),
     ]);
     const truncated = tagged.truncated || homeserver.truncated;
     const namespaces = new Set<string>();
@@ -265,9 +275,22 @@ export class BrokerTaskStore {
     }
 
     const namespaceList = [...namespaces];
-    const entries = await Promise.all(
-      namespaceList.map((namespace) => this.munin.read(namespace, STATUS_KEY)),
-    );
+    const entries = [];
+    for (
+      let offset = 0;
+      offset < namespaceList.length;
+      offset += CANONICAL_HISTORY_READ_CONCURRENCY
+    ) {
+      const chunk = namespaceList.slice(
+        offset,
+        offset + CANONICAL_HISTORY_READ_CONCURRENCY,
+      );
+      entries.push(
+        ...(await Promise.all(
+          chunk.map((namespace) => this.munin.read(namespace, STATUS_KEY)),
+        )),
+      );
+    }
 
     const rows = [];
     for (const entry of entries) {

--- a/src/context-loader.ts
+++ b/src/context-loader.ts
@@ -33,6 +33,8 @@ import {
 } from "./provenance.js";
 
 const DEFAULT_BUDGET_CHARS = 8_000;
+export const MAX_CONTEXT_BUDGET_CHARS = 100_000;
+export const MAX_CONTEXT_REFS = 50;
 
 export type InjectionPolicy = "off" | "warn" | "block" | "fail";
 
@@ -121,10 +123,25 @@ export async function resolveContextRefs(
   munin: MuninClient,
   options: ResolveContextOptions = {},
 ): Promise<ContextResolution> {
-  const maxChars = budget ?? DEFAULT_BUDGET_CHARS;
+  const maxChars = Number.isSafeInteger(budget) && (budget ?? 0) > 0
+    ? Math.min(budget!, MAX_CONTEXT_BUDGET_CHARS)
+    : DEFAULT_BUDGET_CHARS;
   const policy = readPolicy(options.injectionPolicy);
   const externalPolicy = readExternalPolicy(options.externalPolicy);
-  const refsRequested = refList.map((r) => r.trim()).filter(Boolean);
+  const refsRequested: string[] = [];
+  let refsWereTruncated = false;
+  for (const rawRef of refList) {
+    const ref = rawRef.trim();
+    if (!ref) continue;
+    if (refsRequested.length >= MAX_CONTEXT_REFS) {
+      refsWereTruncated = true;
+      break;
+    }
+    refsRequested.push(ref);
+  }
+  if (refsWereTruncated) {
+    console.warn(`Context ref list capped at ${MAX_CONTEXT_REFS}; excess refs omitted`);
+  }
   const refsResolved: string[] = [];
   const refsMissing: string[] = [];
   const refsQuarantined: string[] = [];
@@ -274,7 +291,7 @@ export async function resolveContextRefs(
 
   const joined = sections.join("\n\n---\n\n");
   const totalChars = joined.length;
-  const truncated = totalChars > maxChars;
+  const truncated = refsWereTruncated || totalChars > maxChars;
   const content = truncated ? joined.slice(0, maxChars) + "\n\n[...truncated]" : joined;
 
   return {

--- a/src/heimdall-descriptor.ts
+++ b/src/heimdall-descriptor.ts
@@ -41,8 +41,6 @@ export const HEIMDALL_DESCRIPTOR = {
   ],
   alerts: { rules: [], active_count: 0, firing: [] },
   links: {
-    self: "/heimdall.json",
-    health: "/health",
     repo: "https://github.com/Magnus-Gille/hugin",
   },
   ui: { icon: "cpu", category: "infra" },

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import {
   type MuninClientConfig,
   type MuninReadResult,
 } from "./munin-client.js";
-import { getFoundBatchEntry, extractTaskId, pickEarliestTask, selectNextTask, checkoutTaskBranch, finalizeTaskBranch, shouldReapExpiredLease, decideStartupRecovery, decideDeliveryRetry, finalizeTaskCompletion, resolveContext, normalizeRoot, DEFAULT_REPOS_ROOT } from "./task-helpers.js";
+import { getFoundBatchEntry, extractTaskId, pickEarliestTask, selectNextTask, checkoutTaskBranch, finalizeTaskBranch, shouldReapExpiredLease, decideStartupRecovery, decideDeliveryRetry, finalizeTaskCompletion, resolveTaskWorkingDirectory, normalizeRoot, DEFAULT_REPOS_ROOT, MAX_TASK_OUTPUT_TOKENS, MAX_TASK_TIMEOUT_MS, parseBoundedPositiveInt } from "./task-helpers.js";
 import { queryAllMuninEntries } from "./munin-pagination.js";
 import { executeSdkTask, type SdkExecutorResult, type SdkExecutorOptions, type SdkTaskConfig, type TaskPermissionProfile } from "./sdk-executor.js";
 import {
@@ -28,13 +28,22 @@ import {
 } from "./failure-classification.js";
 import {
   decideAuthAlarm,
+  alertDeliveryCommitsTransition,
   INITIAL_AUTH_ALARM_STATE,
   type AlertEnvelope,
+  type AlertDeliveryStatus,
   type AuthAlarmState,
 } from "./auth-alarm.js";
 import {
   buildVersionSnapshot,
   compareVersionSnapshots,
+  hydrateVersionDriftAlertLifecycle,
+  INITIAL_VERSION_DRIFT_ALERT_LIFECYCLE,
+  recordVersionDriftFiring,
+  recordVersionDriftResolutionAttempt,
+  VERSION_DRIFT_DEDUP_KEY,
+  versionDriftStartupResolution,
+  type VersionDriftAlertLifecycle,
   type VersionDriftResult,
   type VersionSnapshot,
 } from "./version-drift.js";
@@ -272,8 +281,8 @@ const CANCEL_WATCH_INTERVAL_MS = 2000;
 // interval settings so a malformed env var (e.g. `NaN`) cannot produce an
 // immortal task or a tight-loop `setInterval` (review MED).
 function parsePositiveIntEnv(raw: string | undefined, fallback: number): number {
-  const n = parseInt((raw ?? "").trim(), 10);
-  return Number.isFinite(n) && n > 0 ? n : fallback;
+  const n = Number((raw ?? "").trim());
+  return Number.isSafeInteger(n) && n > 0 ? n : fallback;
 }
 
 /**
@@ -289,19 +298,31 @@ function parseChatIdEnv(raw: string | undefined): number | null {
 }
 
 const config = {
-  port: parseInt(process.env.HUGIN_PORT || "3032"),
+  port: parseBoundedPositiveInt(process.env.HUGIN_PORT, 3032, 65_535),
   host: process.env.HUGIN_HOST || "127.0.0.1",
   muninUrl: process.env.MUNIN_URL || "http://localhost:3030",
   muninApiKey: process.env.MUNIN_API_KEY || "",
-  pollIntervalMs: parseInt(process.env.HUGIN_POLL_INTERVAL_MS || "30000"),
-  defaultTimeoutMs: parseInt(process.env.HUGIN_DEFAULT_TIMEOUT_MS || "300000"),
+  pollIntervalMs: parseBoundedPositiveInt(
+    process.env.HUGIN_POLL_INTERVAL_MS,
+    30_000,
+    3_600_000,
+  ),
+  defaultTimeoutMs: parseBoundedPositiveInt(
+    process.env.HUGIN_DEFAULT_TIMEOUT_MS,
+    300_000,
+    MAX_TASK_TIMEOUT_MS,
+  ),
   workspace: process.env.HUGIN_WORKSPACE || "/home/magnus/workspace",
   // Root under which `repo:<name>` aliases resolve and task branches are cut
   // (#139). Point this at an isolated tree to keep hugin tasks off the
   // production deploy checkouts under /home/magnus/repos. Default preserves
   // the historical hardcoded behavior.
   reposRoot: normalizeRoot(process.env.HUGIN_REPOS_ROOT || DEFAULT_REPOS_ROOT),
-  maxOutputChars: parseInt(process.env.HUGIN_MAX_OUTPUT_CHARS || "50000"),
+  maxOutputChars: parseBoundedPositiveInt(
+    process.env.HUGIN_MAX_OUTPUT_CHARS,
+    50_000,
+    1_000_000,
+  ),
   allowedSubmitters: (process.env.HUGIN_ALLOWED_SUBMITTERS || "Codex,Codex-desktop,ratatoskr,Codex-web,Codex-mobile,claude-code,claude-desktop,claude-web,claude-mobile,hugin")
     .split(",")
     .map((s) => s.trim())
@@ -347,8 +368,10 @@ const config = {
   submitterKeys: loadKeyStoreFromEnv() as KeyStore,
   exfilPolicy: parseExfilPolicy(process.env.HUGIN_EXFIL_POLICY),
   externalPolicy: parseExternalPolicy(process.env.HUGIN_EXTERNAL_POLICY),
-  brokerReconciliationIntervalMs: parseInt(
-    process.env.HUGIN_BROKER_RECONCILIATION_INTERVAL_MS || "60000",
+  brokerReconciliationIntervalMs: parseBoundedPositiveInt(
+    process.env.HUGIN_BROKER_RECONCILIATION_INTERVAL_MS,
+    60_000,
+    3_600_000,
   ),
   // Runtime-owned artefact delivery (issue #68). `parseDeliveryPolicy` and
   // `loadDeliveryTargets` throw on malformed input — fail fast at startup
@@ -657,7 +680,7 @@ interface TaskConfig {
   artifactManifestGrammarViolation?: boolean;
   homeserverTaskType?: string;
   homeserverVerifier?: HomeserverVerifierSpec;
-  homeserverMaxTokens?: number;
+  maxOutputTokens?: number;
   homeserverPolicyError?: string;
 }
 
@@ -827,9 +850,10 @@ function parseTask(content: string): TaskConfig | null {
   if ((!prompt && !canonicalBrokerEnvelope) || (!runtime && !isAutoRoute)) return null;
 
   // Resolution priority: Context > Working dir > config.workspace
-  const resolvedDir = contextRaw
-    ? resolveContext(contextRaw, { reposRoot: config.reposRoot, workspace: config.workspace })
-    : workingDir || config.workspace;
+  const resolvedDir = resolveTaskWorkingDirectory(contextRaw, workingDir, {
+    reposRoot: config.reposRoot,
+    workspace: config.workspace,
+  });
 
   // Runtime-owned artefact delivery manifest (issue #68). Parsed unconditionally
   // so submit-time validation can reject a malformed/placeholder-leaking
@@ -853,7 +877,11 @@ function parseTask(content: string): TaskConfig | null {
     runtime: runtime || "claude",  // temporary for auto — overwritten by router
     workingDir: resolvedDir,
     context: contextRaw || undefined,
-    timeoutMs: canonicalBrokerEnvelope?.timeout_ms ?? (timeoutStr ? parseInt(timeoutStr) : config.defaultTimeoutMs),
+    timeoutMs: parseBoundedPositiveInt(
+      canonicalBrokerEnvelope?.timeout_ms ?? timeoutStr,
+      config.defaultTimeoutMs,
+      MAX_TASK_TIMEOUT_MS,
+    ),
     submittedBy: submittedBy || "unknown",
     submittedAt: submittedAt || new Date().toISOString(),
     replyTo: replyTo || undefined,
@@ -888,8 +916,13 @@ function parseTask(content: string): TaskConfig | null {
     homeserverVerifier: canonicalBrokerEnvelope?.acceptance.mode === "verifier"
       ? canonicalBrokerEnvelope.acceptance.verifier
       : homeserverVerifier,
-    homeserverMaxTokens: canonicalBrokerEnvelope?.max_output_tokens
-      ?? (homeserverMaxTokensRaw ? Number(homeserverMaxTokensRaw) : undefined),
+    maxOutputTokens: homeserverMaxTokensRaw || canonicalBrokerEnvelope?.max_output_tokens
+      ? parseBoundedPositiveInt(
+          canonicalBrokerEnvelope?.max_output_tokens ?? homeserverMaxTokensRaw,
+          4_096,
+          MAX_TASK_OUTPUT_TOKENS,
+        )
+      : undefined,
     homeserverPolicyError,
     pipeline:
       pipelineId && pipelinePhase
@@ -1566,9 +1599,11 @@ async function probeClaudeUsage(): Promise<{
    * failed refresh / logout) to alarm. Prevents an ~8h false-alarm loop.
    */
   expiresAtMs: number | null;
+  expiryEvidence: "known" | "not-applicable" | "unknown";
 }> {
   const none: QuotaSnapshot = { q5: null, q7: null };
   let expiresAtMs: number | null = null;
+  let expiryEvidence: "known" | "not-applicable" | "unknown" = "unknown";
   try {
     const credPath = path.join(process.env.HOME || "/home/magnus", ".claude", ".credentials.json");
     const creds = JSON.parse(fs.readFileSync(credPath, "utf-8"));
@@ -1577,14 +1612,17 @@ async function probeClaudeUsage(): Promise<{
     const hasRefreshToken =
       typeof creds?.claudeAiOauth?.refreshToken === "string" &&
       creds.claudeAiOauth.refreshToken.length > 0;
-    if (
+    if (hasRefreshToken) {
+      expiryEvidence = "not-applicable";
+    } else if (
       !hasRefreshToken &&
       typeof rawExpiry === "number" &&
       Number.isFinite(rawExpiry)
     ) {
       expiresAtMs = rawExpiry;
+      expiryEvidence = "known";
     }
-    if (!token) return { auth: "unknown", snapshot: none, expiresAtMs };
+    if (!token) return { auth: "unknown", snapshot: none, expiresAtMs, expiryEvidence };
 
     const res = await fetch("https://api.anthropic.com/api/oauth/usage", {
       headers: {
@@ -1606,9 +1644,10 @@ async function probeClaudeUsage(): Promise<{
         auth: hasRefreshToken ? "unknown" : "unauthorized",
         snapshot: none,
         expiresAtMs,
+        expiryEvidence,
       };
     }
-    if (!res.ok) return { auth: "unknown", snapshot: none, expiresAtMs };
+    if (!res.ok) return { auth: "unknown", snapshot: none, expiresAtMs, expiryEvidence };
     const data = await res.json() as Record<string, Record<string, number>>;
     return {
       auth: "ok",
@@ -1617,9 +1656,10 @@ async function probeClaudeUsage(): Promise<{
         q7: data?.seven_day?.utilization ?? null,
       },
       expiresAtMs,
+      expiryEvidence,
     };
   } catch {
-    return { auth: "unknown", snapshot: none, expiresAtMs };
+    return { auth: "unknown", snapshot: none, expiresAtMs, expiryEvidence };
   }
 }
 
@@ -1710,10 +1750,64 @@ function checkVersionDrift(): VersionDriftResult | null {
 // Edge-triggered like the auth alarm (#131): once the drift alert has been
 // successfully delivered (or there is no send target configured), don't
 // re-push it on every subsequent refused task — the worker still refuses
-// EVERY task while drifted, only the Telegram push is deduped. Reset only by
-// a process restart (which re-takes the baseline and clears this).
+// EVERY task while drifted, only the alert push is deduped. A process restart
+// re-takes the baseline and may resolve a previously persisted firing alert.
 let versionDriftAlerted = false;
-const VERSION_DRIFT_DEDUP_KEY = "hugin-version-drift";
+let versionDriftAlarmLifecycle: VersionDriftAlertLifecycle =
+  INITIAL_VERSION_DRIFT_ALERT_LIFECYCLE;
+let versionDriftFiringPersistencePending = false;
+const VERSION_DRIFT_ALARM_NS = "tasks/_version_drift_alarm";
+
+async function hydrateVersionDriftAlarmState(): Promise<void> {
+  try {
+    const entry = await reaperMunin.read(VERSION_DRIFT_ALARM_NS, "state");
+    if (!entry) return;
+    const parsed = JSON.parse(entry.content) as { active?: unknown };
+    versionDriftAlarmLifecycle = hydrateVersionDriftAlertLifecycle(
+      parsed.active === true,
+      versionDriftBaseline !== null,
+    );
+  } catch {
+    // Missing/malformed state means there is no proven external firing alert.
+  }
+}
+
+async function persistVersionDriftAlarmState(active: boolean): Promise<boolean> {
+  try {
+    await reaperMunin.write(
+      VERSION_DRIFT_ALARM_NS,
+      "state",
+      JSON.stringify({ active }),
+      ["version-drift-alarm"],
+    );
+    return true;
+  } catch (err) {
+    console.error("[version-drift] Failed to persist alert state:", err);
+    return false;
+  }
+}
+
+async function maybeResolveVersionDriftAlert(): Promise<void> {
+  const resolution = versionDriftStartupResolution(versionDriftAlarmLifecycle);
+  if (!resolution) return;
+  const status = await sendRatatoskrAlert(resolution);
+  if (status !== "delivered") return;
+  // Persist before clearing in-memory state. If persistence fails, the next
+  // poll retries the idempotent resolution rather than forgetting it.
+  const persisted = await persistVersionDriftAlarmState(false);
+  versionDriftAlarmLifecycle = recordVersionDriftResolutionAttempt(
+    versionDriftAlarmLifecycle,
+    true,
+    persisted,
+  );
+}
+
+async function flushVersionDriftFiringState(): Promise<void> {
+  if (!versionDriftFiringPersistencePending) return;
+  if (await persistVersionDriftAlarmState(true)) {
+    versionDriftFiringPersistencePending = false;
+  }
+}
 
 async function maybeAlertVersionDrift(drift: VersionDriftResult): Promise<void> {
   if (versionDriftAlerted) return;
@@ -1726,7 +1820,14 @@ async function maybeAlertVersionDrift(drift: VersionDriftResult): Promise<void> 
     dedup_key: VERSION_DRIFT_DEDUP_KEY,
   };
   const status = await sendRatatoskrAlert(alert);
-  if (status !== "failed") {
+  if (status === "delivered") {
+    versionDriftAlarmLifecycle = recordVersionDriftFiring();
+    versionDriftFiringPersistencePending =
+      !(await persistVersionDriftAlarmState(true));
+    versionDriftAlerted = true;
+  } else if (status === "skipped") {
+    // Nothing external was opened, but avoid repeating the local log for every
+    // refused task in this process.
     versionDriftAlerted = true;
   }
 }
@@ -2521,15 +2622,52 @@ async function reconcileDeliveryPending(
   await refreshPipelineSummaryFromContent(entry.content, client);
 }
 
-async function recoverStaleTasks(): Promise<void> {
-  try {
-    const { results } = await munin.query({
-      query: "task",
-      tags: ["running"],
+// Operational sweeps must see beyond Munin's 50-row response cap, but they
+// also run on timers and cannot be allowed to turn one backlog into unbounded
+// network/read work. Repeated sweeps drain the bounded window as lifecycle
+// tags are cleared. `truncated` is logged so operators know the pass was a
+// lower bound rather than a complete census.
+const OPERATIONAL_SCAN_BUDGET = { maxPages: 4, maxResults: 200 } as const;
+const operationalScanCursors = new Map<string, string>();
+
+async function queryOperationalTaskEntries(
+  client: MuninClient,
+  tags: string[],
+  label: string,
+): Promise<import("./munin-client.js").MuninQueryResult[]> {
+  const cursorKey = `${label}\0${tags.join("\0")}`;
+  const until = operationalScanCursors.get(cursorKey);
+  const page = await queryAllMuninEntries(
+    client,
+    {
+      tags,
       namespace: "tasks/",
       entry_type: "state",
-      limit: 20,
-    });
+      ...(until ? { until } : {}),
+    },
+    OPERATIONAL_SCAN_BUDGET,
+  );
+  if (page.budgetExhausted) {
+    if (page.continuationUntil) {
+      operationalScanCursors.set(cursorKey, page.continuationUntil);
+    } else {
+      operationalScanCursors.delete(cursorKey);
+    }
+    console.warn(
+      `${label}: operational scan reached its ${OPERATIONAL_SCAN_BUDGET.maxResults}-entry budget; ` +
+        "this pass is a lower bound and the next sweep will continue from the oldest scanned timestamp",
+    );
+  } else {
+    // The older tail is exhausted. Restart at the newest edge next time so
+    // entries created or retagged while this scan rotated are observed.
+    operationalScanCursors.delete(cursorKey);
+  }
+  return page.results;
+}
+
+async function recoverStaleTasks(): Promise<void> {
+  try {
+    const results = await queryOperationalTaskEntries(munin, ["running"], "startup recovery");
 
     for (const result of results) {
       if (!result.key || result.key !== "status") continue;
@@ -2634,13 +2772,11 @@ async function recoverStaleTasks(): Promise<void> {
 
 async function reapExpiredLeases(): Promise<void> {
   try {
-    const { results } = await reaperMunin.query({
-      query: "task",
-      tags: ["running"],
-      namespace: "tasks/",
-      entry_type: "state",
-      limit: 20,
-    });
+    const results = await queryOperationalTaskEntries(
+      reaperMunin,
+      ["running"],
+      "lease reaper",
+    );
 
     const now = Date.now();
 
@@ -2804,13 +2940,11 @@ function stopLeaseReaper(): void {
 async function reapDeferredDeliveries(): Promise<void> {
   if (config.deliveryPolicy !== "defer") return;
   try {
-    const { results } = await reaperMunin.query({
-      query: "task",
-      tags: ["running", "delivery:pending"],
-      namespace: "tasks/",
-      entry_type: "state",
-      limit: 20,
-    });
+    const results = await queryOperationalTaskEntries(
+      reaperMunin,
+      ["running", "delivery:pending"],
+      "delivery retry reaper",
+    );
     for (const result of results) {
       if (!result.key || result.key !== "status") continue;
       // Never touch the live in-process delivery (mirrors the lease reaper's
@@ -2863,10 +2997,10 @@ const AUTH_ALARM_NS = "tasks/_auth_alarm";
 // configured, nothing more we can do (treated as terminal so we don't re-log
 // every tick). `failed` — configured but the push errored/non-2xx, so the
 // caller must NOT advance the edge state and should retry next tick.
-type AlertDeliveryStatus = "delivered" | "skipped" | "failed";
-
 async function sendRatatoskrAlert(alert: AlertEnvelope): Promise<AlertDeliveryStatus> {
-  const logLine = `[auth-alarm] ${alert.severity ?? "info"}: ${alert.title}`;
+  const logLine = alert.state === "resolved"
+    ? `[alert-bus] resolved: ${alert.dedup_key ?? "unknown"}`
+    : `[alert-bus] ${alert.severity ?? "info"}: ${alert.title ?? "untitled"}`;
   if (alert.severity === "error" || alert.severity === "critical") {
     console.error(logLine);
   } else {
@@ -2960,6 +3094,7 @@ function withAuthAlarmLock(fn: () => Promise<void>): Promise<void> {
 async function applyAuthReadingLocked(reading: {
   auth: "ok" | "unauthorized" | "unknown";
   expiresAtMs: number | null;
+  expiryEvidence?: "known" | "not-applicable" | "unknown";
 }): Promise<void> {
   const prevState = authAlarmState;
   const { alerts, nextState } = decideAuthAlarm(prevState, reading, {
@@ -2970,7 +3105,12 @@ async function applyAuthReadingLocked(reading: {
   let allDelivered = true;
   for (const alert of alerts) {
     const status = await sendRatatoskrAlert(alert);
-    if (status === "failed") allDelivered = false;
+    // A firing alert may commit when no transport is configured (the existing
+    // anti-spam behavior). A resolution is an external state mutation: only a
+    // confirmed Ratatoskr 2xx may clear the persisted firing state.
+    if (!alertDeliveryCommitsTransition(alert, status)) {
+      allDelivered = false;
+    }
   }
   if (alerts.length > 0 && !allDelivered) {
     // Hold the old state; retry the undelivered alert on the next reading.
@@ -2989,6 +3129,7 @@ async function applyAuthReadingLocked(reading: {
 function processAuthReading(reading: {
   auth: "ok" | "unauthorized" | "unknown";
   expiresAtMs: number | null;
+  expiryEvidence?: "known" | "not-applicable" | "unknown";
 }): Promise<void> {
   return withAuthAlarmLock(() => applyAuthReadingLocked(reading));
 }
@@ -3001,7 +3142,11 @@ async function runAuthAlarmProbe(): Promise<void> {
   // order and the probe reflect reality at apply time.
   await withAuthAlarmLock(async () => {
     const probe = await probeClaudeUsage();
-    await applyAuthReadingLocked({ auth: probe.auth, expiresAtMs: probe.expiresAtMs });
+    await applyAuthReadingLocked({
+      auth: probe.auth,
+      expiresAtMs: probe.expiresAtMs,
+      expiryEvidence: probe.expiryEvidence,
+    });
   });
 }
 
@@ -3016,7 +3161,7 @@ async function runAuthAlarmProbe(): Promise<void> {
  */
 async function noteClaudeAuthOutcome(auth: "ok" | "unauthorized"): Promise<void> {
   if (!config.authAlarm) return;
-  await processAuthReading({ auth, expiresAtMs: null });
+  await processAuthReading({ auth, expiresAtMs: null, expiryEvidence: "unknown" });
 }
 
 function startAuthAlarmReaper(): void {
@@ -3156,13 +3301,11 @@ async function promoteDependents(
   client: MuninClient = munin,
 ): Promise<void> {
   try {
-    const { results, total } = await client.query({
-      query: "task",
-      tags: ["blocked", `depends-on:${completedTaskId}`],
-      namespace: "tasks/",
-      entry_type: "state",
-      limit: 100,
-    });
+    const results = await queryOperationalTaskEntries(
+      client,
+      ["blocked", `depends-on:${completedTaskId}`],
+      `dependency scan for ${completedTaskId}`,
+    );
 
     let promoted = 0;
     let failed = 0;
@@ -3177,9 +3320,9 @@ async function promoteDependents(
       }
     }
 
-    if (promoted > 0 || failed > 0 || total > results.length) {
+    if (promoted > 0 || failed > 0) {
       console.log(
-        `Dependency scan for ${completedTaskId}: promoted=${promoted}, failed=${failed}, scanned=${results.length}, total_matches=${total}`
+        `Dependency scan for ${completedTaskId}: promoted=${promoted}, failed=${failed}, scanned=${results.length}`
       );
     }
   } catch (err) {
@@ -3189,13 +3332,11 @@ async function promoteDependents(
 
 async function reconcileBlockedTasks(): Promise<void> {
   try {
-    const { results, total } = await munin.query({
-      query: "task",
-      tags: ["blocked"],
-      namespace: "tasks/",
-      entry_type: "state",
-      limit: 100,
-    });
+    const results = await queryOperationalTaskEntries(
+      munin,
+      ["blocked"],
+      "blocked-task reconciliation",
+    );
 
     let promoted = 0;
     let failed = 0;
@@ -3210,9 +3351,9 @@ async function reconcileBlockedTasks(): Promise<void> {
       }
     }
 
-    if (promoted > 0 || failed > 0 || total > results.length) {
+    if (promoted > 0 || failed > 0) {
       console.log(
-        `Blocked-task reconciliation: promoted=${promoted}, failed=${failed}, scanned=${results.length}, total_blocked=${total}`
+        `Blocked-task reconciliation: promoted=${promoted}, failed=${failed}, scanned=${results.length}`
       );
     }
   } catch (err) {
@@ -3520,13 +3661,11 @@ async function gatePendingTaskForApproval(
 }
 
 async function processApprovalDecisions(): Promise<boolean> {
-  const { results } = await munin.query({
-    query: "task",
-    tags: ["awaiting-approval"],
-    namespace: "tasks/",
-    entry_type: "state",
-    limit: 50,
-  });
+  const results = await queryOperationalTaskEntries(
+    munin,
+    ["awaiting-approval"],
+    "approval decisions",
+  );
 
   let processed = false;
   for (const result of results) {
@@ -3662,13 +3801,11 @@ async function processPipelineCancellationRequest(
 }
 
 async function processCancellationRequests(): Promise<boolean> {
-  const { results } = await munin.query({
-    query: "task",
-    tags: [CANCEL_REQUESTED_TAG],
-    namespace: "tasks/",
-    entry_type: "state",
-    limit: 50,
-  });
+  const results = await queryOperationalTaskEntries(
+    munin,
+    [CANCEL_REQUESTED_TAG],
+    "cancellation requests",
+  );
 
   let processed = false;
   for (const result of results) {
@@ -3707,13 +3844,11 @@ async function processCancellationRequests(): Promise<boolean> {
 }
 
 async function processResumeRequests(): Promise<boolean> {
-  const { results } = await munin.query({
-    query: "task",
-    tags: [RESUME_REQUESTED_TAG],
-    namespace: "tasks/",
-    entry_type: "state",
-    limit: 50,
-  });
+  const results = await queryOperationalTaskEntries(
+    munin,
+    [RESUME_REQUESTED_TAG],
+    "resume requests",
+  );
 
   let processed = false;
   for (const result of results) {
@@ -4435,6 +4570,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
           ollamaBaseUrl: host.baseUrl,
           timeoutMs: task.timeoutMs,
           maxOutputChars: config.maxOutputChars,
+          maxOutputTokens: task.maxOutputTokens,
           injectedContext: contextResolution?.content || undefined,
           reasoning: task.reasoning,
         },
@@ -4568,7 +4704,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         apiKey: gateway.apiKey,
         path: "delegate",
         taskType: task.homeserverTaskType,
-        maxTokens: task.homeserverMaxTokens,
+        maxTokens: task.maxOutputTokens,
         verifier: task.homeserverVerifier,
         timeoutMs: task.timeoutMs,
         maxOutputChars: config.maxOutputChars,
@@ -5577,6 +5713,14 @@ async function pollLoop(): Promise<void> {
   await primeTrackedPipelineSummaries();
   await reconcileTrackedPipelineSummaries();
 
+  // A clean process restart is the recovery action for dependency drift. Only
+  // a successfully captured fresh baseline may resolve the prior firing alert;
+  // a failed baseline remains inconclusive and leaves it open.
+  await hydrateVersionDriftAlarmState();
+  await maybeResolveVersionDriftAlert().catch((err) =>
+    console.error("[version-drift] Failed to resolve prior drift alert:", err),
+  );
+
   // Clean up old log files
   await rotateOldLogs();
 
@@ -5607,6 +5751,8 @@ async function pollLoop(): Promise<void> {
     let queueDepth = 0;
     try {
       pollCount++;
+      await flushVersionDriftFiringState();
+      await maybeResolveVersionDriftAlert();
       await reconcileTrackedPipelineSummaries();
       const processedCancellation = await processCancellationRequests();
       const processedResume = await processResumeRequests();

--- a/src/learning-loop-collector.ts
+++ b/src/learning-loop-collector.ts
@@ -27,6 +27,7 @@ import {
   learningExperimentStateSchema,
   type LearningExperimentState,
 } from "./learning/experiment-schema.js";
+import { MUNIN_QUERY_MAX, queryAllMuninEntries } from "./munin-pagination.js";
 
 /** Dashboard-facing data: refresh a few times an hour, not every 60s poll. */
 export const DEFAULT_COLLECT_TTL_MS = 300_000;
@@ -226,25 +227,31 @@ export class LearningLoopCollector {
     // A FAILED query is not an empty corpus. If we cannot enumerate the tasks,
     // say the corpus is unavailable — never let it collapse into a confident
     // zero downstream.
+    const budget = {
+      maxPages: Math.max(1, Math.ceil(this.maxTasks / MUNIN_QUERY_MAX)),
+      maxResults: this.maxTasks,
+    };
     const [tagged, homeserver] = await Promise.all([
-      this.munin
-        .query({
-          query: "task",
+      queryAllMuninEntries(
+        this.munin,
+        {
           tags: ["broker:mcp-v2"],
           namespace: "tasks/",
           entry_type: "state",
-          limit: this.maxTasks,
-        })
+        },
+        budget,
+      )
         .then((r) => ({ ok: true as const, r }))
         .catch(() => ({ ok: false as const })),
-      this.munin
-        .query({
-          query: "task",
+      queryAllMuninEntries(
+        this.munin,
+        {
           tags: ["runtime:homeserver"],
           namespace: "tasks/",
           entry_type: "state",
-          limit: this.maxTasks,
-        })
+        },
+        budget,
+      )
         .then((r) => ({ ok: true as const, r }))
         .catch(() => ({ ok: false as const })),
     ]);
@@ -262,7 +269,12 @@ export class LearningLoopCollector {
     ];
     const namespaces = all.slice(0, this.maxTasks);
     // A cap that hides what it dropped turns a lower bound into a fact.
-    const truncated = all.length > namespaces.length || !tagged.ok || !homeserver.ok;
+    const truncated =
+      all.length > namespaces.length ||
+      !tagged.ok ||
+      !homeserver.ok ||
+      (tagged.ok && tagged.r.truncated) ||
+      (homeserver.ok && homeserver.r.truncated);
 
     const tasks: ProductTaskEvidence[] = [];
     let readFailures = 0;

--- a/src/munin-pagination.ts
+++ b/src/munin-pagination.ts
@@ -14,10 +14,22 @@ export interface MuninFilterQueryOptions {
 export interface MuninPaginatedQueryResult {
   results: MuninQueryResult[];
   /**
-   * True only when an exact updated_at bucket itself reaches Munin's cap.
-   * Without a composite cursor, that bucket cannot be proven complete.
+   * True whenever the walk cannot prove the returned result set is complete,
+   * including exact-timestamp ambiguity, caller budget exhaustion, or a
+   * malformed page cursor. Use `budgetExhausted` for the caller-limit case.
    */
   truncated: boolean;
+  /** True when caller limits, rather than the corpus end, stopped the walk. */
+  budgetExhausted: boolean;
+  /** Cursor immediately before the oldest returned row, for a later sweep. */
+  continuationUntil?: string;
+}
+
+export interface MuninPaginationBudget {
+  /** Maximum ordinary pages to request. Exact-boundary probes are additional. */
+  maxPages?: number;
+  /** Maximum unique rows returned to the caller. */
+  maxResults?: number;
 }
 
 function normalizeIsoTimestamp(value: string | undefined): string | undefined {
@@ -54,13 +66,17 @@ function addResults(
 export async function queryAllMuninEntries(
   munin: Pick<MuninClient, "query">,
   options: MuninFilterQueryOptions,
+  budget: MuninPaginationBudget = {},
 ): Promise<MuninPaginatedQueryResult> {
   const since = normalizeIsoTimestamp(options.since);
   let until = normalizeIsoTimestamp(options.until);
   const unique = new Map<string, MuninQueryResult>();
   let truncated = false;
+  let budgetExhausted = false;
+  let pages = 0;
 
   while (true) {
+    pages += 1;
     const page = await munin.query({
       tags: options.tags,
       namespace: options.namespace,
@@ -93,6 +109,18 @@ export async function queryAllMuninEntries(
     addResults(unique, boundaryPage.results);
     if (boundaryPage.results.length >= MUNIN_QUERY_MAX) truncated = true;
 
+    if (
+      (budget.maxPages !== undefined && pages >= budget.maxPages) ||
+      (budget.maxResults !== undefined && unique.size >= budget.maxResults)
+    ) {
+      // A full page means another older page may exist. Stop honestly at the
+      // caller's work budget instead of allowing history/recovery surfaces to
+      // grow without bound.
+      truncated = true;
+      budgetExhausted = true;
+      break;
+    }
+
     const previousMillisecond = Date.parse(boundary) - 1;
     if (!Number.isFinite(previousMillisecond)) {
       truncated = true;
@@ -108,5 +136,32 @@ export async function queryAllMuninEntries(
     until = nextUntil;
   }
 
-  return { results: [...unique.values()], truncated };
+  const results = [...unique.values()].sort((a, b) => {
+    const byTime = (b.updated_at ?? "").localeCompare(a.updated_at ?? "");
+    return byTime || resultIdentity(a).localeCompare(resultIdentity(b));
+  });
+  if (budget.maxResults !== undefined && results.length > budget.maxResults) {
+    results.length = budget.maxResults;
+    truncated = true;
+    budgetExhausted = true;
+  }
+  let continuationUntil: string | undefined;
+  if (budgetExhausted) {
+    const oldestTimestamp = results
+      .map((entry) => Date.parse(entry.updated_at))
+      .filter(Number.isFinite)
+      .reduce<number | null>(
+        (oldest, value) => oldest === null || value < oldest ? value : oldest,
+        null,
+      );
+    if (oldestTimestamp !== null) {
+      continuationUntil = new Date(oldestTimestamp - 1).toISOString();
+    }
+  }
+  return {
+    results,
+    truncated,
+    budgetExhausted,
+    ...(continuationUntil ? { continuationUntil } : {}),
+  };
 }

--- a/src/ollama-executor.ts
+++ b/src/ollama-executor.ts
@@ -17,6 +17,8 @@ export interface OllamaTaskConfig {
   ollamaBaseUrl: string;
   timeoutMs: number;
   maxOutputChars: number;
+  /** Hard generation cap forwarded to Ollama. */
+  maxOutputTokens?: number;
   injectedContext?: string;
   /**
    * Control hybrid-reasoning behaviour for models that generate internal
@@ -103,6 +105,7 @@ export async function executeOllamaTask(
       `Model: ${task.model}`,
       `Host: ${task.ollamaBaseUrl}`,
       `Timeout: ${task.timeoutMs}ms`,
+      `Max output tokens: ${task.maxOutputTokens ?? "default"}`,
       `Context injected: ${task.injectedContext ? `${task.injectedContext.length} chars` : "none"}`,
       `Free memory: ${freeMemBeforeMb} MB`,
       `Started: ${startedAt}`,
@@ -171,9 +174,14 @@ export async function executeOllamaTask(
     };
     if (needsNativeChat) {
       body.think = thinkValue;
+      if (task.maxOutputTokens !== undefined) {
+        body.options = { num_predict: task.maxOutputTokens };
+      }
       // Log-only metadata — must not go through appendOutput(), which would
       // pollute output/resultText and corrupt tasks that expect clean JSON.
       logStream.write(`[Ollama native /api/chat, think:${thinkValue}]\n`);
+    } else if (task.maxOutputTokens !== undefined) {
+      body.max_tokens = task.maxOutputTokens;
     }
 
     const res = await fetch(`${task.ollamaBaseUrl}${endpoint}`, {

--- a/src/task-helpers.ts
+++ b/src/task-helpers.ts
@@ -24,6 +24,10 @@ export interface WorkspaceRoots {
   workspace?: string;
 }
 
+/** Hard dispatcher resource ceilings for ordinary (non-Broker) task fields. */
+export const MAX_TASK_TIMEOUT_MS = 43_200_000; // 12h
+export const MAX_TASK_OUTPUT_TOKENS = 32_768;
+
 /** Strip any trailing slashes so `${root}/` composition is unambiguous. */
 export function normalizeRoot(root: string): string {
   return root.replace(/\/+$/, "");
@@ -42,14 +46,14 @@ export function normalizeRoot(root: string): string {
  * the original hardcoded `/home/magnus/repos` + `/home/magnus/workspace`.
  */
 export function resolveContext(raw: string, roots: WorkspaceRoots = {}): string {
-  const reposRoot = normalizeRoot(roots.reposRoot ?? DEFAULT_REPOS_ROOT);
-  const workspace = roots.workspace ?? DEFAULT_WORKSPACE;
+  const reposRoot = path.resolve(normalizeRoot(roots.reposRoot ?? DEFAULT_REPOS_ROOT));
+  const workspace = path.resolve(roots.workspace ?? DEFAULT_WORKSPACE);
   const trimmed = raw.trim();
   if (trimmed.startsWith("repo:")) {
     const name = trimmed.slice(5);
-    const resolved = path.resolve(`${reposRoot}/${name}`);
+    const resolved = path.resolve(reposRoot, name);
     // Guard against traversal (e.g. repo:../../tmp) escaping the repos root.
-    if (!resolved.startsWith(`${reposRoot}/`)) {
+    if (!resolved.startsWith(`${reposRoot}${path.sep}`)) {
       return workspace;
     }
     return resolved;
@@ -58,15 +62,41 @@ export function resolveContext(raw: string, roots: WorkspaceRoots = {}): string 
     case "scratch": return "/home/magnus/scratch";
     case "files": return "/home/magnus/mimir";
     default: {
-      // Only allow absolute paths under /home/magnus/; reject others
-      if (trimmed.startsWith("/home/magnus/")) return trimmed;
-      if (trimmed.startsWith("/")) {
+      // Normalize before checking the prefix. A lexical prefix check alone
+      // accepts `/home/magnus/../../etc`, which later filesystem calls resolve
+      // outside the intended workspace boundary.
+      if (path.isAbsolute(trimmed)) {
+        const resolved = path.resolve(trimmed);
+        if (resolved.startsWith(`/home/magnus${path.sep}`)) return resolved;
         console.warn(`Context path outside /home/magnus/ rejected: ${trimmed}`);
         return workspace;
       }
       return workspace;
     }
   }
+}
+
+/** Apply the same path policy to both Context and the legacy Working dir field. */
+export function resolveTaskWorkingDirectory(
+  context: string | undefined,
+  workingDir: string | undefined,
+  roots: WorkspaceRoots = {},
+): string {
+  const fallback = path.resolve(roots.workspace ?? DEFAULT_WORKSPACE);
+  if (context) return resolveContext(context, roots);
+  if (workingDir) return resolveContext(workingDir, { ...roots, workspace: fallback });
+  return fallback;
+}
+
+/** Parse a positive integer and clamp it to a caller-owned hard ceiling. */
+export function parseBoundedPositiveInt(
+  raw: string | number | undefined,
+  fallback: number,
+  max: number,
+): number {
+  const parsed = typeof raw === "number" ? raw : Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) return fallback;
+  return Math.min(parsed, max);
 }
 
 export function getFoundBatchEntry(

--- a/src/version-drift.ts
+++ b/src/version-drift.ts
@@ -53,6 +53,56 @@ export interface VersionDriftResult {
   message: string;
 }
 
+export const VERSION_DRIFT_DEDUP_KEY = "hugin-version-drift";
+
+export interface VersionDriftAlertLifecycle {
+  active: boolean;
+  /** True only for active state hydrated by a clean, baseline-ready restart. */
+  restartResolutionPending: boolean;
+}
+
+export const INITIAL_VERSION_DRIFT_ALERT_LIFECYCLE: VersionDriftAlertLifecycle = {
+  active: false,
+  restartResolutionPending: false,
+};
+
+export function hydrateVersionDriftAlertLifecycle(
+  persistedActive: boolean,
+  baselineCaptured: boolean,
+): VersionDriftAlertLifecycle {
+  return {
+    active: persistedActive,
+    restartResolutionPending: persistedActive && baselineCaptured,
+  };
+}
+
+/** A firing created now is never eligible for same-process resolution. */
+export function recordVersionDriftFiring(): VersionDriftAlertLifecycle {
+  return { active: true, restartResolutionPending: false };
+}
+
+/**
+ * A clean restart may resolve a previously delivered drift alert only when the
+ * new process successfully captured a fresh SDK baseline. A failed baseline is
+ * inconclusive and must leave Heimdall firing.
+ */
+export function versionDriftStartupResolution(
+  lifecycle: VersionDriftAlertLifecycle,
+): { state: "resolved"; dedup_key: typeof VERSION_DRIFT_DEDUP_KEY } | null {
+  if (!lifecycle.active || !lifecycle.restartResolutionPending) return null;
+  return { state: "resolved", dedup_key: VERSION_DRIFT_DEDUP_KEY };
+}
+
+/** Delivery and persistence both gate clearing; otherwise the next poll retries. */
+export function recordVersionDriftResolutionAttempt(
+  lifecycle: VersionDriftAlertLifecycle,
+  delivered: boolean,
+  persisted: boolean,
+): VersionDriftAlertLifecycle {
+  if (!delivered || !persisted) return lifecycle;
+  return INITIAL_VERSION_DRIFT_ALERT_LIFECYCLE;
+}
+
 const FIELD_LABELS: Array<{ field: keyof VersionSnapshot; label: string }> = [
   { field: "sdkVersion", label: "sdkVersion" },
   { field: "cliPath", label: "cliPath" },

--- a/tests/auth-alarm.test.ts
+++ b/tests/auth-alarm.test.ts
@@ -3,6 +3,7 @@ import {
   AUTH_ALARM_DEDUP_KEY,
   AUTH_EXPIRY_DEDUP_KEY,
   INITIAL_AUTH_ALARM_STATE,
+  alertDeliveryCommitsTransition,
   decideAuthAlarm,
   type AuthAlarmState,
 } from "../src/auth-alarm.js";
@@ -60,7 +61,7 @@ describe("decideAuthAlarm — edge-triggered auth transitions", () => {
     expect(nextState.lastAuth).toBe("unauthorized");
   });
 
-  it("fires one recovery info alert on unauthorized → ok", () => {
+  it("resolves the firing auth alert on confirmed unauthorized → ok", () => {
     const prev: AuthAlarmState = { lastAuth: "unauthorized", expiryWarned: false };
     const { alerts, nextState } = decideAuthAlarm(
       prev,
@@ -68,8 +69,10 @@ describe("decideAuthAlarm — edge-triggered auth transitions", () => {
       opts,
     );
     expect(alerts).toHaveLength(1);
-    expect(alerts[0].severity).toBe("info");
-    expect(alerts[0].dedup_key).toBe(AUTH_ALARM_DEDUP_KEY);
+    expect(alerts[0]).toEqual({
+      state: "resolved",
+      dedup_key: AUTH_ALARM_DEDUP_KEY,
+    });
     expect(nextState.lastAuth).toBe("ok");
   });
 
@@ -109,15 +112,45 @@ describe("decideAuthAlarm — impending-expiry warning", () => {
     expect(alerts).toHaveLength(0);
   });
 
-  it("re-arms the warning when a fresh token pushes expiry beyond the window", () => {
+  it("resolves and re-arms the warning when expiry moves beyond the window", () => {
     const prev: AuthAlarmState = { lastAuth: "ok", expiryWarned: true };
     const { alerts, nextState } = decideAuthAlarm(
       prev,
       { auth: "ok", expiresAtMs: farExpiry },
       opts,
     );
-    expect(alerts).toHaveLength(0);
+    expect(alerts).toEqual([{
+      state: "resolved",
+      dedup_key: AUTH_EXPIRY_DEDUP_KEY,
+    }]);
     expect(nextState.expiryWarned).toBe(false);
+  });
+
+  it("resolves expiry only when refresh-token evidence proves hard expiry is not applicable", () => {
+    const prev: AuthAlarmState = { lastAuth: "ok", expiryWarned: true };
+    const { alerts, nextState } = decideAuthAlarm(
+      prev,
+      { auth: "unknown", expiresAtMs: null, expiryEvidence: "not-applicable" },
+      opts,
+    );
+    expect(alerts).toEqual([{
+      state: "resolved",
+      dedup_key: AUTH_EXPIRY_DEDUP_KEY,
+    }]);
+    expect(nextState.expiryWarned).toBe(false);
+    // Auth remained inconclusive; expiry evidence must not fake auth recovery.
+    expect(nextState.lastAuth).toBe("ok");
+  });
+
+  it("does not clear an active expiry warning when expiresAtMs:null is unknown", () => {
+    const prev: AuthAlarmState = { lastAuth: "ok", expiryWarned: true };
+    const { alerts, nextState } = decideAuthAlarm(
+      prev,
+      { auth: "ok", expiresAtMs: null, expiryEvidence: "unknown" },
+      opts,
+    );
+    expect(alerts).toEqual([]);
+    expect(nextState.expiryWarned).toBe(true);
   });
 
   it("does not warn when expiry is unknown (null)", () => {
@@ -139,5 +172,21 @@ describe("decideAuthAlarm — impending-expiry warning", () => {
       opts,
     );
     expect(alerts).toHaveLength(0);
+  });
+});
+
+describe("alert delivery gating", () => {
+  it("retries a resolution unless Ratatoskr confirms delivery", () => {
+    const resolution = { state: "resolved" as const, dedup_key: AUTH_ALARM_DEDUP_KEY };
+    expect(alertDeliveryCommitsTransition(resolution, "delivered")).toBe(true);
+    expect(alertDeliveryCommitsTransition(resolution, "skipped")).toBe(false);
+    expect(alertDeliveryCommitsTransition(resolution, "failed")).toBe(false);
+  });
+
+  it("preserves the existing log-only terminal behavior for firing alerts", () => {
+    const firing = { title: "Auth invalid", dedup_key: AUTH_ALARM_DEDUP_KEY };
+    expect(alertDeliveryCommitsTransition(firing, "delivered")).toBe(true);
+    expect(alertDeliveryCommitsTransition(firing, "skipped")).toBe(true);
+    expect(alertDeliveryCommitsTransition(firing, "failed")).toBe(false);
   });
 });

--- a/tests/context-loader.test.ts
+++ b/tests/context-loader.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { resolveContextRefs } from "../src/context-loader.js";
+import {
+  MAX_CONTEXT_BUDGET_CHARS,
+  MAX_CONTEXT_REFS,
+  resolveContextRefs,
+} from "../src/context-loader.js";
 
 type BatchRef = { namespace: string; key: string };
 type BatchEntry =
@@ -114,6 +118,53 @@ describe("context-loader", () => {
     expect(batchCallCount).toBe(1);
     expect(resolution.refsResolved).toHaveLength(3);
     expect(resolution.refsMissing).toHaveLength(0);
+  });
+
+  it("bounds context ref fan-out and discloses the omitted tail", async () => {
+    let requested = 0;
+    const refs = Array.from({ length: MAX_CONTEXT_REFS + 10 }, (_, index) =>
+      `projects/p${index}/status`,
+    );
+    const resolution = await resolveContextRefs(
+      refs,
+      8_000,
+      {
+        async readBatch(batch: BatchRef[]): Promise<BatchEntry[]> {
+          requested = batch.length;
+          return batch.map(({ namespace, key }) =>
+            makeEntry(namespace, key, "ok", "internal"),
+          );
+        },
+      } as never,
+    );
+
+    expect(requested).toBe(MAX_CONTEXT_REFS);
+    expect(resolution.refsRequested).toHaveLength(MAX_CONTEXT_REFS);
+    expect(resolution.truncated).toBe(true);
+  });
+
+  it("clamps an oversized context character budget", async () => {
+    const resolution = await resolveContextRefs(
+      ["projects/large/status"],
+      MAX_CONTEXT_BUDGET_CHARS * 10,
+      {
+        async readBatch(): Promise<BatchEntry[]> {
+          return [
+            makeEntry(
+              "projects/large",
+              "status",
+              "x".repeat(MAX_CONTEXT_BUDGET_CHARS + 1_000),
+              "internal",
+            ),
+          ];
+        },
+      } as never,
+    );
+
+    expect(resolution.content.length).toBeLessThanOrEqual(
+      MAX_CONTEXT_BUDGET_CHARS + "\n\n[...truncated]".length,
+    );
+    expect(resolution.truncated).toBe(true);
   });
 
   it("handles a mix of found and missing refs", async () => {

--- a/tests/daily-analysis-input.test.ts
+++ b/tests/daily-analysis-input.test.ts
@@ -1,0 +1,148 @@
+import { execFileSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function runSummary(lines: string[]) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "hugin-daily-analysis-"));
+  tempDirs.push(dir);
+  const journal = path.join(dir, "journal.jsonl");
+  fs.writeFileSync(journal, lines.join("\n") + "\n");
+  const output = execFileSync(
+    process.execPath,
+    [
+      path.resolve("scripts/build-daily-analysis-input.mjs"),
+      journal,
+      "2026-07-13T12:00:00.000Z",
+    ],
+    { encoding: "utf8" },
+  );
+  return { parsed: JSON.parse(output), output };
+}
+
+describe("bounded Daily Analysis evidence", () => {
+  it("aggregates outcomes, runtimes, cost, quota, and longest tasks", () => {
+    const { parsed } = runSummary([
+      JSON.stringify({
+        ts: "2026-07-13T10:00:00.000Z",
+        task_id: "ok",
+        runtime: "claude",
+        exit_code: 0,
+        duration_s: 10,
+        cost_usd: 0.25,
+        quota_before: { q5: 10, q7: 20 },
+        quota_after: { q5: 11, q7: 21 },
+      }),
+      JSON.stringify({
+        ts: "2026-07-13T11:00:00.000Z",
+        task_id: "slow",
+        runtime: "ollama",
+        exit_code: "TIMEOUT",
+        duration_s: 300,
+        cost_usd: null,
+      }),
+      // Outside the 24h window and therefore excluded.
+      JSON.stringify({
+        ts: "2026-07-11T11:00:00.000Z",
+        task_id: "old",
+        runtime: "codex",
+        exit_code: 1,
+        duration_s: 1,
+      }),
+    ]);
+
+    expect(parsed.entries).toBe(2);
+    expect(parsed.outcomes).toMatchObject({
+      succeeded: 1,
+      failed: 0,
+      timed_out: 1,
+      success_rate_pct: 50,
+      failure_rate_pct: 50,
+    });
+    expect(parsed.by_runtime.claude.average_duration_s).toBe(10);
+    expect(parsed.by_runtime.ollama.timed_out).toBe(1);
+    expect(parsed.cost).toEqual({ total_usd: 0.25, samples: 1, missing: 1 });
+    expect(parsed.quota.q5).toEqual({ first: 10, last: 11, min: 10, max: 11 });
+    expect(parsed.longest_tasks[0].task_id).toBe("slow");
+  });
+
+  it("counts malformed and non-object JSON as invalid without aborting", () => {
+    const { parsed } = runSummary([
+      "{not-json",
+      "null",
+      "[]",
+      '"string"',
+      "42",
+      JSON.stringify({
+        ts: "2026-07-13T10:00:00.000Z",
+        task_id: "valid",
+        runtime: "claude",
+        exit_code: 0,
+        duration_s: 4,
+        cost_usd: 0.01,
+      }),
+    ]);
+
+    expect(parsed.invalid_lines).toBe(5);
+    expect(parsed.entries).toBe(1);
+    expect(parsed.outcomes.succeeded).toBe(1);
+    expect(parsed.longest_tasks).toEqual([
+      { task_id: "valid", runtime: "claude", duration_s: 4, outcome: "succeeded" },
+    ]);
+  });
+
+  it("ignores negative, non-finite, and overflowing aggregate samples", () => {
+    const { parsed } = runSummary([
+      JSON.stringify({
+        ts: "2026-07-13T09:00:00.000Z",
+        task_id: "negative",
+        runtime: "claude",
+        exit_code: 0,
+        duration_s: -1,
+        cost_usd: -1,
+      }),
+      '{"ts":"2026-07-13T10:00:00.000Z","task_id":"non-finite","runtime":"claude","exit_code":0,"duration_s":1e309,"cost_usd":1e309}',
+      '{"ts":"2026-07-13T11:00:00.000Z","task_id":"huge-1","runtime":"ollama","exit_code":0,"duration_s":1e308,"cost_usd":1e308}',
+      '{"ts":"2026-07-13T11:30:00.000Z","task_id":"huge-2","runtime":"ollama","exit_code":0,"duration_s":1e308,"cost_usd":1e308}',
+    ]);
+
+    expect(parsed.entries).toBe(4);
+    expect(parsed.by_runtime.claude).toMatchObject({
+      average_duration_s: null,
+      max_duration_s: null,
+    });
+    expect(parsed.by_runtime.ollama).toMatchObject({
+      average_duration_s: 1e308,
+      max_duration_s: 1e308,
+    });
+    expect(parsed.cost).toEqual({ total_usd: 1e308, samples: 1, missing: 3 });
+    expect(parsed.longest_tasks).toHaveLength(1);
+  });
+
+  it("keeps model input bounded as journal volume grows", () => {
+    const rows = Array.from({ length: 2_000 }, (_, index) =>
+      JSON.stringify({
+        ts: "2026-07-13T10:00:00.000Z",
+        task_id: `task-${index}`,
+        runtime: index % 2 ? "ollama" : "claude",
+        exit_code: index % 10 === 0 ? "TIMEOUT" : 0,
+        duration_s: index,
+        cost_usd: null,
+      }),
+    );
+    const { parsed, output } = runSummary(rows);
+
+    expect(parsed.entries).toBe(2_000);
+    expect(parsed.longest_tasks).toHaveLength(5);
+    expect(output.length).toBeLessThan(5_000);
+  });
+});

--- a/tests/dispatcher.test.ts
+++ b/tests/dispatcher.test.ts
@@ -5,7 +5,12 @@ import { describe, it, expect } from "vitest";
 
 // --- resolveContext unit tests ---
 
-import { resolveContext } from "../src/task-helpers.js";
+import {
+  MAX_TASK_TIMEOUT_MS,
+  parseBoundedPositiveInt,
+  resolveContext,
+  resolveTaskWorkingDirectory,
+} from "../src/task-helpers.js";
 
 type RuntimeCapability = "tools" | "code" | "structured-output";
 type TaskPermissionProfile = "read-only" | "trusted-code";
@@ -76,9 +81,7 @@ function parseTask(content: string, workspace = "/home/magnus/workspace") {
 
   if (!prompt || (!runtime && !isAutoRoute)) return null;
 
-  const resolvedDir = contextRaw
-    ? resolveContext(contextRaw)
-    : workingDir || workspace;
+  const resolvedDir = resolveTaskWorkingDirectory(contextRaw, workingDir, { workspace });
 
   const validCapabilities: RuntimeCapability[] = [];
   if (capabilitiesRaw) {
@@ -94,7 +97,7 @@ function parseTask(content: string, workspace = "/home/magnus/workspace") {
     runtime: runtime || "claude",  // placeholder for auto — overwritten by router
     workingDir: resolvedDir,
     context: contextRaw || undefined,
-    timeoutMs: timeoutStr ? parseInt(timeoutStr) : 300000,
+    timeoutMs: parseBoundedPositiveInt(timeoutStr, 300_000, MAX_TASK_TIMEOUT_MS),
     submittedBy: submittedBy || "unknown",
     submittedAt: submittedAt || new Date().toISOString(),
     replyTo: replyTo || undefined,
@@ -157,6 +160,33 @@ describe("resolveContext", () => {
   it("should reject relative paths as fallback", () => {
     expect(resolveContext("foo")).toBe("/home/magnus/workspace");
     expect(resolveContext("relative/path")).toBe("/home/magnus/workspace");
+  });
+
+  it("normalizes absolute paths before enforcing the home boundary", () => {
+    expect(resolveContext("/home/magnus/../../etc")).toBe("/home/magnus/workspace");
+    expect(resolveContext("/home/magnus/workspace/../scratch")).toBe(
+      "/home/magnus/scratch",
+    );
+  });
+
+  it("applies the context path policy to legacy Working dir values", () => {
+    expect(resolveTaskWorkingDirectory(undefined, "/etc")).toBe(
+      "/home/magnus/workspace",
+    );
+    expect(resolveTaskWorkingDirectory(undefined, "relative/path")).toBe(
+      "/home/magnus/workspace",
+    );
+    expect(resolveTaskWorkingDirectory(undefined, "/home/magnus/scratch/job")).toBe(
+      "/home/magnus/scratch/job",
+    );
+  });
+
+  it("clamps task resource integers and rejects partial/non-positive values", () => {
+    expect(parseBoundedPositiveInt("999999999", 300_000, MAX_TASK_TIMEOUT_MS)).toBe(
+      MAX_TASK_TIMEOUT_MS,
+    );
+    expect(parseBoundedPositiveInt("12ms", 300_000, MAX_TASK_TIMEOUT_MS)).toBe(300_000);
+    expect(parseBoundedPositiveInt("0", 300_000, MAX_TASK_TIMEOUT_MS)).toBe(300_000);
   });
 });
 

--- a/tests/heimdall-descriptor.test.ts
+++ b/tests/heimdall-descriptor.test.ts
@@ -64,10 +64,11 @@ describe("HEIMDALL_DESCRIPTOR", () => {
       kind: "http-service",
       status: "pass",
       links: {
-        self: "/heimdall.json",
-        health: "/health",
         repo: "https://github.com/Magnus-Gille/hugin",
       },
+    });
+    expect(HEIMDALL_DESCRIPTOR.links).toEqual({
+      repo: "https://github.com/Magnus-Gille/hugin",
     });
   });
 });

--- a/tests/munin-pagination.test.ts
+++ b/tests/munin-pagination.test.ts
@@ -49,6 +49,7 @@ describe("queryAllMuninEntries", () => {
 
     expect(result.results).toHaveLength(125);
     expect(result.truncated).toBe(false);
+    expect(result.budgetExhausted).toBe(false);
     expect(munin.calls.length).toBeGreaterThan(3);
     expect(munin.calls.every((call) => call.query === undefined)).toBe(true);
   });
@@ -134,5 +135,47 @@ describe("queryAllMuninEntries", () => {
       since: timestamp,
       until: timestamp,
     }));
+  });
+
+  it("stops at a caller-owned work budget and reports the partial history honestly", async () => {
+    const base = Date.UTC(2026, 6, 12, 12, 0, 0);
+    const rows = Array.from({ length: 300 }, (_, index) =>
+      makeTask(index, new Date(base + index).toISOString()),
+    );
+    const munin = new FilterOnlyMunin(rows);
+
+    const result = await queryAllMuninEntries(
+      munin as unknown as MuninClient,
+      {
+        tags: ["pending"],
+        namespace: "tasks/",
+        entry_type: "state",
+      },
+      { maxPages: 2, maxResults: 100 },
+    );
+
+    expect(result.results).toHaveLength(100);
+    expect(result.truncated).toBe(true);
+    expect(result.budgetExhausted).toBe(true);
+    expect(result.continuationUntil).toBeDefined();
+    // Two ordinary pages plus their exact-timestamp boundary probes.
+    expect(munin.calls).toHaveLength(4);
+
+    const older = await queryAllMuninEntries(
+      munin as unknown as MuninClient,
+      {
+        tags: ["pending"],
+        namespace: "tasks/",
+        entry_type: "state",
+        until: result.continuationUntil,
+      },
+      { maxPages: 2, maxResults: 100 },
+    );
+    expect(older.results.every((row) =>
+      row.updated_at <= result.continuationUntil!,
+    )).toBe(true);
+    expect(
+      older.results.some((row) => result.results.some((current) => current.id === row.id)),
+    ).toBe(false);
   });
 });

--- a/tests/ollama-executor.test.ts
+++ b/tests/ollama-executor.test.ts
@@ -103,6 +103,22 @@ describe("executeOllamaTask — endpoint selection", () => {
     expect(body.think).toBeUndefined();
   });
 
+  it("forwards an output-token cap to the OpenAI-compatible endpoint", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(sseResponse(["data: [DONE]\n\n"]));
+
+    await executeOllamaTask(
+      makeTaskConfig({ model: "qwen2.5:3b", maxOutputTokens: 192 }),
+      "test-openai-token-cap",
+      tmpLogDir,
+    );
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.max_tokens).toBe(192);
+  });
+
   it("routes reasoning-family models to /api/chat with think:false by default", async () => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
@@ -139,6 +155,26 @@ describe("executeOllamaTask — endpoint selection", () => {
     const body = JSON.parse((init as RequestInit).body as string);
     expect(body.think).toBe(false);
     expect(body.stream).toBe(true);
+  });
+
+  it("forwards an output-token cap as num_predict on native chat", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        ndjsonResponse([
+          `${JSON.stringify({ message: { content: "ok" }, done: true })}\n`,
+        ]),
+      );
+
+    await executeOllamaTask(
+      makeTaskConfig({ model: "qwen3:4b", maxOutputTokens: 256 }),
+      "test-native-token-cap",
+      tmpLogDir,
+    );
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    const body = JSON.parse((init as RequestInit).body as string);
+    expect(body.options).toEqual({ num_predict: 256 });
   });
 
   it("honours explicit reasoning:true on any model via /api/chat", async () => {

--- a/tests/version-drift.test.ts
+++ b/tests/version-drift.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   buildVersionSnapshot,
   compareVersionSnapshots,
+  hydrateVersionDriftAlertLifecycle,
+  recordVersionDriftFiring,
+  recordVersionDriftResolutionAttempt,
+  VERSION_DRIFT_DEDUP_KEY,
+  versionDriftStartupResolution,
   type VersionSnapshot,
 } from "../src/version-drift.js";
 
@@ -127,5 +132,44 @@ describe("compareVersionSnapshots", () => {
     const result = compareVersionSnapshots(zeroBaseline, current);
     expect(result.drifted).toBe(true);
     expect(result.changedFields).toEqual(["cliSizeBytes"]);
+  });
+});
+
+describe("version-drift alert lifecycle", () => {
+  it("resolves a previously firing alert after a successful fresh baseline", () => {
+    const lifecycle = hydrateVersionDriftAlertLifecycle(true, true);
+    expect(versionDriftStartupResolution(lifecycle)).toEqual({
+      state: "resolved",
+      dedup_key: VERSION_DRIFT_DEDUP_KEY,
+    });
+  });
+
+  it("does not resolve when fresh baseline capture failed", () => {
+    const lifecycle = hydrateVersionDriftAlertLifecycle(true, false);
+    expect(versionDriftStartupResolution(lifecycle)).toBeNull();
+  });
+
+  it("does not emit a resolution when no drift alert was active", () => {
+    const lifecycle = hydrateVersionDriftAlertLifecycle(false, true);
+    expect(versionDriftStartupResolution(lifecycle)).toBeNull();
+  });
+
+  it("never resolves a firing created by the current process", () => {
+    const lifecycle = recordVersionDriftFiring();
+    expect(lifecycle).toEqual({ active: true, restartResolutionPending: false });
+    expect(versionDriftStartupResolution(lifecycle)).toBeNull();
+  });
+
+  it("retains restart resolution for retry until delivery and persistence both succeed", () => {
+    const hydrated = hydrateVersionDriftAlertLifecycle(true, true);
+    const deliveryFailed = recordVersionDriftResolutionAttempt(hydrated, false, false);
+    expect(versionDriftStartupResolution(deliveryFailed)).not.toBeNull();
+
+    const persistenceFailed = recordVersionDriftResolutionAttempt(hydrated, true, false);
+    expect(versionDriftStartupResolution(persistenceFailed)).not.toBeNull();
+
+    const cleared = recordVersionDriftResolutionAttempt(hydrated, true, true);
+    expect(cleared).toEqual({ active: false, restartResolutionPending: false });
+    expect(versionDriftStartupResolution(cleared)).toBeNull();
   });
 });


### PR DESCRIPTION
## Scope

Reliability and operational hardening only; no new product functionality.

- bound Munin recovery/history scans and daily-analysis input with honest truncation/continuation
- enforce workspace/repository path guards plus timeout, output-token, context-size, and context-reference ceilings
- make Claude auth-expiry and dependency-drift alerts resolve only on exact, delivered recovery evidence
- preserve the #196 continuous M5 experiment harness and its Heimdall evidence
- remove misleading relative Heimdall self/health links while retaining the repository link
- refresh the lockfile without vulnerable dependencies

## Validation

- `npm ci`
- `npm run build`
- full suite: 103 files / 1,721 tests
- focused integration: 8 files / 149 tests
- standalone Gate D runner typecheck
- deploy/bootstrap shell suites and Bash/Node syntax
- `npm audit` and `npm audit --omit=dev`: 0 vulnerabilities
- `git diff --check`

Parent Codex fallback review completed because Claude Opus CLI authentication is unavailable.