### PR TITLE
feat(learning): harden prompt-axis M5 experiments

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,7 @@
 # Hugin — Status
 
 **Latest session:** 2026-07-13 (Codex) — **GitHub-independent overnight dev screen completed; evaluator and transport recovery hardened locally**
-**Branch/worktree:** `codex/gate-d-prompt-prefix` in `/private/tmp/hugin-gate-d-prompt-prefix`, with implementation through local-only `79db404` plus this STATUS handoff, on exact `origin/main@d5eb909267111590c7b4b2442794197334fbedb2` (#199). Implementation commits are `56ba7b0` (bound prompt prefixes) and `79db404` (durable observation recovery + numeric gate fix); neither is pushed.
+**Branch/worktree:** `codex/gate-d-prompt-prefix` in `/private/tmp/hugin-gate-d-prompt-prefix`, based on exact `origin/main@d5eb909267111590c7b4b2442794197334fbedb2` (#199). Implementation commits `56ba7b0` (bound prompt prefixes) and `79db404` (durable observation recovery + numeric gate fix), plus the STATUS handoff, are published in draft PR [#200](https://github.com/Magnus-Gille/hugin/pull/200).
 
 ## Latest — development prompt evidence plus two failures converted into harness improvements
 
@@ -48,14 +48,15 @@
 - Final local verification: TypeScript build, manifest dry-run with exact corpus
   `341cebdb...e8b3b`, `git diff --check`, focused recovery/evaluator/client tests,
   and the full suite (105 files / 1,739 tests) pass. Production remains exact
-  `d5eb909267111590c7b4b2442794197334fbedb2`; no push, PR, merge, deploy, or
-  production champion mutation occurred. GitHub CLI authentication is still invalid.
+  `d5eb909267111590c7b4b2442794197334fbedb2`. GitHub authentication is healthy;
+  draft PR #200 is open and its initial CI run is in progress. No merge, deploy,
+  or production champion mutation occurred.
 
-**Next:** (1) have the gille-inference owner land #250's fresh, model-unseen
-deterministic cases; (2) add M5-side idempotent `client_run_id` + request binding
-and content-blind agent check-execution telemetry in the owning repo; (3) after
-GitHub authentication returns, publish the two local Hugin commits for
-independent review; (4) predeclare fresh holdouts, regenerate/dry-run a
+**Next:** (1) let draft PR #200 complete CI and obtain independent review; (2)
+have the gille-inference owner land #250's fresh, model-unseen deterministic
+cases; (3) add M5-side idempotent `client_run_id` + request binding and
+content-blind agent check-execution telemetry in the owning repo; (4) after
+both owning-repo changes merge, predeclare fresh holdouts, regenerate/dry-run a
 prompt-only manifest, and run a production-scope experiment exactly once. Keep
 the current champion unless every strict gate passes on uncontaminated evidence.
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,51 +1,63 @@
 # Hugin — Status
 
-**Latest session:** 2026-07-13 (Codex) — **first live M5 learning iteration rejected safely; prompt-axis runner support validated locally**
-**Branch/worktree:** `codex/gate-d-prompt-prefix` in `/private/tmp/hugin-gate-d-prompt-prefix`, based on exact `origin/main@d5eb909267111590c7b4b2442794197334fbedb2` (#199).
+**Latest session:** 2026-07-13 (Codex) — **GitHub-independent overnight dev screen completed; evaluator and transport recovery hardened locally**
+**Branch/worktree:** `codex/gate-d-prompt-prefix` in `/private/tmp/hugin-gate-d-prompt-prefix`, with implementation through local-only `79db404` plus this STATUS handoff, on exact `origin/main@d5eb909267111590c7b4b2442794197334fbedb2` (#199). Implementation commits are `56ba7b0` (bound prompt prefixes) and `79db404` (durable observation recovery + numeric gate fix); neither is pushed.
 
-## Latest — evidence-driven iteration 1 and honest preparation for iteration 2
+## Latest — development prompt evidence plus two failures converted into harness improvements
 
-- Approved owner/principal credentials were provisioned directly into macOS
-  Keychain (`hs-m5/owner`, `hugin-broker/claude-code`) without printing or file
-  persistence. The first live experiment,
-  `gate-d-edit-deadline-v1-20260713`, completed all 10 matched Gate D pairs (20
-  `qwen3-coder-next-80b` code-loop executions), including two holdouts, with 100%
-  independent-verifier and product-rating coverage.
-- The turn-6 edit-deadline challenger improved mean edit-start from 13,325.5 ms
-  to 11,848.8 ms (11.08%, clearing the 10% target) and reduced mean latency from
-  35,315.7 ms to 26,931.9 ms. It nevertheless reduced quality/usefulness from
-  0.9 to 0.8 and raised rescue rate from 0.1 to 0.2. Hugin rejected it on all
-  three strict monotonic guards. The champion remains unchanged; no promotion
-  was attempted.
-- Re-fetched the three failed work results and reran the deterministic verifier.
-  Both sample-04 arms exhausted the 13-turn cap with an unresolved `formatJson`
-  TypeScript error; challenger sample 05 completed with an invalid Node
-  `assert` import. Gate D's external typecheck caught every failure.
-- The next one-axis hypothesis is a content-bound prompt prefix requiring a
-  clean pre-finish `tsc --noEmit` pass and correction of any errors. The runner
-  now supports local-only per-arm `prompt_prefix_file` content, hashes every
-  byte into the versioned prompt ref, preserves the previous passthrough prompt
-  byte-for-byte, and rejects fingerprint drift before creating an experiment or
-  calling M5. Focused tests, old-manifest compatibility dry-run, valid-prefix
-  dry-run, deliberate tamper rejection, standalone runner typecheck, TypeScript
-  build, and the full suite (104 files / 1,732 tests) pass.
-- A second paid run is intentionally not using the old ten cases: holdout 05
-  informed the new prompt, so those holdouts are contaminated. The M5-owning
-  repo forbids this Hugin agent from editing its corpus directly; routed
-  gille-inference issue #250 requests at least four fresh, model-unseen,
-  deterministic Gate D cases with exact acceptance criteria.
-- Independently verified merged #199 live: remote marker equals exact
-  `d5eb909267111590c7b4b2442794197334fbedb2`, remote `.git` is intentionally
-  absent, user service health is `ok`, polling is true, queue depth is 0, and
-  all three inference hosts are available. The earlier remote-Git preflight
-  branch is superseded and must not be published.
+- The production-scope experiment `gate-d-edit-deadline-v1-20260713` remains
+  safely rejected. Its turn-6 challenger improved edit-start by 11.08% but
+  reduced quality/usefulness from 0.9 to 0.8 and increased rescue from 0.1 to
+  0.2. The production champion remains unchanged and no promotion was attempted.
+- A separate, explicitly non-production experiment,
+  `gate-d-typecheck-prompt-dev-v1-20260713` (`scope: m5-code-edit-dev`), screened
+  the content-bound pre-finish TypeScript-check prefix on the already observed,
+  contaminated ten-case Gate D corpus. All 20 matched
+  `qwen3-coder-next-80b` arms completed with independent verification and
+  mechanical ratings. Challenger quality/usefulness was 10/10 versus champion
+  9/10; mean latency was 22,863.0 versus 36,969.9 ms and edit-start was 12,472.1
+  versus 15,801.9 ms. This is candidate-screening evidence only and must never
+  drive production promotion.
+- Hugin nevertheless recorded that dev experiment as `rejected`: exact +0.10
+  quality became `0.09999999999999998` under IEEE-754 and missed the configured
+  `0.1` threshold. Local commit `79db404` makes all evaluator boundary
+  comparisons tolerant only to a handful of machine epsilons and adds both an
+  exact-boundary promotion regression and a materially-below-threshold negative
+  regression. The already terminal dev experiment was not rewritten or promoted.
+- The lone champion failure (sample 09) exhausted the turn cap and left the word
+  `widget` in a comment; Gate D's structural oracle correctly rejected it. The
+  prompt asked for TypeScript verification, so this win does not prove the
+  prefix caused the improvement. In the decisive results M5 reported
+  `check.ran:false` even when the agent summary claimed TypeScript/tests passed;
+  Hugin currently cannot prove which agent-side check command actually ran.
+  Fresh unseen cases from gille-inference #250 and content-blind agent tool/check
+  execution telemetry are required before causal or promotion claims.
+- Two real transport failures sharpened the runner. An M5 start response was
+  lost after the work had completed; the job was identified as
+  `cl-20260713-33167799`, independently reverified, and recorded exactly once.
+  A later Broker observation response timed out after the final observation had
+  committed; durable status showed all 20 observations. `79db404` now reconciles
+  ambiguous observation writes by exact `run_id` + evidence before retrying and
+  marks mutating M5 transport failures as ambiguous. Because M5 start has no
+  client idempotency key/request fingerprint, the runner now stops with the
+  bound experiment run ID and explicitly forbids a blind rerun.
+- Prompt support in `56ba7b0` remains intact: local-only per-arm
+  `prompt_prefix_file`, exact prompt-byte SHA-256 binding, unchanged passthrough
+  compatibility, and fail-closed tamper detection. Dev artifacts are under
+  `/tmp/gate-d-typecheck-prompt-dev-v1/` while that temporary directory exists.
+- Final local verification: TypeScript build, manifest dry-run with exact corpus
+  `341cebdb...e8b3b`, `git diff --check`, focused recovery/evaluator/client tests,
+  and the full suite (105 files / 1,739 tests) pass. Production remains exact
+  `d5eb909267111590c7b4b2442794197334fbedb2`; no push, PR, merge, deploy, or
+  production champion mutation occurred. GitHub CLI authentication is still invalid.
 
-**Next:** obtain the fresh corpus through gille-inference #250, predeclare its
-holdouts before any model run, generate/dry-run the prompt-only manifest, then
-run and rate the matched experiment. Keep the champion unless every protected
-gate passes. The current Hugin runner changes remain local; GitHub CLI
-authentication is still invalid, so do not begin a publish flow until it is
-re-authenticated or an explicitly approved connector-only flow is chosen.
+**Next:** (1) have the gille-inference owner land #250's fresh, model-unseen
+deterministic cases; (2) add M5-side idempotent `client_run_id` + request binding
+and content-blind agent check-execution telemetry in the owning repo; (3) after
+GitHub authentication returns, publish the two local Hugin commits for
+independent review; (4) predeclare fresh holdouts, regenerate/dry-run a
+prompt-only manifest, and run a production-scope experiment exactly once. Keep
+the current champion unless every strict gate passes on uncontaminated evidence.
 
 ---
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,45 +1,51 @@
 # Hugin — Status
 
-**Latest session:** 2026-07-13 (Codex) — **repo-local deployment provenance hardening complete locally; awaiting parent review/publish/deploy**
-**Branch:** `codex/hugin-deploy-marker-hardening` from exact `origin/main@6c8428cf64d1fb0e9b33ac4875c524a094f47d6b` (merged auth lifecycle PR #198).
+**Latest session:** 2026-07-13 (Codex) — **first live M5 learning iteration rejected safely; prompt-axis runner support validated locally**
+**Branch/worktree:** `codex/gate-d-prompt-prefix` in `/private/tmp/hugin-gate-d-prompt-prefix`, based on exact `origin/main@d5eb909267111590c7b4b2442794197334fbedb2` (#199).
 
-## Latest — markerless failure boundary and exact local-commit deployment
+## Latest — evidence-driven iteration 1 and honest preparation for iteration 2
 
-- Fleet validation found that `scripts/deploy-pi.sh` let `rsync --delete`
-  remove `.deployed-commit`, then later ran `git fetch && git reset` inside the
-  remote Hugin tree even though authoritative Grimnir deployments intentionally
-  leave that tree without `.git`. The service stayed healthy while deployment
-  provenance disappeared.
-- The repo-local deploy now accepts only a clean repository-root checkout with
-  an addressable full `HEAD` SHA. It rechecks cleanliness and the exact SHA
-  after the local build and again after rsync, so a build/source race cannot be
-  accepted as the named commit.
-- The previous marker (and abandoned temp marker) is removed as the first remote
-  mutation. Rsync excludes `.deployed-commit` in addition to preserving the
-  existing `.env`, `node_modules`, `.git`, tests, and macOS exclusions. The
-  obsolete remote Hugin `git fetch/reset` step is gone. Production dependencies
-  install with `npm ci --omit=dev`, so the shipped lockfile cannot be rewritten
-  after the local commit has been pinned.
-- Only after user-service restart/status and the loopback health check succeed
-  does one final remote command atomically write the exact local full SHA via a
-  temp file and rename. Any earlier failure remains markerless; no fallible
-  deployment operation follows the stamp.
-- The shell regression harness now covers unversioned/dirty sources, build and
-  rsync source drift, invalidation-before-sync ordering, real rsync marker
-  exclusion semantics, invalidation failure, health failure, markerless failure
-  paths, no remote-Hugin-Git dependency, and health-before-exact-SHA stamping.
-- Validation: `npm ci`; TypeScript build; standalone Gate D runner typecheck;
-  full suite (103 files / 1,729 tests); both CI shell suites; all Bash/Node
-  syntax; changed-script warning/error shellcheck and fleet-wide error-severity
-  shellcheck; `git diff --check`; full and production npm audit (0
-  vulnerabilities).
+- Approved owner/principal credentials were provisioned directly into macOS
+  Keychain (`hs-m5/owner`, `hugin-broker/claude-code`) without printing or file
+  persistence. The first live experiment,
+  `gate-d-edit-deadline-v1-20260713`, completed all 10 matched Gate D pairs (20
+  `qwen3-coder-next-80b` code-loop executions), including two holdouts, with 100%
+  independent-verifier and product-rating coverage.
+- The turn-6 edit-deadline challenger improved mean edit-start from 13,325.5 ms
+  to 11,848.8 ms (11.08%, clearing the 10% target) and reduced mean latency from
+  35,315.7 ms to 26,931.9 ms. It nevertheless reduced quality/usefulness from
+  0.9 to 0.8 and raised rescue rate from 0.1 to 0.2. Hugin rejected it on all
+  three strict monotonic guards. The champion remains unchanged; no promotion
+  was attempted.
+- Re-fetched the three failed work results and reran the deterministic verifier.
+  Both sample-04 arms exhausted the 13-turn cap with an unresolved `formatJson`
+  TypeScript error; challenger sample 05 completed with an invalid Node
+  `assert` import. Gate D's external typecheck caught every failure.
+- The next one-axis hypothesis is a content-bound prompt prefix requiring a
+  clean pre-finish `tsc --noEmit` pass and correction of any errors. The runner
+  now supports local-only per-arm `prompt_prefix_file` content, hashes every
+  byte into the versioned prompt ref, preserves the previous passthrough prompt
+  byte-for-byte, and rejects fingerprint drift before creating an experiment or
+  calling M5. Focused tests, old-manifest compatibility dry-run, valid-prefix
+  dry-run, deliberate tamper rejection, standalone runner typecheck, TypeScript
+  build, and the full suite (104 files / 1,732 tests) pass.
+- A second paid run is intentionally not using the old ten cases: holdout 05
+  informed the new prompt, so those holdouts are contaminated. The M5-owning
+  repo forbids this Hugin agent from editing its corpus directly; routed
+  gille-inference issue #250 requests at least four fresh, model-unseen,
+  deterministic Gate D cases with exact acceptance criteria.
+- Independently verified merged #199 live: remote marker equals exact
+  `d5eb909267111590c7b4b2442794197334fbedb2`, remote `.git` is intentionally
+  absent, user service health is `ok`, polling is true, queue depth is 0, and
+  all three inference hosts are available. The earlier remote-Git preflight
+  branch is superseded and must not be published.
 
-**Next:** parent agent reviews and publishes the clean local commit, merges only
-with green CI, then deploys from an exact clean merged worktree. Verify the
-remote Hugin tree remains `.git`-absent, `.deployed-commit` equals the merged
-full SHA, the user service is active/enabled, and loopback health is green. No
-push, PR, deployment, live SSH, marker write, Munin write, or other production
-mutation occurred in this implementation session.
+**Next:** obtain the fresh corpus through gille-inference #250, predeclare its
+holdouts before any model run, generate/dry-run the prompt-only manifest, then
+run and rate the matched experiment. Keep the champion unless every protected
+gate passes. The current Hugin runner changes remain local; GitHub CLI
+authentication is still invalid, so do not begin a publish flow until it is
+re-authenticated or an explicitly approved connector-only flow is chosen.
 
 ---
 

--- a/docs/continuous-learning-loop.md
+++ b/docs/continuous-learning-loop.md
@@ -144,6 +144,12 @@ sample's instruction/seed directory/check. Before any remote mutation it:
 5. runs matched pairs sequentially, counterbalancing which arm runs first;
 6. records only content-blind observations—never diffs, prompts, check output, or seed contents.
 
+An arm may declare a local-only `prompt_prefix_file`. The runner reads it once, verifies every byte
+against that arm's versioned `prompt.sha256`, and prepends it to each corpus instruction. Hugin still
+stores only the content hash and prompt version, so prompt-axis experiments remain reproducible and
+content-blind. Omitting the file preserves the original instruction byte-for-byte and validates the
+deployed passthrough prompt fingerprint.
+
 Credentials stay in environment variables. Use the Keychain helper and tailnet path; never put
 tokens in the manifest:
 

--- a/docs/continuous-learning-loop.md
+++ b/docs/continuous-learning-loop.md
@@ -144,6 +144,16 @@ sample's instruction/seed directory/check. Before any remote mutation it:
 5. runs matched pairs sequentially, counterbalancing which arm runs first;
 6. records only content-blind observations—never diffs, prompts, check output, or seed contents.
 
+Observation writes are reconciled after ambiguous Broker timeouts: the runner first reads the
+durable experiment state and retries only an identical, absent `run_id`. This avoids rerunning a
+paid M5 arm merely because Hugin committed the evidence but its HTTP response was lost.
+
+An ambiguous `code_loop_start` response is different because the current M5 protocol does not
+accept a client idempotency key or echo a request fingerprint. The runner stops with the exact
+experiment `run_id` and explicitly forbids a blind rerun. Reconcile the recent M5 work id first;
+long-term, the M5 owner should add an idempotent client run identifier plus request binding so this
+recovery can be automatic and fail-closed.
+
 An arm may declare a local-only `prompt_prefix_file`. The runner reads it once, verifies every byte
 against that arm's versioned `prompt.sha256`, and prepends it to each corpus instruction. Hugin still
 stores only the content hash and prompt version, so prompt-axis experiments remain reproducible and

--- a/scripts/run-m5-code-loop-experiment.ts
+++ b/scripts/run-m5-code-loop-experiment.ts
@@ -33,6 +33,10 @@ import {
   type M5CodeLoopResult,
 } from "../src/learning/m5-code-loop-adapter.js";
 import {
+  applyCodeLoopPromptPrefix,
+  codeLoopPromptSha256,
+} from "../src/learning/m5-code-loop-prompt.js";
+import {
   M5CodeLoopClient,
   type M5CodeLoopRequest,
 } from "../src/learning/m5-code-loop-client.js";
@@ -52,6 +56,12 @@ const capsSchema = z.object({
   }
 });
 
+const armSchema = z.object({
+  caps: capsSchema,
+  /** Local-only prompt content; Hugin stores only the bound prompt ref. */
+  prompt_prefix_file: z.string().min(1).optional(),
+}).strict();
+
 const sampleSchema = z.object({
   id: z.string().min(1).max(120),
   holdout: z.boolean(),
@@ -66,8 +76,8 @@ const manifestSchema = z.object({
   schema_version: z.literal(1),
   experiment: learningExperimentCreateSchema,
   arms: z.object({
-    champion: z.object({ caps: capsSchema }).strict(),
-    challenger: z.object({ caps: capsSchema }).strict(),
+    champion: armSchema,
+    challenger: armSchema,
   }).strict(),
   verifier: z.object({
     script: z.string().min(1),
@@ -299,13 +309,14 @@ async function runArm(input: {
   manifest: Manifest;
   sample: LoadedSample;
   arm: "champion" | "challenger";
+  promptPrefix: string | undefined;
   manifestDir: string;
 }): Promise<void> {
-  const { m5, broker, manifest, sample, arm, manifestDir } = input;
+  const { m5, broker, manifest, sample, arm, promptPrefix, manifestDir } = input;
   const config = manifest.experiment[arm];
   const runId = `${manifest.experiment.experiment_id}:${sample.id}:${arm}:${config.fingerprint.slice(0, 12)}`;
   const request: M5CodeLoopRequest = {
-    instruction: sample.instruction,
+    instruction: applyCodeLoopPromptPrefix(sample.instruction, promptPrefix),
     files: sample.files,
     check_cmd: sample.m5_check_cmd,
     protected: sample.protected,
@@ -357,6 +368,25 @@ async function main(): Promise<void> {
   const manifestDir = dirname(manifestPath);
   const manifest = manifestSchema.parse(JSON.parse(readFileSync(manifestPath, "utf8")));
   const samples = loadSamples(manifest, manifestDir);
+  const promptPrefixes = Object.fromEntries(
+    (["champion", "challenger"] as const).map((arm) => {
+      const path = manifest.arms[arm].prompt_prefix_file;
+      const prefix = path === undefined
+        ? undefined
+        : readFileSync(resolve(manifestDir, path), "utf8");
+      if (prefix !== undefined && prefix.length > 20_000) {
+        throw new Error(`${arm} prompt prefix exceeds 20,000 characters`);
+      }
+      const expected = codeLoopPromptSha256(prefix);
+      const declared = manifest.experiment[arm].prompt.sha256;
+      if (declared !== expected) {
+        throw new Error(
+          `${arm} prompt fingerprint mismatch: manifest=${declared} actual=${expected}`,
+        );
+      }
+      return [arm, prefix];
+    }),
+  ) as Record<"champion" | "challenger", string | undefined>;
   const verifierSha256 = createHash("sha256")
     .update(readFileSync(resolve(manifestDir, manifest.verifier.script)))
     .digest("hex");
@@ -408,7 +438,15 @@ async function main(): Promise<void> {
         process.stdout.write(`[${sample.id}/${arm}] already recorded; skipping\n`);
         continue;
       }
-      await runArm({ m5, broker, manifest, sample, arm, manifestDir });
+      await runArm({
+        m5,
+        broker,
+        manifest,
+        sample,
+        arm,
+        promptPrefix: promptPrefixes[arm],
+        manifestDir,
+      });
       recorded.add(runId);
     }
   }

--- a/scripts/run-m5-code-loop-experiment.ts
+++ b/scripts/run-m5-code-loop-experiment.ts
@@ -32,12 +32,14 @@ import {
   observationFromM5CodeLoop,
   type M5CodeLoopResult,
 } from "../src/learning/m5-code-loop-adapter.js";
+import { observeDurably } from "../src/learning/durable-observation.js";
 import {
   applyCodeLoopPromptPrefix,
   codeLoopPromptSha256,
 } from "../src/learning/m5-code-loop-prompt.js";
 import {
   M5CodeLoopClient,
+  M5CodeLoopError,
   type M5CodeLoopRequest,
 } from "../src/learning/m5-code-loop-client.js";
 
@@ -324,7 +326,19 @@ async function runArm(input: {
     caps: manifest.arms[arm].caps,
   };
   process.stdout.write(`[${sample.id}/${arm}] starting\n`);
-  const started = await m5.start(request);
+  let started: Awaited<ReturnType<M5CodeLoopClient["start"]>>;
+  try {
+    started = await m5.start(request);
+  } catch (error) {
+    if (error instanceof M5CodeLoopError && error.ambiguousOutcome) {
+      throw new Error(
+        `[${sample.id}/${arm}] M5 start outcome is ambiguous for run ${runId}; ` +
+        "do not blindly rerun. Reconcile the recent M5 work id before resuming.",
+        { cause: error },
+      );
+    }
+    throw error;
+  }
   const deadline = Date.now() + manifest.result_deadline_s * 1_000;
   for (;;) {
     await sleep(manifest.poll_ms);
@@ -355,7 +369,12 @@ async function runArm(input: {
     },
     externalVerification,
   });
-  await broker.experimentObserve(observation);
+  const persisted = await observeDurably(broker, observation);
+  if (persisted.reconciled) {
+    process.stdout.write(
+      `[${sample.id}/${arm}] observation reconciled after an ambiguous broker response\n`,
+    );
+  }
   process.stdout.write(
     `[${sample.id}/${arm}] ${observation.quality_outcome}; edit=${observation.edit_start_ms ?? "unmeasured"}ms; work=${result.work_id}\n`,
   );

--- a/src/learning/durable-observation.ts
+++ b/src/learning/durable-observation.ts
@@ -1,0 +1,116 @@
+/** Retry and reconcile idempotent learning observations after ambiguous HTTP failures. */
+
+import { BrokerClient, BrokerNetworkError } from "../mcp/broker-client.js";
+import {
+  learningObservationSchema,
+  learningExperimentStateSchema,
+  type LearningObservationInput,
+  type RecordedLearningObservation,
+} from "./experiment-schema.js";
+
+type ObservationBroker = Pick<
+  BrokerClient,
+  "experimentObserve" | "experimentStatus"
+>;
+
+export interface DurableObservationResult {
+  attempts: number;
+  reconciled: boolean;
+}
+
+function stable(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stable).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, child]) => `${JSON.stringify(key)}:${stable(child)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sameEvidence(
+  recorded: RecordedLearningObservation,
+  expected: LearningObservationInput,
+): boolean {
+  const {
+    recorded_at: _recordedAt,
+    recorded_by: _recordedBy,
+    product_rated_at: _productRatedAt,
+    product_rated_by: _productRatedBy,
+    ...evidence
+  } = recorded;
+  // Munin persistence crosses a JSON boundary, which removes optional keys
+  // whose value is undefined. Compare against that same canonical shape.
+  const canonicalExpected = learningObservationSchema.parse(
+    JSON.parse(JSON.stringify(expected)),
+  );
+  return stable(evidence) === stable(canonicalExpected);
+}
+
+async function reconcile(
+  broker: ObservationBroker,
+  observation: LearningObservationInput,
+): Promise<boolean> {
+  const response = await broker.experimentStatus({
+    experiment_id: observation.experiment_id,
+  }) as { state?: unknown };
+  const state = learningExperimentStateSchema.parse(response.state);
+  const recorded = state.observations.find(
+    (candidate) => candidate.run_id === observation.run_id,
+  );
+  if (!recorded) return false;
+  if (!sameEvidence(recorded, observation)) {
+    throw new Error(
+      `run_id ${observation.run_id} was committed with different evidence after an ambiguous write`,
+    );
+  }
+  return true;
+}
+
+/**
+ * Observation writes are server-side idempotent by run_id. A client timeout is
+ * ambiguous, so first read back the durable state; only retry the identical
+ * payload when it is absent. Never retry HTTP conflicts or validation errors.
+ */
+export async function observeDurably(
+  broker: ObservationBroker,
+  observation: LearningObservationInput,
+  options: {
+    maxAttempts?: number;
+    retryDelayMs?: number;
+    sleep?: (milliseconds: number) => Promise<void>;
+  } = {},
+): Promise<DurableObservationResult> {
+  const maxAttempts = options.maxAttempts ?? 3;
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1 || maxAttempts > 10) {
+    throw new Error("maxAttempts must be an integer between 1 and 10");
+  }
+  const retryDelayMs = options.retryDelayMs ?? 1_000;
+  const sleep = options.sleep ?? ((milliseconds: number) =>
+    new Promise<void>((resolve) => setTimeout(resolve, milliseconds)));
+  let lastNetworkError: BrokerNetworkError | undefined;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      await broker.experimentObserve(observation);
+      return { attempts: attempt, reconciled: false };
+    } catch (error) {
+      if (!(error instanceof BrokerNetworkError)) throw error;
+      lastNetworkError = error;
+    }
+
+    try {
+      if (await reconcile(broker, observation)) {
+        return { attempts: attempt, reconciled: true };
+      }
+    } catch (error) {
+      if (!(error instanceof BrokerNetworkError)) throw error;
+      lastNetworkError = error;
+    }
+
+    if (attempt < maxAttempts) await sleep(retryDelayMs);
+  }
+
+  throw lastNetworkError ?? new Error("observation persistence failed without a network error");
+}

--- a/src/learning/experiment-evaluator.ts
+++ b/src/learning/experiment-evaluator.ts
@@ -14,6 +14,23 @@ function mean(values: Array<number | undefined>): number | null {
   return measured.reduce((sum, value) => sum + value, 0) / measured.length;
 }
 
+/**
+ * Treat values separated only by IEEE-754 rounding noise as equal. Promotion
+ * gates still fail closed for any material shortfall: the tolerance is only a
+ * handful of machine epsilons at the magnitude being compared.
+ */
+function comparisonTolerance(left: number, right: number): number {
+  return Number.EPSILON * 8 * Math.max(1, Math.abs(left), Math.abs(right));
+}
+
+function materiallyLessThan(left: number, right: number): boolean {
+  return left < right - comparisonTolerance(left, right);
+}
+
+function materiallyGreaterThan(left: number, right: number): boolean {
+  return left > right + comparisonTolerance(left, right);
+}
+
 function isAuthoritative(observation: RecordedLearningObservation): boolean {
   return (
     observation.verifier.independent &&
@@ -182,16 +199,16 @@ function addCoverageRequirements(
   gates: LearningExperimentGates,
 ): void {
   if (
-    champion.verifiedCoverage < gates.minVerifiedCoverage ||
-    challenger.verifiedCoverage < gates.minVerifiedCoverage
+    materiallyLessThan(champion.verifiedCoverage, gates.minVerifiedCoverage) ||
+    materiallyLessThan(challenger.verifiedCoverage, gates.minVerifiedCoverage)
   ) {
     missing.push(
       `verified coverage must be >= ${gates.minVerifiedCoverage} on both arms`,
     );
   }
   if (
-    champion.ratedCoverage < gates.minRatedCoverage ||
-    challenger.ratedCoverage < gates.minRatedCoverage
+    materiallyLessThan(champion.ratedCoverage, gates.minRatedCoverage) ||
+    materiallyLessThan(challenger.ratedCoverage, gates.minRatedCoverage)
   ) {
     missing.push(`rated coverage must be >= ${gates.minRatedCoverage} on both arms`);
   }
@@ -206,32 +223,47 @@ function addGuardFailures(
   if (
     champion.qualityRate !== null &&
     challenger.qualityRate !== null &&
-    challenger.qualityRate + gates.maxQualityRegression < champion.qualityRate
+    materiallyLessThan(
+      challenger.qualityRate + gates.maxQualityRegression,
+      champion.qualityRate,
+    )
   ) {
     failures.push("quality regression exceeded the configured tolerance");
   }
   if (
     champion.usefulRate !== null &&
     challenger.usefulRate !== null &&
-    challenger.usefulRate + gates.maxUsefulRegression < champion.usefulRate
+    materiallyLessThan(
+      challenger.usefulRate + gates.maxUsefulRegression,
+      champion.usefulRate,
+    )
   ) {
     failures.push("useful-completion regression exceeded the configured tolerance");
   }
   if (
     champion.rescueRate !== null &&
     challenger.rescueRate !== null &&
-    challenger.rescueRate > champion.rescueRate + gates.maxRescueRateIncrease
+    materiallyGreaterThan(
+      challenger.rescueRate,
+      champion.rescueRate + gates.maxRescueRateIncrease,
+    )
   ) {
     failures.push("human rescue rate increased beyond the configured tolerance");
   }
-  if (challenger.infraRate > champion.infraRate + gates.maxInfraRateIncrease) {
+  if (materiallyGreaterThan(
+    challenger.infraRate,
+    champion.infraRate + gates.maxInfraRateIncrease,
+  )) {
     failures.push("infrastructure failure rate increased beyond the configured tolerance");
   }
   if (
     gates.maxLatencyRatio !== null &&
     champion.latencyMeanMs !== null &&
     challenger.latencyMeanMs !== null &&
-    challenger.latencyMeanMs > champion.latencyMeanMs * gates.maxLatencyRatio
+    materiallyGreaterThan(
+      challenger.latencyMeanMs,
+      champion.latencyMeanMs * gates.maxLatencyRatio,
+    )
   ) {
     failures.push("latency exceeded the configured ratio guard");
   }
@@ -239,7 +271,10 @@ function addGuardFailures(
     gates.maxCostRatio !== null &&
     champion.costMeanUsd !== null &&
     challenger.costMeanUsd !== null &&
-    challenger.costMeanUsd > champion.costMeanUsd * gates.maxCostRatio
+    materiallyGreaterThan(
+      challenger.costMeanUsd,
+      champion.costMeanUsd * gates.maxCostRatio,
+    )
   ) {
     failures.push("cost exceeded the configured ratio guard");
   }
@@ -362,7 +397,10 @@ export function evaluateLearningExperiment(input: {
     nextAction =
       `Keep the champion. The next experiment should address ${failureSignals[0]?.signal ?? "the failed guard"} ` +
       "and change only one declared axis.";
-  } else if (improvement === null || improvement < input.gates.minPrimaryImprovement) {
+  } else if (
+    improvement === null ||
+    materiallyLessThan(improvement, input.gates.minPrimaryImprovement)
+  ) {
     decision = "reject";
     reason =
       `The challenger did not clear the predeclared ${input.gates.primaryMetric} improvement threshold.`;

--- a/src/learning/m5-code-loop-client.ts
+++ b/src/learning/m5-code-loop-client.ts
@@ -51,7 +51,12 @@ const statusSchema = z.object({
 }).strict();
 
 export class M5CodeLoopError extends Error {
-  constructor(message: string, public readonly detail?: unknown) {
+  constructor(
+    message: string,
+    public readonly detail?: unknown,
+    /** The remote side may have accepted the mutation even though no response arrived. */
+    public readonly ambiguousOutcome = false,
+  ) {
     super(message);
     this.name = "M5CodeLoopError";
   }
@@ -164,10 +169,16 @@ export class M5CodeLoopClient {
     } catch (err) {
       if (err instanceof M5CodeLoopError) throw err;
       if (err instanceof Error && err.name === "AbortError") {
-        throw new M5CodeLoopError(`M5 JSON-RPC timed out after ${this.timeoutMs}ms`);
+        throw new M5CodeLoopError(
+          `M5 JSON-RPC timed out after ${this.timeoutMs}ms`,
+          undefined,
+          true,
+        );
       }
       throw new M5CodeLoopError(
         `M5 JSON-RPC request failed: ${err instanceof Error ? err.message : String(err)}`,
+        undefined,
+        true,
       );
     } finally {
       clearTimeout(timer);

--- a/src/learning/m5-code-loop-prompt.ts
+++ b/src/learning/m5-code-loop-prompt.ts
@@ -1,0 +1,27 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Existing Gate D prompt contract. Keep this text stable: the first live
+ * experiment's champion fingerprint binds its SHA-256.
+ */
+export const PASSTHROUGH_PROMPT_CONTRACT =
+  "Gate D sample instruction, passed through byte-for-byte; per-sample content is bound by corpusSha256";
+
+const PREFIX_PROMPT_CONTRACT =
+  "Gate D instruction prefix v1, prepended byte-for-byte; per-sample content is bound by corpusSha256";
+
+/** Content hash stored in the experiment's prompt ref. */
+export function codeLoopPromptSha256(prefix: string | undefined): string {
+  const payload = prefix === undefined
+    ? PASSTHROUGH_PROMPT_CONTRACT
+    : `${PREFIX_PROMPT_CONTRACT}\n${prefix}`;
+  return createHash("sha256").update(payload).digest("hex");
+}
+
+/** Build the exact instruction sent to M5 for one arm. */
+export function applyCodeLoopPromptPrefix(
+  instruction: string,
+  prefix: string | undefined,
+): string {
+  return prefix === undefined ? instruction : `${prefix}\n\n${instruction}`;
+}

--- a/tests/durable-observation.test.ts
+++ b/tests/durable-observation.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it, vi } from "vitest";
+import { BrokerNetworkError } from "../src/mcp/broker-client.js";
+import { observeDurably } from "../src/learning/durable-observation.js";
+import type { RecordedLearningObservation } from "../src/learning/experiment-schema.js";
+import { makeExperimentInput, makeObservation } from "./fixtures/learning.js";
+
+function stateWith(observations: RecordedLearningObservation[]) {
+  const experiment = makeExperimentInput();
+  return {
+    state: {
+      schemaVersion: 1,
+      experimentId: experiment.experiment_id,
+      scope: experiment.scope,
+      taskType: experiment.task_type,
+      ownerPrincipal: "codex",
+      hypothesis: experiment.hypothesis,
+      changeAxis: experiment.change_axis,
+      champion: experiment.champion,
+      challenger: experiment.challenger,
+      gates: experiment.gates,
+      status: "running",
+      revision: 1,
+      createdAt: "2026-07-13T12:00:00.000Z",
+      updatedAt: "2026-07-13T12:00:00.000Z",
+      observations,
+      evaluation: {
+        decision: "gathering",
+        reason: "waiting",
+        evaluatedAt: "2026-07-13T12:00:00.000Z",
+        matchedPairs: 0,
+        holdoutPairs: 0,
+        unmatchedObservations: observations.length,
+        champion: {
+          samples: 0, verifiedSamples: 0, verifiedCoverage: 0,
+          qualityRate: null, ratedSamples: 0, ratedCoverage: 0,
+          usefulRate: null, rescueRate: null, infraRate: 0,
+          latencyMeanMs: null, costMeanUsd: null,
+          humanReviewMeanSeconds: null, editStartMeanMs: null,
+          observabilityCoverageMean: null, verifierScoreMean: null,
+        },
+        challenger: {
+          samples: 0, verifiedSamples: 0, verifiedCoverage: 0,
+          qualityRate: null, ratedSamples: 0, ratedCoverage: 0,
+          usefulRate: null, rescueRate: null, infraRate: 0,
+          latencyMeanMs: null, costMeanUsd: null,
+          humanReviewMeanSeconds: null, editStartMeanMs: null,
+          observabilityCoverageMean: null, verifierScoreMean: null,
+        },
+        primaryMetric: experiment.gates.primaryMetric,
+        primaryChampion: null,
+        primaryChallenger: null,
+        primaryImprovement: null,
+        guardFailures: [],
+        missingRequirements: ["waiting"],
+        failureSignals: [],
+        nextAction: "wait",
+      },
+    },
+  };
+}
+
+function recordedObservation() {
+  return {
+    ...makeObservation("case-1", "champion"),
+    recorded_at: "2026-07-13T12:00:00.000Z",
+    recorded_by: "codex",
+  };
+}
+
+describe("observeDurably", () => {
+  it("returns after the first acknowledged write", async () => {
+    const broker = {
+      experimentObserve: vi.fn(async () => ({})),
+      experimentStatus: vi.fn(async () => stateWith([])),
+    };
+    await expect(observeDurably(broker, makeObservation("case-1", "champion")))
+      .resolves.toEqual({ attempts: 1, reconciled: false });
+    expect(broker.experimentStatus).not.toHaveBeenCalled();
+  });
+
+  it("reconciles a write whose response was lost", async () => {
+    const observation = {
+      ...makeObservation("case-1", "champion"),
+      task_id: undefined,
+    };
+    const broker = {
+      experimentObserve: vi.fn(async () => {
+        throw new BrokerNetworkError("response timed out");
+      }),
+      experimentStatus: vi.fn(async () => stateWith([recordedObservation()])),
+    };
+    await expect(observeDurably(broker, observation))
+      .resolves.toEqual({ attempts: 1, reconciled: true });
+    expect(broker.experimentObserve).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries the identical evidence when reconciliation proves it absent", async () => {
+    const broker = {
+      experimentObserve: vi.fn()
+        .mockRejectedValueOnce(new BrokerNetworkError("request failed"))
+        .mockResolvedValueOnce({}),
+      experimentStatus: vi.fn(async () => stateWith([])),
+    };
+    await expect(observeDurably(
+      broker,
+      makeObservation("case-1", "champion"),
+      { retryDelayMs: 0, sleep: async () => undefined },
+    )).resolves.toEqual({ attempts: 2, reconciled: false });
+    expect(broker.experimentObserve).toHaveBeenCalledTimes(2);
+  });
+
+  it("never hides a conflicting durable observation", async () => {
+    const expected = makeObservation("case-1", "champion");
+    const conflicting = { ...recordedObservation(), latency_ms: 999 };
+    const broker = {
+      experimentObserve: vi.fn(async () => {
+        throw new BrokerNetworkError("response timed out");
+      }),
+      experimentStatus: vi.fn(async () => stateWith([conflicting])),
+    };
+    await expect(observeDurably(broker, expected)).rejects.toThrow(/different evidence/);
+  });
+});

--- a/tests/learning-experiment.test.ts
+++ b/tests/learning-experiment.test.ts
@@ -89,6 +89,57 @@ describe("evaluateLearningExperiment", () => {
     expect(evaluation.failureSignals[0]).toMatchObject({ signal: "tests-failed" });
   });
 
+  it("accepts an exact decimal rate improvement at the configured threshold", () => {
+    const input = makeExperimentInput({
+      gates: {
+        ...makeExperimentInput().gates,
+        minMatchedPairs: 10,
+        primaryMetric: "quality-rate",
+        minPrimaryImprovement: 0.1,
+      },
+    });
+    const observations = Array.from({ length: 10 }, (_, index) => {
+      const sample = `case-${index + 1}`;
+      return [
+        recorded(makeObservation(sample, "champion", index === 0 ? {
+          quality_outcome: "fail",
+          product_outcome: "discarded",
+          failure_kind: "protected-check-failed",
+        } : {})),
+        recorded(makeObservation(sample, "challenger")),
+      ];
+    }).flat();
+
+    const evaluation = evaluateLearningExperiment({ observations, gates: input.gates });
+    expect(evaluation.primaryImprovement).toBeCloseTo(0.1, 15);
+    expect(evaluation.decision).toBe("promotion-ready");
+  });
+
+  it("still rejects a decimal rate improvement materially below the threshold", () => {
+    const input = makeExperimentInput({
+      gates: {
+        ...makeExperimentInput().gates,
+        minMatchedPairs: 10,
+        primaryMetric: "quality-rate",
+        minPrimaryImprovement: 0.100_001,
+      },
+    });
+    const observations = Array.from({ length: 10 }, (_, index) => {
+      const sample = `case-${index + 1}`;
+      return [
+        recorded(makeObservation(sample, "champion", index === 0 ? {
+          quality_outcome: "fail",
+          product_outcome: "discarded",
+          failure_kind: "protected-check-failed",
+        } : {})),
+        recorded(makeObservation(sample, "challenger")),
+      ];
+    }).flat();
+
+    const evaluation = evaluateLearningExperiment({ observations, gates: input.gates });
+    expect(evaluation.decision).toBe("reject");
+  });
+
   it("does not count a judge-only verdict as verified quality evidence", () => {
     const input = makeExperimentInput();
     const observations = ["case-1", "case-2"].flatMap((sample) => [

--- a/tests/m5-code-loop-client.test.ts
+++ b/tests/m5-code-loop-client.test.ts
@@ -39,7 +39,26 @@ describe("M5CodeLoopClient", () => {
       fetchImpl: (async () => rpcResult({ refusal: "busy" }, true)) as typeof fetch,
     });
     await expect(client.start({ instruction: "fix", files: [{ path: "a", content: "b" }] }))
-      .rejects.toMatchObject({ name: "M5CodeLoopError", detail: { refusal: "busy" } });
+      .rejects.toMatchObject({
+        name: "M5CodeLoopError",
+        detail: { refusal: "busy" },
+        ambiguousOutcome: false,
+      });
+  });
+
+  it("marks transport failures as ambiguous for mutating calls", async () => {
+    const client = new M5CodeLoopClient({
+      endpoint: "http://m5.test:8080/mcp",
+      bearerToken: "x",
+      fetchImpl: (async () => {
+        throw new TypeError("connection reset");
+      }) as typeof fetch,
+    });
+    await expect(client.start({ instruction: "fix", files: [{ path: "a", content: "b" }] }))
+      .rejects.toMatchObject({
+        name: "M5CodeLoopError",
+        ambiguousOutcome: true,
+      });
   });
 
   it("rejects unsafe or wrong-path endpoints", () => {

--- a/tests/m5-code-loop-prompt.test.ts
+++ b/tests/m5-code-loop-prompt.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyCodeLoopPromptPrefix,
+  codeLoopPromptSha256,
+} from "../src/learning/m5-code-loop-prompt.js";
+
+describe("M5 code-loop prompt contract", () => {
+  it("preserves the deployed passthrough prompt fingerprint and instruction bytes", () => {
+    expect(codeLoopPromptSha256(undefined)).toBe(
+      "0b90fa0628704c2d775c2d805444d56be7e0afdba34250d26160f8c12b1f02c3",
+    );
+    expect(applyCodeLoopPromptPrefix("fix the bug\n", undefined)).toBe("fix the bug\n");
+  });
+
+  it("prepends the declared policy without normalizing either input", () => {
+    expect(applyCodeLoopPromptPrefix("instruction\n", "policy\n")).toBe(
+      "policy\n\n\ninstruction\n",
+    );
+  });
+
+  it("binds every prefix byte and domain-separates it from passthrough", () => {
+    expect(codeLoopPromptSha256("policy")).not.toBe(codeLoopPromptSha256("policy\n"));
+    expect(codeLoopPromptSha256("")).not.toBe(codeLoopPromptSha256(undefined));
+  });
+});


### PR DESCRIPTION
## Summary

- Bind optional per-arm local prompt prefixes to the versioned prompt SHA-256 before any M5 call, while preserving byte-for-byte passthrough compatibility.
- Reconcile ambiguous Broker observation writes against exact durable evidence before retrying, and mark transport-failed M5 starts as ambiguous so the runner forbids blind duplicate work.
- Make promotion-gate boundary comparisons tolerant only to IEEE-754 rounding noise, with positive and materially-below-threshold regression tests.
- Document the observed learning-loop evidence and remaining fresh-holdout/protocol requirements.

## Why

The first live M5 learning iterations exposed three concrete reliability gaps:

1. Prompt-axis experiments needed executable local prompt content bound to the content-blind configuration fingerprint.
2. A lost M5 start response and a timed-out observation response made it possible to duplicate paid work unless the runner reconciled durable state.
3. An exact `+0.10` quality improvement evaluated as `0.09999999999999998`, incorrectly missing a predeclared `0.1` threshold.

The development prompt screen itself used a contaminated corpus and remains non-production evidence. This PR does not promote a challenger, mutate the production champion, or deploy anything. A fresh unseen corpus is still tracked in gille-inference #250.

## Impact

- Prompt content stays local; Hugin persists only the version/hash.
- Ambiguous observation responses are retry-safe and evidence-bound.
- Ambiguous starts stop for operator reconciliation until M5 supports an idempotent client run identifier/request binding.
- Material gate regressions remain fail-closed; only machine-precision boundary noise is treated as equality.

## Validation

- `npm test` — 105 files, 1,739 tests passed
- `npm run build`
- Gate D manifest dry-run with exact corpus fingerprint
- Focused prompt tamper, durable-observation, M5 client, and evaluator boundary regressions
- `git diff --check`
