### PR TITLE
Run daily exam factory in production

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,7 @@ hugin/
 │   ├── ollama-executor.ts # Ollama executor (streaming, OpenAI-compatible API)
 │   ├── ollama-hosts.ts    # Lazy host resolution with negative caching
 │   ├── context-loader.ts  # Context-refs resolver (fetch Munin entries for prompt injection)
+│   ├── daily-exam-harvest-cli.ts # Production-built, read-only Munin sweep → mode-0600 candidate manifest
 │   ├── prompt-injection-scanner.ts # Regex scanner for adversarial patterns in context-ref content
 │   ├── exfiltration-scanner.ts   # Regex scanner for data-leak patterns in task output
 │   ├── provenance.ts               # External-vs-trusted provenance detection for context-refs
@@ -146,7 +147,6 @@ hugin/
 │   └── sdk-executor.test.ts
 └── scripts/
     ├── deploy-pi.sh
-    ├── harvest-daily-exam-candidates.ts # Read-only Munin sweep → mode-0600 candidate manifest
     ├── run-m5-code-loop-experiment.ts # Resumable matched Gate D experiment runner
     ├── submit-daily-analysis.sh  # Submit daily journal analysis as ollama task
     ├── sync-claude-config.sh     # DEPRECATED — config now lives in the claude-config repo (bootstrap.sh)
@@ -235,3 +235,10 @@ M5 `/delegate` leaf; the gateway owns model selection and capability evidence.
 The complete envelope is embedded in the task and revalidated at claim time.
 Historical v1 aliases and journal rows remain readable but are never advertised
 or executed. Readiness depends on a valid M5 gateway configuration.
+
+**Daily exam factory:** deployment enables
+`hugin-daily-exam-factory.timer` (05:30 daily, with jitter). Its compiled,
+read-only CLI inspects a rolling 48-hour Munin window and atomically replaces
+the private content-blind manifest at
+`~/.hugin/daily-exam-candidates/latest.json`. It does not run Harbor/models or
+write learning state.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,7 @@
 # Hugin — Status
 
-**Latest session:** 2026-07-14 (Codex) — **daily-use exam factory implemented locally; CI-equivalent suite green**
-**Branch:** `codex/daily-exam-factory` from `main@509e9cd7d50f5ff1ace142f941033ba9bc348238`.
+**Latest session:** 2026-07-14 (Codex) — **daily-use factory merged/deployed; production runner fix validated locally**
+**Main/deployed:** `413c7f4ab610c0ebcdf2c5dcaa7fdd2a4a5f62f1` via merged PR [#207](https://github.com/Magnus-Gille/hugin/pull/207). Fix branch: `codex/daily-exam-factory-runner`.
 
 ## Latest — real Hugin code work can feed quarantined Harbor exam candidates
 
@@ -22,11 +22,16 @@
   The owner-side, content-blind cross-client exposure lookup is routed to
   [gille-inference#257](https://github.com/Magnus-Gille/gille-inference/issues/257).
 - Documentation: `docs/daily-exam-factory.md`. Validation: TypeScript build;
-  focused 4 files / 54 tests; full suite 108 files / 1,767 tests; both exact CI
+  focused 4 files / 55 tests; full suite 108 files / 1,768 tests; both exact CI
   shell suites; CLI help; `git diff --check`.
+- The first post-deploy sweep correctly exposed that production omits the `tsx`
+  dev dependency; sourcing all of `.env` also attempted to execute non-shell
+  values. The focused fix moves the CLI under `src/` so `tsc` ships runnable JS,
+  adds a sandboxed 05:30 systemd timer with a rolling 48-hour window, and makes
+  a content-blind sweep a deployment acceptance gate using `EnvironmentFile=`.
 
-**Next:** review and publish this branch, merge only with green GitHub CI, deploy
-the exact merged Hugin commit, then run the first read-only candidate sweep.
+**Next:** publish the production-runner fix, merge only with green GitHub CI,
+deploy the exact merged commit, and require the first read-only sweep to pass.
 Keep all holdouts provisional until gille-inference#257 provides complete
 cross-client exposure evidence and a reviewed independent verifier is attached.
 

--- a/docs/daily-exam-factory.md
+++ b/docs/daily-exam-factory.md
@@ -47,6 +47,12 @@ The output file is created mode `0600`. Omit `--output` to write JSON to stdout.
 The command reports `historyComplete:false` whenever Munin pagination or the
 caller limit prevents it from proving that the selected history is complete.
 
+Production runs the same compiled CLI from
+`hugin-daily-exam-factory.timer` once per day. It inspects a rolling 48-hour
+window and atomically replaces the private manifest at
+`~/.hugin/daily-exam-candidates/latest.json`. Deployment installs the timer and
+runs one acceptance sweep; the timer never invokes Harbor or a model.
+
 ## Safety boundary and next stage
 
 The factory does not:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:pii-fixtures": "tsx scripts/build-pii-fixtures.ts",
     "eval:pii": "tsx scripts/run-pii-eval.ts",
     "experiment:m5-code-loop": "tsx scripts/run-m5-code-loop-experiment.ts",
-    "harvest:daily-exams": "tsx scripts/harvest-daily-exam-candidates.ts",
+    "harvest:daily-exams": "node dist/daily-exam-harvest-cli.js",
     "pilot:harbor": "tsx scripts/harbor_pilot/run-pilot.ts",
     "pilot:harbor:import": "tsx scripts/harbor_pilot/import-learning-report.ts",
     "test": "vitest run",

--- a/scripts/deploy-pi.sh
+++ b/scripts/deploy-pi.sh
@@ -117,12 +117,15 @@ ssh "$REMOTE" "
   fi
 "
 
-echo "==> Installing user-level systemd service..."
+echo "==> Installing user-level systemd services..."
 ssh "$REMOTE" "
-  mkdir -p ~/.config/systemd/user
+  mkdir -p ~/.config/systemd/user ~/.hugin/daily-exam-candidates
   cp $REMOTE_DIR/hugin.service ~/.config/systemd/user/hugin.service
+  cp $REMOTE_DIR/systemd/hugin-daily-exam-factory.service ~/.config/systemd/user/hugin-daily-exam-factory.service
+  cp $REMOTE_DIR/systemd/hugin-daily-exam-factory.timer ~/.config/systemd/user/hugin-daily-exam-factory.timer
   XDG_RUNTIME_DIR=/run/user/1000 systemctl --user daemon-reload
   XDG_RUNTIME_DIR=/run/user/1000 systemctl --user enable hugin.service
+  XDG_RUNTIME_DIR=/run/user/1000 systemctl --user enable --now hugin-daily-exam-factory.timer
   loginctl enable-linger magnus 2>/dev/null || true
 "
 
@@ -231,6 +234,13 @@ ssh "$REMOTE" "XDG_RUNTIME_DIR=/run/user/1000 systemctl --user restart hugin.ser
 
 echo "==> Health check..."
 ssh "$REMOTE" "curl -fsS http://127.0.0.1:3032/health"
+
+echo "==> Daily exam factory acceptance..."
+ssh "$REMOTE" "
+  XDG_RUNTIME_DIR=/run/user/1000 systemctl --user start hugin-daily-exam-factory.service
+  test -s /home/$DEPLOY_USER/.hugin/daily-exam-candidates/latest.json
+  /usr/bin/node -e 'const m=JSON.parse(require(\"node:fs\").readFileSync(process.argv[1],\"utf8\")); process.stdout.write(JSON.stringify({generatedAt:m.generatedAt,inspectedTasks:m.inspectedTasks,historyComplete:m.historyComplete,counts:m.counts})+\"\\n\")' /home/$DEPLOY_USER/.hugin/daily-exam-candidates/latest.json
+"
 
 echo ""
 echo "Acceptance gates passed; finalizing deployment."

--- a/scripts/deploy-pi.test.sh
+++ b/scripts/deploy-pi.test.sh
@@ -246,8 +246,11 @@ assert_not_contains "$full_calls" "git reset" "deployment never depends on a rem
 assert_contains "$full_calls" "npm ci --omit=dev" "deployment installs the shipped lockfile deterministically"
 assert_not_contains "$full_calls" "npm install --omit=dev" "deployment never rewrites the shipped lockfile with npm install"
 assert_contains "$full_calls" "curl -fsS http://127.0.0.1:3032/health" "deployment retains the health acceptance gate"
+assert_contains "$full_calls" "enable --now hugin-daily-exam-factory.timer" "deployment enables the automatic daily factory"
+assert_contains "$full_calls" "start hugin-daily-exam-factory.service" "deployment runs a factory acceptance sweep"
 assert_contains "$full_calls" "$full_sha" "deployment stamps the exact local full SHA"
 assert_order "$full_calls" "curl -fsS http://127.0.0.1:3032/health" "mv '/home/magnus/repos/hugin/.deployed-commit.tmp' '/home/magnus/repos/hugin/.deployed-commit'" "health acceptance precedes atomic marker stamp"
+assert_order "$full_calls" "start hugin-daily-exam-factory.service" "mv '/home/magnus/repos/hugin/.deployed-commit.tmp' '/home/magnus/repos/hugin/.deployed-commit'" "factory acceptance precedes atomic marker stamp"
 
 # If the marker cannot be invalidated, the script must not begin payload sync.
 : >"$CALL_LOG"
@@ -276,6 +279,22 @@ export FAKE_SSH_FAIL_MATCH=""
 health_fail_calls="$(cat "$CALL_LOG")"
 assert_contains "$health_fail_calls" "rm -f '/home/magnus/repos/hugin/.deployed-commit'" "failed deployment first invalidates the old marker"
 assert_not_contains "$health_fail_calls" "mv '/home/magnus/repos/hugin/.deployed-commit.tmp' '/home/magnus/repos/hugin/.deployed-commit'" "failed health acceptance remains markerless"
+
+# The automatic factory is part of production acceptance: a broken compiled
+# runner, unit sandbox, Munin credential, or manifest write must also leave the
+# deployed revision markerless.
+: >"$CALL_LOG"
+export FAKE_SSH_FAIL_MATCH="start hugin-daily-exam-factory.service"
+export FAKE_SSH_FAIL_RC=72
+set +e
+(cd "$FULL_SOURCE" && bash "$DEPLOY_SCRIPT" testhost >/dev/null 2>&1)
+factory_fail_rc=$?
+set -e
+export FAKE_SSH_FAIL_MATCH=""
+[[ "$factory_fail_rc" -ne 0 ]] || fail "failed factory acceptance must fail deployment"
+factory_fail_calls="$(cat "$CALL_LOG")"
+assert_contains "$factory_fail_calls" "start hugin-daily-exam-factory.service" "factory failure reaches the new acceptance gate"
+assert_not_contains "$factory_fail_calls" "mv '/home/magnus/repos/hugin/.deployed-commit.tmp' '/home/magnus/repos/hugin/.deployed-commit'" "failed factory acceptance remains markerless"
 
 if [[ "$failures" -gt 0 ]]; then
   echo "$failures assertion(s) failed" >&2

--- a/src/daily-exam-harvest-cli.ts
+++ b/src/daily-exam-harvest-cli.ts
@@ -12,12 +12,12 @@ import {
 import { randomUUID } from "node:crypto";
 import { dirname, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
-import { MuninClient, type MuninEntry } from "../src/munin-client.js";
-import { queryAllMuninEntries } from "../src/munin-pagination.js";
+import { MuninClient, type MuninEntry } from "./munin-client.js";
+import { queryAllMuninEntries } from "./munin-pagination.js";
 import {
   buildDailyExamManifest,
   type DailyTaskHarvestSource,
-} from "../src/learning/daily-task-exam-factory.js";
+} from "./learning/daily-task-exam-factory.js";
 
 interface CliOptions {
   since?: string;
@@ -36,6 +36,7 @@ function usage(): string {
     "",
     "Options:",
     "  --since <ISO>    Only inspect tasks updated at/after this timestamp",
+    "  --lookback-hours <N>  Inspect a rolling window ending now (1..8760)",
     "  --until <ISO>    Only inspect tasks updated at/before this timestamp",
     "  --limit <N>      Maximum task status rows to inspect (default 500)",
     "  --output <path>  Write mode-0600 JSON here instead of stdout",
@@ -49,8 +50,9 @@ function normalizedTimestamp(value: string, flag: string): string {
   return new Date(parsed).toISOString();
 }
 
-export function parseArgs(argv: string[]): CliOptions {
+export function parseArgs(argv: string[], nowMs = Date.now()): CliOptions {
   const options: CliOptions = { limit: 500 };
+  let lookbackHours: number | undefined;
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index]!;
     if (arg === "--help") {
@@ -60,6 +62,13 @@ export function parseArgs(argv: string[]): CliOptions {
     const value = argv[index + 1];
     if (!value) throw new Error(`${arg} requires a value`);
     if (arg === "--since") options.since = normalizedTimestamp(value, arg);
+    else if (arg === "--lookback-hours") {
+      const hours = Number(value);
+      if (!Number.isInteger(hours) || hours < 1 || hours > 8_760) {
+        throw new Error("--lookback-hours must be an integer from 1 to 8760");
+      }
+      lookbackHours = hours;
+    }
     else if (arg === "--until") options.until = normalizedTimestamp(value, arg);
     else if (arg === "--output") options.output = resolve(value);
     else if (arg === "--limit") {
@@ -72,6 +81,12 @@ export function parseArgs(argv: string[]): CliOptions {
       throw new Error(`unknown option: ${arg}`);
     }
     index += 1;
+  }
+  if (options.since && lookbackHours !== undefined) {
+    throw new Error("--since and --lookback-hours are mutually exclusive");
+  }
+  if (lookbackHours !== undefined) {
+    options.since = new Date(nowMs - lookbackHours * 60 * 60 * 1_000).toISOString();
   }
   if (options.since && options.until && options.since > options.until) {
     throw new Error("--since must not be later than --until");

--- a/systemd/hugin-daily-exam-factory.service
+++ b/systemd/hugin-daily-exam-factory.service
@@ -1,0 +1,34 @@
+[Unit]
+Description=Hugin daily-use exam candidate factory (read-only Munin sweep)
+After=network-online.target munin-memory.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/magnus/repos/hugin
+EnvironmentFile=/home/magnus/repos/hugin/.env
+ExecStart=/usr/bin/node dist/daily-exam-harvest-cli.js --lookback-hours 48 --limit 500 --output /home/magnus/.hugin/daily-exam-candidates/latest.json
+TimeoutStartSec=120
+UMask=0077
+
+# The factory reads Hugin/Munin and can only persist its content-blind manifest.
+ProtectSystem=strict
+ProtectHome=read-only
+ReadOnlyPaths=/home/magnus/repos/hugin
+ReadWritePaths=/home/magnus/.hugin/daily-exam-candidates
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictSUIDSGID=yes
+PrivateDevices=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+LockPersonality=yes
+ProtectClock=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+SystemCallArchitectures=native
+
+[Install]
+WantedBy=default.target

--- a/systemd/hugin-daily-exam-factory.timer
+++ b/systemd/hugin-daily-exam-factory.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run Hugin daily-use exam candidate factory every day
+
+[Timer]
+OnCalendar=*-*-* 05:30:00
+Persistent=true
+RandomizedDelaySec=300
+Unit=hugin-daily-exam-factory.service
+
+[Install]
+WantedBy=timers.target

--- a/tests/daily-exam-cli.test.ts
+++ b/tests/daily-exam-cli.test.ts
@@ -13,7 +13,7 @@ import { describe, expect, it } from "vitest";
 import {
   parseArgs,
   writeManifestFile,
-} from "../scripts/harvest-daily-exam-candidates.js";
+} from "../src/daily-exam-harvest-cli.js";
 
 describe("daily exam factory CLI", () => {
   it("normalizes timestamps and keeps a bounded default", () => {
@@ -28,6 +28,18 @@ describe("daily exam factory CLI", () => {
       "--since", "2026-07-15T00:00:00Z",
       "--until", "2026-07-14T00:00:00Z",
     ])).toThrow("--since must not be later than --until");
+  });
+
+  it("computes a bounded rolling window for the daily systemd job", () => {
+    expect(parseArgs(
+      ["--lookback-hours", "48"],
+      Date.parse("2026-07-14T12:00:00.000Z"),
+    )).toEqual({
+      since: "2026-07-12T12:00:00.000Z",
+      limit: 500,
+    });
+    expect(() => parseArgs(["--since", "2026-07-14T00:00:00Z", "--lookback-hours", "48"]))
+      .toThrow("mutually exclusive");
   });
 
   it("rejects unbounded or unknown options", () => {


### PR DESCRIPTION
## What changed

- compile the daily exam harvester into `dist/` so it runs with the production `npm ci --omit=dev` install
- install a sandboxed daily systemd timer that harvests a rolling 48-hour window into a private atomic manifest
- use systemd's `EnvironmentFile=` instead of sourcing the Pi environment as shell code
- make a successful real factory sweep part of transactional deployment acceptance

## Why

The first live sweep after #207 exposed that the TypeScript-only script depended on the omitted `tsx` development package. The Pi environment also contains valid systemd values that are not valid shell syntax. This makes the runner production-native and verifies it before a deploy receives its accepted-commit marker.

## Safety boundary

The scheduled job remains read-only against Munin and writes only the content-blind mode-0600 `latest.json` manifest. It does not run Harbor or a model, import learning evidence, change routing, or promote anything.

## Validation

- `npm run build`
- `npm test` — 108 files / 1,768 tests
- `bash scripts/deploy-pi.test.sh`
- `bash scripts/lib/claude-config-bootstrap.test.sh`
- compiled `npm run harvest:daily-exams -- --help`
- `git diff --check`
