### PR TITLE
Record Harbor Gate D v2 no-go

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,42 +1,50 @@
 # Hugin — Status
 
-**Latest session:** 2026-07-14 (Codex) — **M5 v4 live; Harbor r2 campaign implemented and predeclared, not yet run**
-**Branch:** `codex/harbor-gate-d-v2` from `main@57e1affbcda0c2a202ba14bccb04a67d95b7f48e`.
+**Latest session:** 2026-07-14 (Codex) — **fresh four-case Harbor campaign completed; official result no-go**
+**Branch:** `codex/harbor-gate-d-v2-result` from merged runner `main@ea3b7dd36d22307e5eac717208bb24539fdb5ad0`.
 
-## Latest — durable four-case Harbor campaign ready for review
+## Latest — v2 run preserved as no-go; verifier packaging fixed for next declaration
 
-- gille-inference PRs #253/#254 are merged and exact `main@a9b92211` is now
-  deployed on M5. Post-restart acceptance passed: gateway/M5/Orin health,
-  owner-only `tools/list`, `client-run-id-v1`, v4 harness
-  `code-loop-pi-2026-07-14-v4`, pre-inference invalid-request refusal, and a
-  checksum rsync zero-delta check. No Gate D r2 model call was made.
-- The Harbor runner now targets fresh cases 11–14, with cases 11/12 selected as
-  holdouts by the predeclared lowest-task-ID-SHA-256 rule. The exact source
-  commit, task/holdout set, corpus/verifier hashes, model, caps, no-network
-  policy, and image digest are frozen in
-  `docs/research/harbor-gate-d-v2-declaration-2026-07-14.json` with model call
-  count zero.
-- Every direct and Harbor live M5 call carries a deterministic
-  `client_run_id`. Hugin validates the echoed request fingerprint, v4 execution
-  binding, and `pi-bash-events-v1` evidence; a lost start response is retried
-  only under the identical durable binding. The general matched-experiment
-  runner uses the same recovery contract.
-- The post-run importer defaults to dry-run, requires a clean Linux/no-network
-  `go` report at the pinned image digest, independently validates host/replay
-  parity and live bindings, and emits only content-blind observations to an
-  isolated pilot scope. It never calls promotion.
-- Validation: model-free generation against exact gille `a9b92211` reproduced
-  corpus `02ab9ee7...ef4ac` and verifier `bda62f9f...eb77b`; TypeScript build;
-  focused 24 tests including an intentionally lost/recovered start and an
-  explicit start/result work-ID mismatch rejection; full suite 106 files /
-  1,751 tests outside the port-restricted sandbox; both CI shell
-  suites; Python compile; declaration JSON parse; `git diff --check`.
+- The predeclared cases 11–14 ran on exact gille-inference `a9b92211` with
+  cases 11/12 held out. Eight new model calls occurred: four host baselines and
+  four independent Harbor live samples. A corrected worker invocation recovered
+  the original four baseline work IDs through `client-run-id-v1`; it did not
+  repeat their inference.
+- The M5 owner credential never entered the Docker-socket worker. Magnus
+  explicitly approved a temporary split-capability bridge: the host held the
+  owner token without Docker access; the worker received a random token limited
+  to the eight declared client IDs, unchanged retries, exact caps, and their
+  status/result reads. A forbidden tool was rejected. The bridge is stopped,
+  its mode-0600 token is deleted, and no listener remains.
+- The first worker path used `/output` inside nested Docker and failed before
+  every Harbor agent. Re-running with an identical host/container
+  `/private/tmp/...` path recovered all baselines for free and completed all
+  live trials with zero Harbor exceptions.
+- Official result: **no-go**. Host baselines were 3/4 (11 fail; 12–14 pass),
+  but replay was 1/4 parity because the generated verifier copied `check.sh`
+  without its fresh `check-ts-contract.mjs` dependency. Live-adapter bindings
+  completed 4/4; its declared rewards are not adopted because the same verifier
+  package was incomplete. No learning import or promotion was attempted.
+- A separate no-network, no-credential, no-Docker-socket model-free regrade of
+  the exact recorded artifacts reproduced host replay parity 4/4 and graded the
+  live artifacts 3/4 (11–13 pass; 14 fail). This diagnoses the packaging bug but
+  does **not** supersede the predeclared no-go report.
+- The packager now copies every top-level `check-*.mjs` verifier support file,
+  binds their hashes into both host and Harbor verifier digests, and restores a
+  `/tests/node_modules` link so the ESM helpers resolve pinned TypeScript. An
+  end-to-end no-network Harbor replay of the four recorded diffs then produced
+  the exact expected 0/1/1/1 rewards, all diff/work IDs matched, and zero
+  exceptions or model calls. The content-blind record is
+  `docs/research/harbor-gate-d-v2-result-2026-07-14.json`.
+- Validation: TypeScript build; focused 3 files / 26 tests; full suite 106 files
+  / 1,753 tests; both CI shell suites; JSON parse; importer rejects the official
+  no-go report; credential value/name scan clean; bridge/token absent;
+  `git diff --check`.
 
-**Next:** review and merge this declaration/runner PR before any r2 inference.
-Then run the frozen campaign once in the accepted Linux/no-network Harbor
-worker, review/dry-run/commit only its content-blind parity import, and record
-the result in a follow-up PR. Keep Harbor out of dispatcher production and do
-not promote automatically.
+**Next:** validate/review this fix and evidence record, merge the follow-up PR,
+then add and predeclare genuinely fresh cases before another model-bearing
+Harbor run. Do not import the v2 no-go report, reuse these cases as holdouts, or
+promote automatically.
 
 ---
 

--- a/docs/harbor-gate-d-pilot.md
+++ b/docs/harbor-gate-d-pilot.md
@@ -96,6 +96,9 @@ as matched quality observations.
 The r2 task set, holdouts, source commit, corpus/verifier hashes, model, harness,
 caps, network policy, and image digest were frozen before inference in
 [`harbor-gate-d-v2-declaration-2026-07-14.json`](research/harbor-gate-d-v2-declaration-2026-07-14.json).
+That declaration is now consumed by the recorded no-go run. The verifier
+packaging fix deliberately changes the generated verifier/corpus hashes, so the
+old declaration fails binding before inference and must not be reused.
 
 ## Run
 
@@ -123,6 +126,11 @@ HARBOR_BIN=/private/tmp/hugin-harbor-pilot/venv/bin/harbor \
   --holdout-ids 11-node-path-containment,12-add-csv-cli-format \
   --network-mode no-network
 ```
+
+When Harbor itself runs inside a container against the host Docker socket, the
+pilot output directory must be mounted at the **same absolute path** inside the
+worker. Nested Docker Compose passes that path to the host daemon; a worker-only
+alias such as `/output` is not a host-shared path and fails before agent setup.
 
 The final `pilot-report.json` contains:
 
@@ -153,6 +161,33 @@ npm run pilot:harbor:import -- /path/to/pilot-report.json
 `m5-code-edit-harbor-pilot` experiment and appends idempotent host/replay
 observations. It never imports prompts, diffs, verifier logs, or trajectories,
 and never calls the promotion endpoint.
+
+## Fresh four-case outcome (2026-07-14)
+
+The content-blind record is
+[`harbor-gate-d-v2-result-2026-07-14.json`](research/harbor-gate-d-v2-result-2026-07-14.json).
+The predeclared run made eight new M5 calls: four direct baselines and four
+independent Harbor live samples. Durable IDs recovered the baselines during a
+worker-path correction without repeating inference. The temporary credential
+bridge kept the owner token outside the Docker-socket worker, rejected an
+undeclared tool, and was stopped with its worker token deleted after the run.
+
+The official recommendation is **no-go**. Host baselines passed 3/4, but the
+declared Harbor verifier package copied `check.sh` without the new
+`check-ts-contract.mjs` helper used by the fresh structural checks. Replay
+therefore disagreed on three passing baselines even though all diff, work, and
+client-ID bindings matched. The learning importer correctly remains unused.
+
+A no-network model-free regrade of the exact recorded artifacts, using the full
+source verifier suite, restored replay parity 4/4 and graded live artifacts 3/4
+(tasks 11–13 pass; task 14 fails). That establishes the packaging diagnosis but
+does not retroactively change the pre-inference verifier digest or supersede the
+official no-go. The generator now copies every top-level `check-*.mjs` support
+file, binds those files into both verifier digests, and links the pinned
+dependencies under `/tests/node_modules` so the helpers' ESM imports resolve.
+An end-to-end model-free Harbor replay after the fix reproduced the exact host
+0/1/1/1 decisions, with matching diff/work IDs and zero exceptions. Another
+model-bearing run requires a new declaration and genuinely fresh cases.
 
 ## Initial pilot outcome (2026-07-14)
 

--- a/docs/research/harbor-gate-d-v2-result-2026-07-14.json
+++ b/docs/research/harbor-gate-d-v2-result-2026-07-14.json
@@ -1,0 +1,110 @@
+{
+  "schema_version": 1,
+  "status": "completed-no-go",
+  "campaign_id": "gate-d-fresh-v2-20260714",
+  "pilot_version": "harbor-0.18.0-gate-d-v2",
+  "harbor_version": "0.18.0",
+  "runner_commit": "ea3b7dd36d22307e5eac717208bb24539fdb5ad0",
+  "source_commit": "a9b92211d18a039a5893c4bdb3a51e177b3efaa9",
+  "declaration_sha256": "03f2d76fd1693a3b7c5d112106621609722573c075f96b9a7434bbba951be4a5",
+  "official_report_sha256": "27da7331ab5f4c3adfd8d5bdff0016b4eb937702d671a9713ba9954fef703a42",
+  "model_free_regrade_sha256": "7c378a9c90e5ca211a4d390d88ead0ac6d1ead4467c374a199db8ab4a3d290a7",
+  "environment": {
+    "worker": "Linux ARM64 container against Docker Desktop LinuxKit",
+    "network_mode": "no-network",
+    "base_image": "node:22.17.0-bookworm-slim@sha256:b04ce4ae4e95b522112c2e5c52f781471a5cbc3b594527bcddedee9bc48c03a0",
+    "harbor_concurrency": 1,
+    "credential_boundary": "bounded temporary bridge; owner token stayed outside Docker-socket worker",
+    "bridge_stopped": true,
+    "temporary_worker_token_deleted": true
+  },
+  "execution_accounting": {
+    "declared_logical_model_calls": 8,
+    "new_baseline_model_calls": 4,
+    "recovered_baseline_starts": 4,
+    "duplicate_baseline_model_calls": 0,
+    "new_live_model_calls": 4,
+    "total_new_model_calls": 8,
+    "first_worker_attempt": {
+      "report_sha256": "edbd253970369edeade3d26b245cfad1135996c57cc08c174206f4aa1defc0de",
+      "new_baseline_model_calls": 4,
+      "new_live_model_calls": 0,
+      "failure": "nested Docker could not resolve the worker-only /output mount path"
+    },
+    "corrected_worker_attempt": {
+      "baseline_starts_recovered": 4,
+      "new_live_model_calls": 4,
+      "host_container_output_path_identical": true
+    }
+  },
+  "official_report": {
+    "recommendation": "no-go",
+    "baseline_decisions_verified": true,
+    "exact_replay_parity": false,
+    "live_adapter_completed": true,
+    "baseline": [
+      { "task_id": "11-node-path-containment", "holdout": true, "passed": false, "status": "completed", "diff_sha256": "7a596bb98251be25a21a81edf3e89476e707eed22d69b9d3e0b66f3aed7443fb" },
+      { "task_id": "12-add-csv-cli-format", "holdout": true, "passed": true, "status": "cap-exceeded", "diff_sha256": "1d79e8a5a6f49ec8323465d15453fda9fab230e8369ced4773e1c7814b7e51d0" },
+      { "task_id": "13-type-safe-slug-tests", "holdout": false, "passed": true, "status": "completed", "diff_sha256": "c94b9af2bea8c30eaf7e11b6629ce59f38fecfdeab503e70edc2652bf181368b" },
+      { "task_id": "14-shared-handle-validation", "holdout": false, "passed": true, "status": "completed", "diff_sha256": "6e0de2415527c8e4ee0643f2c36aaeab9e474a5de1826f3af7c82e94b6229798" }
+    ],
+    "reported_replay_passes": [
+      { "task_id": "11-node-path-containment", "passed": false },
+      { "task_id": "12-add-csv-cli-format", "passed": false },
+      { "task_id": "13-type-safe-slug-tests", "passed": false },
+      { "task_id": "14-shared-handle-validation", "passed": false }
+    ],
+    "reported_live_passes": [
+      { "task_id": "11-node-path-containment", "passed": true },
+      { "task_id": "12-add-csv-cli-format", "passed": false },
+      { "task_id": "13-type-safe-slug-tests", "passed": false },
+      { "task_id": "14-shared-handle-validation", "passed": false }
+    ]
+  },
+  "diagnosis": {
+    "failure_kind": "verifier-packaging",
+    "detail": "The generated Harbor verifier copied gate-d/check.sh but omitted its check-*.mjs support files; after copying them, their ESM imports also required the pinned dependency link at /tests/node_modules.",
+    "why_official_no_go_stands": "Adding the missing helper changes the predeclared verifier package and its digest after inference.",
+    "importer_rejected_no_go": true,
+    "learning_ledger_write_attempted": false,
+    "promotion_attempted": false
+  },
+  "model_free_post_run_regrade": {
+    "supersedes_official_report": false,
+    "additional_model_calls": 0,
+    "replay_exact_host_parity": true,
+    "replay": [
+      { "task_id": "11-node-path-containment", "passed": false, "artifact_sha256": "79e7d0fcca84a4c540c10eb2291bd43b6728469a27c800eaef4e66906ca28d00" },
+      { "task_id": "12-add-csv-cli-format", "passed": true, "artifact_sha256": "8373b97e7241e3134050b39085f9322482486dfce2e933f96d5253373b32a982" },
+      { "task_id": "13-type-safe-slug-tests", "passed": true, "artifact_sha256": "2a86636164f74869fd2a82e40a2b698baf0207a1dd20e0cbdb8b4fed39bdb2cd" },
+      { "task_id": "14-shared-handle-validation", "passed": true, "artifact_sha256": "05f0b79101369b9622da55efdcd84981d6eecaa134ef450a27572f796aa7cc60" }
+    ],
+    "live": [
+      { "task_id": "11-node-path-containment", "passed": true, "artifact_sha256": "89b7cac4c4158f73bffc7ecc7f24a83d023cf1431da0d4945043066955c3f521" },
+      { "task_id": "12-add-csv-cli-format", "passed": true, "artifact_sha256": "11262ef714d129014eb513a86c3f754c96e018daa57e820418a5d367ebe67e13" },
+      { "task_id": "13-type-safe-slug-tests", "passed": true, "artifact_sha256": "0e170314c75beb9e1851d197adee9c89afcc29c9cf33bdd6f636415b2f8e6309" },
+      { "task_id": "14-shared-handle-validation", "passed": false, "artifact_sha256": "76bc9a2fa9b27a144f332707754cff288926265b6e33778a8960225f86e8c22f" }
+    ]
+  },
+  "packaging_fix_validation": {
+    "additional_model_calls": 0,
+    "network_mode": "no-network",
+    "harbor_exceptions": 0,
+    "generated_manifest_sha256": "6010590e4a96812a4656358750abf8048324d1d78d4f280dab9a88eb80050516",
+    "host_verifier_sha256": "16056622617cb5bcd3fdfaa9decf1d5dfd27ccff745f82b3ac10bf1871c99507",
+    "harbor_verifier_sha256": "baf5c06a3d449f3baa74a4fbb14baf7bae35e1e577daff329a91b93e2c06cf8f",
+    "harbor_job_result_sha256": "7fae7614e2c9a2461fdad3106dbe0dd70d031967e15b5948e3a3a31ba81d4922",
+    "exact_replay_parity": true,
+    "results": [
+      { "task_id": "11-node-path-containment", "passed": false, "diff_sha256": "7a596bb98251be25a21a81edf3e89476e707eed22d69b9d3e0b66f3aed7443fb" },
+      { "task_id": "12-add-csv-cli-format", "passed": true, "diff_sha256": "1d79e8a5a6f49ec8323465d15453fda9fab230e8369ced4773e1c7814b7e51d0" },
+      { "task_id": "13-type-safe-slug-tests", "passed": true, "diff_sha256": "c94b9af2bea8c30eaf7e11b6629ce59f38fecfdeab503e70edc2652bf181368b" },
+      { "task_id": "14-shared-handle-validation", "passed": true, "diff_sha256": "6e0de2415527c8e4ee0643f2c36aaeab9e474a5de1826f3af7c82e94b6229798" }
+    ]
+  },
+  "decision": {
+    "import_into_learning_ledger": false,
+    "promote": false,
+    "next": "Land verifier-support binding/copy fix, then predeclare a new fresh corpus before any further model-bearing Harbor run."
+  }
+}

--- a/scripts/harbor_pilot/prepare-gate-d.ts
+++ b/scripts/harbor_pilot/prepare-gate-d.ts
@@ -59,6 +59,22 @@ function sha256Json(value: unknown): string {
   return createHash("sha256").update(JSON.stringify(value)).digest("hex");
 }
 
+function verifierSupportBindings(
+  gateDRoot: string,
+): Array<{ path: string; sha256: string }> {
+  return readdirSync(gateDRoot)
+    .filter((name) => /^check-[a-z0-9-]+\.mjs$/.test(name))
+    .sort()
+    .map((name) => {
+      const path = join(gateDRoot, name);
+      const stat = lstatSync(path);
+      if (stat.isSymbolicLink() || !stat.isFile()) {
+        throw new Error(`unsafe Gate D verifier support file: ${path}`);
+      }
+      return { path: name, sha256: sha256File(path) };
+    });
+}
+
 function clientRunId(campaignId: string, taskId: string, lane: "baseline" | "live"): string {
   const value = `harbor:${campaignId}:${taskId}:${lane}`;
   if (!/^[A-Za-z0-9._:-]{1,128}$/.test(value)) {
@@ -197,6 +213,11 @@ mkdir -p /logs/verifier
 if [ ! -e /app/node_modules ]; then
   ln -s /opt/gate-d/node_modules /app/node_modules
 fi
+# The copied verifier helpers import TypeScript as ESM. Node resolves that
+# dependency relative to /tests, not the artifact mounted at /app.
+if [ ! -e /tests/node_modules ]; then
+  ln -s /opt/gate-d/node_modules /tests/node_modules
+fi
 set +e
 bash /tests/gate-d-check.sh /tests/task /app > /logs/verifier/gate-d-check.log 2>&1
 status=$?
@@ -255,6 +276,7 @@ export function prepareGateDHarborPilot(input: {
   const baseImage = input.baseImage ?? HARBOR_PILOT_DEFAULT_BASE_IMAGE;
   const sourceGateD = join(sourceRepo, "gate-d");
   const checkPath = join(sourceGateD, "check.sh");
+  const verifierSupport = verifierSupportBindings(sourceGateD);
 
   if (!/^[a-z0-9][a-z0-9-]{1,47}$/.test(campaignId)) {
     throw new Error("Harbor campaign id must be a 2-48 character lowercase slug");
@@ -337,6 +359,9 @@ export function prepareGateDHarborPilot(input: {
     writeFileSync(join(testsDir, "Dockerfile"), verifierDockerfile(baseImage));
     writeFileSync(join(testsDir, "test.sh"), verifierScript, { mode: 0o755 });
     cpSync(checkPath, join(testsDir, "gate-d-check.sh"));
+    for (const support of verifierSupport) {
+      cpSync(join(sourceGateD, support.path), join(testsDir, support.path));
+    }
     cpSync(metaPath, join(testsTaskDir, "meta.json"));
     cpSync(seedPath, join(testsTaskDir, "repo"), { recursive: true });
     const hiddenOracle = (meta as { hiddenOracle?: unknown }).hiddenOracle;
@@ -351,7 +376,11 @@ export function prepareGateDHarborPilot(input: {
     }
   }
 
-  const verifierSha256 = sha256File(checkPath);
+  const gateDCheckSha256 = sha256File(checkPath);
+  const verifierSha256 = sha256Json({
+    check_sh_sha256: gateDCheckSha256,
+    support: verifierSupport,
+  });
   const corpusSha256 = sha256Json({
     source_commit: sourceCommit,
     holdout_revision: holdoutRevision,
@@ -363,7 +392,8 @@ export function prepareGateDHarborPilot(input: {
     base_image: baseImage,
     verifier_dockerfile: verifierDockerfile(baseImage),
     verifier_script: verifierScript,
-    gate_d_check_sha256: verifierSha256,
+    gate_d_check_sha256: gateDCheckSha256,
+    verifier_support: verifierSupport,
   });
 
   writeFileSync(join(outputDir, "manifest.json"), `${JSON.stringify({
@@ -378,6 +408,7 @@ export function prepareGateDHarborPilot(input: {
     holdout_revision: holdoutRevision,
     corpus_sha256: corpusSha256,
     verifier_sha256: verifierSha256,
+    verifier_support: verifierSupport,
     harbor_verifier_sha256: harborVerifierSha256,
     task_bindings: taskBindings,
     network_mode: networkMode,

--- a/tests/harbor-pilot.test.ts
+++ b/tests/harbor-pilot.test.ts
@@ -4,6 +4,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -50,10 +51,12 @@ function git(repo: string, args: string[]): void {
   if (result.status !== 0) throw new Error(result.stderr);
 }
 
-function fakeGateDRepo(root: string): string {
+function fakeGateDRepo(root: string, helperContent = "export const marker = 'one';\n"): string {
   const repo = join(root, "gille-inference");
   mkdirSync(repo);
   write(join(repo, "gate-d", "check.sh"), "#!/usr/bin/env bash\nexit 0\n");
+  write(join(repo, "gate-d", "check-test-assertions.mjs"), "export const assertions = true;\n");
+  write(join(repo, "gate-d", "check-ts-contract.mjs"), helperContent);
   const task = join(repo, "gate-d", "tasks", "01-make-failing-test-pass");
   write(join(task, "INSTRUCTION.md"), "Make the test pass.\n");
   write(join(task, "meta.json"), `${JSON.stringify({
@@ -129,15 +132,57 @@ describe("Harbor Gate D pilot", () => {
       corpus_sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
       verifier_sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
       harbor_verifier_sha256: expect.stringMatching(/^[a-f0-9]{64}$/),
+      verifier_support: [
+        { path: "check-test-assertions.mjs", sha256: expect.stringMatching(/^[a-f0-9]{64}$/) },
+        { path: "check-ts-contract.mjs", sha256: expect.stringMatching(/^[a-f0-9]{64}$/) },
+      ],
     });
     expect(readFileSync(join(task, "tests", "test.sh"), "utf8"))
       .toContain("ln -s /opt/gate-d/node_modules /app/node_modules");
+    expect(readFileSync(join(task, "tests", "test.sh"), "utf8"))
+      .toContain("ln -s /opt/gate-d/node_modules /tests/node_modules");
     expect(readFileSync(join(task, "tests", "test.sh"), "utf8"))
       .toContain("gate_d_all_gates");
     expect(readFileSync(join(task, "tests", "Dockerfile"), "utf8"))
       .toContain("COPY . /tests/");
     expect(readFileSync(join(task, "tests", "Dockerfile"), "utf8"))
       .toContain("@types/node@22.13.0");
+    expect(readFileSync(join(task, "tests", "check-test-assertions.mjs"), "utf8"))
+      .toContain("assertions");
+    expect(readFileSync(join(task, "tests", "check-ts-contract.mjs"), "utf8"))
+      .toContain("marker");
+  });
+
+  it("binds verifier support content into the host and Harbor verifier digests", () => {
+    const firstRoot = tempRoot();
+    const first = prepareGateDHarborPilot({
+      sourceRepo: fakeGateDRepo(firstRoot, "export const marker = 'one';\n"),
+      outputDir: join(firstRoot, "prepared"),
+      taskIds: ["01-make-failing-test-pass"],
+    });
+    const secondRoot = tempRoot();
+    const second = prepareGateDHarborPilot({
+      sourceRepo: fakeGateDRepo(secondRoot, "export const marker = 'two';\n"),
+      outputDir: join(secondRoot, "prepared"),
+      taskIds: ["01-make-failing-test-pass"],
+    });
+
+    expect(first.verifierSha256).not.toBe(second.verifierSha256);
+    expect(first.harborVerifierSha256).not.toBe(second.harborVerifierSha256);
+  });
+
+  it("rejects a verifier support symlink before packaging", () => {
+    const root = tempRoot();
+    const repo = fakeGateDRepo(root);
+    const support = join(repo, "gate-d", "check-ts-contract.mjs");
+    rmSync(support);
+    symlinkSync("../check.sh", support);
+
+    expect(() => prepareGateDHarborPilot({
+      sourceRepo: repo,
+      outputDir: join(root, "prepared"),
+      taskIds: ["01-make-failing-test-pass"],
+    })).toThrow(/unsafe Gate D verifier support file/);
   });
 
   it("refuses a dirty source corpus", () => {


### PR DESCRIPTION
## Outcome
- preserve the predeclared four-case campaign as an official `no-go`; do not import or promote it
- record eight new M5 calls, durable baseline recovery with zero duplicate inference, and the bounded credential bridge cleanup
- separate model-free diagnosis: exact replay parity 4/4 and live artifacts 3/4 when graded with the complete source verifier

## Fix
- copy and hash-bind all top-level `check-*.mjs` verifier support files
- link pinned dependencies at `/tests/node_modules` for helper ESM resolution
- reject verifier support symlinks
- document identical nested-Docker host/container output paths

## Validation
- full suite: 106 files, 1,753 tests
- focused Harbor/M5: 3 files, 26 tests
- end-to-end no-network/model-free Harbor replay: exact 0/1/1/1 parity, matching diff/work IDs, zero exceptions
- final generator reproduces the recorded fixed manifest hash
- importer rejects the official no-go; no ledger write or promotion
- exact credential value/name scan clean; bridge stopped and temporary token deleted

Claude review was not run because this current diff was not authorized for external transmission. Native review found and fixed missing helper dependency resolution and verifier-support symlink hardening.