### PR TITLE
Add durable Harbor Gate D v2 pilot

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,45 @@
 # Hugin — Status
 
+**Latest session:** 2026-07-14 (Codex) — **M5 v4 live; Harbor r2 campaign implemented and predeclared, not yet run**
+**Branch:** `codex/harbor-gate-d-v2` from `main@57e1affbcda0c2a202ba14bccb04a67d95b7f48e`.
+
+## Latest — durable four-case Harbor campaign ready for review
+
+- gille-inference PRs #253/#254 are merged and exact `main@a9b92211` is now
+  deployed on M5. Post-restart acceptance passed: gateway/M5/Orin health,
+  owner-only `tools/list`, `client-run-id-v1`, v4 harness
+  `code-loop-pi-2026-07-14-v4`, pre-inference invalid-request refusal, and a
+  checksum rsync zero-delta check. No Gate D r2 model call was made.
+- The Harbor runner now targets fresh cases 11–14, with cases 11/12 selected as
+  holdouts by the predeclared lowest-task-ID-SHA-256 rule. The exact source
+  commit, task/holdout set, corpus/verifier hashes, model, caps, no-network
+  policy, and image digest are frozen in
+  `docs/research/harbor-gate-d-v2-declaration-2026-07-14.json` with model call
+  count zero.
+- Every direct and Harbor live M5 call carries a deterministic
+  `client_run_id`. Hugin validates the echoed request fingerprint, v4 execution
+  binding, and `pi-bash-events-v1` evidence; a lost start response is retried
+  only under the identical durable binding. The general matched-experiment
+  runner uses the same recovery contract.
+- The post-run importer defaults to dry-run, requires a clean Linux/no-network
+  `go` report at the pinned image digest, independently validates host/replay
+  parity and live bindings, and emits only content-blind observations to an
+  isolated pilot scope. It never calls promotion.
+- Validation: model-free generation against exact gille `a9b92211` reproduced
+  corpus `02ab9ee7...ef4ac` and verifier `bda62f9f...eb77b`; TypeScript build;
+  focused 24 tests including an intentionally lost/recovered start and an
+  explicit start/result work-ID mismatch rejection; full suite 106 files /
+  1,751 tests outside the port-restricted sandbox; both CI shell
+  suites; Python compile; declaration JSON parse; `git diff --check`.
+
+**Next:** review and merge this declaration/runner PR before any r2 inference.
+Then run the frozen campaign once in the accepted Linux/no-network Harbor
+worker, review/dry-run/commit only its content-blind parity import, and record
+the result in a follow-up PR. Keep Harbor out of dispatcher production and do
+not promote automatically.
+
+---
+
 **Latest session:** 2026-07-14 (Codex) — **Harbor/M5 Linux acceptance completed; go for the offline evaluation lane**
 **Main:** `052dd71e94dfedc8561f6be960dc2aa0fada278e`; Harbor pilot PR [#201](https://github.com/Magnus-Gille/hugin/pull/201) and Linux acceptance/preflight PR [#202](https://github.com/Magnus-Gille/hugin/pull/202) are merged.
 

--- a/docs/continuous-learning-loop.md
+++ b/docs/continuous-learning-loop.md
@@ -148,11 +148,12 @@ Observation writes are reconciled after ambiguous Broker timeouts: the runner fi
 durable experiment state and retries only an identical, absent `run_id`. This avoids rerunning a
 paid M5 arm merely because Hugin committed the evidence but its HTTP response was lost.
 
-An ambiguous `code_loop_start` response is different because the current M5 protocol does not
-accept a client idempotency key or echo a request fingerprint. The runner stops with the exact
-experiment `run_id` and explicitly forbids a blind rerun. Reconcile the recent M5 work id first;
-long-term, the M5 owner should add an idempotent client run identifier plus request binding so this
-recovery can be automatic and fail-closed.
+Every `code_loop_start` now carries a deterministic, content-blind `client_run_id` derived from the
+experiment run ID. M5 v4 durably binds that identifier to the canonical request fingerprint before
+execution. A lost start response is retried only with the identical request and therefore recovers
+the original work rather than starting a duplicate paid run. A different request under the same ID
+is an explicit conflict. The runner also binds `client-run-id-v1` and `pi-bash-events-v1` in the
+effective result before accepting an observation.
 
 An arm may declare a local-only `prompt_prefix_file`. The runner reads it once, verifies every byte
 against that arm's versioned `prompt.sha256`, and prepends it to each corpus instruction. Hugin still
@@ -169,7 +170,7 @@ HUGIN_BROKER_URL=http://huginmunin.<tailnet>.ts.net:3035 \
 HUGIN_BROKER_TOKEN=<keychain-or-env-token> \
 npm run experiment:m5-code-loop -- /path/to/gate-d-wave.json --dry-run
 
-# Remove --dry-run only after gille-inference #247 and this Hugin branch are deployed.
+# Remove --dry-run only after the declared M5 harness version is live and preflighted.
 ```
 
 After mechanical collection, rate each run through `hugin_experiment_rate`. Do not promote while

--- a/docs/harbor-gate-d-pilot.md
+++ b/docs/harbor-gate-d-pilot.md
@@ -1,18 +1,24 @@
 # Harbor Gate D proof-of-fit
 
 This pilot evaluates Harbor as Hugin's isolated task-execution and verification
-laboratory. It does **not** add Harbor to production dispatch, publish anything
-to Harbor Hub, or write observations to Munin.
+laboratory. It does **not** add Harbor to production dispatch or publish
+anything to Harbor Hub. A separate review-gated importer may write only a
+content-blind parity summary to Hugin's existing learning ledger.
 
 ## Pinned contract
 
 - Harbor: `0.18.0` on Python 3.12+
 - M5 model: `qwen3-coder-next-80b`
-- M5 harness: `code-loop-pi-2026-07-13-v2`
+- M5 harness: `code-loop-pi-2026-07-14-v4`
 - Caps: 600 wall seconds, 13 turns, 60,000 completion tokens
-- Tasks: Gate D `01-make-failing-test-pass` and `04-add-cli-flag`
+- Tasks: the fresh Gate D r2 cases `11` through `14`
+- Holdouts: `11-node-path-containment` and `12-add-csv-cli-format`, selected
+  before inference as the two lowest SHA-256 task IDs
+- M5 start contract: deterministic `client_run_id`, exact request binding, and
+  content-blind `pi-bash-events-v1` check evidence
 - Harbor concurrency: one trial
 - Container network: disabled on supported Linux providers; see the macOS note below
+- Base image: `node:22.17.0-bookworm-slim` pinned to digest `b04ce4ae...03a0`
 - Verifier: separate fresh container, original Gate D `check.sh`, no model
 
 The corpus remains owned by `gille-inference`. The runner requires that source
@@ -71,18 +77,25 @@ hashes, outcomes, usage, and provenance should cross into Hugin/Munin.
 
 ## Evidence layers
 
-1. The baseline calls the live M5 `code_loop`, applies each returned diff to a
+1. The baseline calls the live M5 `code_loop` once per task, applies each returned diff to a
    pristine host copy, and runs the original Gate D verifier.
 2. Harbor replays those exact diffs in its task containers. Reward and diff
    hashes must agree exactly with the baseline. This tests packaging and
    separate-verifier parity without model sampling noise.
-3. Harbor then runs both tasks through the live external M5 agent. Hugin's
+3. Harbor then runs every task through the live external M5 agent. Hugin's
    existing TypeScript client validates the response and effective model,
    harness, and caps before the adapter applies the diff. The separate verifier
    produces the authoritative reward.
 
 Only content-blind summaries belong in Hugin. Full replay results and Harbor
-trajectories contain task content and remain in the local pilot output.
+trajectories contain task content and remain in the local pilot output. The
+learning comparison is host verifier versus Harbor replay of the **same diff**;
+the separate live-adapter samples are operational evidence and are not treated
+as matched quality observations.
+
+The r2 task set, holdouts, source commit, corpus/verifier hashes, model, harness,
+caps, network policy, and image digest were frozen before inference in
+[`harbor-gate-d-v2-declaration-2026-07-14.json`](research/harbor-gate-d-v2-declaration-2026-07-14.json).
 
 ## Run
 
@@ -95,7 +108,8 @@ uv pip install \
   -r scripts/harbor_pilot/requirements.txt
 ```
 
-Start Docker Desktop, load the M5 owner credential through Keychain, and run:
+From the accepted Linux worker (using Docker Desktop's Linux daemon is fine),
+load the M5 owner credential through the host bridge and run:
 
 ```bash
 eval "$(m5-auth --env --tailnet)"
@@ -103,8 +117,11 @@ HARBOR_BIN=/private/tmp/hugin-harbor-pilot/venv/bin/harbor \
   HARBOR_TELEMETRY=off \
   npm run pilot:harbor -- \
   --source-repo /Users/magnus/repos/gille-inference \
-  --network-mode public \
-  --base-image hugin/harbor-gate-d-base:node22.17-ts5.9.3-types22.13-arm64
+  --campaign-id gate-d-fresh-v2-20260714 \
+  --declaration docs/research/harbor-gate-d-v2-declaration-2026-07-14.json \
+  --task-ids 11-node-path-containment,12-add-csv-cli-format,13-type-safe-slug-tests,14-shared-handle-validation \
+  --holdout-ids 11-node-path-containment,12-add-csv-cli-format \
+  --network-mode no-network
 ```
 
 The final `pilot-report.json` contains:
@@ -123,6 +140,19 @@ does not authorize automatic promotion or production routing.
 provider could not enforce network isolation. Re-run the same pin and source
 commit on Linux with `--network-mode no-network` before treating the pilot as a
 full go.
+
+After reviewing a `go` report from the accepted Linux/no-network environment,
+dry-run the content-blind import and inspect the exact experiment and
+observations:
+
+```bash
+npm run pilot:harbor:import -- /path/to/pilot-report.json
+```
+
+`--commit` is the only mutating mode. It creates or resumes the isolated
+`m5-code-edit-harbor-pilot` experiment and appends idempotent host/replay
+observations. It never imports prompts, diffs, verifier logs, or trajectories,
+and never calls the promotion endpoint.
 
 ## Initial pilot outcome (2026-07-14)
 

--- a/docs/research/harbor-gate-d-v2-declaration-2026-07-14.json
+++ b/docs/research/harbor-gate-d-v2-declaration-2026-07-14.json
@@ -1,0 +1,50 @@
+{
+  "schema_version": 1,
+  "status": "declared-not-run",
+  "declared_at": "2026-07-14T19:58:00+02:00",
+  "campaign_id": "gate-d-fresh-v2-20260714",
+  "pilot_version": "harbor-0.18.0-gate-d-v2",
+  "harbor_version": "0.18.0",
+  "runner_source": "the clean merged Hugin commit containing this declaration; pilot-report.json records its exact SHA",
+  "source_commit": "a9b92211d18a039a5893c4bdb3a51e177b3efaa9",
+  "task_ids": [
+    "11-node-path-containment",
+    "12-add-csv-cli-format",
+    "13-type-safe-slug-tests",
+    "14-shared-handle-validation"
+  ],
+  "holdout_ids": [
+    "11-node-path-containment",
+    "12-add-csv-cli-format"
+  ],
+  "holdout_revision": "sha256-lowest-two-of-four-v1",
+  "holdout_selection": {
+    "method": "lexicographically lowest two SHA-256 digests of the four task IDs",
+    "ordered_task_id_hashes": [
+      "10c1c22933fe1363bd01660e4b67a336cb89680240d3c3b7a4187d0dd51bf99b  11-node-path-containment",
+      "716f4db52d4f970bd910401898fb473fe33bd59c8929b058000ccc28fd371de8  12-add-csv-cli-format",
+      "9bbb78558ab5b5fd5eaf738baaa5614a1891a43a7edbf48ce57560572d330f9d  14-shared-handle-validation",
+      "b52ece9c7811eb1c51560e2eed12b23ba34c7705741cdf5dfa495ad004ceb614  13-type-safe-slug-tests"
+    ]
+  },
+  "corpus_sha256": "02ab9ee7e00f9670a803c55f2540e3b64a6ac01d5d647256c6c0ff7e2ceef4ac",
+  "verifier_sha256": "bda62f9f61098adba89a2f309e5abfb95b3b71840cbb4307397cf2c5ab9eb77b",
+  "harbor_verifier_sha256": "cae35089c094d13f2b8c328e7f56628d9636811a1bc8e7c826f092eb04b628a7",
+  "model": "qwen3-coder-next-80b",
+  "harness_version": "code-loop-pi-2026-07-14-v4",
+  "caps": {
+    "wall_s": 600,
+    "turns": 13,
+    "completion_tokens": 60000
+  },
+  "required_capabilities": {
+    "start_idempotency": "client-run-id-v1",
+    "agent_checks": "pi-bash-events-v1"
+  },
+  "network_mode": "no-network",
+  "base_image": "node:22.17.0-bookworm-slim@sha256:b04ce4ae4e95b522112c2e5c52f781471a5cbc3b594527bcddedee9bc48c03a0",
+  "harbor_concurrency": 1,
+  "attempts_per_task": 1,
+  "model_calls_at_declaration": 0,
+  "promotion_policy": "never automatic; reviewed content-blind import only"
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "eval:pii": "tsx scripts/run-pii-eval.ts",
     "experiment:m5-code-loop": "tsx scripts/run-m5-code-loop-experiment.ts",
     "pilot:harbor": "tsx scripts/harbor_pilot/run-pilot.ts",
+    "pilot:harbor:import": "tsx scripts/harbor_pilot/import-learning-report.ts",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/scripts/harbor_pilot/import-learning-report.ts
+++ b/scripts/harbor_pilot/import-learning-report.ts
@@ -1,0 +1,469 @@
+#!/usr/bin/env tsx
+
+/**
+ * Review gate between a local Harbor report and Hugin's content-blind learning
+ * ledger. The default is a dry run. `--commit` is the only mutating mode and
+ * never promotes a configuration.
+ */
+
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { z } from "zod";
+import { BrokerClient, BrokerHttpError } from "../../src/mcp/broker-client.js";
+import { observeDurably } from "../../src/learning/durable-observation.js";
+import {
+  computeConfigurationFingerprint,
+  learningExperimentCreateSchema,
+  learningExperimentStateSchema,
+  learningObservationSchema,
+  type LearningConfiguration,
+  type LearningExperimentCreate,
+  type LearningObservationInput,
+  type RecordedLearningObservation,
+} from "../../src/learning/experiment-schema.js";
+import { codeLoopPromptSha256 } from "../../src/learning/m5-code-loop-prompt.js";
+
+const hashSchema = z.string().regex(/^[a-f0-9]{64}$/);
+const gitCommitSchema = z.string().regex(/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/);
+const baselineSchema = z.object({
+  taskId: z.string().min(1),
+  holdout: z.boolean(),
+  passed: z.boolean(),
+  applyReturnCode: z.number().int().nullable(),
+  checkReturnCode: z.number().int().nullable(),
+  failureKind: z.enum(["empty-diff", "apply-failed", "check-failed"]).nullable(),
+  workId: z.string().min(1),
+  status: z.string().min(1),
+  diffBytes: z.number().int().nonnegative(),
+}).passthrough();
+const replaySchema = z.object({
+  taskId: z.string().min(1),
+  holdout: z.boolean(),
+  baselinePassed: z.boolean(),
+  harborPassed: z.boolean(),
+  rewardMeasured: z.literal(true),
+  rewardParity: z.literal(true),
+  diffParity: z.literal(true),
+  workParity: z.literal(true),
+  clientRunParity: z.literal(true),
+  applyReturnCode: z.literal(0),
+  exceptionType: z.null(),
+}).passthrough();
+const liveSchema = z.object({
+  taskId: z.string().min(1),
+  holdout: z.boolean(),
+  reward: z.union([z.literal(0), z.literal(1)]),
+  workId: z.string().min(1),
+  clientRunId: z.string().regex(/^[A-Za-z0-9._:-]{1,128}$/),
+  requestFingerprint: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+  startCapabilities: z.object({
+    start_idempotency: z.literal("client-run-id-v1"),
+    agent_checks: z.literal("pi-bash-events-v1"),
+  }).passthrough(),
+  execution: z.object({
+    model: z.string().min(1),
+    harness_version: z.literal("code-loop-pi-2026-07-14-v4"),
+    effective_caps: z.object({
+      wall_s: z.number().int().positive(),
+      turns: z.number().int().positive(),
+      completion_tokens: z.number().int().positive(),
+    }).passthrough(),
+    capabilities: z.object({
+      start_idempotency: z.literal("client-run-id-v1"),
+      agent_checks: z.literal("pi-bash-events-v1"),
+    }).passthrough(),
+  }).passthrough(),
+  agentChecks: z.object({
+    source: z.literal("pi-bash-events"),
+    work_id: z.string().min(1),
+  }).passthrough(),
+  exceptionType: z.null(),
+}).passthrough();
+const reportSchema = z.object({
+  schema_version: z.literal(2),
+  pilot_version: z.literal("harbor-0.18.0-gate-d-v2"),
+  campaign_id: z.string().regex(/^[a-z0-9][a-z0-9-]{1,47}$/),
+  harbor_version: z.literal("0.18.0"),
+  runner_commit: gitCommitSchema,
+  declaration_sha256: hashSchema,
+  source_commit: gitCommitSchema,
+  task_ids: z.array(z.string().min(1)).min(4).max(100),
+  holdout_ids: z.array(z.string().min(1)).min(2).max(100),
+  holdout_revision: z.string().min(1).max(120),
+  corpus_sha256: hashSchema,
+  verifier_sha256: hashSchema,
+  harbor_verifier_sha256: hashSchema,
+  caps: z.object({
+    wall_s: z.number().int().positive(),
+    turns: z.number().int().positive(),
+    completion_tokens: z.number().int().positive(),
+  }).strict(),
+  model: z.string().min(1).max(120),
+  harness_version: z.literal("code-loop-pi-2026-07-14-v4"),
+  network_mode: z.literal("no-network"),
+  network_isolation_met: z.literal(true),
+  base_image: z.literal("node:22.17.0-bookworm-slim@sha256:b04ce4ae4e95b522112c2e5c52f781471a5cbc3b594527bcddedee9bc48c03a0"),
+  standard_base_image_met: z.literal(true),
+  exact_replay_parity: z.literal(true),
+  baseline_decisions_verified: z.literal(true),
+  live_adapter_completed: z.literal(true),
+  recommendation: z.literal("go"),
+  baseline: z.array(baselineSchema).min(4).max(100),
+  replay_parity: z.array(replaySchema).min(4).max(100),
+  live_adapter: z.array(liveSchema).min(4).max(100),
+}).passthrough().superRefine((report, ctx) => {
+  const expected = [...report.task_ids].sort();
+  const baseline = report.baseline.map((row) => row.taskId).sort();
+  const replay = report.replay_parity.map((row) => row.taskId).sort();
+  const live = report.live_adapter.map((row) => row.taskId).sort();
+  if (new Set(expected).size !== expected.length) {
+    ctx.addIssue({ code: "custom", path: ["task_ids"], message: "duplicate task id" });
+  }
+  if (JSON.stringify(baseline) !== JSON.stringify(expected)) {
+    ctx.addIssue({ code: "custom", path: ["baseline"], message: "baseline task set mismatch" });
+  }
+  if (JSON.stringify(replay) !== JSON.stringify(expected)) {
+    ctx.addIssue({ code: "custom", path: ["replay_parity"], message: "replay task set mismatch" });
+  }
+  if (JSON.stringify(live) !== JSON.stringify(expected)) {
+    ctx.addIssue({ code: "custom", path: ["live_adapter"], message: "live task set mismatch" });
+  }
+  const holdouts = new Set(report.holdout_ids);
+  if (holdouts.size !== report.holdout_ids.length || [...holdouts].some((id) => !expected.includes(id))) {
+    ctx.addIssue({ code: "custom", path: ["holdout_ids"], message: "invalid holdout set" });
+  }
+  for (const row of report.baseline) {
+    if (row.holdout !== holdouts.has(row.taskId)) {
+      ctx.addIssue({ code: "custom", path: ["baseline"], message: `holdout mismatch for ${row.taskId}` });
+    }
+    if (row.applyReturnCode !== 0 || row.checkReturnCode === null || row.passed !== (row.checkReturnCode === 0)) {
+      ctx.addIssue({ code: "custom", path: ["baseline"], message: `unverified host decision for ${row.taskId}` });
+    }
+  }
+  const baselineByTask = new Map(report.baseline.map((row) => [row.taskId, row]));
+  for (const row of report.replay_parity) {
+    if (
+      row.holdout !== holdouts.has(row.taskId) ||
+      row.baselinePassed !== row.harborPassed ||
+      baselineByTask.get(row.taskId)?.passed !== row.baselinePassed
+    ) {
+      ctx.addIssue({ code: "custom", path: ["replay_parity"], message: `parity mismatch for ${row.taskId}` });
+    }
+  }
+  for (const row of report.live_adapter) {
+    if (
+      row.holdout !== holdouts.has(row.taskId) ||
+      row.clientRunId !== `harbor:${report.campaign_id}:${row.taskId}:live` ||
+      row.execution.model !== report.model ||
+      row.execution.effective_caps.wall_s !== report.caps.wall_s ||
+      row.execution.effective_caps.turns !== report.caps.turns ||
+      row.execution.effective_caps.completion_tokens !== report.caps.completion_tokens ||
+      row.agentChecks.work_id !== row.workId
+    ) {
+      ctx.addIssue({ code: "custom", path: ["live_adapter"], message: `live binding mismatch for ${row.taskId}` });
+    }
+  }
+});
+
+type HarborReport = z.infer<typeof reportSchema>;
+
+function sha256(value: unknown): string {
+  return createHash("sha256").update(
+    typeof value === "string" ? value : JSON.stringify(value),
+  ).digest("hex");
+}
+
+function stable(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stable).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, child]) => `${JSON.stringify(key)}:${stable(child)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function sameObservation(
+  recorded: RecordedLearningObservation,
+  expected: LearningObservationInput,
+): boolean {
+  const {
+    recorded_at: _recordedAt,
+    recorded_by: _recordedBy,
+    product_rated_at: _productRatedAt,
+    product_rated_by: _productRatedBy,
+    ...evidence
+  } = recorded;
+  const canonicalExpected = learningObservationSchema.parse(
+    JSON.parse(JSON.stringify(expected)),
+  );
+  return stable(evidence) === stable(canonicalExpected);
+}
+
+function configuration(
+  report: HarborReport,
+  kind: "host" | "harbor",
+  evidenceDigest: string,
+): LearningConfiguration {
+  const payload = {
+    prompt: {
+      id: "gate-d-instruction-passthrough",
+      version: "1",
+      sha256: codeLoopPromptSha256(undefined),
+    },
+    harness: {
+      id: "pi-code-loop",
+      version: report.harness_version,
+      configSha256: sha256({ caps: report.caps, capabilities: ["client-run-id-v1", "pi-bash-events-v1"] }),
+      maxTurns: report.caps.turns,
+      timeoutMs: report.caps.wall_s * 1_000,
+      contextStrategy: "inline-seed-v1",
+      toolPolicyVersion: "pi-pinned-ndjson-v1",
+    },
+    model: {
+      id: report.model,
+      provider: "m5",
+      runtime: "pi-llama-swap",
+      config: {
+        contextWindow: 131_072,
+        maxOutputTokens: report.caps.completion_tokens,
+        templateVersion: "m5-live-2026-07-14",
+        extraConfigSha256: sha256("client-run-id-v1+pi-bash-events-v1"),
+      },
+    },
+    logging: {
+      schemaVersion: "code-loop-result-v4",
+      requiredFieldsSha256: sha256("execution+telemetry+agent_checks+durable-start"),
+    },
+    testHarness: kind === "host"
+      ? {
+          id: "gate-d-host",
+          version: `gille-${report.source_commit.slice(0, 12)}`,
+          corpusSha256: report.corpus_sha256,
+          oracleVersion: `sha256-${report.verifier_sha256.slice(0, 16)}`,
+          holdoutRevision: report.holdout_revision,
+        }
+      : {
+          id: "gate-d-harbor",
+          version: report.pilot_version,
+          corpusSha256: report.corpus_sha256,
+          oracleVersion: `sha256-${report.harbor_verifier_sha256.slice(0, 16)}`,
+          holdoutRevision: report.holdout_revision,
+        },
+    routing: {
+      policyId: "harbor-parity-pilot",
+      version: "1",
+      configSha256: sha256({
+        campaign: report.campaign_id,
+        replay: "same-diff-v1",
+        evidence_digest: evidenceDigest,
+      }),
+    },
+  };
+  return {
+    ...payload,
+    fingerprint: computeConfigurationFingerprint(payload),
+  };
+}
+
+export interface HarborLearningImport {
+  experiment: LearningExperimentCreate;
+  observations: LearningObservationInput[];
+}
+
+export function harborLearningImportFromReport(raw: unknown): HarborLearningImport {
+  const report = reportSchema.parse(raw);
+  const experimentId = `harbor-${report.campaign_id}`;
+  const evidenceDigest = sha256({
+    source_commit: report.source_commit,
+    runner_commit: report.runner_commit,
+    declaration_sha256: report.declaration_sha256,
+    corpus_sha256: report.corpus_sha256,
+    verifier_sha256: report.verifier_sha256,
+    harbor_verifier_sha256: report.harbor_verifier_sha256,
+    baseline: [...report.baseline].sort((a, b) => a.taskId.localeCompare(b.taskId)).map((row) => ({
+      task_id: row.taskId,
+      holdout: row.holdout,
+      passed: row.passed,
+      work_id: row.workId,
+      diff_bytes: row.diffBytes,
+    })),
+    replay: [...report.replay_parity].sort((a, b) => a.taskId.localeCompare(b.taskId)).map((row) => ({
+      task_id: row.taskId,
+      passed: row.harborPassed,
+      reward_parity: row.rewardParity,
+      diff_parity: row.diffParity,
+    })),
+    live: [...report.live_adapter].sort((a, b) => a.taskId.localeCompare(b.taskId)).map((row) => ({
+      task_id: row.taskId,
+      work_id: row.workId,
+      reward: row.reward,
+      request_fingerprint: row.requestFingerprint,
+    })),
+  });
+  const champion = configuration(report, "host", evidenceDigest);
+  const challenger = configuration(report, "harbor", evidenceDigest);
+  const experiment = learningExperimentCreateSchema.parse({
+    experiment_id: experimentId,
+    scope: "m5-code-edit-harbor-pilot",
+    task_type: "code-edit",
+    hypothesis:
+      "Harbor 0.18's isolated Gate D verifier reproduces the host Gate D decision and diff identity on a predeclared fresh corpus.",
+    change_axis: "test-harness",
+    champion,
+    challenger,
+    gates: {
+      minMatchedPairs: report.task_ids.length,
+      minHoldoutPairs: report.holdout_ids.length,
+      minVerifiedCoverage: 1,
+      minRatedCoverage: 0,
+      maxQualityRegression: 0,
+      maxUsefulRegression: 0,
+      maxRescueRateIncrease: 0,
+      maxInfraRateIncrease: 0,
+      maxLatencyRatio: null,
+      maxCostRatio: null,
+      primaryMetric: "verifier-score",
+      minPrimaryImprovement: 0,
+    },
+  });
+  const baselineByTask = new Map(report.baseline.map((row) => [row.taskId, row]));
+  const replayByTask = new Map(report.replay_parity.map((row) => [row.taskId, row]));
+  const observations = report.task_ids.flatMap((taskId) => {
+    const baseline = baselineByTask.get(taskId)!;
+    const replay = replayByTask.get(taskId)!;
+    const common = {
+      experiment_id: experimentId,
+      sample_id: taskId,
+      holdout: baseline.holdout,
+      product_outcome: "unrated" as const,
+      edited: baseline.diffBytes > 0,
+      tests_run: true,
+      task_id: taskId,
+      ledger_id: `harbor-report:${evidenceDigest}`,
+      work_id: baseline.workId,
+    };
+    return [
+      learningObservationSchema.parse({
+        ...common,
+        run_id: `${experimentId}:${taskId}:host`,
+        arm: "champion",
+        configuration_fingerprint: champion.fingerprint,
+        quality_outcome: baseline.passed ? "pass" : "fail",
+        verifier: {
+          kind: "mechanical",
+          independent: true,
+          id: "gate-d-host",
+          version: `sha256-${report.verifier_sha256.slice(0, 16)}`,
+        },
+        verifier_score: baseline.passed ? 1 : 0,
+        tests_passed: baseline.passed,
+        failure_kind: baseline.failureKind ?? undefined,
+      }),
+      learningObservationSchema.parse({
+        ...common,
+        run_id: `${experimentId}:${taskId}:harbor`,
+        arm: "challenger",
+        configuration_fingerprint: challenger.fingerprint,
+        quality_outcome: replay.harborPassed ? "pass" : "fail",
+        verifier: {
+          kind: "mechanical",
+          independent: true,
+          id: "gate-d-harbor",
+          version: `sha256-${report.harbor_verifier_sha256.slice(0, 16)}`,
+        },
+        verifier_score: replay.harborPassed ? 1 : 0,
+        tests_passed: replay.harborPassed,
+        failure_kind: replay.harborPassed ? undefined : "gate-d-check-failed",
+      }),
+    ];
+  });
+  return { experiment, observations };
+}
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value || value.trim() === "") throw new Error(`missing required environment variable ${name}`);
+  return value;
+}
+
+async function commitImport(payload: HarborLearningImport): Promise<void> {
+  const broker = new BrokerClient({
+    baseUrl: requiredEnv("HUGIN_BROKER_URL"),
+    bearerToken: requiredEnv("HUGIN_BROKER_TOKEN"),
+  });
+  let state;
+  try {
+    const response = await broker.experimentStatus({
+      experiment_id: payload.experiment.experiment_id,
+    }) as { state: unknown };
+    state = learningExperimentStateSchema.parse(response.state);
+  } catch (err) {
+    if (!(err instanceof BrokerHttpError) || err.httpStatus !== 404) throw err;
+    const response = await broker.experimentCreate(payload.experiment) as { state: unknown };
+    state = learningExperimentStateSchema.parse(response.state);
+  }
+  if (
+    state.champion.fingerprint !== payload.experiment.champion.fingerprint ||
+    state.challenger.fingerprint !== payload.experiment.challenger.fingerprint
+  ) {
+    throw new Error("existing Harbor experiment has a different immutable configuration");
+  }
+  if (state.status !== "running") {
+    const complete = payload.observations.every((observation) => {
+      const recorded = state.observations.find((row) => row.run_id === observation.run_id);
+      return recorded !== undefined && sameObservation(recorded, observation);
+    });
+    if (!complete) {
+      throw new Error(`terminal Harbor experiment ${state.status} is missing declared evidence`);
+    }
+  } else {
+    for (const observation of payload.observations) {
+      await observeDurably(broker, observation);
+    }
+  }
+  const finalResponse = await broker.experimentStatus({
+    experiment_id: payload.experiment.experiment_id,
+  }) as { state: unknown };
+  const finalState = learningExperimentStateSchema.parse(finalResponse.state);
+  process.stdout.write(`${JSON.stringify({
+    experiment_id: finalState.experimentId,
+    status: finalState.status,
+    matched_pairs: finalState.evaluation.matchedPairs,
+    holdout_pairs: finalState.evaluation.holdoutPairs,
+    decision: finalState.evaluation.decision,
+    reason: finalState.evaluation.reason,
+    next_action: finalState.evaluation.nextAction,
+    promotion_attempted: false,
+  }, null, 2)}\n`);
+}
+
+async function main(): Promise<void> {
+  const reportArg = process.argv[2];
+  if (!reportArg) {
+    throw new Error("usage: import-learning-report.ts <pilot-report.json> [--commit]");
+  }
+  const raw = JSON.parse(readFileSync(resolve(reportArg), "utf8"));
+  const payload = harborLearningImportFromReport(raw);
+  if (!process.argv.includes("--commit")) {
+    process.stdout.write(`${JSON.stringify({
+      mode: "dry-run",
+      experiment: payload.experiment,
+      observations: payload.observations,
+      promotion_attempted: false,
+    }, null, 2)}\n`);
+    return;
+  }
+  await commitImport(payload);
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : "";
+if (import.meta.url === invokedPath) {
+  main().catch((err: unknown) => {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/harbor_pilot/m5-code-loop-once.ts
+++ b/scripts/harbor_pilot/m5-code-loop-once.ts
@@ -11,7 +11,9 @@ import {
 } from "../../src/learning/m5-code-loop-adapter.js";
 import {
   M5CodeLoopClient,
+  M5CodeLoopError,
   type M5CodeLoopRequest,
+  type M5CodeLoopStart,
 } from "../../src/learning/m5-code-loop-client.js";
 
 const capsSchema = z.object({
@@ -30,6 +32,7 @@ const capsSchema = z.object({
 });
 
 const requestSchema = z.object({
+  client_run_id: z.string().regex(/^[A-Za-z0-9._:-]{1,128}$/).optional(),
   instruction: z.string().min(1),
   files: z.array(z.object({
     path: z.string().min(1),
@@ -47,6 +50,10 @@ const inputSchema = z.object({
     model: z.string().min(1),
     harnessVersion: z.string().min(1),
     caps: capsSchema,
+    capabilities: z.object({
+      startIdempotency: z.literal("client-run-id-v1"),
+      agentChecks: z.literal("pi-bash-events-v1"),
+    }).strict().optional(),
   }).strict(),
   pollMs: z.number().int().min(250).max(30_000).default(5_000),
   resultDeadlineS: z.number().int().min(60).max(3_600).default(900),
@@ -54,6 +61,13 @@ const inputSchema = z.object({
 }).strict();
 
 export type HarborCodeLoopOnceInput = z.infer<typeof inputSchema>;
+export interface HarborCodeLoopOnceOutput {
+  result: M5CodeLoopResult;
+  start: null | Pick<
+    M5CodeLoopStart,
+    "work_id" | "status" | "client_run_id" | "request_fingerprint" | "recovered" | "capabilities"
+  >;
+}
 
 function requiredEnv(name: string): string {
   const value = process.env[name];
@@ -83,13 +97,34 @@ function supportsRequestedContract(
 ): boolean {
   const start = tools.find((tool) => tool.name === "code_loop_start");
   if (!start) return false;
+  if (request.client_run_id !== undefined && !JSON.stringify(start).includes("client_run_id")) {
+    return false;
+  }
   if (request.caps?.edit_deadline_turn === undefined) return true;
   return JSON.stringify(start).includes("edit_deadline_turn");
 }
 
+async function startDurably(
+  client: M5CodeLoopClient,
+  request: M5CodeLoopRequest,
+): Promise<M5CodeLoopStart> {
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await client.start(request);
+    } catch (err) {
+      const safelyRetryable =
+        request.client_run_id !== undefined &&
+        err instanceof M5CodeLoopError &&
+        err.ambiguousOutcome;
+      if (!safelyRetryable || attempt >= 3) throw err;
+      await sleep(attempt * 500);
+    }
+  }
+}
+
 export async function runCodeLoopOnce(
   rawInput: HarborCodeLoopOnceInput,
-): Promise<M5CodeLoopResult> {
+): Promise<HarborCodeLoopOnceOutput> {
   const input = inputSchema.parse(rawInput);
   let result: M5CodeLoopResult;
 
@@ -97,7 +132,12 @@ export async function runCodeLoopOnce(
     result = m5CodeLoopResultSchema.parse(
       JSON.parse(readFileSync(resolve(input.replayPath), "utf8")),
     );
+    assertM5CodeLoopExecutionBinding(result, input.expected);
+    return { result, start: null };
   } else {
+    if (!input.request.client_run_id) {
+      throw new Error("live Harbor code_loop requests require client_run_id");
+    }
     const client = new M5CodeLoopClient({
       endpoint: m5McpEndpoint(),
       bearerToken: requiredEnv("M5_API_KEY"),
@@ -107,21 +147,39 @@ export async function runCodeLoopOnce(
       throw new Error("M5 does not advertise the requested code_loop contract");
     }
 
-    const started = await client.start(input.request);
+    const started = await startDurably(client, input.request);
+    if (started.client_run_id !== input.request.client_run_id) {
+      throw new Error("M5 did not echo the declared client_run_id");
+    }
+    if (!started.request_fingerprint) {
+      throw new Error("M5 omitted the durable request fingerprint");
+    }
     const deadline = Date.now() + input.resultDeadlineS * 1_000;
-    for (;;) {
+    let status = started.status;
+    while (status === "running") {
       await sleep(input.pollMs);
-      const status = await client.status(started.work_id);
-      if (status.status !== "running") break;
-      if (Date.now() >= deadline) {
+      status = (await client.status(started.work_id)).status;
+      if (status === "running" && Date.now() >= deadline) {
         throw new Error(`M5 result deadline exceeded for ${started.work_id}`);
       }
     }
     result = await client.result(started.work_id);
+    if (result.work_id !== started.work_id) {
+      throw new Error("M5 result belongs to a different work id than the durable start");
+    }
+    assertM5CodeLoopExecutionBinding(result, input.expected);
+    return {
+      result,
+      start: {
+        work_id: started.work_id,
+        status: started.status,
+        client_run_id: started.client_run_id,
+        request_fingerprint: started.request_fingerprint,
+        recovered: started.recovered,
+        capabilities: started.capabilities,
+      },
+    };
   }
-
-  assertM5CodeLoopExecutionBinding(result, input.expected);
-  return result;
 }
 
 async function main(): Promise<void> {
@@ -130,8 +188,8 @@ async function main(): Promise<void> {
     throw new Error("usage: m5-code-loop-once.ts <input.json> <output.json>");
   }
   const input = inputSchema.parse(JSON.parse(readFileSync(resolve(inputArg), "utf8")));
-  const result = await runCodeLoopOnce(input);
-  writeFileSync(resolve(outputArg), `${JSON.stringify(result)}\n`, { mode: 0o600 });
+  const output = await runCodeLoopOnce(input);
+  writeFileSync(resolve(outputArg), `${JSON.stringify(output)}\n`, { mode: 0o600 });
 }
 
 const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : "";

--- a/scripts/harbor_pilot/m5_code_loop_agent.py
+++ b/scripts/harbor_pilot/m5_code_loop_agent.py
@@ -27,7 +27,7 @@ class M5CodeLoopAgent(BaseAgent):
         self,
         logs_dir: Path,
         model_name: str | None = None,
-        expected_harness_version: str = "code-loop-pi-2026-07-13-v2",
+        expected_harness_version: str = "code-loop-pi-2026-07-14-v4",
         wall_s: int | str = 600,
         turns: int | str = 13,
         completion_tokens: int | str = 60_000,
@@ -76,7 +76,7 @@ class M5CodeLoopAgent(BaseAgent):
 
     @override
     def version(self) -> str:
-        return "0.1.0-harbor-0.18.0"
+        return "0.2.0-harbor-0.18.0"
 
     @override
     async def setup(self, environment: BaseEnvironment) -> None:
@@ -87,13 +87,33 @@ class M5CodeLoopAgent(BaseAgent):
         raw = json.loads(path.read_text())
         task_id = raw.get("task_id")
         protected = raw.get("protected")
+        holdout = raw.get("holdout")
+        client_run_ids = raw.get("client_run_ids")
         if not isinstance(task_id, str) or not task_id or "/" in task_id or ".." in task_id:
             raise ValueError("invalid Harbor pilot task_id")
         if not isinstance(protected, list) or not all(
             isinstance(item, str) and item for item in protected
         ):
             raise ValueError("invalid Harbor pilot protected paths")
-        return {"task_id": task_id, "protected": protected}
+        if not isinstance(holdout, bool):
+            raise ValueError("invalid Harbor pilot holdout flag")
+        if not isinstance(client_run_ids, dict):
+            raise ValueError("missing Harbor pilot client run ids")
+        for lane in ("baseline", "live"):
+            value = client_run_ids.get(lane)
+            if (
+                not isinstance(value, str)
+                or not value
+                or len(value) > 128
+                or any(not (ch.isalnum() or ch in "._:-") for ch in value)
+            ):
+                raise ValueError(f"invalid Harbor pilot {lane} client run id")
+        return {
+            "task_id": task_id,
+            "protected": protected,
+            "holdout": holdout,
+            "client_run_ids": client_run_ids,
+        }
 
     @staticmethod
     def _seed_files(root: Path) -> list[dict[str, str]]:
@@ -129,18 +149,29 @@ class M5CodeLoopAgent(BaseAgent):
 
     @staticmethod
     def _redacted_result(
-        result: dict[str, Any], apply_return_code: int | None, mode: str
+        result: dict[str, Any],
+        start: dict[str, Any] | None,
+        apply_return_code: int | None,
+        mode: str,
+        holdout: bool,
+        declared_client_run_id: str,
     ) -> dict[str, Any]:
         diff = result.get("diff") if isinstance(result.get("diff"), str) else ""
         check = result.get("check") if isinstance(result.get("check"), dict) else {}
         return {
             "schema_version": 1,
             "mode": mode,
+            "holdout": holdout,
             "status": result.get("status"),
             "work_id": result.get("work_id"),
+            "client_run_id": declared_client_run_id,
+            "request_fingerprint": start.get("request_fingerprint") if start else None,
+            "recovered": start.get("recovered") if start else None,
+            "start_capabilities": start.get("capabilities") if start else None,
             "usage": result.get("usage"),
             "execution": result.get("execution"),
             "telemetry": result.get("telemetry"),
+            "agent_checks": result.get("agent_checks"),
             "changed_files": result.get("changed_files"),
             "protected_violations": result.get("protected_violations"),
             "diff_sha256": hashlib.sha256(diff.encode()).hexdigest(),
@@ -220,8 +251,13 @@ class M5CodeLoopAgent(BaseAgent):
                 target_dir=seed_dir,
                 exclude=["node_modules", ".git", ".harbor-pilot.json"],
             )
+            replay_path = self._replay_path(control["task_id"])
+            request_client_run_id = control["client_run_ids"][
+                "baseline" if replay_path is not None else "live"
+            ]
             request: dict[str, Any] = {
                 "request": {
+                    "client_run_id": request_client_run_id,
                     "instruction": instruction,
                     "files": self._seed_files(seed_dir),
                     "protected": control["protected"],
@@ -232,11 +268,14 @@ class M5CodeLoopAgent(BaseAgent):
                     "model": self.model_name,
                     "harnessVersion": self.expected_harness_version,
                     "caps": self.caps,
+                    "capabilities": {
+                        "startIdempotency": "client-run-id-v1",
+                        "agentChecks": "pi-bash-events-v1",
+                    },
                 },
                 "pollMs": self.poll_ms,
                 "resultDeadlineS": self.result_deadline_s,
             }
-            replay_path = self._replay_path(control["task_id"])
             if replay_path is not None:
                 request["replayPath"] = str(replay_path)
 
@@ -245,7 +284,13 @@ class M5CodeLoopAgent(BaseAgent):
             request_path.write_text(json.dumps(request))
             request_path.chmod(0o600)
             await self._invoke_helper(request_path, result_path)
-            result = json.loads(result_path.read_text())
+            output = json.loads(result_path.read_text())
+            result = output.get("result")
+            start = output.get("start")
+            if not isinstance(result, dict):
+                raise RuntimeError("M5 code_loop helper omitted its result envelope")
+            if start is not None and not isinstance(start, dict):
+                raise RuntimeError("M5 code_loop helper returned invalid start evidence")
 
             diff = result.get("diff") if isinstance(result.get("diff"), str) else ""
             apply_return_code: int | None = None
@@ -258,7 +303,17 @@ class M5CodeLoopAgent(BaseAgent):
                     await environment.upload_dir(seed_dir, "/app")
 
             mode = "replay" if replay_path is not None else "live"
-            redacted = self._redacted_result(result, apply_return_code, mode)
+            declared_client_run_id = control["client_run_ids"][
+                "baseline" if mode == "replay" else "live"
+            ]
+            redacted = self._redacted_result(
+                result,
+                start,
+                apply_return_code,
+                mode,
+                control["holdout"],
+                declared_client_run_id,
+            )
             (self.logs_dir / "m5-result.json").write_text(
                 json.dumps(redacted, indent=2, sort_keys=True) + "\n"
             )

--- a/scripts/harbor_pilot/prepare-gate-d.ts
+++ b/scripts/harbor_pilot/prepare-gate-d.ts
@@ -14,12 +14,21 @@ import { spawnSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
 import { z } from "zod";
 
-export const HARBOR_PILOT_VERSION = "harbor-0.18.0-gate-d-v1";
-export const HARBOR_PILOT_DEFAULT_BASE_IMAGE = "node:22.17.0-bookworm-slim";
+export const HARBOR_PILOT_VERSION = "harbor-0.18.0-gate-d-v2";
+export const HARBOR_PILOT_CAMPAIGN_ID = "gate-d-fresh-v2-20260714";
+export const HARBOR_PILOT_DEFAULT_BASE_IMAGE =
+  "node:22.17.0-bookworm-slim@sha256:b04ce4ae4e95b522112c2e5c52f781471a5cbc3b594527bcddedee9bc48c03a0";
 export const HARBOR_PILOT_TASK_IDS = [
-  "01-make-failing-test-pass",
-  "04-add-cli-flag",
+  "11-node-path-containment",
+  "12-add-csv-cli-format",
+  "13-type-safe-slug-tests",
+  "14-shared-handle-validation",
 ] as const;
+export const HARBOR_PILOT_HOLDOUT_IDS = [
+  "11-node-path-containment",
+  "12-add-csv-cli-format",
+] as const;
+export const HARBOR_PILOT_HOLDOUT_REVISION = "sha256-lowest-two-of-four-v1";
 
 const metaSchema = z.object({
   id: z.string().min(1),
@@ -28,6 +37,34 @@ const metaSchema = z.object({
 
 function sha256File(path: string): string {
   return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function fileBindings(rootInput: string): Array<{ path: string; sha256: string }> {
+  const root = resolve(rootInput);
+  const output: Array<{ path: string; sha256: string }> = [];
+  const walk = (dir: string): void => {
+    for (const name of readdirSync(dir).sort()) {
+      const path = join(dir, name);
+      const stat = lstatSync(path);
+      if (stat.isSymbolicLink()) throw new Error(`Harbor pilot source contains a symlink: ${path}`);
+      if (stat.isDirectory()) walk(path);
+      else if (stat.isFile()) output.push({ path: relative(root, path), sha256: sha256File(path) });
+    }
+  };
+  walk(root);
+  return output;
+}
+
+function sha256Json(value: unknown): string {
+  return createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+function clientRunId(campaignId: string, taskId: string, lane: "baseline" | "live"): string {
+  const value = `harbor:${campaignId}:${taskId}:${lane}`;
+  if (!/^[A-Za-z0-9._:-]{1,128}$/.test(value)) {
+    throw new Error(`campaign/task combination cannot form a safe M5 client_run_id: ${taskId}`);
+  }
+  return value;
 }
 
 function assertNoSymlinks(rootInput: string): void {
@@ -58,6 +95,8 @@ function taskToml(input: {
   sourceCommit: string;
   instructionSha256: string;
   metaSha256: string;
+  campaignId: string;
+  holdout: boolean;
   networkMode: "no-network" | "public";
 }): string {
   return `schema_version = "1.3"
@@ -68,7 +107,9 @@ exclude = ["node_modules", ".git", ".harbor-pilot.json"]
 
 [metadata]
 pilot_version = ${JSON.stringify(HARBOR_PILOT_VERSION)}
+campaign_id = ${JSON.stringify(input.campaignId)}
 gate_d_id = ${JSON.stringify(input.taskId)}
+holdout = ${input.holdout}
 source_commit = ${JSON.stringify(input.sourceCommit)}
 instruction_sha256 = ${JSON.stringify(input.instructionSha256)}
 meta_sha256 = ${JSON.stringify(input.metaSha256)}
@@ -174,7 +215,13 @@ export interface PreparedHarborPilot {
   outputDir: string;
   tasksDir: string;
   sourceCommit: string;
+  campaignId: string;
   taskIds: string[];
+  holdoutIds: string[];
+  holdoutRevision: string;
+  corpusSha256: string;
+  verifierSha256: string;
+  harborVerifierSha256: string;
   networkMode: "no-network" | "public";
   baseImage: string;
 }
@@ -183,16 +230,41 @@ export function prepareGateDHarborPilot(input: {
   sourceRepo: string;
   outputDir: string;
   taskIds?: readonly string[];
+  holdoutIds?: readonly string[];
+  campaignId?: string;
   networkMode?: "no-network" | "public";
   baseImage?: string;
 }): PreparedHarborPilot {
   const sourceRepo = resolve(input.sourceRepo);
   const outputDir = resolve(input.outputDir);
   const taskIds = [...(input.taskIds ?? HARBOR_PILOT_TASK_IDS)];
+  const holdoutIds = input.holdoutIds
+    ? [...input.holdoutIds]
+    : [...HARBOR_PILOT_HOLDOUT_IDS].filter((taskId) => taskIds.includes(taskId));
+  const holdouts = new Set(holdoutIds);
+  const isDefaultHoldoutSet =
+    taskIds.length === HARBOR_PILOT_TASK_IDS.length &&
+    taskIds.every((taskId, index) => taskId === HARBOR_PILOT_TASK_IDS[index]) &&
+    holdoutIds.length === HARBOR_PILOT_HOLDOUT_IDS.length &&
+    holdoutIds.every((taskId, index) => taskId === HARBOR_PILOT_HOLDOUT_IDS[index]);
+  const holdoutRevision = isDefaultHoldoutSet
+    ? HARBOR_PILOT_HOLDOUT_REVISION
+    : `explicit-${sha256Json([...holdoutIds].sort()).slice(0, 16)}-v1`;
+  const campaignId = input.campaignId ?? HARBOR_PILOT_CAMPAIGN_ID;
   const networkMode = input.networkMode ?? "no-network";
   const baseImage = input.baseImage ?? HARBOR_PILOT_DEFAULT_BASE_IMAGE;
   const sourceGateD = join(sourceRepo, "gate-d");
   const checkPath = join(sourceGateD, "check.sh");
+
+  if (!/^[a-z0-9][a-z0-9-]{1,47}$/.test(campaignId)) {
+    throw new Error("Harbor campaign id must be a 2-48 character lowercase slug");
+  }
+  if (new Set(taskIds).size !== taskIds.length) throw new Error("duplicate Gate D task id");
+  if (new Set(holdoutIds).size !== holdoutIds.length) throw new Error("duplicate Harbor holdout id");
+  const unknownHoldouts = holdoutIds.filter((taskId) => !taskIds.includes(taskId));
+  if (unknownHoldouts.length > 0) {
+    throw new Error(`Harbor holdout is not in the task set: ${unknownHoldouts.join(", ")}`);
+  }
 
   const dirty = gitOutput(sourceRepo, ["status", "--short"]);
   if (dirty) {
@@ -202,6 +274,7 @@ export function prepareGateDHarborPilot(input: {
   mkdirSync(outputDir, { recursive: false });
   const tasksDir = join(outputDir, "tasks");
   mkdirSync(tasksDir);
+  const taskBindings: Array<Record<string, unknown>> = [];
 
   for (const taskId of taskIds) {
     if (!/^[a-z0-9][a-z0-9-]{0,119}$/.test(taskId)) {
@@ -224,20 +297,39 @@ export function prepareGateDHarborPilot(input: {
     mkdirSync(testsTaskDir, { recursive: true });
 
     const instruction = readFileSync(instructionPath, "utf8");
+    const holdout = holdouts.has(taskId);
+    const instructionSha256 = sha256File(instructionPath);
+    const metaSha256 = sha256File(metaPath);
+    const sourceFiles = fileBindings(sourceTask);
+    taskBindings.push({
+      task_id: taskId,
+      holdout,
+      instruction_sha256: instructionSha256,
+      meta_sha256: metaSha256,
+      source_files: sourceFiles,
+    });
     writeFileSync(join(taskDir, "instruction.md"), instruction);
     writeFileSync(join(taskDir, "task.toml"), taskToml({
       taskId,
       sourceCommit,
-      instructionSha256: sha256File(instructionPath),
-      metaSha256: sha256File(metaPath),
+      instructionSha256,
+      metaSha256,
+      campaignId,
+      holdout,
       networkMode,
     }));
     writeFileSync(join(environmentDir, "Dockerfile"), dockerfile(baseImage));
     writeFileSync(join(environmentDir, "control.json"), `${JSON.stringify({
       schema_version: 1,
       pilot_version: HARBOR_PILOT_VERSION,
+      campaign_id: campaignId,
       task_id: taskId,
+      holdout,
       protected: meta.oracleFiles,
+      client_run_ids: {
+        baseline: clientRunId(campaignId, taskId, "baseline"),
+        live: clientRunId(campaignId, taskId, "live"),
+      },
     }, null, 2)}\n`);
     cpSync(seedPath, join(environmentDir, "repo"), { recursive: true });
 
@@ -259,18 +351,53 @@ export function prepareGateDHarborPilot(input: {
     }
   }
 
+  const verifierSha256 = sha256File(checkPath);
+  const corpusSha256 = sha256Json({
+    source_commit: sourceCommit,
+    holdout_revision: holdoutRevision,
+    verifier_sha256: verifierSha256,
+    tasks: taskBindings,
+  });
+  const harborVerifierSha256 = sha256Json({
+    pilot_version: HARBOR_PILOT_VERSION,
+    base_image: baseImage,
+    verifier_dockerfile: verifierDockerfile(baseImage),
+    verifier_script: verifierScript,
+    gate_d_check_sha256: verifierSha256,
+  });
+
   writeFileSync(join(outputDir, "manifest.json"), `${JSON.stringify({
     schema_version: 1,
     pilot_version: HARBOR_PILOT_VERSION,
     harbor_version: "0.18.0",
     source_repo: basename(sourceRepo),
     source_commit: sourceCommit,
+    campaign_id: campaignId,
     task_ids: taskIds,
+    holdout_ids: holdoutIds,
+    holdout_revision: holdoutRevision,
+    corpus_sha256: corpusSha256,
+    verifier_sha256: verifierSha256,
+    harbor_verifier_sha256: harborVerifierSha256,
+    task_bindings: taskBindings,
     network_mode: networkMode,
     base_image: baseImage,
   }, null, 2)}\n`);
 
-  return { outputDir, tasksDir, sourceCommit, taskIds, networkMode, baseImage };
+  return {
+    outputDir,
+    tasksDir,
+    sourceCommit,
+    campaignId,
+    taskIds,
+    holdoutIds,
+    holdoutRevision,
+    corpusSha256,
+    verifierSha256,
+    harborVerifierSha256,
+    networkMode,
+    baseImage,
+  };
 }
 
 async function main(): Promise<void> {

--- a/scripts/harbor_pilot/run-pilot.ts
+++ b/scripts/harbor_pilot/run-pilot.ts
@@ -25,34 +25,85 @@ import {
   type HarborCodeLoopOnceInput,
 } from "./m5-code-loop-once.js";
 import {
+  HARBOR_PILOT_CAMPAIGN_ID,
   HARBOR_PILOT_DEFAULT_BASE_IMAGE,
+  HARBOR_PILOT_HOLDOUT_IDS,
   HARBOR_PILOT_TASK_IDS,
   HARBOR_PILOT_VERSION,
   prepareGateDHarborPilot,
+  type PreparedHarborPilot,
 } from "./prepare-gate-d.js";
 
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(SCRIPT_DIR, "../..");
 const MODEL = "qwen3-coder-next-80b";
-const HARNESS_VERSION = "code-loop-pi-2026-07-13-v2";
+const HARNESS_VERSION = "code-loop-pi-2026-07-14-v4";
 const CAPS = { wall_s: 600, turns: 13, completion_tokens: 60_000 } as const;
+const EXPECTED_CAPABILITIES = {
+  startIdempotency: "client-run-id-v1",
+  agentChecks: "pi-bash-events-v1",
+} as const;
 
 const controlSchema = z.object({
   task_id: z.string().min(1),
+  holdout: z.boolean(),
   protected: z.array(z.string().min(1)),
+  client_run_ids: z.object({
+    baseline: z.string().regex(/^[A-Za-z0-9._:-]{1,128}$/),
+    live: z.string().regex(/^[A-Za-z0-9._:-]{1,128}$/),
+  }).strict(),
+}).passthrough();
+const gitCommitSchema = z.string().regex(/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/);
+
+const declarationSchema = z.object({
+  schema_version: z.literal(1),
+  status: z.literal("declared-not-run"),
+  campaign_id: z.string().min(1),
+  pilot_version: z.string().min(1),
+  harbor_version: z.literal("0.18.0"),
+  source_commit: gitCommitSchema,
+  task_ids: z.array(z.string().min(1)),
+  holdout_ids: z.array(z.string().min(1)),
+  holdout_revision: z.string().min(1),
+  corpus_sha256: z.string().regex(/^[a-f0-9]{64}$/),
+  verifier_sha256: z.string().regex(/^[a-f0-9]{64}$/),
+  harbor_verifier_sha256: z.string().regex(/^[a-f0-9]{64}$/),
+  model: z.string().min(1),
+  harness_version: z.string().min(1),
+  caps: z.object({
+    wall_s: z.number().int().positive(),
+    turns: z.number().int().positive(),
+    completion_tokens: z.number().int().positive(),
+  }).strict(),
+  required_capabilities: z.object({
+    start_idempotency: z.literal("client-run-id-v1"),
+    agent_checks: z.literal("pi-bash-events-v1"),
+  }).strict(),
+  network_mode: z.literal("no-network"),
+  base_image: z.string().min(1),
+  harbor_concurrency: z.literal(1),
+  attempts_per_task: z.literal(1),
+  model_calls_at_declaration: z.literal(0),
 }).passthrough();
 
 interface BaselineResult {
   taskId: string;
   passed: boolean;
+  holdout: boolean;
   applyReturnCode: number | null;
   checkReturnCode: number | null;
-  checkTail: string;
+  checkDurationMs: number;
+  failureKind: "empty-diff" | "apply-failed" | "check-failed" | null;
   workId: string;
+  clientRunId: string;
+  requestFingerprint: string;
+  recovered: boolean;
+  startCapabilities: Record<string, string>;
   status: string;
   usage: M5CodeLoopResult["usage"];
   execution: M5CodeLoopResult["execution"];
   telemetry: M5CodeLoopResult["telemetry"];
+  agentChecks: M5CodeLoopResult["agent_checks"];
   diffSha256: string;
   diffBytes: number;
 }
@@ -74,6 +125,14 @@ function requiredEnv(name: string): string {
 function valueAfter(flag: string): string | undefined {
   const index = process.argv.indexOf(flag);
   return index >= 0 ? process.argv[index + 1] : undefined;
+}
+
+function csvAfter(flag: string): string[] | undefined {
+  const value = valueAfter(flag);
+  if (value === undefined) return undefined;
+  const entries = value.split(",").map((entry) => entry.trim()).filter(Boolean);
+  if (entries.length === 0) throw new Error(`${flag} requires a comma-separated value`);
+  return entries;
 }
 
 function filesUnder(rootInput: string): Array<{ path: string; content: string }> {
@@ -101,6 +160,51 @@ function runChecked(command: string, args: string[], cwd: string): string {
     throw new Error(`${command} ${args.join(" ")} failed: ${(result.stderr || result.stdout).trim()}`);
   }
   return result.stdout.trim();
+}
+
+export function bindDeclaration(input: {
+  path: string;
+  prepared: PreparedHarborPilot;
+  networkMode: "no-network" | "public";
+}): string {
+  const bytes = readFileSync(input.path);
+  const declaration = declarationSchema.parse(JSON.parse(bytes.toString("utf8")));
+  const expected = {
+    campaign_id: input.prepared.campaignId,
+    pilot_version: HARBOR_PILOT_VERSION,
+    source_commit: input.prepared.sourceCommit,
+    task_ids: input.prepared.taskIds,
+    holdout_ids: input.prepared.holdoutIds,
+    holdout_revision: input.prepared.holdoutRevision,
+    corpus_sha256: input.prepared.corpusSha256,
+    verifier_sha256: input.prepared.verifierSha256,
+    harbor_verifier_sha256: input.prepared.harborVerifierSha256,
+    model: MODEL,
+    harness_version: HARNESS_VERSION,
+    caps: CAPS,
+    network_mode: input.networkMode,
+    base_image: input.prepared.baseImage,
+  };
+  const actual = {
+    campaign_id: declaration.campaign_id,
+    pilot_version: declaration.pilot_version,
+    source_commit: declaration.source_commit,
+    task_ids: declaration.task_ids,
+    holdout_ids: declaration.holdout_ids,
+    holdout_revision: declaration.holdout_revision,
+    corpus_sha256: declaration.corpus_sha256,
+    verifier_sha256: declaration.verifier_sha256,
+    harbor_verifier_sha256: declaration.harbor_verifier_sha256,
+    model: declaration.model,
+    harness_version: declaration.harness_version,
+    caps: declaration.caps,
+    network_mode: declaration.network_mode,
+    base_image: declaration.base_image,
+  };
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error("generated Harbor campaign does not match the pre-inference declaration");
+  }
+  return createHash("sha256").update(bytes).digest("hex");
 }
 
 export function customBasePreflightScript(): string {
@@ -153,7 +257,10 @@ function verifyBaseline(input: {
   result: M5CodeLoopResult;
   sourceRepo: string;
   taskId: string;
-}): Pick<BaselineResult, "passed" | "applyReturnCode" | "checkReturnCode" | "checkTail"> {
+}): Pick<
+  BaselineResult,
+  "passed" | "applyReturnCode" | "checkReturnCode" | "checkDurationMs" | "failureKind"
+> {
   const taskDir = join(input.sourceRepo, "gate-d", "tasks", input.taskId);
   const root = mkdtempSync(join(tmpdir(), `hugin-harbor-baseline-${input.taskId}-`));
   const work = join(root, "repo");
@@ -173,20 +280,22 @@ function verifyBaseline(input: {
         passed: false,
         applyReturnCode: applied?.status ?? null,
         checkReturnCode: null,
-        checkTail: applied?.stderr?.slice(-1_000) ?? "empty diff",
+        checkDurationMs: 0,
+        failureKind: applied ? "apply-failed" : "empty-diff",
       };
     }
+    const checkStarted = Date.now();
     const checked = spawnSync(
       "bash",
       [join(input.sourceRepo, "gate-d", "check.sh"), taskDir, work],
       { encoding: "utf8", timeout: 300_000 },
     );
-    const output = `${checked.stdout ?? ""}${checked.stderr ?? ""}`;
     return {
       passed: checked.status === 0,
       applyReturnCode: applied.status,
       checkReturnCode: checked.status,
-      checkTail: output.slice(-1_000),
+      checkDurationMs: Date.now() - checkStarted,
+      failureKind: checked.status === 0 ? null : "check-failed",
     };
   } finally {
     rmSync(root, { recursive: true, force: true });
@@ -196,16 +305,18 @@ function verifyBaseline(input: {
 async function runBaseline(input: {
   sourceRepo: string;
   outputDir: string;
+  taskIds: string[];
 }): Promise<BaselineResult[]> {
   const replayDir = join(input.outputDir, "replays");
   mkdirSync(replayDir);
   const baselines: BaselineResult[] = [];
-  for (const taskId of HARBOR_PILOT_TASK_IDS) {
+  for (const taskId of input.taskIds) {
     const taskDir = join(input.sourceRepo, "gate-d", "tasks", taskId);
     const control = controlSchema.parse(JSON.parse(
       readFileSync(join(input.outputDir, "tasks", taskId, "environment", "control.json"), "utf8"),
     ));
     const request: HarborCodeLoopOnceInput["request"] = {
+      client_run_id: control.client_run_ids.baseline,
       instruction: readFileSync(join(taskDir, "INSTRUCTION.md"), "utf8"),
       files: filesUnder(join(taskDir, "repo")),
       protected: control.protected,
@@ -214,23 +325,38 @@ async function runBaseline(input: {
     };
     const once: HarborCodeLoopOnceInput = {
       request,
-      expected: { model: MODEL, harnessVersion: HARNESS_VERSION, caps: CAPS },
+      expected: {
+        model: MODEL,
+        harnessVersion: HARNESS_VERSION,
+        caps: CAPS,
+        capabilities: EXPECTED_CAPABILITIES,
+      },
       pollMs: 5_000,
       resultDeadlineS: 900,
     };
     process.stdout.write(`[baseline/${taskId}] starting M5 code_loop\n`);
-    const result = await runCodeLoopOnce(once);
+    const output = await runCodeLoopOnce(once);
+    const { result, start } = output;
+    if (!start || !start.request_fingerprint || start.client_run_id !== control.client_run_ids.baseline) {
+      throw new Error(`[baseline/${taskId}] missing durable M5 start evidence`);
+    }
     writeFileSync(join(replayDir, `${taskId}.json`), `${JSON.stringify(result)}\n`, { mode: 0o600 });
     const verified = verifyBaseline({ result, sourceRepo: input.sourceRepo, taskId });
     const diffBytes = Buffer.byteLength(result.diff);
     const baseline: BaselineResult = {
       taskId,
+      holdout: control.holdout,
       ...verified,
       workId: result.work_id,
+      clientRunId: control.client_run_ids.baseline,
+      requestFingerprint: start.request_fingerprint,
+      recovered: start.recovered,
+      startCapabilities: start.capabilities,
       status: result.status,
       usage: result.usage,
       execution: result.execution,
       telemetry: result.telemetry,
+      agentChecks: result.agent_checks,
       diffSha256: createHash("sha256").update(result.diff).digest("hex"),
       diffBytes,
     };
@@ -248,6 +374,7 @@ function runHarbor(input: {
   harborBin: string;
   outputDir: string;
   mode: "replay" | "live";
+  taskCount: number;
 }): Promise<void> {
   const jobsDir = join(input.outputDir, "jobs");
   mkdirSync(jobsDir, { recursive: true });
@@ -280,7 +407,7 @@ function runHarbor(input: {
   } else {
     delete env.HUGIN_HARBOR_REPLAY_DIR;
   }
-  process.stdout.write(`[harbor/${input.mode}] starting sequential two-task job\n`);
+  process.stdout.write(`[harbor/${input.mode}] starting sequential ${input.taskCount}-task job\n`);
   return new Promise((resolveRun, rejectRun) => {
     const child = spawn(input.harborBin, args, {
       cwd: REPO_ROOT,
@@ -326,16 +453,32 @@ export function summarizeHarborJob(jobDir: string): HarborTrialSummary[] {
   }).sort((a, b) => a.taskId.localeCompare(b.taskId));
 }
 
-function assertExpectedTrials(label: string, trials: HarborTrialSummary[]): void {
+function assertExpectedTrials(
+  label: string,
+  trials: HarborTrialSummary[],
+  expectedTaskIds: string[],
+): void {
   const ids = trials.map((trial) => trial.taskId);
-  if (JSON.stringify(ids) !== JSON.stringify([...HARBOR_PILOT_TASK_IDS])) {
+  if (JSON.stringify(ids) !== JSON.stringify([...expectedTaskIds].sort())) {
     throw new Error(`${label} produced unexpected trial set: ${ids.join(", ")}`);
   }
 }
 
 async function main(): Promise<void> {
+  const runnerDirty = runChecked("git", ["status", "--short"], REPO_ROOT);
+  if (runnerDirty) throw new Error("Hugin runner repository must be clean before the pilot");
+  const runnerCommit = runChecked("git", ["rev-parse", "HEAD"], REPO_ROOT);
   const sourceRepo = resolve(valueAfter("--source-repo") ?? join(REPO_ROOT, "../gille-inference"));
   const harborBin = resolve(valueAfter("--harbor-bin") ?? requiredEnv("HARBOR_BIN"));
+  const taskIds = csvAfter("--task-ids") ?? [...HARBOR_PILOT_TASK_IDS];
+  const holdoutIds = csvAfter("--holdout-ids") ?? [...HARBOR_PILOT_HOLDOUT_IDS];
+  const campaignId = valueAfter("--campaign-id") ?? HARBOR_PILOT_CAMPAIGN_ID;
+  const declarationPath = resolve(
+    valueAfter("--declaration") ??
+    join(REPO_ROOT, "docs/research/harbor-gate-d-v2-declaration-2026-07-14.json"),
+  );
+  if (taskIds.length < 4) throw new Error("the larger-corpus pilot requires at least four tasks");
+  if (holdoutIds.length < 2) throw new Error("the larger-corpus pilot requires at least two predeclared holdouts");
   const networkModeArg = valueAfter("--network-mode") ?? (process.platform === "darwin" ? "public" : "no-network");
   if (networkModeArg !== "no-network" && networkModeArg !== "public") {
     throw new Error("--network-mode must be no-network or public");
@@ -361,8 +504,16 @@ async function main(): Promise<void> {
   const prepared = prepareGateDHarborPilot({
     sourceRepo,
     outputDir: preparedDir,
+    taskIds,
+    holdoutIds,
+    campaignId,
     networkMode,
     baseImage,
+  });
+  const declarationSha256 = bindDeclaration({
+    path: declarationPath,
+    prepared,
+    networkMode,
   });
   preflightCustomBaseImage(prepared.baseImage);
   process.stdout.write(
@@ -370,56 +521,121 @@ async function main(): Promise<void> {
     `under ${prepared.outputDir}\n`,
   );
 
-  const baselines = await runBaseline({ sourceRepo, outputDir: prepared.outputDir });
-  await runHarbor({ harborBin, outputDir: prepared.outputDir, mode: "replay" });
-  await runHarbor({ harborBin, outputDir: prepared.outputDir, mode: "live" });
+  const baselines = await runBaseline({
+    sourceRepo,
+    outputDir: prepared.outputDir,
+    taskIds: prepared.taskIds,
+  });
+  await runHarbor({
+    harborBin,
+    outputDir: prepared.outputDir,
+    mode: "replay",
+    taskCount: prepared.taskIds.length,
+  });
+  await runHarbor({
+    harborBin,
+    outputDir: prepared.outputDir,
+    mode: "live",
+    taskCount: prepared.taskIds.length,
+  });
 
   const replay = summarizeHarborJob(join(prepared.outputDir, "jobs", "replay"));
   const live = summarizeHarborJob(join(prepared.outputDir, "jobs", "live"));
-  assertExpectedTrials("Harbor replay", replay);
-  assertExpectedTrials("Harbor live", live);
+  assertExpectedTrials("Harbor replay", replay, prepared.taskIds);
+  assertExpectedTrials("Harbor live", live, prepared.taskIds);
 
   const replayParity = replay.map((trial) => {
     const baseline = baselines.find((item) => item.taskId === trial.taskId)!;
     const metadata = trial.metadata ?? {};
     return {
       taskId: trial.taskId,
+      holdout: baseline.holdout,
       baselinePassed: baseline.passed,
       harborPassed: trial.reward === 1,
+      rewardMeasured: trial.reward === 0 || trial.reward === 1,
       rewardParity: baseline.passed === (trial.reward === 1),
       diffParity: metadata.diff_sha256 === baseline.diffSha256,
+      workParity: metadata.work_id === baseline.workId,
+      clientRunParity: metadata.client_run_id === baseline.clientRunId,
       applyReturnCode: metadata.apply_return_code ?? null,
       exceptionType: trial.exceptionType,
     };
   });
   const liveAdapter = live.map((trial) => ({
     taskId: trial.taskId,
+    holdout: trial.metadata?.holdout ?? null,
     passed: trial.reward === 1,
     reward: trial.reward,
     status: trial.metadata?.status ?? null,
     workId: trial.metadata?.work_id ?? null,
+    clientRunId: trial.metadata?.client_run_id ?? null,
+    requestFingerprint: trial.metadata?.request_fingerprint ?? null,
+    recovered: trial.metadata?.recovered ?? null,
+    startCapabilities: trial.metadata?.start_capabilities ?? null,
     execution: trial.metadata?.execution ?? null,
+    agentChecks: trial.metadata?.agent_checks ?? null,
     applyReturnCode: trial.metadata?.apply_return_code ?? null,
     diffBytes: trial.metadata?.diff_bytes ?? null,
     exceptionType: trial.exceptionType,
   }));
   const exactReplayParity = replayParity.every((row) =>
-    row.rewardParity && row.diffParity && row.exceptionType === null && row.applyReturnCode === 0
+    row.rewardMeasured &&
+    row.rewardParity &&
+    row.diffParity &&
+    row.workParity &&
+    row.clientRunParity &&
+    row.exceptionType === null &&
+    row.applyReturnCode === 0
   );
-  const liveAdapterCompleted = liveAdapter.every((row) =>
-    row.exceptionType === null && typeof row.workId === "string" && row.execution !== null
+  const baselineDecisionsVerified = baselines.every((row) =>
+    row.applyReturnCode === 0 &&
+    row.checkReturnCode !== null &&
+    row.passed === (row.checkReturnCode === 0)
   );
+  const liveAdapterCompleted = liveAdapter.every((row) => {
+    const execution = row.execution as Record<string, unknown> | null;
+    const effectiveCaps = execution?.effective_caps as Record<string, unknown> | undefined;
+    const executionCapabilities = execution?.capabilities as Record<string, unknown> | undefined;
+    const startCapabilities = row.startCapabilities as Record<string, unknown> | null;
+    const agentChecks = row.agentChecks as Record<string, unknown> | null;
+    return row.exceptionType === null &&
+      (row.reward === 0 || row.reward === 1) &&
+      typeof row.workId === "string" &&
+      row.clientRunId === `harbor:${prepared.campaignId}:${row.taskId}:live` &&
+      typeof row.requestFingerprint === "string" &&
+      /^sha256:[a-f0-9]{64}$/.test(row.requestFingerprint) &&
+      row.holdout === prepared.holdoutIds.includes(row.taskId) &&
+      startCapabilities?.start_idempotency === "client-run-id-v1" &&
+      startCapabilities.agent_checks === "pi-bash-events-v1" &&
+      execution?.model === MODEL &&
+      execution.harness_version === HARNESS_VERSION &&
+      effectiveCaps?.wall_s === CAPS.wall_s &&
+      effectiveCaps.turns === CAPS.turns &&
+      effectiveCaps.completion_tokens === CAPS.completion_tokens &&
+      executionCapabilities?.start_idempotency === "client-run-id-v1" &&
+      executionCapabilities.agent_checks === "pi-bash-events-v1" &&
+      agentChecks?.source === "pi-bash-events" &&
+      agentChecks.work_id === row.workId;
+  });
   const environmentConditionsMet =
     networkMode === "no-network" && prepared.baseImage === HARBOR_PILOT_DEFAULT_BASE_IMAGE;
-  const recommendation = exactReplayParity && liveAdapterCompleted
+  const recommendation = baselineDecisionsVerified && exactReplayParity && liveAdapterCompleted
     ? environmentConditionsMet ? "go" : "conditional-go"
     : "no-go";
   const report = {
-    schema_version: 1,
+    schema_version: 2,
     pilot_version: HARBOR_PILOT_VERSION,
+    campaign_id: prepared.campaignId,
     harbor_version: harborVersion,
+    runner_commit: runnerCommit,
+    declaration_sha256: declarationSha256,
     source_commit: prepared.sourceCommit,
     task_ids: prepared.taskIds,
+    holdout_ids: prepared.holdoutIds,
+    holdout_revision: prepared.holdoutRevision,
+    corpus_sha256: prepared.corpusSha256,
+    verifier_sha256: prepared.verifierSha256,
+    harbor_verifier_sha256: prepared.harborVerifierSha256,
     caps: CAPS,
     model: MODEL,
     harness_version: HARNESS_VERSION,
@@ -428,6 +644,7 @@ async function main(): Promise<void> {
     base_image: prepared.baseImage,
     standard_base_image_met: prepared.baseImage === HARBOR_PILOT_DEFAULT_BASE_IMAGE,
     exact_replay_parity: exactReplayParity,
+    baseline_decisions_verified: baselineDecisionsVerified,
     live_adapter_completed: liveAdapterCompleted,
     recommendation,
     baseline: baselines,

--- a/scripts/run-m5-code-loop-experiment.ts
+++ b/scripts/run-m5-code-loop-experiment.ts
@@ -41,7 +41,14 @@ import {
   M5CodeLoopClient,
   M5CodeLoopError,
   type M5CodeLoopRequest,
+  type M5CodeLoopStart,
 } from "../src/learning/m5-code-loop-client.js";
+
+const V4_HARNESS_VERSION = "code-loop-pi-2026-07-14-v4";
+const V4_CAPABILITIES = {
+  startIdempotency: "client-run-id-v1",
+  agentChecks: "pi-bash-events-v1",
+} as const;
 
 const capsSchema = z.object({
   wall_s: z.number().int().positive().max(900),
@@ -114,6 +121,13 @@ const manifestSchema = z.object({
     }
     if (config.editDeadlineTurn !== caps.edit_deadline_turn) {
       ctx.addIssue({ code: "custom", path: ["arms", arm, "caps", "edit_deadline_turn"], message: "edit deadline differs from the versioned harness config" });
+    }
+    if (config.version !== V4_HARNESS_VERSION) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["experiment", arm, "harness", "version"],
+        message: `live experiments require ${V4_HARNESS_VERSION}`,
+      });
     }
   }
 });
@@ -282,13 +296,38 @@ function verifyGateD(
   }
 }
 
-function supportsIssue247(tools: Array<Record<string, unknown>>): boolean {
+function supportsDurableV4(tools: Array<Record<string, unknown>>): boolean {
   const start = tools.find((tool) => tool.name === "code_loop_start");
-  return !!start && JSON.stringify(start).includes("edit_deadline_turn");
+  const serialized = JSON.stringify(start);
+  return !!start &&
+    serialized.includes("edit_deadline_turn") &&
+    serialized.includes("client_run_id");
 }
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+}
+
+function clientRunId(runId: string): string {
+  return `hugin:${createHash("sha256").update(runId).digest("hex")}`;
+}
+
+async function startDurably(
+  m5: M5CodeLoopClient,
+  request: M5CodeLoopRequest,
+): Promise<M5CodeLoopStart> {
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      return await m5.start(request);
+    } catch (error) {
+      const safelyRetryable =
+        error instanceof M5CodeLoopError &&
+        error.ambiguousOutcome &&
+        request.client_run_id !== undefined;
+      if (!safelyRetryable || attempt >= 3) throw error;
+      await sleep(attempt * 500);
+    }
+  }
 }
 
 async function readOrCreate(
@@ -317,7 +356,9 @@ async function runArm(input: {
   const { m5, broker, manifest, sample, arm, promptPrefix, manifestDir } = input;
   const config = manifest.experiment[arm];
   const runId = `${manifest.experiment.experiment_id}:${sample.id}:${arm}:${config.fingerprint.slice(0, 12)}`;
+  const durableClientRunId = clientRunId(runId);
   const request: M5CodeLoopRequest = {
+    client_run_id: durableClientRunId,
     instruction: applyCodeLoopPromptPrefix(sample.instruction, promptPrefix),
     files: sample.files,
     check_cmd: sample.m5_check_cmd,
@@ -326,29 +367,38 @@ async function runArm(input: {
     caps: manifest.arms[arm].caps,
   };
   process.stdout.write(`[${sample.id}/${arm}] starting\n`);
-  let started: Awaited<ReturnType<M5CodeLoopClient["start"]>>;
+  let started: M5CodeLoopStart;
   try {
-    started = await m5.start(request);
+    started = await startDurably(m5, request);
   } catch (error) {
     if (error instanceof M5CodeLoopError && error.ambiguousOutcome) {
       throw new Error(
-        `[${sample.id}/${arm}] M5 start outcome is ambiguous for run ${runId}; ` +
-        "do not blindly rerun. Reconcile the recent M5 work id before resuming.",
+        `[${sample.id}/${arm}] M5 start remained unavailable after safe idempotent recovery ` +
+        `for run ${runId}; resume with the same manifest and client binding.`,
         { cause: error },
       );
     }
     throw error;
   }
+  if (
+    started.client_run_id !== durableClientRunId ||
+    started.request_fingerprint === null
+  ) {
+    throw new Error(`[${sample.id}/${arm}] M5 omitted the durable start binding`);
+  }
   const deadline = Date.now() + manifest.result_deadline_s * 1_000;
-  for (;;) {
+  let runStatus = started.status;
+  while (runStatus === "running") {
     await sleep(manifest.poll_ms);
-    const status = await m5.status(started.work_id);
-    if (status.status !== "running") break;
-    if (Date.now() >= deadline) {
+    runStatus = (await m5.status(started.work_id)).status;
+    if (runStatus === "running" && Date.now() >= deadline) {
       throw new Error(`[${sample.id}/${arm}] result deadline exceeded for ${started.work_id}`);
     }
   }
   const result = await m5.result(started.work_id);
+  if (result.work_id !== started.work_id) {
+    throw new Error(`[${sample.id}/${arm}] M5 result belongs to a different work id`);
+  }
   const externalVerification = verifyGateD(
     result,
     sample,
@@ -366,6 +416,9 @@ async function runArm(input: {
       model: config.model.id,
       harnessVersion: config.harness.version,
       caps: manifest.arms[arm].caps,
+      capabilities: config.harness.version === V4_HARNESS_VERSION
+        ? V4_CAPABILITIES
+        : undefined,
     },
     externalVerification,
   });
@@ -436,8 +489,8 @@ async function main(): Promise<void> {
     baseUrl: requiredEnv("HUGIN_BROKER_URL"),
     bearerToken: requiredEnv("HUGIN_BROKER_TOKEN"),
   });
-  if (!supportsIssue247(await m5.toolDefinitions())) {
-    throw new Error("M5 code_loop does not advertise edit_deadline_turn; deploy gille-inference #247 before creating the experiment");
+  if (!supportsDurableV4(await m5.toolDefinitions())) {
+    throw new Error("M5 code_loop does not advertise the durable v4 experiment contract");
   }
 
   let state = await readOrCreate(broker, manifest.experiment);

--- a/src/learning/m5-code-loop-adapter.ts
+++ b/src/learning/m5-code-loop-adapter.ts
@@ -52,6 +52,39 @@ export const m5CodeLoopTelemetrySchema = z.object({
   }
 });
 
+const m5CodeLoopAgentChecksSchema = z.object({
+  schema_version: z.literal(1),
+  source: z.literal("pi-bash-events"),
+  state: z.enum(["none", "attempted"]),
+  work_id: z.string().min(1).max(200),
+  attempts: z.array(z.object({
+    order: z.number().int().positive(),
+    kind: z.enum(["typescript", "test", "lint", "build", "validation"]),
+    command_fingerprint: z.string().regex(/^sha256:[a-f0-9]{64}$/),
+    started_ms: z.number().int().nonnegative(),
+    ended_ms: z.number().int().nonnegative(),
+    status: z.enum(["passed", "failed", "execution-error"]),
+    exit_code: z.number().int().nullable(),
+  }).strict()).max(1_000),
+}).strict().superRefine((value, ctx) => {
+  if ((value.state === "none") !== (value.attempts.length === 0)) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["state"],
+      message: "agent check state must agree with the attempt list",
+    });
+  }
+  for (const [index, attempt] of value.attempts.entries()) {
+    if (attempt.ended_ms < attempt.started_ms) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["attempts", index, "ended_ms"],
+        message: "agent check cannot end before it starts",
+      });
+    }
+  }
+});
+
 export const m5CodeLoopResultSchema = z.object({
   status: codeLoopStatusSchema,
   diff: z.string(),
@@ -84,8 +117,13 @@ export const m5CodeLoopResultSchema = z.object({
       completion_tokens: z.number().int().positive(),
       edit_deadline_turn: z.number().int().positive().optional(),
     }).strict(),
+    capabilities: z.object({
+      start_idempotency: z.literal("client-run-id-v1"),
+      agent_checks: z.literal("pi-bash-events-v1"),
+    }).strict().optional(),
   }).strict().optional(),
   telemetry: m5CodeLoopTelemetrySchema.optional(),
+  agent_checks: m5CodeLoopAgentChecksSchema.optional(),
 }).strict();
 export type M5CodeLoopResult = z.infer<typeof m5CodeLoopResultSchema>;
 
@@ -106,6 +144,10 @@ export interface M5CodeLoopObservationContext {
       turns: number;
       completion_tokens: number;
       edit_deadline_turn?: number;
+    };
+    capabilities?: {
+      startIdempotency: "client-run-id-v1";
+      agentChecks: "pi-bash-events-v1";
     };
   };
   externalVerification?: {
@@ -174,6 +216,24 @@ export function assertM5CodeLoopExecutionBinding(
   for (const field of fields) {
     if (actual[field] !== expected.caps[field]) {
       throw new Error(`M5 effective cap ${field} does not match the declared experiment arm`);
+    }
+  }
+  if (expected.capabilities) {
+    const actualCapabilities = result.execution.capabilities;
+    if (!actualCapabilities) {
+      throw new Error("M5 result omitted the declared execution capabilities");
+    }
+    if (actualCapabilities.start_idempotency !== expected.capabilities.startIdempotency) {
+      throw new Error("M5 start idempotency capability does not match the declared experiment");
+    }
+    if (actualCapabilities.agent_checks !== expected.capabilities.agentChecks) {
+      throw new Error("M5 agent-check capability does not match the declared experiment");
+    }
+    if (!result.agent_checks) {
+      throw new Error("M5 result omitted declared agent-side check evidence");
+    }
+    if (result.agent_checks.work_id !== result.work_id) {
+      throw new Error("M5 agent-side check evidence belongs to a different work id");
     }
   }
 }

--- a/src/learning/m5-code-loop-client.ts
+++ b/src/learning/m5-code-loop-client.ts
@@ -14,6 +14,8 @@ export interface M5CodeLoopClientConfig {
 }
 
 export interface M5CodeLoopRequest {
+  /** Durable caller idempotency key (M5 client-run-id-v1). */
+  client_run_id?: string;
   instruction: string;
   files: Array<{ path: string; content: string }>;
   check_cmd?: string;
@@ -28,20 +30,33 @@ export interface M5CodeLoopRequest {
   };
 }
 
-const startSchema = z.object({
-  work_id: z.string().min(1),
-  status: z.literal("running"),
+const codeLoopCapabilitiesSchema = z.object({
+  start_idempotency: z.literal("client-run-id-v1"),
+  agent_checks: z.literal("pi-bash-events-v1"),
 }).strict();
 
+const jobStatusSchema = z.enum([
+  "running",
+  "completed",
+  "cap-exceeded",
+  "degenerate",
+  "arm-error",
+  "orphaned",
+]);
+
+const startSchema = z.object({
+  work_id: z.string().min(1),
+  status: jobStatusSchema,
+  client_run_id: z.string().min(1).nullable(),
+  request_fingerprint: z.string().regex(/^sha256:[a-f0-9]{64}$/).nullable(),
+  recovered: z.boolean(),
+  capabilities: codeLoopCapabilitiesSchema,
+  result: m5CodeLoopResultSchema.optional(),
+}).strict();
+export type M5CodeLoopStart = z.infer<typeof startSchema>;
+
 const statusSchema = z.object({
-  status: z.enum([
-    "running",
-    "completed",
-    "cap-exceeded",
-    "degenerate",
-    "arm-error",
-    "orphaned",
-  ]),
+  status: jobStatusSchema,
   usage: z.object({
     turns: z.number().int().nonnegative(),
     wall_ms: z.number().int().nonnegative(),
@@ -87,7 +102,7 @@ export class M5CodeLoopClient {
     this.fetchImpl = config.fetchImpl ?? fetch;
   }
 
-  async start(request: M5CodeLoopRequest): Promise<{ work_id: string; status: "running" }> {
+  async start(request: M5CodeLoopRequest): Promise<M5CodeLoopStart> {
     return startSchema.parse(
       await this.call("code_loop_start", { ...request }),
     );

--- a/tests/harbor-pilot.test.ts
+++ b/tests/harbor-pilot.test.ts
@@ -8,13 +8,18 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { runCodeLoopOnce } from "../scripts/harbor_pilot/m5-code-loop-once.js";
+import { harborLearningImportFromReport } from "../scripts/harbor_pilot/import-learning-report.js";
 import {
+  HARBOR_PILOT_CAMPAIGN_ID,
+  HARBOR_PILOT_HOLDOUT_IDS,
+  HARBOR_PILOT_TASK_IDS,
   HARBOR_PILOT_VERSION,
   prepareGateDHarborPilot,
 } from "../scripts/harbor_pilot/prepare-gate-d.js";
 import {
+  bindDeclaration,
   customBasePreflightScript,
   sourceBaselinePreflightScript,
   summarizeHarborJob,
@@ -24,6 +29,9 @@ const roots: string[] = [];
 
 afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+  vi.unstubAllGlobals();
+  delete process.env.M5_API_KEY;
+  delete process.env.M5_MCP_URL;
 });
 
 function tempRoot(): string {
@@ -108,7 +116,19 @@ describe("Harbor Gate D pilot", () => {
     ));
     expect(control).toMatchObject({
       task_id: "01-make-failing-test-pass",
+      holdout: false,
       protected: ["test/sum.oracle.ts", "tsconfig.json"],
+      client_run_ids: {
+        baseline: expect.stringContaining(":baseline"),
+        live: expect.stringContaining(":live"),
+      },
+    });
+    const manifest = JSON.parse(readFileSync(join(out, "manifest.json"), "utf8"));
+    expect(manifest).toMatchObject({
+      campaign_id: HARBOR_PILOT_CAMPAIGN_ID,
+      corpus_sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+      verifier_sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+      harbor_verifier_sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
     });
     expect(readFileSync(join(task, "tests", "test.sh"), "utf8"))
       .toContain("ln -s /opt/gate-d/node_modules /app/node_modules");
@@ -130,6 +150,56 @@ describe("Harbor Gate D pilot", () => {
       taskIds: ["01-make-failing-test-pass"],
       networkMode: "no-network",
     })).toThrow(/must be clean/);
+  });
+
+  it("binds generated assets to an immutable pre-inference declaration", () => {
+    const root = tempRoot();
+    const repo = fakeGateDRepo(root);
+    const prepared = prepareGateDHarborPilot({
+      sourceRepo: repo,
+      outputDir: join(root, "prepared"),
+      taskIds: ["01-make-failing-test-pass"],
+      networkMode: "no-network",
+    });
+    const declarationPath = join(root, "declaration.json");
+    const declaration = {
+      schema_version: 1,
+      status: "declared-not-run",
+      campaign_id: prepared.campaignId,
+      pilot_version: HARBOR_PILOT_VERSION,
+      harbor_version: "0.18.0",
+      source_commit: prepared.sourceCommit,
+      task_ids: prepared.taskIds,
+      holdout_ids: prepared.holdoutIds,
+      holdout_revision: prepared.holdoutRevision,
+      corpus_sha256: prepared.corpusSha256,
+      verifier_sha256: prepared.verifierSha256,
+      harbor_verifier_sha256: prepared.harborVerifierSha256,
+      model: "qwen3-coder-next-80b",
+      harness_version: "code-loop-pi-2026-07-14-v4",
+      caps: { wall_s: 600, turns: 13, completion_tokens: 60_000 },
+      required_capabilities: {
+        start_idempotency: "client-run-id-v1",
+        agent_checks: "pi-bash-events-v1",
+      },
+      network_mode: "no-network",
+      base_image: prepared.baseImage,
+      harbor_concurrency: 1,
+      attempts_per_task: 1,
+      model_calls_at_declaration: 0,
+    };
+    writeFileSync(declarationPath, JSON.stringify(declaration));
+    expect(bindDeclaration({
+      path: declarationPath,
+      prepared,
+      networkMode: "no-network",
+    })).toMatch(/^[a-f0-9]{64}$/);
+    writeFileSync(declarationPath, JSON.stringify({ ...declaration, corpus_sha256: "0".repeat(64) }));
+    expect(() => bindDeclaration({
+      path: declarationPath,
+      prepared,
+      networkMode: "no-network",
+    })).toThrow(/does not match/);
   });
 
   it("validates replayed M5 results against the declared execution binding", async () => {
@@ -175,6 +245,217 @@ describe("Harbor Gate D pilot", () => {
     })).rejects.toThrow(/effective model/);
   });
 
+  it("recovers an ambiguous live start with the same durable client binding", async () => {
+    const caps = { wall_s: 600, turns: 13, completion_tokens: 60_000 };
+    const clientRunId = "harbor:test-campaign:task-11:live";
+    const calls: Array<{ method: string; params: Record<string, unknown> }> = [];
+    let startAttempts = 0;
+    const result = {
+      status: "completed",
+      diff: "diff --git a/a.ts b/a.ts",
+      diff_truncated: false,
+      changed_files: ["a.ts"],
+      protected_violations: [],
+      summary: "done",
+      check: { ran: false, exit_code: null, output_tail: "" },
+      usage: { turns: 2, wall_ms: 100, prompt_tokens: 10, completion_tokens: 20 },
+      work_id: "cl-durable",
+      detail: "",
+      execution: {
+        schema_version: 1,
+        model: "qwen3-coder-next-80b",
+        engine: "pi",
+        harness_version: "code-loop-pi-2026-07-14-v4",
+        effective_caps: caps,
+        capabilities: {
+          start_idempotency: "client-run-id-v1",
+          agent_checks: "pi-bash-events-v1",
+        },
+      },
+      telemetry: {
+        schema_version: 1,
+        phase_ms: {},
+        mutation_evidence: "diff-only",
+        observability_coverage: 0.5,
+      },
+      agent_checks: {
+        schema_version: 1,
+        source: "pi-bash-events",
+        state: "none",
+        work_id: "cl-durable",
+        attempts: [],
+      },
+    };
+    const fetchMock = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as {
+        id: number;
+        method: string;
+        params: Record<string, unknown>;
+      };
+      calls.push({ method: body.method, params: body.params });
+      if (body.method === "tools/list") {
+        return new Response(JSON.stringify({
+          jsonrpc: "2.0",
+          id: body.id,
+          result: { tools: [{ name: "code_loop_start", inputSchema: { properties: { client_run_id: {} } } }] },
+        }));
+      }
+      const tool = body.params.name;
+      if (tool === "code_loop_start") {
+        startAttempts += 1;
+        if (startAttempts === 1) throw new TypeError("lost response");
+        return new Response(JSON.stringify({
+          jsonrpc: "2.0",
+          id: body.id,
+          result: {
+            content: [{ type: "text", text: JSON.stringify({
+              work_id: "cl-durable",
+              status: "completed",
+              client_run_id: clientRunId,
+              request_fingerprint: `sha256:${"e".repeat(64)}`,
+              recovered: true,
+              capabilities: {
+                start_idempotency: "client-run-id-v1",
+                agent_checks: "pi-bash-events-v1",
+              },
+              result,
+            }) }],
+          },
+        }));
+      }
+      if (tool === "code_loop_result") {
+        return new Response(JSON.stringify({
+          jsonrpc: "2.0",
+          id: body.id,
+          result: { content: [{ type: "text", text: JSON.stringify(result) }] },
+        }));
+      }
+      throw new Error(`unexpected tool ${String(tool)}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    process.env.M5_API_KEY = "owner-secret";
+    process.env.M5_MCP_URL = "http://m5.test:8080/mcp";
+
+    const output = await runCodeLoopOnce({
+      request: {
+        client_run_id: clientRunId,
+        instruction: "fix",
+        files: [{ path: "a.ts", content: "x" }],
+        caps,
+      },
+      expected: {
+        model: "qwen3-coder-next-80b",
+        harnessVersion: "code-loop-pi-2026-07-14-v4",
+        caps,
+        capabilities: {
+          startIdempotency: "client-run-id-v1",
+          agentChecks: "pi-bash-events-v1",
+        },
+      },
+      pollMs: 250,
+      resultDeadlineS: 60,
+    });
+
+    expect(output.start).toMatchObject({
+      client_run_id: clientRunId,
+      recovered: true,
+      work_id: "cl-durable",
+    });
+    const starts = calls.filter((call) => call.params.name === "code_loop_start");
+    expect(starts).toHaveLength(2);
+    expect(starts[0]).toEqual(starts[1]);
+  });
+
+  it("rejects live result evidence from a different work id", async () => {
+    const caps = { wall_s: 600, turns: 13, completion_tokens: 60_000 };
+    const clientRunId = "harbor:test-campaign:task-11:live";
+    const fetchMock = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body)) as {
+        id: number;
+        method: string;
+        params: Record<string, unknown>;
+      };
+      if (body.method === "tools/list") {
+        return new Response(JSON.stringify({
+          jsonrpc: "2.0",
+          id: body.id,
+          result: { tools: [{ name: "code_loop_start", inputSchema: { properties: { client_run_id: {} } } }] },
+        }));
+      }
+      const tool = body.params.name;
+      const text = tool === "code_loop_start"
+        ? {
+            work_id: "cl-start",
+            status: "completed",
+            client_run_id: clientRunId,
+            request_fingerprint: `sha256:${"e".repeat(64)}`,
+            recovered: false,
+            capabilities: {
+              start_idempotency: "client-run-id-v1",
+              agent_checks: "pi-bash-events-v1",
+            },
+          }
+        : {
+            status: "completed",
+            diff: "",
+            diff_truncated: false,
+            changed_files: [],
+            protected_violations: [],
+            summary: "wrong result",
+            check: { ran: false, exit_code: null, output_tail: "" },
+            usage: { turns: 1, wall_ms: 1, prompt_tokens: 1, completion_tokens: 1 },
+            work_id: "cl-other",
+            detail: "",
+            execution: {
+              schema_version: 1,
+              model: "qwen3-coder-next-80b",
+              engine: "pi",
+              harness_version: "code-loop-pi-2026-07-14-v4",
+              effective_caps: caps,
+              capabilities: {
+                start_idempotency: "client-run-id-v1",
+                agent_checks: "pi-bash-events-v1",
+              },
+            },
+            agent_checks: {
+              schema_version: 1,
+              source: "pi-bash-events",
+              state: "none",
+              work_id: "cl-other",
+              attempts: [],
+            },
+          };
+      return new Response(JSON.stringify({
+        jsonrpc: "2.0",
+        id: body.id,
+        result: { content: [{ type: "text", text: JSON.stringify(text) }] },
+      }));
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    process.env.M5_API_KEY = "owner-secret";
+    process.env.M5_MCP_URL = "http://m5.test:8080/mcp";
+
+    await expect(runCodeLoopOnce({
+      request: {
+        client_run_id: clientRunId,
+        instruction: "fix",
+        files: [{ path: "a.ts", content: "x" }],
+        caps,
+      },
+      expected: {
+        model: "qwen3-coder-next-80b",
+        harnessVersion: "code-loop-pi-2026-07-14-v4",
+        caps,
+        capabilities: {
+          startIdempotency: "client-run-id-v1",
+          agentChecks: "pi-bash-events-v1",
+        },
+      },
+      pollMs: 250,
+      resultDeadlineS: 60,
+    })).rejects.toThrow(/different work id/);
+  });
+
   it("summarizes Harbor rewards without importing prompts, diffs, or verifier logs", () => {
     const root = tempRoot();
     const job = join(root, "jobs", "replay");
@@ -199,5 +480,109 @@ describe("Harbor Gate D pilot", () => {
       ["04-add-cli-flag", 0],
     ]);
     expect(JSON.stringify(summary)).not.toContain("must not be copied");
+  });
+
+  it("predeclares four fresh cases and two hash-selected holdouts", () => {
+    expect(HARBOR_PILOT_TASK_IDS).toEqual([
+      "11-node-path-containment",
+      "12-add-csv-cli-format",
+      "13-type-safe-slug-tests",
+      "14-shared-handle-validation",
+    ]);
+    expect(HARBOR_PILOT_HOLDOUT_IDS).toEqual([
+      "11-node-path-containment",
+      "12-add-csv-cli-format",
+    ]);
+  });
+
+  it("builds only content-blind matched learning observations from a reviewed v2 report", () => {
+    const tasks = [...HARBOR_PILOT_TASK_IDS];
+    const holdouts = new Set<string>(HARBOR_PILOT_HOLDOUT_IDS);
+    const baseline = tasks.map((taskId, index) => ({
+      taskId,
+      holdout: holdouts.has(taskId),
+      passed: index !== 3,
+      applyReturnCode: 0,
+      checkReturnCode: index !== 3 ? 0 : 1,
+      checkDurationMs: 10,
+      failureKind: index !== 3 ? null : "check-failed",
+      workId: `cl-${index}`,
+      status: "completed",
+      diffBytes: 42,
+      secret_prompt: "never import me",
+    }));
+    const replay = baseline.map((row) => ({
+      taskId: row.taskId,
+      holdout: row.holdout,
+      baselinePassed: row.passed,
+      harborPassed: row.passed,
+      rewardMeasured: true,
+      rewardParity: true,
+      diffParity: true,
+      workParity: true,
+      clientRunParity: true,
+      applyReturnCode: 0,
+      exceptionType: null,
+      verifier_log: "never import me either",
+    }));
+    const live = baseline.map((row, index) => ({
+      taskId: row.taskId,
+      holdout: row.holdout,
+      reward: row.passed ? 1 : 0,
+      workId: `cl-live-${index}`,
+      clientRunId: `harbor:${HARBOR_PILOT_CAMPAIGN_ID}:${row.taskId}:live`,
+      requestFingerprint: `sha256:${String(index).padStart(64, "0")}`,
+      startCapabilities: {
+        start_idempotency: "client-run-id-v1",
+        agent_checks: "pi-bash-events-v1",
+      },
+      execution: {
+        model: "qwen3-coder-next-80b",
+        harness_version: "code-loop-pi-2026-07-14-v4",
+        effective_caps: { wall_s: 600, turns: 13, completion_tokens: 60_000 },
+        capabilities: {
+          start_idempotency: "client-run-id-v1",
+          agent_checks: "pi-bash-events-v1",
+        },
+      },
+      agentChecks: { source: "pi-bash-events", work_id: `cl-live-${index}` },
+      exceptionType: null,
+    }));
+    const payload = harborLearningImportFromReport({
+      schema_version: 2,
+      pilot_version: HARBOR_PILOT_VERSION,
+      campaign_id: HARBOR_PILOT_CAMPAIGN_ID,
+      harbor_version: "0.18.0",
+      runner_commit: "f".repeat(64),
+      declaration_sha256: "e".repeat(64),
+      source_commit: "a".repeat(64),
+      task_ids: tasks,
+      holdout_ids: [...HARBOR_PILOT_HOLDOUT_IDS],
+      holdout_revision: "sha256-lowest-two-of-four-v1",
+      corpus_sha256: "b".repeat(64),
+      verifier_sha256: "c".repeat(64),
+      harbor_verifier_sha256: "d".repeat(64),
+      caps: { wall_s: 600, turns: 13, completion_tokens: 60_000 },
+      model: "qwen3-coder-next-80b",
+      harness_version: "code-loop-pi-2026-07-14-v4",
+      network_mode: "no-network",
+      network_isolation_met: true,
+      base_image: "node:22.17.0-bookworm-slim@sha256:b04ce4ae4e95b522112c2e5c52f781471a5cbc3b594527bcddedee9bc48c03a0",
+      standard_base_image_met: true,
+      exact_replay_parity: true,
+      baseline_decisions_verified: true,
+      live_adapter_completed: true,
+      recommendation: "go",
+      baseline,
+      replay_parity: replay,
+      live_adapter: live,
+      raw_diff: "secret diff",
+    });
+
+    expect(payload.experiment.change_axis).toBe("test-harness");
+    expect(payload.observations).toHaveLength(8);
+    expect(payload.observations.filter((row) => row.holdout)).toHaveLength(4);
+    expect(JSON.stringify(payload)).not.toContain("never import me");
+    expect(JSON.stringify(payload)).not.toContain("secret diff");
   });
 });

--- a/tests/m5-code-loop-adapter.test.ts
+++ b/tests/m5-code-loop-adapter.test.ts
@@ -145,6 +145,47 @@ describe("M5 code-loop experiment adapter", () => {
     }).configuration_fingerprint).toBe("a".repeat(64));
   });
 
+  it("binds v4 capability evidence and refuses a prose-only result", () => {
+    const caps = { wall_s: 600, turns: 13, completion_tokens: 60_000 };
+    const execution = {
+      schema_version: 1 as const,
+      model: "qwen3-coder-next-80b",
+      engine: "pi",
+      harness_version: "code-loop-pi-2026-07-14-v4",
+      effective_caps: caps,
+      capabilities: {
+        start_idempotency: "client-run-id-v1",
+        agent_checks: "pi-bash-events-v1",
+      },
+    };
+    const expectedExecution = {
+      model: execution.model,
+      harnessVersion: execution.harness_version,
+      caps,
+      capabilities: {
+        startIdempotency: "client-run-id-v1" as const,
+        agentChecks: "pi-bash-events-v1" as const,
+      },
+    };
+    expect(() => observationFromM5CodeLoop(result({ execution }), {
+      ...context,
+      expectedExecution,
+    })).toThrow(/agent-side check evidence/);
+    expect(observationFromM5CodeLoop(result({
+      execution,
+      agent_checks: {
+        schema_version: 1,
+        source: "pi-bash-events",
+        state: "none",
+        work_id: "cl-20260713-abcdef12",
+        attempts: [],
+      },
+    }), {
+      ...context,
+      expectedExecution,
+    }).configuration_fingerprint).toBe("a".repeat(64));
+  });
+
   it("uses an external protected verifier without trusting an M5 self-check", () => {
     const observation = observationFromM5CodeLoop(result({
       status: "cap-exceeded",

--- a/tests/m5-code-loop-client.test.ts
+++ b/tests/m5-code-loop-client.test.ts
@@ -14,21 +14,42 @@ function rpcResult(value: unknown, isError = false): Response {
 
 describe("M5CodeLoopClient", () => {
   it("calls the owner-gated tool without leaking the token into the body", async () => {
-    const fetchImpl = vi.fn(async () => rpcResult({ work_id: "cl-1", status: "running" }));
+    const fetchImpl = vi.fn(async () => rpcResult({
+      work_id: "cl-1",
+      status: "running",
+      client_run_id: "harbor:campaign:task:live",
+      request_fingerprint: `sha256:${"a".repeat(64)}`,
+      recovered: false,
+      capabilities: {
+        start_idempotency: "client-run-id-v1",
+        agent_checks: "pi-bash-events-v1",
+      },
+    }));
     const client = new M5CodeLoopClient({
       endpoint: "http://m5.test:8080/mcp",
       bearerToken: "owner-secret",
       fetchImpl: fetchImpl as unknown as typeof fetch,
     });
 
-    expect(await client.start({ instruction: "fix", files: [{ path: "a.ts", content: "x" }] }))
-      .toEqual({ work_id: "cl-1", status: "running" });
+    expect(await client.start({
+      client_run_id: "harbor:campaign:task:live",
+      instruction: "fix",
+      files: [{ path: "a.ts", content: "x" }],
+    })).toMatchObject({
+      work_id: "cl-1",
+      status: "running",
+      client_run_id: "harbor:campaign:task:live",
+      recovered: false,
+    });
     const [, init] = fetchImpl.mock.calls[0]!;
     expect((init?.headers as Record<string, string>).authorization).toBe("Bearer owner-secret");
     expect(String(init?.body)).not.toContain("owner-secret");
     expect(JSON.parse(String(init?.body))).toMatchObject({
       method: "tools/call",
-      params: { name: "code_loop_start" },
+      params: {
+        name: "code_loop_start",
+        arguments: { client_run_id: "harbor:campaign:task:live" },
+      },
     });
   });
 


### PR DESCRIPTION
## Summary
- freeze the fresh four-case Gate D r2 corpus and two preselected holdouts before inference
- add durable M5 client-run binding, request/result evidence checks, and safe ambiguous-start recovery
- add a Linux/no-network Harbor report gate and dry-run-first content-blind learning importer

## Safety
- no r2 model calls have been made
- importer never promotes and requires a reviewed `go` report
- Harbor remains an offline evaluation plane, not a dispatcher runtime
- Claude review was not run because this current diff was not authorized for external transmission; native review found and fixed a start/result work-ID binding gap

## Validation
- `npm run build`
- `npm test` (106 files, 1,751 tests)
- focused Harbor/M5 tests (3 files, 24 tests)
- both CI shell suites
- Python compile, declaration regeneration/hash match, JSON parse, and `git diff --check`