### PR TITLE
fix: make repo-local deployments transactional

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,6 +170,12 @@ MUNIN_API_KEY=<key> MUNIN_URL=http://localhost:3030 npm run dev
 
 Default host: `huginmunin.local` (or Tailscale IP `100.97.117.37` if mDNS unavailable).
 
+`deploy-pi.sh` accepts only a clean, addressable local Git commit. It deploys
+that local payload by rsync (the remote Hugin tree intentionally needs no
+`.git`), removes `.deployed-commit` before the first payload mutation, and
+atomically stamps the exact local full SHA only after service restart/status and
+the loopback health check succeed. Any failed acceptance remains markerless.
+
 The Pi needs a `.env` file at `/home/magnus/hugin/.env`:
 ```
 MUNIN_API_KEY=<same key Munin uses>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,6 +279,12 @@ MUNIN_API_KEY=<key> MUNIN_URL=http://localhost:3030 npm run dev
 
 Default host: `huginmunin.local` (or Tailscale IP `100.97.117.37` if mDNS unavailable).
 
+`deploy-pi.sh` accepts only a clean, addressable local Git commit. It deploys
+that local payload by rsync (the remote Hugin tree intentionally needs no
+`.git`), removes `.deployed-commit` before the first payload mutation, and
+atomically stamps the exact local full SHA only after service restart/status and
+the loopback health check succeed. Any failed acceptance remains markerless.
+
 The Pi needs a `.env` file at `/home/magnus/repos/hugin/.env`:
 ```
 MUNIN_API_KEY=<same key Munin uses>

--- a/STATUS.md
+++ b/STATUS.md
@@ -17,7 +17,9 @@
 - The previous marker (and abandoned temp marker) is removed as the first remote
   mutation. Rsync excludes `.deployed-commit` in addition to preserving the
   existing `.env`, `node_modules`, `.git`, tests, and macOS exclusions. The
-  obsolete remote Hugin `git fetch/reset` step is gone.
+  obsolete remote Hugin `git fetch/reset` step is gone. Production dependencies
+  install with `npm ci --omit=dev`, so the shipped lockfile cannot be rewritten
+  after the local commit has been pinned.
 - Only after user-service restart/status and the loopback health check succeed
   does one final remote command atomically write the exact local full SHA via a
   temp file and rename. Any earlier failure remains markerless; no fallible

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,47 @@
 # Hugin — Status
 
-**Latest session:** 2026-07-13 (Codex) — **legacy auth-expiry alert lifecycle migration complete locally; awaiting parent review/publish/deploy**
+**Latest session:** 2026-07-13 (Codex) — **repo-local deployment provenance hardening complete locally; awaiting parent review/publish/deploy**
+**Branch:** `codex/hugin-deploy-marker-hardening` from exact `origin/main@6c8428cf64d1fb0e9b33ac4875c524a094f47d6b` (merged auth lifecycle PR #198).
+
+## Latest — markerless failure boundary and exact local-commit deployment
+
+- Fleet validation found that `scripts/deploy-pi.sh` let `rsync --delete`
+  remove `.deployed-commit`, then later ran `git fetch && git reset` inside the
+  remote Hugin tree even though authoritative Grimnir deployments intentionally
+  leave that tree without `.git`. The service stayed healthy while deployment
+  provenance disappeared.
+- The repo-local deploy now accepts only a clean repository-root checkout with
+  an addressable full `HEAD` SHA. It rechecks cleanliness and the exact SHA
+  after the local build and again after rsync, so a build/source race cannot be
+  accepted as the named commit.
+- The previous marker (and abandoned temp marker) is removed as the first remote
+  mutation. Rsync excludes `.deployed-commit` in addition to preserving the
+  existing `.env`, `node_modules`, `.git`, tests, and macOS exclusions. The
+  obsolete remote Hugin `git fetch/reset` step is gone.
+- Only after user-service restart/status and the loopback health check succeed
+  does one final remote command atomically write the exact local full SHA via a
+  temp file and rename. Any earlier failure remains markerless; no fallible
+  deployment operation follows the stamp.
+- The shell regression harness now covers unversioned/dirty sources, build and
+  rsync source drift, invalidation-before-sync ordering, real rsync marker
+  exclusion semantics, invalidation failure, health failure, markerless failure
+  paths, no remote-Hugin-Git dependency, and health-before-exact-SHA stamping.
+- Validation: `npm ci`; TypeScript build; standalone Gate D runner typecheck;
+  full suite (103 files / 1,729 tests); both CI shell suites; all Bash/Node
+  syntax; changed-script warning/error shellcheck and fleet-wide error-severity
+  shellcheck; `git diff --check`; full and production npm audit (0
+  vulnerabilities).
+
+**Next:** parent agent reviews and publishes the clean local commit, merges only
+with green CI, then deploys from an exact clean merged worktree. Verify the
+remote Hugin tree remains `.git`-absent, `.deployed-commit` equals the merged
+full SHA, the user service is active/enabled, and loopback health is green. No
+push, PR, deployment, live SSH, marker write, Munin write, or other production
+mutation occurred in this implementation session.
+
+---
+
+**Previous session:** 2026-07-13 (Codex) — **legacy auth-expiry alert lifecycle migration merged as PR #198 (`6c8428c`)**
 **Branch:** `codex/hugin-auth-alert-migration` from exact `origin/main@8b444adc3996a0e01095b5dc381a6ed9646de20c`.
 
 ## Latest — reconcile pre-resolution expiry alerts without weakening auth evidence

--- a/scripts/deploy-pi.sh
+++ b/scripts/deploy-pi.sh
@@ -17,6 +17,33 @@ DEPLOY_USER="${DEPLOY_USER:-magnus}"
 REMOTE="$DEPLOY_USER@$PI_HOST"
 REMOTE_DIR="/home/$DEPLOY_USER/repos/hugin"
 
+read_clean_deploy_sha() {
+  local repo_root source_status source_sha
+  if ! repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    echo "ERROR: deploy source is not an addressable Git checkout." >&2
+    return 1
+  fi
+  if [ "$(pwd -P)" != "$(cd "$repo_root" && pwd -P)" ]; then
+    echo "ERROR: run deploy-pi.sh from the Hugin repository root." >&2
+    return 1
+  fi
+  if ! source_sha="$(git rev-parse --verify 'HEAD^{commit}' 2>/dev/null)" ||
+    [[ ! "$source_sha" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "ERROR: deploy source HEAD is not an addressable full commit." >&2
+    return 1
+  fi
+  if ! source_status="$(git status --porcelain=v1 --untracked-files=normal)"; then
+    echo "ERROR: could not verify deploy-source cleanliness." >&2
+    return 1
+  fi
+  if [ -n "$source_status" ]; then
+    echo "ERROR: deploy source must be clean; refusing to stamp uncommitted content." >&2
+    printf '%s\n' "$source_status" >&2
+    return 1
+  fi
+  printf '%s\n' "$source_sha"
+}
+
 echo "==> Checking deploy source..."
 # rsync distinguishes a directory from a symlink to a directory. The trailing-
 # slash node_modules exclusion below therefore does not match the common
@@ -28,9 +55,27 @@ if [ -L node_modules ]; then
   echo "  unlink node_modules && npm ci" >&2
   exit 1
 fi
+DEPLOY_SHA="$(read_clean_deploy_sha)" || exit 1
 
 echo "==> Building locally..."
 npm run build
+
+# Re-read both HEAD and cleanliness after the build. Build output is ignored;
+# any tracked/untracked source drift means the payload no longer represents the
+# single commit whose SHA would be stamped.
+if ! POST_BUILD_SHA="$(read_clean_deploy_sha)"; then
+  echo "ERROR: deploy source changed during build; refusing remote mutation." >&2
+  exit 1
+fi
+if [ "$POST_BUILD_SHA" != "$DEPLOY_SHA" ]; then
+  echo "ERROR: deploy source HEAD changed during build; refusing remote mutation." >&2
+  exit 1
+fi
+
+echo "==> Invalidating prior deployment marker..."
+# This is deliberately the first remote mutation. Every later failure leaves
+# the service markerless; only the final accepted health gate may stamp it.
+ssh "$REMOTE" "rm -f '$REMOTE_DIR/.deployed-commit' '$REMOTE_DIR/.deployed-commit.tmp'"
 
 echo "==> Syncing to $REMOTE:$REMOTE_DIR..."
 rsync -av --delete \
@@ -39,9 +84,22 @@ rsync -av --delete \
   --exclude='.git' \
   --exclude='.git/' \
   --exclude='.env' \
+  --exclude='.deployed-commit' \
   --exclude='tests/' \
   --exclude='.DS_Store' \
   ./ "$REMOTE:$REMOTE_DIR/"
+
+# Close the small race between the post-build check and rsync reading the
+# source. If anything changed while the payload was transferred, stop before
+# install/restart and leave the already-invalidated deployment marker absent.
+if ! POST_SYNC_SHA="$(read_clean_deploy_sha)"; then
+  echo "ERROR: deploy source changed during sync; refusing acceptance." >&2
+  exit 1
+fi
+if [ "$POST_SYNC_SHA" != "$DEPLOY_SHA" ]; then
+  echo "ERROR: deploy source HEAD changed during sync; refusing acceptance." >&2
+  exit 1
+fi
 
 echo "==> Installing dependencies on Pi..."
 ssh "$REMOTE" "cd $REMOTE_DIR && npm install --omit=dev"
@@ -157,9 +215,6 @@ echo "  Cron installed: daily at 04:00"
 echo "==> Ensuring workspace directory exists..."
 ssh "$REMOTE" "mkdir -p /home/$DEPLOY_USER/workspace"
 
-echo "==> Syncing Pi git repo..."
-ssh "$REMOTE" "cd $REMOTE_DIR && git fetch origin && git reset --hard origin/main"
-
 echo "==> Killing orphan Hugin processes..."
 ssh "$REMOTE" "SYSPID=\$(XDG_RUNTIME_DIR=/run/user/1000 systemctl --user show hugin.service --property=MainPID --value 2>/dev/null || echo 0)
 for pid in \$(pgrep -f 'node dist/index.js'); do
@@ -178,6 +233,11 @@ echo "==> Health check..."
 ssh "$REMOTE" "curl -fsS http://127.0.0.1:3032/health"
 
 echo ""
-echo "Deploy complete!"
+echo "Acceptance gates passed; finalizing deployment."
 echo "Health check: curl http://$PI_HOST:3032/health"
 echo "Logs: ssh $PI_HOST journalctl --user -u hugin.service -f"
+echo "==> Recording accepted deployment $DEPLOY_SHA..."
+# The remote tree is intentionally markerless and has no .git checkout. Stamp
+# the exact local commit atomically only after restart/status and health both
+# succeeded. No fallible deployment steps follow this boundary.
+ssh "$REMOTE" "printf '%s\n' '$DEPLOY_SHA' > '$REMOTE_DIR/.deployed-commit.tmp' && mv '$REMOTE_DIR/.deployed-commit.tmp' '$REMOTE_DIR/.deployed-commit'"

--- a/scripts/deploy-pi.sh
+++ b/scripts/deploy-pi.sh
@@ -102,7 +102,7 @@ if [ "$POST_SYNC_SHA" != "$DEPLOY_SHA" ]; then
 fi
 
 echo "==> Installing dependencies on Pi..."
-ssh "$REMOTE" "cd $REMOTE_DIR && npm install --omit=dev"
+ssh "$REMOTE" "cd $REMOTE_DIR && npm ci --omit=dev"
 
 echo "==> Removing legacy system-level service (one-time migration, idempotent)..."
 ssh "$REMOTE" "

--- a/scripts/deploy-pi.test.sh
+++ b/scripts/deploy-pi.test.sh
@@ -149,7 +149,7 @@ assert_contains "$calls" "--exclude=tests/" "rsync retains the tests exclusion"
 assert_contains "$calls" "--exclude=.DS_Store" "rsync retains the .DS_Store exclusion"
 assert_contains "$calls" "rm -f '/home/magnus/repos/hugin/.deployed-commit'" "normal deployment invalidates the old marker before rsync"
 assert_order "$calls" "rm -f '/home/magnus/repos/hugin/.deployed-commit'" "rsync " "normal deployment invalidates the marker before rsync"
-assert_not_contains "$calls" "npm install --omit=dev" "rsync failure stops before later remote mutation"
+assert_not_contains "$calls" "npm ci --omit=dev" "rsync failure stops before later remote mutation"
 assert_not_contains "$calls" "mv '/home/magnus/repos/hugin/.deployed-commit.tmp' '/home/magnus/repos/hugin/.deployed-commit'" "rsync failure remains markerless"
 
 # A deploy payload must be one clean, addressable local commit. Reject both a
@@ -199,7 +199,7 @@ export FAKE_RSYNC_RC=42
 assert_contains "$sync_dirty_output" "changed during sync" "post-sync failure explains source drift"
 sync_dirty_calls="$(cat "$CALL_LOG")"
 assert_contains "$sync_dirty_calls" "rm -f '/home/magnus/repos/hugin/.deployed-commit'" "sync-drift deployment invalidates the old marker"
-assert_not_contains "$sync_dirty_calls" "npm install --omit=dev" "source drift during rsync fails before remote install"
+assert_not_contains "$sync_dirty_calls" "npm ci --omit=dev" "source drift during rsync fails before remote install"
 assert_not_contains "$sync_dirty_calls" "mv '/home/magnus/repos/hugin/.deployed-commit.tmp' '/home/magnus/repos/hugin/.deployed-commit'" "source drift during rsync remains markerless"
 
 # Prove the exclusion semantics themselves against a real rsync: even if the
@@ -243,6 +243,8 @@ assert_contains "$full_calls" "rm -f '/home/magnus/repos/hugin/.deployed-commit'
 assert_order "$full_calls" "rm -f '/home/magnus/repos/hugin/.deployed-commit'" "rsync " "marker invalidation precedes payload sync"
 assert_not_contains "$full_calls" "git fetch origin" "deployment never depends on remote Git fetch"
 assert_not_contains "$full_calls" "git reset" "deployment never depends on a remote Git checkout"
+assert_contains "$full_calls" "npm ci --omit=dev" "deployment installs the shipped lockfile deterministically"
+assert_not_contains "$full_calls" "npm install --omit=dev" "deployment never rewrites the shipped lockfile with npm install"
 assert_contains "$full_calls" "curl -fsS http://127.0.0.1:3032/health" "deployment retains the health acceptance gate"
 assert_contains "$full_calls" "$full_sha" "deployment stamps the exact local full SHA"
 assert_order "$full_calls" "curl -fsS http://127.0.0.1:3032/health" "mv '/home/magnus/repos/hugin/.deployed-commit.tmp' '/home/magnus/repos/hugin/.deployed-commit'" "health acceptance precedes atomic marker stamp"

--- a/scripts/deploy-pi.test.sh
+++ b/scripts/deploy-pi.test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Regression coverage for deploy-pi.sh source-tree safety (issue #187).
+# Regression coverage for deploy-pi.sh source and deployment-marker safety.
 
 set -euo pipefail
 
@@ -18,24 +18,46 @@ mkdir -p "$FAKE_BIN"
 cat >"$FAKE_BIN/npm" <<'EOF'
 #!/usr/bin/env bash
 printf 'npm %s\n' "$*" >>"$CALL_LOG"
+if [[ "${FAKE_NPM_DIRTY_ON_BUILD:-0}" == "1" ]]; then
+  printf 'build dirtied source\n' >>tracked.txt
+fi
+exit "${FAKE_NPM_RC:-0}"
 EOF
 
 cat >"$FAKE_BIN/rsync" <<'EOF'
 #!/usr/bin/env bash
 printf 'rsync %s\n' "$*" >>"$CALL_LOG"
-# Stop a normal-source run immediately after capturing the sync arguments.
-exit 42
+if [[ "${FAKE_RSYNC_DIRTY_ON_SYNC:-0}" == "1" ]]; then
+  printf 'sync dirtied source\n' >>tracked.txt
+fi
+exit "${FAKE_RSYNC_RC:-42}"
 EOF
 
 cat >"$FAKE_BIN/ssh" <<'EOF'
 #!/usr/bin/env bash
-printf 'ssh %s\n' "$*" >>"$CALL_LOG"
-exit 99
+call="${*//$'\n'/ }"
+printf 'ssh %s\n' "$call" >>"$CALL_LOG"
+if [[ -n "${FAKE_SSH_FAIL_MATCH:-}" && "$call" == *"$FAKE_SSH_FAIL_MATCH"* ]]; then
+  exit "${FAKE_SSH_FAIL_RC:-99}"
+fi
+if [[ "$call" == *"test -d ~/repos/claude-config"* ]]; then
+  exit 1
+fi
+if [[ "$call" == *"curl -fsS http://127.0.0.1:3032/health"* ]]; then
+  printf '{"status":"ok","polling":true}\n'
+fi
+exit 0
 EOF
 
 chmod +x "$FAKE_BIN/npm" "$FAKE_BIN/rsync" "$FAKE_BIN/ssh"
 export PATH="$FAKE_BIN:$PATH"
 export CALL_LOG
+export FAKE_NPM_DIRTY_ON_BUILD=0
+export FAKE_NPM_RC=0
+export FAKE_RSYNC_RC=42
+export FAKE_RSYNC_DIRTY_ON_SYNC=0
+export FAKE_SSH_FAIL_MATCH=""
+export FAKE_SSH_FAIL_RC=99
 
 failures=0
 
@@ -47,6 +69,32 @@ fail() {
 assert_contains() {
   local haystack="$1" needle="$2" label="$3"
   [[ "$haystack" == *"$needle"* ]] || fail "$label (missing: $needle)"
+}
+
+assert_not_contains() {
+  local haystack="$1" needle="$2" label="$3"
+  [[ "$haystack" != *"$needle"* ]] || fail "$label (unexpected: $needle)"
+}
+
+assert_order() {
+  local haystack="$1" before="$2" after="$3" label="$4"
+  if [[ "$haystack" != *"$before"* || "$haystack" != *"$after"* ]]; then
+    fail "$label (missing ordering token)"
+    return
+  fi
+  local tail="${haystack#*"$before"}"
+  [[ "$tail" == *"$after"* ]] || fail "$label ($after appeared before $before)"
+}
+
+init_clean_source() {
+  local source_dir="$1"
+  mkdir -p "$source_dir/node_modules"
+  printf 'node_modules/\n' >"$source_dir/.gitignore"
+  printf 'tracked payload\n' >"$source_dir/tracked.txt"
+  git -C "$source_dir" init -q
+  git -C "$source_dir" add .gitignore tracked.txt
+  git -C "$source_dir" -c user.name=Test -c user.email=test@example.invalid \
+    commit -q -m initial
 }
 
 # A worktree commonly links dependencies from its owning checkout. The deploy
@@ -65,10 +113,22 @@ assert_contains "$symlink_output" "node_modules is a symlink" "symlink failure e
 assert_contains "$symlink_output" "npm ci" "symlink failure gives a safe remediation"
 [[ ! -s "$CALL_LOG" ]] || fail "symlink preflight must run before npm, rsync, or ssh"
 
+# A normal directory without an addressable Git HEAD is not a deploy source.
+UNVERSIONED_SOURCE="$TMP_DIR/unversioned-source"
+mkdir -p "$UNVERSIONED_SOURCE/node_modules"
+: >"$CALL_LOG"
+set +e
+unversioned_output="$(cd "$UNVERSIONED_SOURCE" && bash "$DEPLOY_SCRIPT" testhost 2>&1)"
+unversioned_rc=$?
+set -e
+[[ "$unversioned_rc" -ne 0 ]] || fail "unversioned source must fail deployment"
+assert_contains "$unversioned_output" "addressable Git checkout" "unversioned-source failure explains the commit contract"
+[[ ! -s "$CALL_LOG" ]] || fail "unversioned-source preflight must run before npm, rsync, or ssh"
+
 # Defence in depth: a normal source reaches rsync with exclusions for both the
 # symlink entry and directory contents, while retaining all existing excludes.
 NORMAL_SOURCE="$TMP_DIR/normal-source"
-mkdir -p "$NORMAL_SOURCE/node_modules"
+init_clean_source "$NORMAL_SOURCE"
 : >"$CALL_LOG"
 
 set +e
@@ -84,9 +144,63 @@ assert_contains "$calls" "--exclude=node_modules/" "rsync retains the node_modul
 assert_contains "$calls" "--exclude=.git" "rsync retains the .git entry exclusion"
 assert_contains "$calls" "--exclude=.git/" "rsync retains the .git directory exclusion"
 assert_contains "$calls" "--exclude=.env" "rsync retains the .env exclusion"
+assert_contains "$calls" "--exclude=.deployed-commit" "rsync excludes the deployment marker"
 assert_contains "$calls" "--exclude=tests/" "rsync retains the tests exclusion"
 assert_contains "$calls" "--exclude=.DS_Store" "rsync retains the .DS_Store exclusion"
-[[ "$calls" != *"ssh "* ]] || fail "rsync failure must stop before any remote command"
+assert_contains "$calls" "rm -f '/home/magnus/repos/hugin/.deployed-commit'" "normal deployment invalidates the old marker before rsync"
+assert_order "$calls" "rm -f '/home/magnus/repos/hugin/.deployed-commit'" "rsync " "normal deployment invalidates the marker before rsync"
+assert_not_contains "$calls" "npm install --omit=dev" "rsync failure stops before later remote mutation"
+assert_not_contains "$calls" "mv '/home/magnus/repos/hugin/.deployed-commit.tmp' '/home/magnus/repos/hugin/.deployed-commit'" "rsync failure remains markerless"
+
+# A deploy payload must be one clean, addressable local commit. Reject both a
+# dirty source and a build that dirties tracked files before remote mutation.
+DIRTY_SOURCE="$TMP_DIR/dirty-source"
+init_clean_source "$DIRTY_SOURCE"
+printf 'uncommitted\n' >>"$DIRTY_SOURCE/tracked.txt"
+: >"$CALL_LOG"
+set +e
+dirty_output="$(cd "$DIRTY_SOURCE" && bash "$DEPLOY_SCRIPT" testhost 2>&1)"
+dirty_rc=$?
+set -e
+[[ "$dirty_rc" -ne 0 ]] || fail "dirty source must fail deployment"
+assert_contains "$dirty_output" "clean" "dirty-source failure explains the clean-commit contract"
+[[ ! -s "$CALL_LOG" ]] || fail "dirty-source preflight must run before npm, rsync, or ssh"
+
+BUILD_DIRTY_SOURCE="$TMP_DIR/build-dirty-source"
+init_clean_source "$BUILD_DIRTY_SOURCE"
+: >"$CALL_LOG"
+export FAKE_NPM_DIRTY_ON_BUILD=1
+set +e
+build_dirty_output="$(cd "$BUILD_DIRTY_SOURCE" && bash "$DEPLOY_SCRIPT" testhost 2>&1)"
+build_dirty_rc=$?
+set -e
+export FAKE_NPM_DIRTY_ON_BUILD=0
+[[ "$build_dirty_rc" -ne 0 ]] || fail "a build that changes tracked source must fail deployment"
+assert_contains "$build_dirty_output" "changed during build" "post-build failure explains source drift"
+build_dirty_calls="$(cat "$CALL_LOG")"
+assert_contains "$build_dirty_calls" "npm run build" "post-build source check runs after build"
+assert_not_contains "$build_dirty_calls" "rsync " "post-build source drift fails before rsync"
+assert_not_contains "$build_dirty_calls" "ssh " "post-build source drift fails before remote mutation"
+
+# If the source changes while rsync is reading it, fail markerless before any
+# install/restart operation can accept a mixed payload.
+SYNC_DIRTY_SOURCE="$TMP_DIR/sync-dirty-source"
+init_clean_source "$SYNC_DIRTY_SOURCE"
+: >"$CALL_LOG"
+export FAKE_RSYNC_RC=0
+export FAKE_RSYNC_DIRTY_ON_SYNC=1
+set +e
+sync_dirty_output="$(cd "$SYNC_DIRTY_SOURCE" && bash "$DEPLOY_SCRIPT" testhost 2>&1)"
+sync_dirty_rc=$?
+set -e
+export FAKE_RSYNC_DIRTY_ON_SYNC=0
+export FAKE_RSYNC_RC=42
+[[ "$sync_dirty_rc" -ne 0 ]] || fail "source drift during rsync must fail deployment"
+assert_contains "$sync_dirty_output" "changed during sync" "post-sync failure explains source drift"
+sync_dirty_calls="$(cat "$CALL_LOG")"
+assert_contains "$sync_dirty_calls" "rm -f '/home/magnus/repos/hugin/.deployed-commit'" "sync-drift deployment invalidates the old marker"
+assert_not_contains "$sync_dirty_calls" "npm install --omit=dev" "source drift during rsync fails before remote install"
+assert_not_contains "$sync_dirty_calls" "mv '/home/magnus/repos/hugin/.deployed-commit.tmp' '/home/magnus/repos/hugin/.deployed-commit'" "source drift during rsync remains markerless"
 
 # Prove the exclusion semantics themselves against a real rsync: even if the
 # preflight is accidentally bypassed in a future refactor, the local symlink
@@ -96,15 +210,70 @@ DEFENCE_REMOTE="$TMP_DIR/defence-remote"
 mkdir -p "$DEFENCE_SOURCE" "$DEFENCE_REMOTE/node_modules" "$TMP_DIR/defence-shared"
 ln -s "$TMP_DIR/defence-shared" "$DEFENCE_SOURCE/node_modules"
 printf 'preserve me\n' >"$DEFENCE_REMOTE/node_modules/marker.txt"
+printf 'accepted old sha\n' >"$DEFENCE_REMOTE/.deployed-commit"
 
 PATH="$ORIGINAL_PATH" "$REAL_RSYNC" -a --delete \
   --exclude='node_modules' \
   --exclude='node_modules/' \
+  --exclude='.deployed-commit' \
   "$DEFENCE_SOURCE/" "$DEFENCE_REMOTE/"
 
 [[ -d "$DEFENCE_REMOTE/node_modules" ]] || fail "rsync exclusions must preserve the remote dependency directory"
 [[ ! -L "$DEFENCE_REMOTE/node_modules" ]] || fail "rsync exclusions must not replace remote dependencies with a symlink"
 [[ "$(cat "$DEFENCE_REMOTE/node_modules/marker.txt")" == "preserve me" ]] || fail "rsync exclusions must not delete remote dependencies"
+[[ "$(cat "$DEFENCE_REMOTE/.deployed-commit")" == "accepted old sha" ]] || fail "rsync exclusion must leave marker ownership to the deploy lifecycle"
+
+# A complete fake deployment proves the transactional marker boundary: remove
+# the old marker before rsync, never touch remote Git, accept service + health,
+# then stamp the exact local full SHA as the final remote mutation.
+FULL_SOURCE="$TMP_DIR/full-source"
+init_clean_source "$FULL_SOURCE"
+full_sha="$(git -C "$FULL_SOURCE" rev-parse HEAD)"
+: >"$CALL_LOG"
+export FAKE_RSYNC_RC=0
+set +e
+(cd "$FULL_SOURCE" && bash "$DEPLOY_SCRIPT" testhost >/dev/null 2>&1)
+full_rc=$?
+set -e
+[[ "$full_rc" -eq 0 ]] || fail "clean full deployment should pass the fake acceptance path"
+full_calls="$(cat "$CALL_LOG")"
+full_first_ssh="$(grep -m1 '^ssh ' "$CALL_LOG")"
+assert_contains "$full_first_ssh" "rm -f '/home/magnus/repos/hugin/.deployed-commit'" "marker invalidation is the first remote command"
+assert_contains "$full_calls" "rm -f '/home/magnus/repos/hugin/.deployed-commit'" "deployment invalidates the old marker"
+assert_order "$full_calls" "rm -f '/home/magnus/repos/hugin/.deployed-commit'" "rsync " "marker invalidation precedes payload sync"
+assert_not_contains "$full_calls" "git fetch origin" "deployment never depends on remote Git fetch"
+assert_not_contains "$full_calls" "git reset" "deployment never depends on a remote Git checkout"
+assert_contains "$full_calls" "curl -fsS http://127.0.0.1:3032/health" "deployment retains the health acceptance gate"
+assert_contains "$full_calls" "$full_sha" "deployment stamps the exact local full SHA"
+assert_order "$full_calls" "curl -fsS http://127.0.0.1:3032/health" "mv '/home/magnus/repos/hugin/.deployed-commit.tmp' '/home/magnus/repos/hugin/.deployed-commit'" "health acceptance precedes atomic marker stamp"
+
+# If the marker cannot be invalidated, the script must not begin payload sync.
+: >"$CALL_LOG"
+export FAKE_SSH_FAIL_MATCH="rm -f '/home/magnus/repos/hugin/.deployed-commit'"
+export FAKE_SSH_FAIL_RC=74
+set +e
+(cd "$FULL_SOURCE" && bash "$DEPLOY_SCRIPT" testhost >/dev/null 2>&1)
+invalidate_fail_rc=$?
+set -e
+export FAKE_SSH_FAIL_MATCH=""
+[[ "$invalidate_fail_rc" -ne 0 ]] || fail "failed marker invalidation must fail deployment"
+invalidate_fail_calls="$(cat "$CALL_LOG")"
+assert_not_contains "$invalidate_fail_calls" "rsync " "failed marker invalidation prevents payload sync"
+
+# Any failure after invalidation must remain markerless. A failed health check
+# may not stamp merely because the service restart itself succeeded.
+: >"$CALL_LOG"
+export FAKE_SSH_FAIL_MATCH="curl -fsS http://127.0.0.1:3032/health"
+export FAKE_SSH_FAIL_RC=73
+set +e
+(cd "$FULL_SOURCE" && bash "$DEPLOY_SCRIPT" testhost >/dev/null 2>&1)
+health_fail_rc=$?
+set -e
+export FAKE_SSH_FAIL_MATCH=""
+[[ "$health_fail_rc" -ne 0 ]] || fail "failed health acceptance must fail deployment"
+health_fail_calls="$(cat "$CALL_LOG")"
+assert_contains "$health_fail_calls" "rm -f '/home/magnus/repos/hugin/.deployed-commit'" "failed deployment first invalidates the old marker"
+assert_not_contains "$health_fail_calls" "mv '/home/magnus/repos/hugin/.deployed-commit.tmp' '/home/magnus/repos/hugin/.deployed-commit'" "failed health acceptance remains markerless"
 
 if [[ "$failures" -gt 0 ]]; then
   echo "$failures assertion(s) failed" >&2


### PR DESCRIPTION
## What changed

- Require `scripts/deploy-pi.sh` to ship one clean, addressable local commit.
- Invalidate the prior deployment marker before remote mutation and keep failures markerless.
- Preserve the marker during rsync, remove the obsolete remote `.git` fetch/reset dependency, and install production dependencies with deterministic `npm ci --omit=dev`.
- Atomically stamp the exact local full SHA only after service status and loopback health acceptance pass.
- Add regression coverage for source drift, ordering, marker preservation/failure behavior, deterministic install, and gitless deployments.

## Root cause

The final fleet validator found Hugin healthy but markerless. The repo-local deploy path used `rsync --delete` without excluding `.deployed-commit`, then attempted a remote Git update even though the authoritative Grimnir deployment intentionally ships no `.git`. That path could erase deployment provenance and could no longer complete on the current production layout.

## Impact

No product functionality changes. This hardens deployment provenance, failure semantics, and reproducibility.

## Validation

- 1,729 tests passed
- build and standalone typecheck passed
- deploy regression suite and CI shell suites passed
- Bash/Node syntax and shellcheck passed
- full and production npm audits: 0 vulnerabilities
- parent Codex reviewed the exact diff because Claude Opus CLI is unauthenticated