### PR TITLE
Build daily-use exam factory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,14 @@ Content format:
 
 Results are written to the same namespace under key `result`.
 
+Current successful managed-repository tasks also bind an optional
+`repositoryChange` object into `result-structured`: the pre-agent `origin/main`
+commit, final task-branch commit, changed-file paths, and SHA-256 of the binary
+Git diff. The daily exam factory uses this content-blind evidence to classify
+Munin history as provisional holdout, regression, or quarantine candidates;
+it never runs or promotes a candidate by itself. See
+`docs/daily-exam-factory.md`.
+
 ## Project structure
 
 ```
@@ -130,6 +138,7 @@ hugin/
 │       ├── experiment-evaluator.ts # Pure matched-pair promotion/rejection logic
 │       ├── experiment-store.ts   # Principal-isolated Munin state + CAS/idempotency
 │       ├── experiment-handlers.ts # Authenticated Broker learning endpoints
+│       ├── daily-task-exam-factory.ts # Content-blind daily task → holdout/regression/quarantine candidates
 │       ├── m5-code-loop-adapter.ts # Honest M5 result → content-blind observation mapping
 │       └── m5-code-loop-client.ts  # Owner-gated async code_loop JSON-RPC client
 ├── tests/
@@ -137,6 +146,7 @@ hugin/
 │   └── sdk-executor.test.ts
 └── scripts/
     ├── deploy-pi.sh
+    ├── harvest-daily-exam-candidates.ts # Read-only Munin sweep → mode-0600 candidate manifest
     ├── run-m5-code-loop-experiment.ts # Resumable matched Gate D experiment runner
     ├── submit-daily-analysis.sh  # Submit daily journal analysis as ollama task
     ├── sync-claude-config.sh     # DEPRECATED — config now lives in the claude-config repo (bootstrap.sh)

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,37 @@
 # Hugin — Status
 
+**Latest session:** 2026-07-14 (Codex) — **daily-use exam factory implemented locally; CI-equivalent suite green**
+**Branch:** `codex/daily-exam-factory` from `main@509e9cd7d50f5ff1ace142f941033ba9bc348238`.
+
+## Latest — real Hugin code work can feed quarantined Harbor exam candidates
+
+- Successful managed-repository tasks now pin `origin/main` before the agent
+  runs, then bind the final commit, changed-file paths, and SHA-256 of the
+  binary/no-textconv Git diff into optional `result-structured.repositoryChange`.
+  An agent-mutated remote ref therefore cannot redefine the exam's before tree.
+- `npm run harvest:daily-exams` performs a read-only, paginated Munin sweep and
+  emits a mode-0600, content-blind manifest. It copies neither prompt/answer nor
+  diff/file contents and performs no model call, Harbor run, learning import,
+  route change, or promotion.
+- Candidates are separated into `provisional-holdout` (no Hugin-local M5
+  evidence), `regression` (M5 provenance exists), and `quarantine` (missing
+  reproducibility/privacy/completion/exposure evidence). Every usable candidate
+  still requires an independent verifier; private tasks are quarantined and
+  omit repository metadata.
+- "No Hugin-local M5 evidence" deliberately does not claim global freshness.
+  The owner-side, content-blind cross-client exposure lookup is routed to
+  [gille-inference#257](https://github.com/Magnus-Gille/gille-inference/issues/257).
+- Documentation: `docs/daily-exam-factory.md`. Validation: TypeScript build;
+  focused 4 files / 54 tests; full suite 108 files / 1,767 tests; both exact CI
+  shell suites; CLI help; `git diff --check`.
+
+**Next:** review and publish this branch, merge only with green GitHub CI, deploy
+the exact merged Hugin commit, then run the first read-only candidate sweep.
+Keep all holdouts provisional until gille-inference#257 provides complete
+cross-client exposure evidence and a reviewed independent verifier is attached.
+
+---
+
 **Latest session:** 2026-07-14 (Codex) — **fresh four-case Harbor campaign completed; official result no-go**
 **Main:** `465ad19e88c2d691447bce1d7644e3340db29515`; runner/declaration PR [#204](https://github.com/Magnus-Gille/hugin/pull/204) and no-go/fix PR [#205](https://github.com/Magnus-Gille/hugin/pull/205) are merged.
 

--- a/docs/daily-exam-factory.md
+++ b/docs/daily-exam-factory.md
@@ -1,0 +1,68 @@
+# Daily-use exam factory
+
+Hugin can turn completed managed-repository tasks into quarantined candidates
+for the offline Harbor evaluation lane. This is a **candidate factory**, not an
+automatic learning or promotion path.
+
+## What is captured
+
+For a successful task branch, Hugin records a content-blind repository binding
+in `result-structured`:
+
+- exact `origin/main` commit used as the before tree;
+- exact task-branch head commit;
+- repository-relative changed-file names; and
+- SHA-256 of the binary Git diff.
+
+The prompt, answer, diff, file contents, and credentials are not copied into the
+factory manifest. They remain in their existing owner-controlled systems. The
+manifest keeps hashes and Munin/Git references so a later, reviewed packager can
+reconstruct and verify the candidate.
+
+## Candidate lanes
+
+`npm run harvest:daily-exams` reads completed `tasks/` entries from Munin and
+classifies them without running a model or writing any learning state:
+
+| Lane | Meaning |
+|---|---|
+| `provisional-holdout` | Hugin has no evidence that M5 saw the task. A cross-client exposure check and an independent verifier are still required before sealing it. |
+| `regression` | Hugin has evidence that the task reached an M5 runtime or leaf. It may test non-regression, but it is not fresh. |
+| `quarantine` | Reproducibility, privacy, completion, repository, PR, or exposure evidence is incomplete. |
+
+Every non-quarantined candidate still has readiness
+`needs-independent-verifier`. Agent prose and a changed test file are not an
+independent grading oracle.
+
+## Run it
+
+```bash
+MUNIN_API_KEY=... npm run harvest:daily-exams -- \
+  --since 2026-07-14T00:00:00Z \
+  --limit 500 \
+  --output /private/tmp/hugin-daily-exam-candidates.json
+```
+
+The output file is created mode `0600`. Omit `--output` to write JSON to stdout.
+The command reports `historyComplete:false` whenever Munin pagination or the
+caller limit prevents it from proving that the selected history is complete.
+
+## Safety boundary and next stage
+
+The factory does not:
+
+- claim that absence of Hugin-local M5 provenance proves global freshness;
+- copy private tasks into an evaluation package;
+- invent or trust a verifier;
+- run Harbor or M5;
+- import a learning observation; or
+- promote a model, harness, prompt, or route.
+
+The next stage consumes a reviewed candidate, checks a shared exposure registry,
+reconstructs the base tree, derives and validates an independent verifier, and
+only then creates a frozen Harbor declaration. The reusable Gate D corpus and
+M5 capability ledger remain owned by `gille-inference`; this Hugin-side factory
+owns daily task discovery and reproducibility evidence.
+
+The owner-side exposure lookup is tracked in
+[`gille-inference#257`](https://github.com/Magnus-Gille/gille-inference/issues/257).

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build:pii-fixtures": "tsx scripts/build-pii-fixtures.ts",
     "eval:pii": "tsx scripts/run-pii-eval.ts",
     "experiment:m5-code-loop": "tsx scripts/run-m5-code-loop-experiment.ts",
+    "harvest:daily-exams": "tsx scripts/harvest-daily-exam-candidates.ts",
     "pilot:harbor": "tsx scripts/harbor_pilot/run-pilot.ts",
     "pilot:harbor:import": "tsx scripts/harbor_pilot/import-learning-report.ts",
     "test": "vitest run",

--- a/scripts/harvest-daily-exam-candidates.ts
+++ b/scripts/harvest-daily-exam-candidates.ts
@@ -1,0 +1,177 @@
+#!/usr/bin/env tsx
+
+import {
+  closeSync,
+  constants,
+  mkdirSync,
+  openSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { randomUUID } from "node:crypto";
+import { dirname, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { MuninClient, type MuninEntry } from "../src/munin-client.js";
+import { queryAllMuninEntries } from "../src/munin-pagination.js";
+import {
+  buildDailyExamManifest,
+  type DailyTaskHarvestSource,
+} from "../src/learning/daily-task-exam-factory.js";
+
+interface CliOptions {
+  since?: string;
+  until?: string;
+  limit: number;
+  output?: string;
+}
+
+function usage(): string {
+  return [
+    "Usage: npm run harvest:daily-exams -- [options]",
+    "",
+    "Read completed Hugin tasks from Munin and emit a content-blind, quarantined",
+    "exam-candidate manifest. This command never runs a model, writes Munin, or",
+    "imports/promotes learning evidence.",
+    "",
+    "Options:",
+    "  --since <ISO>    Only inspect tasks updated at/after this timestamp",
+    "  --until <ISO>    Only inspect tasks updated at/before this timestamp",
+    "  --limit <N>      Maximum task status rows to inspect (default 500)",
+    "  --output <path>  Write mode-0600 JSON here instead of stdout",
+    "  --help           Show this help",
+  ].join("\n");
+}
+
+function normalizedTimestamp(value: string, flag: string): string {
+  const parsed = Date.parse(value);
+  if (Number.isNaN(parsed)) throw new Error(`${flag} must be an ISO timestamp`);
+  return new Date(parsed).toISOString();
+}
+
+export function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = { limit: 500 };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]!;
+    if (arg === "--help") {
+      process.stdout.write(`${usage()}\n`);
+      process.exit(0);
+    }
+    const value = argv[index + 1];
+    if (!value) throw new Error(`${arg} requires a value`);
+    if (arg === "--since") options.since = normalizedTimestamp(value, arg);
+    else if (arg === "--until") options.until = normalizedTimestamp(value, arg);
+    else if (arg === "--output") options.output = resolve(value);
+    else if (arg === "--limit") {
+      const limit = Number(value);
+      if (!Number.isInteger(limit) || limit < 1 || limit > 10_000) {
+        throw new Error("--limit must be an integer from 1 to 10000");
+      }
+      options.limit = limit;
+    } else {
+      throw new Error(`unknown option: ${arg}`);
+    }
+    index += 1;
+  }
+  if (options.since && options.until && options.since > options.until) {
+    throw new Error("--since must not be later than --until");
+  }
+  return options;
+}
+
+export function writeManifestFile(outputPath: string, json: string): void {
+  mkdirSync(dirname(outputPath), { recursive: true });
+  const temporary = `${outputPath}.tmp-${process.pid}-${randomUUID()}`;
+  let fd: number | undefined;
+  try {
+    fd = openSync(
+      temporary,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
+      0o600,
+    );
+    writeFileSync(fd, json, { encoding: "utf8" });
+    closeSync(fd);
+    fd = undefined;
+    // Atomic replacement does not follow an existing destination symlink.
+    renameSync(temporary, outputPath);
+  } catch (error) {
+    if (fd !== undefined) {
+      try { closeSync(fd); } catch { /* best-effort cleanup */ }
+    }
+    try { unlinkSync(temporary); } catch { /* best-effort cleanup */ }
+    throw error;
+  }
+}
+
+async function loadSources(
+  munin: MuninClient,
+  options: CliOptions,
+): Promise<{ sources: DailyTaskHarvestSource[]; historyComplete: boolean }> {
+  const queried = await queryAllMuninEntries(
+    munin,
+    {
+      tags: ["completed"],
+      namespace: "tasks/",
+      entry_type: "state",
+      ...(options.since ? { since: options.since } : {}),
+      ...(options.until ? { until: options.until } : {}),
+    },
+    {
+      maxPages: Math.max(1, Math.ceil(options.limit / 50)),
+      maxResults: options.limit,
+    },
+  );
+  const namespaces = [...new Set(
+    queried.results
+      .filter((entry) => entry.key === "status" && entry.namespace.startsWith("tasks/"))
+      .map((entry) => entry.namespace),
+  )].sort();
+  const [statuses, results] = await Promise.all([
+    munin.readBatch(namespaces.map((namespace) => ({ namespace, key: "status" }))),
+    munin.readBatch(namespaces.map((namespace) => ({ namespace, key: "result-structured" }))),
+  ]);
+  const sources: DailyTaskHarvestSource[] = [];
+  for (let index = 0; index < namespaces.length; index += 1) {
+    const status = statuses[index];
+    if (!status?.found) continue;
+    const result = results[index];
+    sources.push({
+      status: status as MuninEntry,
+      resultStructured: result?.found ? result as MuninEntry : null,
+    });
+  }
+  return { sources, historyComplete: !queried.truncated };
+}
+
+export async function main(argv = process.argv.slice(2)): Promise<void> {
+  const options = parseArgs(argv);
+  const apiKey = process.env.MUNIN_API_KEY?.trim();
+  if (!apiKey) throw new Error("MUNIN_API_KEY is required");
+  const munin = new MuninClient({
+    baseUrl: process.env.MUNIN_URL?.trim() || "http://localhost:3030",
+    apiKey,
+  });
+  const loaded = await loadSources(munin, options);
+  const manifest = buildDailyExamManifest({
+    generatedAt: new Date().toISOString(),
+    historyComplete: loaded.historyComplete,
+    sources: loaded.sources,
+  });
+  const json = `${JSON.stringify(manifest, null, 2)}\n`;
+  if (options.output) {
+    writeManifestFile(options.output, json);
+    process.stderr.write(
+      `Wrote ${manifest.candidates.length} content-blind candidate record(s) to ${options.output}\n`,
+    );
+  } else {
+    process.stdout.write(json);
+  }
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : "";
+if (import.meta.url === invokedPath) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4404,6 +4404,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     if (task.runtime !== "homeserver") {
       branchResult = await checkoutTaskBranch(task.workingDir, taskId, {
         reposRoot: config.reposRoot,
+        captureBaseCommit: true,
       });
       if (branchResult.action === "fetch-failed") {
         console.warn(`Pre-task branch checkout failed for ${taskNs} (non-fatal, proceeding without branch): ${branchResult.error}`);
@@ -4978,6 +4979,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
 
     // Post-task: finalize branch — auto-commit leftovers, push, open PR (#47)
     let prUrl: string | undefined;
+    let repositoryChange: StructuredTaskResult["repositoryChange"];
     if (ok && !isCancelled && branchResult.action === "created" && branchResult.branchName) {
       const prBody = [
         `Automated changes from Hugin task \`${taskId}\`.`,
@@ -4993,7 +4995,12 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         branchResult.branchName,
         prBody,
         egressPolicy.allowedHosts,
+        {
+          captureRepositoryChange: true,
+          baseCommit: branchResult.baseCommit,
+        },
       );
+      repositoryChange = finalizeResult.repositoryChange;
       if (finalizeResult.action === "pr-created" && finalizeResult.prUrl) {
         prUrl = finalizeResult.prUrl;
         await munin.log(taskNs, `PR created: ${prUrl}`);
@@ -5565,6 +5572,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
             sequence: task.sequence,
             costUsd: costUsd ?? undefined,
             prUrl,
+            repositoryChange,
             bodyKind: structuredBodyKind,
             bodyText: structuredBodyText,
             errorMessage: ok

--- a/src/learning/daily-task-exam-factory.ts
+++ b/src/learning/daily-task-exam-factory.ts
@@ -1,0 +1,270 @@
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import type { MuninEntry } from "../munin-client.js";
+import {
+  structuredTaskResultSchema,
+  type StructuredTaskResult,
+} from "../task-result-schema.js";
+
+const sha256Schema = z.string().regex(/^[0-9a-f]{64}$/);
+const gitCommitSchema = z.string().regex(/^[0-9a-f]{40,64}$/);
+
+export const dailyExamCandidateSchema = z.object({
+  schemaVersion: z.literal(1),
+  candidateId: z.string().regex(/^daily-[0-9a-f]{24}$/),
+  source: z.object({
+    taskNamespace: z.string().startsWith("tasks/"),
+    taskId: z.string().min(1),
+    statusUpdatedAt: z.string().min(1),
+    taskDocumentSha256: sha256Schema,
+    promptSha256: sha256Schema.optional(),
+    structuredResultSha256: sha256Schema.optional(),
+    runtime: z.string().min(1).optional(),
+    taskType: z.string().min(1).optional(),
+    sensitivity: z.enum(["public", "internal", "private"]).optional(),
+  }).strict(),
+  repository: z.object({
+    githubRepository: z.string().regex(/^[^/\s]+\/[^/\s]+$/),
+    contextAlias: z.string().regex(/^repo:[A-Za-z0-9._-]+$/).optional(),
+    pullRequestUrl: z.string().url(),
+    baseCommit: gitCommitSchema,
+    headCommit: gitCommitSchema,
+    changedFiles: z.array(z.string().min(1)).min(1).max(10_000),
+    diffSha256: sha256Schema,
+  }).strict().optional(),
+  exposure: z.object({
+    state: z.enum(["no-m5-evidence", "m5-exposed", "unknown"]),
+    models: z.array(z.string().min(1)),
+    evidence: z.array(z.string().min(1)),
+  }).strict(),
+  lane: z.enum(["provisional-holdout", "regression", "quarantine"]),
+  readiness: z.enum(["needs-independent-verifier", "quarantined"]),
+  reasons: z.array(z.string().min(1)),
+  contentPolicy: z.literal("content-blind-references-only"),
+}).strict();
+export type DailyExamCandidate = z.infer<typeof dailyExamCandidateSchema>;
+
+export const dailyExamManifestSchema = z.object({
+  schemaVersion: z.literal(1),
+  generatedAt: z.string().min(1),
+  source: z.literal("hugin-munin-daily-tasks"),
+  contentPolicy: z.literal("content-blind-references-only"),
+  historyComplete: z.boolean(),
+  inspectedTasks: z.number().int().nonnegative(),
+  counts: z.object({
+    provisionalHoldout: z.number().int().nonnegative(),
+    regression: z.number().int().nonnegative(),
+    quarantine: z.number().int().nonnegative(),
+  }).strict(),
+  candidates: z.array(dailyExamCandidateSchema),
+}).strict();
+export type DailyExamManifest = z.infer<typeof dailyExamManifestSchema>;
+
+export interface DailyTaskHarvestSource {
+  status: MuninEntry;
+  resultStructured?: MuninEntry | null;
+}
+
+function sha256(value: string | Buffer): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function field(content: string, label: string): string | undefined {
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return content.match(new RegExp(`\\*\\*${escaped}:\\*\\*\\s*(.+)`, "i"))?.[1]?.trim();
+}
+
+function promptFromTask(content: string): string | undefined {
+  const prompt = content.match(/###\s*Prompt\s*\n([\s\S]+)$/i)?.[1]?.trim();
+  return prompt || undefined;
+}
+
+function contextAliasFromTask(content: string): string | undefined {
+  const context = field(content, "Context");
+  return context && /^repo:[A-Za-z0-9._-]+$/.test(context) ? context : undefined;
+}
+
+function githubRepositoryFromPr(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname.toLowerCase() !== "github.com") return undefined;
+    const match = parsed.pathname.match(/^\/([^/]+)\/([^/]+)\/pull\/\d+\/?$/);
+    return match ? `${match[1]}/${match[2]}` : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function parseStructuredResult(content: string | undefined): StructuredTaskResult | undefined {
+  if (!content) return undefined;
+  try {
+    const parsed = structuredTaskResultSchema.safeParse(JSON.parse(content));
+    return parsed.success ? parsed.data : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function exposureFor(result: StructuredTaskResult | undefined): DailyExamCandidate["exposure"] {
+  if (!result) return { state: "unknown", models: [], evidence: ["structured-result-unavailable"] };
+  const models = new Set<string>();
+  const evidence = new Set<string>();
+  const delegation = result.runtimeMetadata?.delegation;
+  if (result.runtimeMetadata?.effectiveModel) models.add(result.runtimeMetadata.effectiveModel);
+  if (delegation?.modelId) models.add(delegation.modelId);
+  if (delegation) evidence.add("runtime-m5-delegation-provenance");
+  if (result.runtimeMetadata?.effectiveHost?.toLowerCase() === "m5") {
+    evidence.add("runtime-effective-host-m5");
+  }
+  if (result.runtime === "homeserver") evidence.add("runtime-homeserver");
+  if (result.runtime === "opencode") evidence.add("runtime-opencode-m5");
+
+  for (const outcome of result.orchestratorOutcomes ?? []) {
+    if (outcome.delegation?.modelId) models.add(outcome.delegation.modelId);
+    if (outcome.delegation || outcome.provider.toLowerCase() === "homeserver") {
+      evidence.add(`orchestrator-m5-leaf:${outcome.subtaskId}`);
+    }
+  }
+
+  if (evidence.size > 0) {
+    return { state: "m5-exposed", models: [...models].sort(), evidence: [...evidence].sort() };
+  }
+  if (["claude", "codex", "ollama"].includes(result.runtime)) {
+    return {
+      state: "no-m5-evidence",
+      models: [...models].sort(),
+      evidence: [`completed-via-${result.runtime}`],
+    };
+  }
+  if (result.runtime === "orchestrator" && (result.orchestratorOutcomes?.length ?? 0) > 0) {
+    return {
+      state: "no-m5-evidence",
+      models: [...models].sort(),
+      evidence: ["orchestrator-outcomes-have-no-m5-leaf"],
+    };
+  }
+  return { state: "unknown", models: [...models].sort(), evidence: ["runtime-exposure-ambiguous"] };
+}
+
+function taskTypeFromTags(tags: readonly string[]): string | undefined {
+  return tags
+    .find((tag) => tag.startsWith("type:") && !tag.startsWith("type:task-result"))
+    ?.slice("type:".length);
+}
+
+/**
+ * Convert one completed daily task into content-blind exam-candidate metadata.
+ * "No M5 evidence" is intentionally only provisional: Hugin cannot prove the
+ * same prompt was not shown through another client, so a later exposure-ledger
+ * check remains mandatory before a candidate is sealed as a holdout.
+ */
+export function buildDailyExamCandidate(source: DailyTaskHarvestSource): DailyExamCandidate {
+  const taskDocument = source.status.content;
+  const prompt = promptFromTask(taskDocument);
+  const resultContent = source.resultStructured?.content;
+  const result = parseStructuredResult(resultContent);
+  const exposure = exposureFor(result);
+  const contextAlias = contextAliasFromTask(taskDocument);
+  const githubRepository = githubRepositoryFromPr(result?.prUrl);
+  const change = result?.repositoryChange;
+  const sensitivity = result?.sensitivity?.effective;
+  const sourceClassification = source.status.classification?.trim().toLowerCase();
+  const sourceClassificationIsPrivate = Boolean(
+    sourceClassification && !["public", "internal"].includes(sourceClassification),
+  );
+  const reasons: string[] = [];
+
+  if (!source.status.tags.includes("completed")) reasons.push("source-task-not-completed");
+  if (!prompt) reasons.push("task-prompt-missing");
+  if (!result) reasons.push("valid-result-structured-missing");
+  if (result && (result.lifecycle !== "completed" || result.outcome !== "completed")) {
+    reasons.push("structured-result-not-completed");
+  }
+  if (!change) reasons.push("repository-change-evidence-missing");
+  if (!result?.prUrl || !githubRepository) reasons.push("github-pull-request-binding-missing");
+  if (!contextAlias) reasons.push("portable-repo-context-missing");
+  if (!sensitivity) reasons.push("task-sensitivity-evidence-missing");
+  if (sensitivity === "private") reasons.push("private-task-not-eligible-for-automatic-packaging");
+  if (sourceClassificationIsPrivate) reasons.push("source-classification-not-eligible-for-automatic-packaging");
+  if (exposure.state === "unknown") reasons.push("m5-exposure-unknown");
+
+  const repository = sensitivity !== "private" && !sourceClassificationIsPrivate && change && result?.prUrl && githubRepository
+    ? {
+        githubRepository,
+        ...(contextAlias ? { contextAlias } : {}),
+        pullRequestUrl: result.prUrl,
+        ...change,
+      }
+    : undefined;
+
+  const quarantine = reasons.length > 0;
+  const lane: DailyExamCandidate["lane"] = quarantine
+    ? "quarantine"
+    : exposure.state === "m5-exposed"
+      ? "regression"
+      : "provisional-holdout";
+  if (!quarantine) reasons.push(
+    lane === "regression"
+      ? "already-exposed-to-m5-use-only-as-regression"
+      : "requires-cross-client-exposure-check-before-holdout-seal",
+    "independent-verifier-required",
+  );
+
+  const identity = JSON.stringify({
+    taskNamespace: source.status.namespace,
+    taskDocumentSha256: sha256(taskDocument),
+    promptSha256: prompt ? sha256(prompt) : null,
+    baseCommit: change?.baseCommit ?? null,
+    headCommit: change?.headCommit ?? null,
+    diffSha256: change?.diffSha256 ?? null,
+  });
+  const candidate: DailyExamCandidate = {
+    schemaVersion: 1,
+    candidateId: `daily-${sha256(identity).slice(0, 24)}`,
+    source: {
+      taskNamespace: source.status.namespace,
+      taskId: result?.taskId ?? source.status.namespace.replace(/^tasks\//, ""),
+      statusUpdatedAt: source.status.updated_at,
+      taskDocumentSha256: sha256(taskDocument),
+      ...(prompt ? { promptSha256: sha256(prompt) } : {}),
+      ...(resultContent ? { structuredResultSha256: sha256(resultContent) } : {}),
+      ...(result?.runtime ? { runtime: result.runtime } : {}),
+      ...(taskTypeFromTags(source.status.tags)
+        ? { taskType: taskTypeFromTags(source.status.tags) }
+        : {}),
+      ...(sensitivity ? { sensitivity } : {}),
+    },
+    repository,
+    exposure,
+    lane,
+    readiness: quarantine ? "quarantined" : "needs-independent-verifier",
+    reasons,
+    contentPolicy: "content-blind-references-only",
+  };
+  return dailyExamCandidateSchema.parse(candidate);
+}
+
+export function buildDailyExamManifest(input: {
+  generatedAt: string;
+  historyComplete: boolean;
+  sources: DailyTaskHarvestSource[];
+}): DailyExamManifest {
+  const candidates = input.sources
+    .map(buildDailyExamCandidate)
+    .sort((a, b) => a.candidateId.localeCompare(b.candidateId));
+  return dailyExamManifestSchema.parse({
+    schemaVersion: 1,
+    generatedAt: input.generatedAt,
+    source: "hugin-munin-daily-tasks",
+    contentPolicy: "content-blind-references-only",
+    historyComplete: input.historyComplete,
+    inspectedTasks: input.sources.length,
+    counts: {
+      provisionalHoldout: candidates.filter((candidate) => candidate.lane === "provisional-holdout").length,
+      regression: candidates.filter((candidate) => candidate.lane === "regression").length,
+      quarantine: candidates.filter((candidate) => candidate.lane === "quarantine").length,
+    },
+    candidates,
+  });
+}

--- a/src/task-helpers.ts
+++ b/src/task-helpers.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
 import * as path from "node:path";
 import type { MuninEntry, MuninQueryResult, MuninReadResult } from "./munin-client.js";
 
@@ -436,12 +437,15 @@ export interface TaskBranchOptions {
    * can never branch a production checkout.
    */
   reposRoot?: string;
+  /** Pin origin/main before the agent runs so later exam evidence cannot trust an agent-mutated ref. */
+  captureBaseCommit?: boolean;
 }
 
 export interface TaskBranchResult {
   /** skipped: not a managed git repo; created: branch ready; fetch-failed: network error, no branch */
   action: "skipped" | "created" | "fetch-failed";
   branchName?: string;
+  baseCommit?: string;
   error?: string;
 }
 
@@ -449,7 +453,28 @@ export interface BranchFinalizeResult {
   action: "skipped" | "no-changes" | "pr-created" | "push-failed";
   prUrl?: string;
   branchName?: string;
+  repositoryChange?: RepositoryChangeEvidence;
+  repositoryChangeError?: string;
   error?: string;
+}
+
+/**
+ * Content-blind binding for turning a completed managed-repository task into a
+ * reproducible evaluation candidate. The task prompt/result remain in Munin;
+ * this record only pins the exact before/after trees and their changed paths.
+ */
+export interface RepositoryChangeEvidence {
+  baseCommit: string;
+  headCommit: string;
+  changedFiles: string[];
+  diffSha256: string;
+}
+
+export interface BranchFinalizeOptions {
+  /** Capture exact before/after repository evidence for the daily exam factory. */
+  captureRepositoryChange?: boolean;
+  /** Pre-agent origin/main commit returned by checkoutTaskBranch. */
+  baseCommit?: string;
 }
 
 const DEFAULT_FETCH_RETRY_DELAYS_MS = [500, 2000];
@@ -565,6 +590,19 @@ export async function checkoutTaskBranch(
     };
   }
 
+  let baseCommit: string | undefined;
+  if (options.captureBaseCommit) {
+    const base = await runGitCapture(workingDir, ["rev-parse", "origin/main"]);
+    const candidate = base.stdout.toString("utf8").trim().toLowerCase();
+    if (!base.ok || !/^[0-9a-f]{40,64}$/.test(candidate)) {
+      return {
+        action: "fetch-failed",
+        error: `Failed to pin origin/main before task execution: ${base.stderr || "invalid commit id"}`,
+      };
+    }
+    baseCommit = candidate;
+  }
+
   const branchName = `hugin/${taskId}`;
 
   const checkoutOk = await new Promise<boolean>((resolve) => {
@@ -593,7 +631,7 @@ export async function checkoutTaskBranch(
   }
 
   console.log(`Pre-task: checked out branch ${branchName} from origin/main in ${workingDir}`);
-  return { action: "created", branchName };
+  return { action: "created", branchName, baseCommit };
 }
 
 /**
@@ -613,6 +651,7 @@ export async function finalizeTaskBranch(
   branchName: string,
   prBody: string,
   allowedEgressHosts: string[],
+  options: BranchFinalizeOptions = {},
 ): Promise<BranchFinalizeResult> {
   // Auto-commit uncommitted changes (task may have written files without committing)
   const isDirty = await new Promise<boolean>((resolve) => {
@@ -674,6 +713,22 @@ export async function finalizeTaskBranch(
     return { action: "no-changes" };
   }
 
+  let repositoryChange: RepositoryChangeEvidence | undefined;
+  let repositoryChangeError: string | undefined;
+  if (options.captureRepositoryChange) {
+    const captured = await captureRepositoryChange(workingDir, options.baseCommit);
+    repositoryChange = captured.evidence;
+    repositoryChangeError = captured.error;
+    if (repositoryChangeError) {
+      // Evidence capture must never discard a successful task or prevent its
+      // PR from being delivered. The harvester will quarantine this task until
+      // the missing binding is repaired independently.
+      console.warn(
+        `Post-task repository evidence unavailable for ${branchName}: ${repositoryChangeError}`,
+      );
+    }
+  }
+
   // Egress check
   const remoteUrl = await new Promise<string | null>((resolve) => {
     const child = spawn("git", ["remote", "get-url", "--push", "origin"], {
@@ -689,7 +744,13 @@ export async function finalizeTaskBranch(
 
   if (!remoteUrl || !isRemoteHostAllowed(remoteUrl, allowedEgressHosts)) {
     console.warn(`Post-task git push skipped in ${workingDir}: remote missing or not in egress allowlist`);
-    return { action: "push-failed", branchName, error: "Remote not allowed by egress policy" };
+    return {
+      action: "push-failed",
+      branchName,
+      repositoryChange,
+      repositoryChangeError,
+      error: "Remote not allowed by egress policy",
+    };
   }
 
   // Push branch
@@ -712,18 +773,109 @@ export async function finalizeTaskBranch(
   });
 
   if (!pushOk) {
-    return { action: "push-failed", branchName, error: "git push failed" };
+    return {
+      action: "push-failed",
+      branchName,
+      repositoryChange,
+      repositoryChangeError,
+      error: "git push failed",
+    };
   }
 
   // Open PR
   const taskId = branchName.replace(/^hugin\//, "");
   const prUrl = await createPullRequest(workingDir, branchName, taskId, prBody);
   if (!prUrl) {
-    return { action: "push-failed", branchName, error: "gh pr create failed" };
+    return {
+      action: "push-failed",
+      branchName,
+      repositoryChange,
+      repositoryChangeError,
+      error: "gh pr create failed",
+    };
   }
 
   console.log(`Post-task: PR created: ${prUrl}`);
-  return { action: "pr-created", prUrl, branchName };
+  return {
+    action: "pr-created",
+    prUrl,
+    branchName,
+    repositoryChange,
+    repositoryChangeError,
+  };
+}
+
+async function runGitCapture(
+  workingDir: string,
+  args: string[],
+): Promise<{ ok: boolean; stdout: Buffer; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn("git", args, {
+      cwd: workingDir,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, HOME: "/home/magnus" },
+    });
+    const stdout: Buffer[] = [];
+    let stderr = "";
+    child.stdout?.on("data", (chunk: Buffer) => stdout.push(Buffer.from(chunk)));
+    child.stderr?.on("data", (chunk: Buffer) => (stderr += chunk.toString()));
+    child.on("close", (code) => resolve({
+      ok: code === 0,
+      stdout: Buffer.concat(stdout),
+      stderr: stderr.trim(),
+    }));
+    child.on("error", (err) => resolve({
+      ok: false,
+      stdout: Buffer.alloc(0),
+      stderr: err.message,
+    }));
+  });
+}
+
+async function captureRepositoryChange(
+  workingDir: string,
+  preTaskBaseCommit: string | undefined,
+): Promise<{ evidence?: RepositoryChangeEvidence; error?: string }> {
+  const baseCommit = preTaskBaseCommit?.trim().toLowerCase();
+  if (!baseCommit || !/^[0-9a-f]{40,64}$/.test(baseCommit)) {
+    return { error: "pre-task base commit is unavailable or invalid" };
+  }
+  const head = await runGitCapture(workingDir, ["rev-parse", "HEAD"]);
+  if (!head.ok) return { error: `git rev-parse HEAD failed: ${head.stderr || "unknown"}` };
+  const headCommit = head.stdout.toString("utf8").trim().toLowerCase();
+  if (!/^[0-9a-f]{40,64}$/.test(headCommit)) {
+    return { error: "git returned an invalid head commit id" };
+  }
+  if (baseCommit === headCommit) return { error: "base and head commits are identical" };
+
+  const range = `${baseCommit}..${headCommit}`;
+  const names = await runGitCapture(workingDir, [
+    "diff", "--name-only", "-z", "--no-ext-diff", range,
+  ]);
+  if (!names.ok) return { error: `git diff --name-only failed: ${names.stderr || "unknown"}` };
+  const changedFiles = names.stdout
+    .toString("utf8")
+    .split("\0")
+    .filter(Boolean);
+  if (changedFiles.length === 0) return { error: "commit range contains no changed files" };
+  if (changedFiles.some((file) => path.isAbsolute(file) || file.split("/").includes(".."))) {
+    return { error: "git returned an unsafe changed-file path" };
+  }
+
+  const diff = await runGitCapture(workingDir, [
+    "diff", "--binary", "--no-ext-diff", "--no-textconv", range,
+  ]);
+  if (!diff.ok) return { error: `git diff --binary failed: ${diff.stderr || "unknown"}` };
+  if (diff.stdout.length === 0) return { error: "commit range contains an empty diff" };
+
+  return {
+    evidence: {
+      baseCommit,
+      headCommit,
+      changedFiles,
+      diffSha256: createHash("sha256").update(diff.stdout).digest("hex"),
+    },
+  };
 }
 
 async function cleanupLocalBranch(workingDir: string, branchName: string): Promise<void> {

--- a/src/task-result-schema.ts
+++ b/src/task-result-schema.ts
@@ -289,6 +289,36 @@ export type TaskSubmissionProvenance = z.infer<
   typeof taskSubmissionProvenanceSchema
 >;
 
+// Exact, content-blind repository binding for completed managed-checkout work.
+// This is deliberately optional for historical/non-code tasks and contains no
+// prompt, answer, diff, credential, or file contents. It lets the offline exam
+// factory reconstruct the exact before/after trees from Git without trusting
+// an agent's prose claim that it edited or tested something.
+export const repositoryChangeEvidenceSchema = z.object({
+  baseCommit: z.string().regex(/^[0-9a-f]{40,64}$/),
+  headCommit: z.string().regex(/^[0-9a-f]{40,64}$/),
+  changedFiles: z.array(z.string().min(1)).min(1).max(10_000),
+  diffSha256: z.string().regex(/^[0-9a-f]{64}$/),
+}).strict().superRefine((value, ctx) => {
+  if (value.baseCommit === value.headCommit) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["headCommit"],
+      message: "head commit must differ from base commit",
+    });
+  }
+  value.changedFiles.forEach((file, index) => {
+    if (file.startsWith("/") || file.split("/").includes("..") || file.includes("\0")) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["changedFiles", index],
+        message: "changed file must be a safe repository-relative path",
+      });
+    }
+  });
+});
+export type RepositoryChangeEvidence = z.infer<typeof repositoryChangeEvidenceSchema>;
+
 export const structuredTaskResultSchema = z.object({
   schemaVersion: z.literal(1),
   taskId: z.string().min(1),
@@ -316,6 +346,7 @@ export const structuredTaskResultSchema = z.object({
   bodyText: z.string(),
   errorMessage: z.string().min(1).optional(),
   prUrl: z.string().url().optional(),
+  repositoryChange: repositoryChangeEvidenceSchema.optional(),
   runtimeMetadata: taskExecutionRuntimeMetadataSchema.optional(),
   pipeline: taskExecutionPipelineContextSchema.optional(),
   approval: taskExecutionApprovalMetadataSchema.optional(),

--- a/tests/daily-exam-cli.test.ts
+++ b/tests/daily-exam-cli.test.ts
@@ -1,0 +1,56 @@
+import {
+  lstatSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  parseArgs,
+  writeManifestFile,
+} from "../scripts/harvest-daily-exam-candidates.js";
+
+describe("daily exam factory CLI", () => {
+  it("normalizes timestamps and keeps a bounded default", () => {
+    expect(parseArgs(["--since", "2026-07-14T10:00:00+02:00"])).toEqual({
+      since: "2026-07-14T08:00:00.000Z",
+      limit: 500,
+    });
+  });
+
+  it("rejects an inverted time window", () => {
+    expect(() => parseArgs([
+      "--since", "2026-07-15T00:00:00Z",
+      "--until", "2026-07-14T00:00:00Z",
+    ])).toThrow("--since must not be later than --until");
+  });
+
+  it("rejects unbounded or unknown options", () => {
+    expect(() => parseArgs(["--limit", "10001"])).toThrow("--limit");
+    expect(() => parseArgs(["--publish", "yes"])).toThrow("unknown option");
+  });
+
+  it("atomically writes mode-0600 output without following a destination symlink", () => {
+    const dir = mkdtempSync(join(tmpdir(), "hugin-daily-exam-cli-"));
+    try {
+      const victim = join(dir, "victim.txt");
+      const output = join(dir, "manifest.json");
+      writeFileSync(victim, "do-not-overwrite", "utf8");
+      symlinkSync(victim, output);
+
+      writeManifestFile(output, "{\"ok\":true}\n");
+
+      expect(readFileSync(victim, "utf8")).toBe("do-not-overwrite");
+      expect(lstatSync(output).isSymbolicLink()).toBe(false);
+      expect(readFileSync(output, "utf8")).toBe("{\"ok\":true}\n");
+      expect(statSync(output).mode & 0o777).toBe(0o600);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/daily-task-exam-factory.test.ts
+++ b/tests/daily-task-exam-factory.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import type { MuninEntry } from "../src/munin-client.js";
+import {
+  buildDailyExamCandidate,
+  buildDailyExamManifest,
+} from "../src/learning/daily-task-exam-factory.js";
+import { buildStructuredTaskResult } from "../src/task-result-schema.js";
+
+const BASE = "a".repeat(40);
+const HEAD = "b".repeat(40);
+const DIFF = "c".repeat(64);
+
+function entry(input: Partial<MuninEntry> & Pick<MuninEntry, "namespace" | "key" | "content">): MuninEntry {
+  return {
+    id: `${input.namespace}/${input.key}`,
+    tags: [],
+    classification: "internal",
+    created_at: "2026-07-14T10:00:00.000Z",
+    updated_at: "2026-07-14T11:00:00.000Z",
+    ...input,
+  };
+}
+
+function taskDocument(runtime = "claude"): string {
+  return `## Task: Repair the parser
+
+- **Runtime:** ${runtime}
+- **Context:** repo:demo
+- **Sensitivity:** internal
+
+### Prompt
+Fix the parser and add a regression test.`;
+}
+
+function resultContent(runtime: "claude" | "homeserver" = "claude"): string {
+  return JSON.stringify(buildStructuredTaskResult({
+    schemaVersion: 1,
+    taskId: "daily-1",
+    taskNamespace: "tasks/daily-1",
+    lifecycle: "completed",
+    outcome: "completed",
+    runtime,
+    executor: runtime === "homeserver" ? "homeserver-delegate" : "claude-sdk",
+    resultSource: runtime === "homeserver" ? "homeserver-delegate" : "sdk-result",
+    exitCode: 0,
+    completedAt: "2026-07-14T11:00:00.000Z",
+    bodyKind: "response",
+    bodyText: "Sensitive answer text that must not enter the candidate manifest",
+    prUrl: "https://github.com/Magnus-Gille/demo/pull/42",
+    repositoryChange: {
+      baseCommit: BASE,
+      headCommit: HEAD,
+      changedFiles: ["src/parser.ts", "tests/parser.test.ts"],
+      diffSha256: DIFF,
+    },
+    sensitivity: { declared: "internal", effective: "internal", mismatch: false },
+    ...(runtime === "homeserver"
+      ? {
+          runtimeMetadata: {
+            effectiveHost: "m5",
+            effectiveModel: "qwen3-coder-next-80b",
+            delegation: {
+              delegated: true,
+              nodeId: "m5",
+              modelId: "qwen3-coder-next-80b",
+              ledgerId: "ledger-1",
+            },
+          },
+        }
+      : {}),
+  }));
+}
+
+function source(runtime: "claude" | "homeserver" = "claude") {
+  return {
+    status: entry({
+      namespace: "tasks/daily-1",
+      key: "status",
+      content: taskDocument(runtime),
+      tags: ["completed", "runtime:claude", "type:code-repair"],
+    }),
+    resultStructured: entry({
+      namespace: "tasks/daily-1",
+      key: "result-structured",
+      content: resultContent(runtime),
+      tags: ["type:task-result", "type:task-result-structured"],
+    }),
+  };
+}
+
+describe("daily task exam factory", () => {
+  it("turns cloud-completed repository work into a provisional, content-blind holdout candidate", () => {
+    const candidate = buildDailyExamCandidate(source("claude"));
+    expect(candidate.lane).toBe("provisional-holdout");
+    expect(candidate.readiness).toBe("needs-independent-verifier");
+    expect(candidate.exposure.state).toBe("no-m5-evidence");
+    expect(candidate.repository).toEqual(expect.objectContaining({
+      githubRepository: "Magnus-Gille/demo",
+      contextAlias: "repo:demo",
+      baseCommit: BASE,
+      headCommit: HEAD,
+      diffSha256: DIFF,
+    }));
+    const serialized = JSON.stringify(candidate);
+    expect(serialized).not.toContain("Fix the parser");
+    expect(serialized).not.toContain("Sensitive answer text");
+    expect(candidate.reasons).toContain("requires-cross-client-exposure-check-before-holdout-seal");
+  });
+
+  it("routes a task already seen by M5 to regression rather than a holdout", () => {
+    const candidate = buildDailyExamCandidate(source("homeserver"));
+    expect(candidate.lane).toBe("regression");
+    expect(candidate.exposure.state).toBe("m5-exposed");
+    expect(candidate.exposure.models).toContain("qwen3-coder-next-80b");
+    expect(candidate.reasons).toContain("already-exposed-to-m5-use-only-as-regression");
+  });
+
+  it("quarantines historical tasks without exact repository evidence", () => {
+    const historical = source("claude");
+    const parsed = JSON.parse(historical.resultStructured.content) as Record<string, unknown>;
+    delete parsed.repositoryChange;
+    historical.resultStructured.content = JSON.stringify(parsed);
+    const candidate = buildDailyExamCandidate(historical);
+    expect(candidate.lane).toBe("quarantine");
+    expect(candidate.readiness).toBe("quarantined");
+    expect(candidate.reasons).toContain("repository-change-evidence-missing");
+  });
+
+  it("quarantines malformed results instead of trusting result prose", () => {
+    const malformed = source("claude");
+    malformed.resultStructured.content = "not json";
+    const candidate = buildDailyExamCandidate(malformed);
+    expect(candidate.lane).toBe("quarantine");
+    expect(candidate.exposure.state).toBe("unknown");
+    expect(candidate.reasons).toContain("valid-result-structured-missing");
+  });
+
+  it("omits repository metadata when quarantining a private task", () => {
+    const privateTask = source("claude");
+    const parsed = JSON.parse(privateTask.resultStructured.content) as Record<string, unknown>;
+    parsed.sensitivity = { declared: "private", effective: "private", mismatch: false };
+    privateTask.resultStructured.content = JSON.stringify(parsed);
+    const candidate = buildDailyExamCandidate(privateTask);
+    expect(candidate.lane).toBe("quarantine");
+    expect(candidate.repository).toBeUndefined();
+    expect(candidate.reasons).toContain("private-task-not-eligible-for-automatic-packaging");
+  });
+
+  it("fails closed when Munin classification is more sensitive than the result snapshot", () => {
+    const classified = source("claude");
+    classified.status.classification = "client-confidential";
+    const candidate = buildDailyExamCandidate(classified);
+    expect(candidate.lane).toBe("quarantine");
+    expect(candidate.repository).toBeUndefined();
+    expect(candidate.reasons).toContain("source-classification-not-eligible-for-automatic-packaging");
+  });
+
+  it("builds deterministic candidate IDs and honest manifest counts", () => {
+    const cloud = source("claude");
+    const m5 = source("homeserver");
+    m5.status.namespace = "tasks/daily-2";
+    m5.status.id = "tasks/daily-2/status";
+    const parsed = JSON.parse(m5.resultStructured.content) as Record<string, unknown>;
+    parsed.taskId = "daily-2";
+    parsed.taskNamespace = "tasks/daily-2";
+    m5.resultStructured.namespace = "tasks/daily-2";
+    m5.resultStructured.id = "tasks/daily-2/result-structured";
+    m5.resultStructured.content = JSON.stringify(parsed);
+
+    const one = buildDailyExamCandidate(cloud);
+    const two = buildDailyExamCandidate(cloud);
+    expect(one.candidateId).toBe(two.candidateId);
+
+    const manifest = buildDailyExamManifest({
+      generatedAt: "2026-07-14T12:00:00.000Z",
+      historyComplete: false,
+      sources: [cloud, m5],
+    });
+    expect(manifest.historyComplete).toBe(false);
+    expect(manifest.counts).toEqual({ provisionalHoldout: 1, regression: 1, quarantine: 0 });
+  });
+});

--- a/tests/repo-sync.test.ts
+++ b/tests/repo-sync.test.ts
@@ -103,6 +103,31 @@ describe("checkoutTaskBranch", () => {
     expect(checkoutCall.args).toEqual(["checkout", "-b", "hugin/task-123", "origin/main"]);
   });
 
+  it("pins origin/main before checkout when repository evidence is requested", async () => {
+    const base = "a".repeat(40);
+    spawnBehaviors = [
+      { exitCode: 0 },
+      { exitCode: 0 },
+      { exitCode: 0 },
+      { exitCode: 0, stdout: `${base}\n` },
+      { exitCode: 0 },
+    ];
+    const result = await checkoutTaskBranch(
+      "/home/magnus/repos/grimnir",
+      "task-pinned",
+      { fetchRetryDelaysMs: [0, 0], captureBaseCommit: true },
+    );
+    expect(result).toEqual({
+      action: "created",
+      branchName: "hugin/task-pinned",
+      baseCommit: base,
+    });
+    expect(spawnCalls[3].args).toEqual(["rev-parse", "origin/main"]);
+    expect(spawnCalls[4].args).toEqual([
+      "checkout", "-b", "hugin/task-pinned", "origin/main",
+    ]);
+  });
+
   it("honors a configured reposRoot: treats it as managed (#139)", async () => {
     spawnBehaviors = [
       { exitCode: 0 }, // git rev-parse --git-dir
@@ -315,6 +340,41 @@ describe("finalizeTaskBranch", () => {
     const pushCall = spawnCalls.find((c) => c.args.includes("push"));
     expect(pushCall?.args).toContain("-u");
     expect(pushCall?.args).toContain("hugin/task-xyz");
+  });
+
+  it("captures exact content-blind repository evidence when requested", async () => {
+    const base = "a".repeat(40);
+    const head = "b".repeat(40);
+    spawnBehaviors = [
+      { exitCode: 0, stdout: "" },
+      { exitCode: 0, stdout: "1\n" },
+      { exitCode: 0, stdout: `${head}\n` },
+      { exitCode: 0, stdout: "src/parser.ts\0tests/parser.test.ts\0" },
+      { exitCode: 0, stdout: "diff --git a/src/parser.ts b/src/parser.ts\n" },
+      { exitCode: 0, stdout: "git@github.com:Magnus-Gille/grimnir.git\n" },
+      { exitCode: 0 },
+      { exitCode: 0, stdout: "https://github.com/Magnus-Gille/grimnir/pull/8\n" },
+    ];
+    const result = await finalizeTaskBranch(
+      "/home/magnus/repos/grimnir",
+      "hugin/task-evidence",
+      "body",
+      allowedHosts,
+      { captureRepositoryChange: true, baseCommit: base },
+    );
+    expect(result.action).toBe("pr-created");
+    expect(result.repositoryChange).toEqual(expect.objectContaining({
+      baseCommit: base,
+      headCommit: head,
+      changedFiles: ["src/parser.ts", "tests/parser.test.ts"],
+      diffSha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+    }));
+    expect(spawnCalls[3].args).toEqual([
+      "diff", "--name-only", "-z", "--no-ext-diff", `${base}..${head}`,
+    ]);
+    expect(spawnCalls[4].args).toEqual([
+      "diff", "--binary", "--no-ext-diff", "--no-textconv", `${base}..${head}`,
+    ]);
   });
 
   it("returns push-failed when remote is not in egress allowlist", async () => {

--- a/tests/task-result-schema.test.ts
+++ b/tests/task-result-schema.test.ts
@@ -2,6 +2,25 @@ import { describe, expect, it } from "vitest";
 import { buildStructuredTaskResult } from "../src/task-result-schema.js";
 
 describe("structured task result schema", () => {
+  it("preserves exact content-blind repository change evidence", () => {
+    const result = buildStructuredTaskResult({
+      schemaVersion: 1, taskId: "daily-1", taskNamespace: "tasks/daily-1",
+      lifecycle: "completed", outcome: "completed", runtime: "claude",
+      executor: "claude-sdk", resultSource: "sdk-result", exitCode: 0,
+      completedAt: "2026-07-14T12:00:00Z", bodyKind: "response", bodyText: "ok",
+      repositoryChange: {
+        baseCommit: "a".repeat(40),
+        headCommit: "b".repeat(40),
+        changedFiles: ["src/parser.ts", "tests/parser.test.ts"],
+        diffSha256: "c".repeat(64),
+      },
+    });
+    expect(result.repositoryChange?.changedFiles).toEqual([
+      "src/parser.ts",
+      "tests/parser.test.ts",
+    ]);
+  });
+
   it("preserves M5 delegation provenance on canonical homeserver results", () => {
     const result = buildStructuredTaskResult({
       schemaVersion: 1, taskId: "mcp-m5-abc", taskNamespace: "tasks/mcp-m5-abc",


### PR DESCRIPTION
## What changed

- bind successful managed-repository tasks to their exact pre-agent base commit, final task-branch commit, changed paths, and binary-diff SHA-256
- add a read-only Munin harvester that classifies real daily work into provisional holdout, regression, or quarantine candidates
- keep candidate output content-blind, mode-0600, and fail closed for privacy, missing sensitivity, incomplete exposure, or missing reproducibility evidence
- document the factory boundary and add focused schema, Git-evidence, privacy, and CLI safety tests

## Why

Daily Hugin usage should be able to grow the evaluation corpus, but a task must not become a trusted exam merely because an agent reported success. This gives the later Harbor workflow exact repository evidence while preserving independent-verifier and freshness gates.

The global cross-client M5 exposure lookup is tracked separately in Magnus-Gille/gille-inference#257. Until that exists, no local M5 evidence means only a provisional holdout.

## Safety boundary

The harvester does not copy prompt, answer, diff, or file contents. It cannot run a model or Harbor, import learning observations, change routing, or promote a challenger. Private and insufficiently classified inputs are quarantined.

## Validation

- `npm run build`
- `npm test` — 108 files / 1,767 tests
- `bash scripts/deploy-pi.test.sh`
- `bash scripts/lib/claude-config-bootstrap.test.sh`
- `npm run harvest:daily-exams -- --help`
- `git diff --check`
