### PR TITLE
Record Harbor Linux acceptance

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,7 @@
 # Hugin — Status
 
-**Latest session:** 2026-07-14 (Codex) — **Harbor/M5 Gate D proof-of-fit completed; conditional-go for an offline evaluation lane**
-**Branch:** `agent/harbor-gate-d-pilot` rebased onto `main@71e796384b177cfb53bc19e7c451f9101bc16a18`; Harbor pilot implementation and evidence passed independent Claude review in PR [#201](https://github.com/Magnus-Gille/hugin/pull/201) and await green CI/merge.
+**Latest session:** 2026-07-14 (Codex) — **Harbor/M5 Linux acceptance completed; go for the offline evaluation lane**
+**Branch:** `codex/harbor-linux-acceptance` from merged `main@7916a17b1517a52ba2ff7cea84ba16afe164558b` (Harbor pilot PR [#201](https://github.com/Magnus-Gille/hugin/pull/201)); records the Linux acceptance and adds a fail-fast worker-dependency preflight.
 
 ## Latest — Harbor 0.18.0 proof-of-fit with the existing M5 code_loop
 
@@ -32,14 +32,28 @@
   requirement was removed, the actual task/verifier tools are now checked, and
   a regression test plus a run against the pinned image passed. Claude refuted
   its only other candidate finding.
-- Recommendation is conditional-go only for an offline evaluation/control
-  plane. Harbor does not replace Hugin dispatch, Broker/Munin lifecycle, M5
-  model routing, or the existing reviewed learning promotion gate. The macOS
-  run used public container networking (Harbor 0.18 cannot enforce no-network
-  there) and a custom native-arm64 base after Docker Desktop registry pulls
-  stalled. Repeat the same source/pin on Linux with no-network plus the standard
-  base, then expand to a predeclared matched corpus before estimating capability
-  rates.
+- PR #201 passed Claude's headless review plus GitHub CI and was squash-merged
+  as `7916a17`. The frozen corpus was then repeated in a disposable Linux ARM64
+  Harbor worker against Docker Desktop's LinuxKit daemon with all task, agent,
+  and verifier policies set to `no-network` and the standard
+  `node:22.17.0-bookworm-slim` image at digest `b04ce4ae...03a0`.
+- The Linux run's first host-baseline grade incorrectly linked the laptop
+  checkout's Darwin `esbuild`, while Harbor's isolated replay passed 2/2. A
+  model-free correction installed dependencies natively, re-applied the same
+  recorded diffs, and ran the original verifier: both baselines passed, both
+  hashes were unchanged, exact Harbor parity was 2/2, and no M5 calls were
+  repeated. The pilot now checks source-local `tsx`/`tsc`, runs a real `esbuild`
+  transform, and invokes `tsc --version` as a fail-fast platform check before
+  any live M5 call.
+- Both independent Linux live-adapter trials passed their separate verifiers,
+  all effective model/harness/caps matched, and Harbor reported zero exceptions.
+  The superseding content-blind record is
+  `docs/research/harbor-gate-d-linux-acceptance-2026-07-14.json`.
+- Recommendation is now go only for the explicit offline evaluation/control
+  plane. Harbor still does not replace Hugin dispatch, Broker/Munin lifecycle,
+  M5 model routing, or the reviewed learning promotion gate. Two tasks prove
+  the execution boundary, not a capability rate; expand to a predeclared
+  matched corpus before routing conclusions.
 - Harbor core and the installed wheel declare Apache-2.0. This local run made no
   Hub upload and Harbor reported $0.00 model API cost; electricity, hardware,
   operator time, Docker licensing, and any optional cloud sandbox/model costs
@@ -47,17 +61,17 @@
 - Security checks found zero M5 credential-prefix matches and zero
   `M5_API_KEY` names in generated task/job outputs. The Gate D source checkout
   remained clean at exact commit `d2d2541dd01519ddf50a9bbba8903d02fcea5284`.
-- Validation: corrected Harbor exact replay 2/2; corrected live-artifact regrade
-  1/2 with zero infrastructure exceptions; TypeScript build; standalone strict
-  typecheck of all pilot TS scripts; Python bytecode compile; focused 12 tests;
-  rebased full suite 106 files / 1,744 tests; both CI shell suites;
+- Validation: Linux corrected baseline 2/2; exact Harbor replay and diff parity
+  2/2; Linux live artifacts 2/2; zero infrastructure exceptions; credential
+  scan clean; cross-platform preflight reproduced red on Darwin dependencies and
+  green after Linux-native `npm ci`; TypeScript build; focused 6 tests; full
+  suite 106 files / 1,745 tests; both CI shell suites; JSON parse;
   `git diff --check`.
 
-**Next:** run the same content pin on a Linux Harbor worker with enforced
-`no-network` and the standard image. If parity stays exact, add a larger
-predeclared Gate D corpus and connect reviewed, content-blind Harbor summaries
-to Hugin's existing learning experiment endpoints. Do not deploy Harbor in the
-dispatcher, publish the dataset, or enable automatic promotion.
+**Next:** merge the narrow acceptance/preflight follow-up, then predeclare and
+run a larger matched Gate D corpus. Connect only reviewed, content-blind Harbor
+summaries to Hugin's existing learning experiment endpoints. Do not deploy
+Harbor in the dispatcher, publish the dataset, or enable automatic promotion.
 
 ---
 

--- a/docs/harbor-gate-d-pilot.md
+++ b/docs/harbor-gate-d-pilot.md
@@ -17,7 +17,11 @@ to Harbor Hub, or write observations to Munin.
 
 The corpus remains owned by `gille-inference`. The runner requires that source
 checkout to be clean, records its exact commit, and generates ephemeral Harbor
-tasks under the selected output directory.
+tasks under the selected output directory. The source checkout's `node_modules`
+must be installed on the Harbor worker itself (`npm ci`); the direct baseline
+uses those dependencies and now checks source-local `tsx`/`tsc`, executes an
+`esbuild` TypeScript transform, and runs `tsc --version` as a fail-fast
+platform-compatibility preflight before making any M5 call.
 
 Harbor 0.18.0's Docker provider rejects `no-network` on Docker Desktop for
 macOS because its egress-control implementation cannot enforce that policy on
@@ -151,6 +155,31 @@ fit is proven, but this macOS run used public container networking and a custom
 native-arm64 base because Docker Desktop's registry path stalled. Require a
 pinned Linux rerun with no network and the standard base before regular or
 automated evaluation use. Do not integrate Harbor into production dispatch.
+
+## Linux acceptance outcome (2026-07-14)
+
+The content-blind acceptance record is
+[`docs/research/harbor-gate-d-linux-acceptance-2026-07-14.json`](research/harbor-gate-d-linux-acceptance-2026-07-14.json).
+Harbor ran inside a disposable Linux worker against Docker Desktop's LinuxKit
+ARM64 daemon. All generated task, agent, and separate-verifier policies were
+`no-network`, and both task/verifier Dockerfiles used the standard
+`node:22.17.0-bookworm-slim` image at digest
+`sha256:b04ce4ae4e95b522112c2e5c52f781471a5cbc3b594527bcddedee9bc48c03a0`.
+
+The first direct-baseline grading attempt was invalid because the Linux worker
+linked the laptop checkout's Darwin `esbuild` binary. Harbor itself correctly
+graded the exact replays 2/2. A model-free correction re-applied the already
+recorded diffs and the original Gate D verifier after a clean Linux-native
+`npm ci`; both passed, both diff hashes remained identical, and no M5 call was
+repeated. The runner now detects this dependency mismatch before live work.
+
+Final acceptance: exact replay parity 2/2, diff-hash parity 2/2, live adapter
+completion 2/2, live verifier passes 2/2, zero Harbor exceptions, and zero
+credential indicators in generated task/job output. The mechanical
+recommendation is therefore **go** for the explicitly offline evaluation lane.
+This clears the environment condition only; the two-task sample is still far
+too small for capability-rate claims. Next expand to a predeclared matched
+corpus and keep routing/promotion review in Hugin rather than Harbor.
 
 ## License and cost
 

--- a/docs/research/harbor-gate-d-linux-acceptance-2026-07-14.json
+++ b/docs/research/harbor-gate-d-linux-acceptance-2026-07-14.json
@@ -1,0 +1,99 @@
+{
+  "schema_version": 1,
+  "pilot_version": "harbor-0.18.0-gate-d-v1",
+  "run_completed_at": "2026-07-14T17:28:25+02:00",
+  "recommendation": "go",
+  "harbor_version": "0.18.0",
+  "source_commit": "d2d2541dd01519ddf50a9bbba8903d02fcea5284",
+  "model": "qwen3-coder-next-80b",
+  "harness_version": "code-loop-pi-2026-07-13-v2",
+  "caps": {
+    "wall_s": 600,
+    "turns": 13,
+    "completion_tokens": 60000
+  },
+  "environment": {
+    "provider": "docker-linuxkit-worker",
+    "physical_host": "macos-docker-desktop",
+    "worker_os": "linux",
+    "architecture": "arm64",
+    "network_mode": "no-network",
+    "network_isolation_met": true,
+    "base_image": "node:22.17.0-bookworm-slim",
+    "base_image_digest": "sha256:b04ce4ae4e95b522112c2e5c52f781471a5cbc3b594527bcddedee9bc48c03a0",
+    "standard_base_image_met": true
+  },
+  "baseline": [
+    {
+      "task_id": "01-make-failing-test-pass",
+      "passed": true,
+      "status": "completed",
+      "work_id": "cl-20260714-7fa3a954",
+      "diff_sha256": "eaee6e0b09df8761072cb9a163652adbb0d9584055e4bcc431d92c8450b5c0af"
+    },
+    {
+      "task_id": "04-add-cli-flag",
+      "passed": true,
+      "status": "cap-exceeded",
+      "work_id": "cl-20260714-53589905",
+      "diff_sha256": "bcd83fc565a898b994d079f96b586d2d5968b5cc5028e20efea2e2b9b48b2081"
+    }
+  ],
+  "baseline_correction": {
+    "required": true,
+    "reason": "The first host baseline linked a Darwin esbuild binary into the Linux worker.",
+    "method": "Re-apply the identical recorded diffs and original Gate D verifier after a clean Linux-native npm ci.",
+    "additional_m5_calls": 0,
+    "replay_diff_hashes_unchanged": true
+  },
+  "exact_replay": {
+    "trials": 2,
+    "passed": 2,
+    "exceptions": 0,
+    "reward_parity": 2,
+    "diff_hash_parity": 2
+  },
+  "live_adapter": [
+    {
+      "task_id": "01-make-failing-test-pass",
+      "adapter_completed": true,
+      "artifact_passed": true,
+      "status": "completed",
+      "work_id": "cl-20260714-e9a7f694",
+      "apply_return_code": 0,
+      "diff_sha256": "71e136eb505ab50b56ac20ba15cb3e3d03c324af149d6e9f1eb66c65eb0f6700"
+    },
+    {
+      "task_id": "04-add-cli-flag",
+      "adapter_completed": true,
+      "artifact_passed": true,
+      "status": "completed",
+      "work_id": "cl-20260714-6fda5b2e",
+      "apply_return_code": 0,
+      "diff_sha256": "5a320514708817f2fbb697a805a9383deb67b24c90a8736571f44996447bee99"
+    }
+  ],
+  "security": {
+    "credential_prefix_matches_in_pilot_outputs": 0,
+    "credential_environment_name_matches_in_task_and_job_outputs": 0,
+    "credential_passed_to_task_or_verifier_containers": false,
+    "telemetry_enabled": false,
+    "hub_upload_performed": false
+  },
+  "cost": {
+    "harbor_reported_model_cost_usd": 0.0,
+    "harbor_license": "Apache-2.0",
+    "unmetered": [
+      "M5 electricity",
+      "hardware depreciation",
+      "operator time",
+      "local storage",
+      "Docker licensing"
+    ]
+  },
+  "required_follow_up": [
+    "Expand to a predeclared matched corpus before estimating capability rates",
+    "Keep full trajectories local and import only reviewed content-blind summaries",
+    "Keep promotion and production routing outside Harbor"
+  ]
+}

--- a/scripts/harbor_pilot/run-pilot.ts
+++ b/scripts/harbor_pilot/run-pilot.ts
@@ -116,6 +116,27 @@ export function customBasePreflightScript(): string {
   ].join(" && ");
 }
 
+export function sourceBaselinePreflightScript(): string {
+  return [
+    "test -x ./node_modules/.bin/tsx",
+    "test -x ./node_modules/.bin/tsc",
+    "node -e \"require('esbuild').transformSync('const x: number = 1', { loader: 'ts' })\"",
+    "./node_modules/.bin/tsc --version",
+  ].join(" && ");
+}
+
+function preflightSourceBaseline(sourceRepo: string): void {
+  try {
+    runChecked("bash", ["-c", sourceBaselinePreflightScript()], sourceRepo);
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      "Gate D source dependencies are missing or incompatible with this Harbor worker. " +
+      `Run npm ci in ${sourceRepo} on the worker before starting the pilot. ${detail}`,
+    );
+  }
+}
+
 function preflightCustomBaseImage(baseImage: string | undefined): void {
   if (!baseImage || baseImage === HARBOR_PILOT_DEFAULT_BASE_IMAGE) return;
   runChecked("docker", [
@@ -321,6 +342,7 @@ async function main(): Promise<void> {
   }
   const networkMode: "no-network" | "public" = networkModeArg;
   const baseImage = valueAfter("--base-image");
+  preflightSourceBaseline(sourceRepo);
   const explicitOut = valueAfter("--out");
   const outputDir = explicitOut
     ? resolve(explicitOut)

--- a/tests/harbor-pilot.test.ts
+++ b/tests/harbor-pilot.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../scripts/harbor_pilot/prepare-gate-d.js";
 import {
   customBasePreflightScript,
+  sourceBaselinePreflightScript,
   summarizeHarborJob,
 } from "../scripts/harbor_pilot/run-pilot.js";
 
@@ -72,6 +73,15 @@ describe("Harbor Gate D pilot", () => {
     expect(script).toContain("command -v grep");
     expect(script).toContain("@types/node/package.json");
     expect(script).not.toContain("command -v git");
+  });
+
+  it("preflights worker-native Gate D dependencies before live calls", () => {
+    const script = sourceBaselinePreflightScript();
+    expect(script).toContain("test -x ./node_modules/.bin/tsx");
+    expect(script).toContain("test -x ./node_modules/.bin/tsc");
+    expect(script).toContain("require('esbuild').transformSync");
+    expect(script).toContain("./node_modules/.bin/tsc --version");
+    expect(script).not.toContain("npx");
   });
 
   it("generates a content-pinned task with a separate no-network verifier", () => {


### PR DESCRIPTION
## What changed

- record the frozen Harbor Gate D Linux/no-network acceptance as a content-blind research artifact
- update the architecture guidance and project handoff from conditional-go to go for the offline evaluation lane
- fail fast before any M5 call when the source checkout's TypeScript dependencies are missing or built for another worker platform

## Acceptance evidence

- Harbor 0.18.0 in a disposable Linux ARM64 worker
- Docker daemon: LinuxKit ARM64
- task, agent, and separate-verifier policies: `no-network`
- standard base: `node:22.17.0-bookworm-slim` at `sha256:b04ce4ae...03a0`
- source: exact `d2d2541`
- corrected direct baselines: 2/2
- exact replay reward parity: 2/2
- exact replay diff-hash parity: 2/2
- live adapter/verifier passes: 2/2
- Harbor exceptions: 0
- credential indicators in generated output: 0

The initial host-baseline grade was invalid because the Linux worker linked the laptop checkout's Darwin `esbuild`. The correction re-applied the identical recorded diffs and original verifier after a Linux-native `npm ci`; hashes were unchanged and no M5 calls were repeated. The new preflight reproduces that mismatch and rejects it before live work.

## Scope

This is an offline evaluation-lane acceptance only. It does not deploy Harbor in Hugin, change production routing, upload to Harbor Hub, write experiment observations, or enable automatic promotion. Two tasks prove the boundary, not a capability rate.

## Validation

- `npm run build`
- strict standalone typecheck of all pilot TypeScript scripts
- focused Harbor tests: 6 passed
- full suite: 106 files / 1,745 tests passed
- both deployment/bootstrap shell suites passed
- JSON parse
- native-dependency preflight green; exact cross-platform mismatch reproduced red
- `git diff --check`

## Review

The original pilot diff received the approved Anthropic Claude headless review in PR #201. This follow-up was not sent to Anthropic because the explicit cloud approval was limited to commit `a74ad39`; it is a narrow evidence/preflight change backed by mechanical regression tests.