### PR TITLE
fix: reconcile legacy auth expiry alerts

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,43 @@
 # Hugin — Status
 
-**Latest session:** 2026-07-13 (Codex) — **general hardening implementation complete locally; awaiting parent review/publish/deploy**
+**Latest session:** 2026-07-13 (Codex) — **legacy auth-expiry alert lifecycle migration complete locally; awaiting parent review/publish/deploy**
+**Branch:** `codex/hugin-auth-alert-migration` from exact `origin/main@8b444adc3996a0e01095b5dc381a6ed9646de20c`.
+
+## Latest — reconcile pre-resolution expiry alerts without weakening auth evidence
+
+- Production showed a pre-#197 split-brain state: the persisted producer state
+  was `{lastAuth:"ok",expiryWarned:false}`, while Heimdall still held the active
+  `hugin-claude-auth-expiry` dedup from 2026-07-03. #197 could resolve that key
+  only when `expiryWarned` was true, so fresh refresh-token
+  `expiryEvidence:"not-applicable"` could not reconcile the external stale alert.
+- `AuthAlarmState` now persists an expiry-alert lifecycle generation. A missing
+  Munin entry starts at the current generation and sends nothing; only an
+  existing pre-generation state hydrates as legacy. The next positively safe
+  expiry reading (`not-applicable`, or a known expiry beyond the warning window)
+  sends one idempotent resolved envelope even when the legacy boolean is false.
+- Unknown evidence and a known already-past expiry remain fail-open and do not
+  migrate state. A new firing warning can establish current lifecycle ownership;
+  an already-active legacy warning does not advance ownership without an
+  external transition.
+- The existing delivery gate remains load-bearing: a legacy resolution advances
+  and persists the generation only after Ratatoskr returns 2xx. Skipped/failed
+  resolutions leave the old state for an idempotent retry. No credential probe,
+  auth classification, transport timeout, or authorization behavior changed.
+- Validation: red/green focused suite (23 auth-alarm tests), TypeScript build,
+  standalone Gate D runner typecheck, full suite (103 files / 1,729 tests), both
+  CI shell suites, Bash/Node syntax, error-severity shellcheck, `git diff --check`,
+  and full plus production-only npm audit (0 vulnerabilities). Default shellcheck
+  still reports only pre-existing warning/info findings in untouched scripts.
+
+**Next:** parent agent reviews the clean local commit, publishes it as a PR,
+merges only with green CI, then deploys from an exact merged worktree and verifies
+that the producer-owned resolved envelope naturally clears the stale Heimdall
+dedup. No push, PR, deploy, alert send, Munin write, or other live mutation
+occurred in this implementation session.
+
+---
+
+**Previous session:** 2026-07-13 (Codex) — **general hardening implementation complete locally; awaiting parent review/publish/deploy**
 **Branch:** `codex/hugin-hardening-20260713` rebased onto `origin/main@bb66fcd` (includes merged starvation/pagination fix #193 and continuous M5 harness #196).
 
 ## Latest — bounded operations, honest alert lifecycle, and Daily Analysis reliability

--- a/src/auth-alarm.ts
+++ b/src/auth-alarm.ts
@@ -68,12 +68,47 @@ export interface AuthAlarmState {
   lastAuth: "ok" | "unauthorized" | null;
   /** Whether the current token's impending-expiry warning has already fired. */
   expiryWarned: boolean;
+  /**
+   * Producer-owned expiry dedup lifecycle generation. Persisted legacy states
+   * have no generation and hydrate as 0 so one positive safe reading can
+   * reconcile an alert that predates resolved-envelope support.
+   */
+  expiryAlertLifecycleVersion: number;
 }
+
+export const AUTH_EXPIRY_LIFECYCLE_VERSION = 1;
 
 export const INITIAL_AUTH_ALARM_STATE: AuthAlarmState = {
   lastAuth: null,
   expiryWarned: false,
+  // No persisted state means no historical producer alert to reconcile.
+  expiryAlertLifecycleVersion: AUTH_EXPIRY_LIFECYCLE_VERSION,
 };
+
+/**
+ * Parse an existing persisted state. Callers intentionally invoke this only
+ * when a Munin entry exists: no entry uses {@link INITIAL_AUTH_ALARM_STATE},
+ * while a pre-generation entry must hydrate as legacy for one reconciliation.
+ */
+export function hydratePersistedAuthAlarmState(value: unknown): AuthAlarmState {
+  const parsed = value && typeof value === "object"
+    ? value as Partial<AuthAlarmState>
+    : {};
+  const rawLifecycleVersion = parsed.expiryAlertLifecycleVersion;
+  return {
+    lastAuth:
+      parsed.lastAuth === "ok" || parsed.lastAuth === "unauthorized"
+        ? parsed.lastAuth
+        : null,
+    expiryWarned: parsed.expiryWarned === true,
+    expiryAlertLifecycleVersion:
+      typeof rawLifecycleVersion === "number" &&
+      Number.isSafeInteger(rawLifecycleVersion) &&
+      rawLifecycleVersion >= AUTH_EXPIRY_LIFECYCLE_VERSION
+        ? rawLifecycleVersion
+        : 0,
+  };
+}
 
 /** Stable dedup keys so Heimdall collapses repeats of the same condition. */
 export const AUTH_ALARM_DEDUP_KEY = "hugin-claude-auth";
@@ -165,9 +200,18 @@ export function decideAuthAlarm(
   const expiryEvidence = reading.expiryEvidence ?? (
     reading.expiresAtMs === null ? "unknown" : "known"
   );
+  const expiryLifecycleCurrent =
+    state.expiryAlertLifecycleVersion >= AUTH_EXPIRY_LIFECYCLE_VERSION;
+  const currentExpiryLifecycleVersion = Math.max(
+    state.expiryAlertLifecycleVersion || 0,
+    AUTH_EXPIRY_LIFECYCLE_VERSION,
+  );
   if (expiryEvidence === "not-applicable") {
-    if (state.expiryWarned) alerts.push(expiryRecoveredAlert());
+    if (state.expiryWarned || !expiryLifecycleCurrent) {
+      alerts.push(expiryRecoveredAlert());
+    }
     nextState.expiryWarned = false;
+    nextState.expiryAlertLifecycleVersion = currentExpiryLifecycleVersion;
   } else if (expiryEvidence === "known" && reading.expiresAtMs !== null) {
     const msLeft = reading.expiresAtMs - opts.nowMs;
     if (msLeft > 0 && msLeft <= opts.expiryWarnMs) {
@@ -175,10 +219,16 @@ export function decideAuthAlarm(
         const hoursLeft = Math.max(1, Math.ceil(msLeft / 3_600_000));
         alerts.push(expiryAlert(hoursLeft));
         nextState.expiryWarned = true;
+        // A successfully committed firing transition establishes ownership of
+        // the current external dedup lifecycle too.
+        nextState.expiryAlertLifecycleVersion = currentExpiryLifecycleVersion;
       }
     } else if (msLeft > opts.expiryWarnMs) {
-      if (state.expiryWarned) alerts.push(expiryRecoveredAlert());
+      if (state.expiryWarned || !expiryLifecycleCurrent) {
+        alerts.push(expiryRecoveredAlert());
+      }
       nextState.expiryWarned = false;
+      nextState.expiryAlertLifecycleVersion = currentExpiryLifecycleVersion;
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import {
 import {
   decideAuthAlarm,
   alertDeliveryCommitsTransition,
+  hydratePersistedAuthAlarmState,
   INITIAL_AUTH_ALARM_STATE,
   type AlertEnvelope,
   type AlertDeliveryStatus,
@@ -3043,14 +3044,7 @@ async function hydrateAuthAlarmState(): Promise<void> {
   try {
     const entry = await reaperMunin.read(AUTH_ALARM_NS, "state");
     if (!entry) return;
-    const parsed = JSON.parse(entry.content) as Partial<AuthAlarmState>;
-    authAlarmState = {
-      lastAuth:
-        parsed.lastAuth === "ok" || parsed.lastAuth === "unauthorized"
-          ? parsed.lastAuth
-          : null,
-      expiryWarned: parsed.expiryWarned === true,
-    };
+    authAlarmState = hydratePersistedAuthAlarmState(JSON.parse(entry.content));
   } catch {
     // Keep INITIAL_AUTH_ALARM_STATE.
   }
@@ -3119,7 +3113,8 @@ async function applyAuthReadingLocked(reading: {
 
   const changed =
     nextState.lastAuth !== prevState.lastAuth ||
-    nextState.expiryWarned !== prevState.expiryWarned;
+    nextState.expiryWarned !== prevState.expiryWarned ||
+    nextState.expiryAlertLifecycleVersion !== prevState.expiryAlertLifecycleVersion;
   authAlarmState = nextState;
   if (changed) {
     await persistAuthAlarmState();

--- a/tests/auth-alarm.test.ts
+++ b/tests/auth-alarm.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from "vitest";
 import {
   AUTH_ALARM_DEDUP_KEY,
   AUTH_EXPIRY_DEDUP_KEY,
+  AUTH_EXPIRY_LIFECYCLE_VERSION,
   INITIAL_AUTH_ALARM_STATE,
   alertDeliveryCommitsTransition,
   decideAuthAlarm,
+  hydratePersistedAuthAlarmState,
   type AuthAlarmState,
 } from "../src/auth-alarm.js";
 
@@ -14,6 +16,17 @@ const opts = { nowMs: NOW, expiryWarnMs: WARN_MS };
 
 // A token that expires comfortably beyond the warn window.
 const farExpiry = NOW + 30 * 3_600_000;
+
+function currentState(
+  lastAuth: AuthAlarmState["lastAuth"],
+  expiryWarned: boolean,
+): AuthAlarmState {
+  return {
+    lastAuth,
+    expiryWarned,
+    expiryAlertLifecycleVersion: AUTH_EXPIRY_LIFECYCLE_VERSION,
+  };
+}
 
 describe("decideAuthAlarm — edge-triggered auth transitions", () => {
   it("does not alarm on a first healthy reading", () => {
@@ -27,7 +40,7 @@ describe("decideAuthAlarm — edge-triggered auth transitions", () => {
   });
 
   it("fires one error alert on ok → unauthorized", () => {
-    const prev: AuthAlarmState = { lastAuth: "ok", expiryWarned: false };
+    const prev = currentState("ok", false);
     const { alerts, nextState } = decideAuthAlarm(
       prev,
       { auth: "unauthorized", expiresAtMs: null },
@@ -51,7 +64,7 @@ describe("decideAuthAlarm — edge-triggered auth transitions", () => {
   });
 
   it("does NOT re-fire while it stays unauthorized (not repeatedly)", () => {
-    const prev: AuthAlarmState = { lastAuth: "unauthorized", expiryWarned: false };
+    const prev = currentState("unauthorized", false);
     const { alerts, nextState } = decideAuthAlarm(
       prev,
       { auth: "unauthorized", expiresAtMs: null },
@@ -62,7 +75,7 @@ describe("decideAuthAlarm — edge-triggered auth transitions", () => {
   });
 
   it("resolves the firing auth alert on confirmed unauthorized → ok", () => {
-    const prev: AuthAlarmState = { lastAuth: "unauthorized", expiryWarned: false };
+    const prev = currentState("unauthorized", false);
     const { alerts, nextState } = decideAuthAlarm(
       prev,
       { auth: "ok", expiresAtMs: farExpiry },
@@ -77,12 +90,12 @@ describe("decideAuthAlarm — edge-triggered auth transitions", () => {
   });
 
   it("treats unknown as fail-open: no alert, state untouched", () => {
-    const prevOk: AuthAlarmState = { lastAuth: "ok", expiryWarned: true };
+    const prevOk = currentState("ok", true);
     const r1 = decideAuthAlarm(prevOk, { auth: "unknown", expiresAtMs: null }, opts);
     expect(r1.alerts).toHaveLength(0);
     expect(r1.nextState).toEqual(prevOk);
 
-    const prevDown: AuthAlarmState = { lastAuth: "unauthorized", expiryWarned: false };
+    const prevDown = currentState("unauthorized", false);
     const r2 = decideAuthAlarm(prevDown, { auth: "unknown", expiresAtMs: null }, opts);
     expect(r2.alerts).toHaveLength(0);
     expect(r2.nextState).toEqual(prevDown);
@@ -91,7 +104,7 @@ describe("decideAuthAlarm — edge-triggered auth transitions", () => {
 
 describe("decideAuthAlarm — impending-expiry warning", () => {
   it("warns once when a valid token is inside the warn window", () => {
-    const prev: AuthAlarmState = { lastAuth: "ok", expiryWarned: false };
+    const prev = currentState("ok", false);
     const soon = NOW + 6 * 3_600_000; // 6h left, inside 12h window
     const { alerts, nextState } = decideAuthAlarm(
       prev,
@@ -106,14 +119,14 @@ describe("decideAuthAlarm — impending-expiry warning", () => {
   });
 
   it("does not re-warn once expiryWarned is set", () => {
-    const prev: AuthAlarmState = { lastAuth: "ok", expiryWarned: true };
+    const prev = currentState("ok", true);
     const soon = NOW + 3 * 3_600_000;
     const { alerts } = decideAuthAlarm(prev, { auth: "ok", expiresAtMs: soon }, opts);
     expect(alerts).toHaveLength(0);
   });
 
   it("resolves and re-arms the warning when expiry moves beyond the window", () => {
-    const prev: AuthAlarmState = { lastAuth: "ok", expiryWarned: true };
+    const prev = currentState("ok", true);
     const { alerts, nextState } = decideAuthAlarm(
       prev,
       { auth: "ok", expiresAtMs: farExpiry },
@@ -127,7 +140,7 @@ describe("decideAuthAlarm — impending-expiry warning", () => {
   });
 
   it("resolves expiry only when refresh-token evidence proves hard expiry is not applicable", () => {
-    const prev: AuthAlarmState = { lastAuth: "ok", expiryWarned: true };
+    const prev = currentState("ok", true);
     const { alerts, nextState } = decideAuthAlarm(
       prev,
       { auth: "unknown", expiresAtMs: null, expiryEvidence: "not-applicable" },
@@ -143,7 +156,7 @@ describe("decideAuthAlarm — impending-expiry warning", () => {
   });
 
   it("does not clear an active expiry warning when expiresAtMs:null is unknown", () => {
-    const prev: AuthAlarmState = { lastAuth: "ok", expiryWarned: true };
+    const prev = currentState("ok", true);
     const { alerts, nextState } = decideAuthAlarm(
       prev,
       { auth: "ok", expiresAtMs: null, expiryEvidence: "unknown" },
@@ -154,7 +167,7 @@ describe("decideAuthAlarm — impending-expiry warning", () => {
   });
 
   it("does not warn when expiry is unknown (null)", () => {
-    const prev: AuthAlarmState = { lastAuth: "ok", expiryWarned: false };
+    const prev = currentState("ok", false);
     const { alerts, nextState } = decideAuthAlarm(
       prev,
       { auth: "ok", expiresAtMs: null },
@@ -165,13 +178,135 @@ describe("decideAuthAlarm — impending-expiry warning", () => {
   });
 
   it("does not warn on an already-past expiry (msLeft <= 0)", () => {
-    const prev: AuthAlarmState = { lastAuth: "ok", expiryWarned: false };
+    const prev = currentState("ok", false);
     const { alerts } = decideAuthAlarm(
       prev,
       { auth: "ok", expiresAtMs: NOW - 1000 },
       opts,
     );
     expect(alerts).toHaveLength(0);
+  });
+});
+
+describe("decideAuthAlarm — legacy expiry lifecycle migration", () => {
+  const legacyState: AuthAlarmState = {
+    lastAuth: "ok",
+    expiryWarned: false,
+    expiryAlertLifecycleVersion: 0,
+  };
+
+  it("reconciles a legacy false state on refresh-token not-applicable evidence", () => {
+    const decision = decideAuthAlarm(
+      legacyState,
+      { auth: "unknown", expiresAtMs: null, expiryEvidence: "not-applicable" },
+      opts,
+    );
+
+    expect(decision.alerts).toEqual([{
+      state: "resolved",
+      dedup_key: AUTH_EXPIRY_DEDUP_KEY,
+    }]);
+    expect(decision.nextState).toEqual(currentState("ok", false));
+  });
+
+  it("hydrates only an existing pre-marker state as legacy", () => {
+    expect(hydratePersistedAuthAlarmState({
+      lastAuth: "ok",
+      expiryWarned: false,
+    })).toEqual(legacyState);
+    expect(hydratePersistedAuthAlarmState(currentState("ok", false))).toEqual(
+      currentState("ok", false),
+    );
+    expect(INITIAL_AUTH_ALARM_STATE.expiryAlertLifecycleVersion).toBe(
+      AUTH_EXPIRY_LIFECYCLE_VERSION,
+    );
+  });
+
+  it("also reconciles a legacy false state on a known-safe distant expiry", () => {
+    const decision = decideAuthAlarm(
+      legacyState,
+      { auth: "ok", expiresAtMs: farExpiry, expiryEvidence: "known" },
+      opts,
+    );
+
+    expect(decision.alerts).toEqual([{
+      state: "resolved",
+      dedup_key: AUTH_EXPIRY_DEDUP_KEY,
+    }]);
+    expect(decision.nextState).toEqual(currentState("ok", false));
+  });
+
+  it("leaves a legacy state untouched on unknown or already-past expiry evidence", () => {
+    const unknown = decideAuthAlarm(
+      legacyState,
+      { auth: "unknown", expiresAtMs: null, expiryEvidence: "unknown" },
+      opts,
+    );
+    const past = decideAuthAlarm(
+      legacyState,
+      { auth: "ok", expiresAtMs: NOW - 1, expiryEvidence: "known" },
+      opts,
+    );
+
+    expect(unknown).toEqual({ alerts: [], nextState: legacyState });
+    expect(past).toEqual({ alerts: [], nextState: legacyState });
+  });
+
+  it("establishes current lifecycle ownership with a newly firing warning", () => {
+    const soon = NOW + 3_600_000;
+    const decision = decideAuthAlarm(
+      legacyState,
+      { auth: "ok", expiresAtMs: soon, expiryEvidence: "known" },
+      opts,
+    );
+
+    expect(decision.alerts).toHaveLength(1);
+    expect(decision.alerts[0]).toMatchObject({
+      dedup_key: AUTH_EXPIRY_DEDUP_KEY,
+      severity: "warn",
+    });
+    expect(decision.nextState).toEqual(currentState("ok", true));
+  });
+
+  it("does not claim current ownership without an external transition", () => {
+    const activeLegacy = { ...legacyState, expiryWarned: true };
+    const decision = decideAuthAlarm(
+      activeLegacy,
+      { auth: "ok", expiresAtMs: NOW + 3_600_000, expiryEvidence: "known" },
+      opts,
+    );
+
+    expect(decision).toEqual({ alerts: [], nextState: activeLegacy });
+  });
+
+  it("does not send a gratuitous resolution for a brand-new current state", () => {
+    const decision = decideAuthAlarm(
+      INITIAL_AUTH_ALARM_STATE,
+      { auth: "unknown", expiresAtMs: null, expiryEvidence: "not-applicable" },
+      opts,
+    );
+
+    expect(decision.alerts).toEqual([]);
+    expect(decision.nextState).toEqual(INITIAL_AUTH_ALARM_STATE);
+  });
+
+  it("becomes steady and idempotent after the delivered migration is committed", () => {
+    const first = decideAuthAlarm(
+      legacyState,
+      { auth: "unknown", expiresAtMs: null, expiryEvidence: "not-applicable" },
+      opts,
+    );
+    const resolution = first.alerts[0];
+    expect(alertDeliveryCommitsTransition(resolution, "skipped")).toBe(false);
+    expect(alertDeliveryCommitsTransition(resolution, "failed")).toBe(false);
+    expect(alertDeliveryCommitsTransition(resolution, "delivered")).toBe(true);
+
+    const steady = decideAuthAlarm(
+      first.nextState,
+      { auth: "unknown", expiresAtMs: null, expiryEvidence: "not-applicable" },
+      opts,
+    );
+    expect(steady).toEqual({ alerts: [], nextState: first.nextState });
   });
 });
 


### PR DESCRIPTION
## Summary
- add a persisted expiry-alert lifecycle generation to distinguish brand-new state from legacy pre-resolution state
- on positively safe expiry evidence, send one idempotent resolution for legacy state even when its old boolean was already false
- advance the generation only through the existing delivery-gated transition; resolved events still require Ratatoskr 2xx
- preserve unknown and already-past expiry fail-open behavior and all existing auth classifications

This repairs a producer/external-state split discovered during live hardening; it does not weaken authentication or add functionality.

## Validation
- focused auth-alarm suite: 23 passed
- full suite: 103 files / 1,729 tests passed
- TypeScript build and standalone Gate D typecheck
- deploy + Claude-bootstrap shell suites; syntax and shellcheck error gate
- full and production `npm audit`: 0 vulnerabilities
- `git diff --check`

## Review
Claude Opus was unavailable. Codex independently reviewed the state-machine/hydration diff and reran the focused suite, build, diff, and full audit gates; no findings remain.