### PR TITLE
Bind Hugin to durable M5 check evidence

### DIFF
--- a/docs/continuous-learning-loop.md
+++ b/docs/continuous-learning-loop.md
@@ -139,7 +139,7 @@ sample's instruction/seed directory/check. Before any remote mutation it:
 1. validates exactly one changed configuration axis;
 2. hashes every instruction, seed file, check command, holdout flag, and protected path and compares
    the result with the declared corpus SHA-256;
-3. verifies that M5 advertises #247's `edit_deadline_turn` contract;
+3. verifies that M5 advertises `edit_deadline_turn` plus durable `client_run_id` starts;
 4. idempotently creates or resumes the Hugin experiment;
 5. runs matched pairs sequentially, counterbalancing which arm runs first;
 6. records only content-blind observations—never diffs, prompts, check output, or seed contents.
@@ -148,12 +148,17 @@ Observation writes are reconciled after ambiguous Broker timeouts: the runner fi
 durable experiment state and retries only an identical, absent `run_id`. This avoids rerunning a
 paid M5 arm merely because Hugin committed the evidence but its HTTP response was lost.
 
-Every `code_loop_start` now carries a deterministic, content-blind `client_run_id` derived from the
-experiment run ID. M5 v4 durably binds that identifier to the canonical request fingerprint before
-execution. A lost start response is retried only with the identical request and therefore recovers
-the original work rather than starting a duplicate paid run. A different request under the same ID
-is an explicit conflict. The runner also binds `client-run-id-v1` and `pi-bash-events-v1` in the
-effective result before accepting an observation.
+Each arm derives a bounded content-blind `client_run_id` from the immutable experiment `run_id`.
+M5 binds that caller id to a canonical request fingerprint before execution. A lost start response
+is retried with the exact same request and id; M5 returns the original running or terminal work
+instead of starting another paid run. Hugin persists the echoed caller id and request fingerprint
+with the observation, and can consume a recovered terminal result directly after a restart.
+
+The v2 result also records immutable content-blind agent-side check events: check kind, command
+fingerprint, timing, pass/fail/execution-error, ordering, and event-stream coverage. It never trusts
+the model summary. `none`, `unobservable`, and `partial` remain distinct. Experiments that need to
+attribute an improvement to genuine agent-side checking should predeclare
+`gates.minChallengerAgentCheckCoverage`; its default is zero for backward compatibility.
 
 An arm may declare a local-only `prompt_prefix_file`. The runner reads it once, verifies every byte
 against that arm's versioned `prompt.sha256`, and prepends it to each corpus instruction. Hugin still
@@ -170,7 +175,7 @@ HUGIN_BROKER_URL=http://huginmunin.<tailnet>.ts.net:3035 \
 HUGIN_BROKER_TOKEN=<keychain-or-env-token> \
 npm run experiment:m5-code-loop -- /path/to/gate-d-wave.json --dry-run
 
-# Remove --dry-run only after the declared M5 harness version is live and preflighted.
+# Remove --dry-run only after the matching gille-inference and Hugin contracts are deployed.
 ```
 
 After mechanical collection, rate each run through `hugin_experiment_rate`. Do not promote while

--- a/docs/continuous-learning-loop.md
+++ b/docs/continuous-learning-loop.md
@@ -139,7 +139,9 @@ sample's instruction/seed directory/check. Before any remote mutation it:
 1. validates exactly one changed configuration axis;
 2. hashes every instruction, seed file, check command, holdout flag, and protected path and compares
    the result with the declared corpus SHA-256;
-3. verifies that M5 advertises `edit_deadline_turn` plus durable `client_run_id` starts;
+3. verifies that M5 advertises the exact
+   `code-loop-pi-2026-07-14-v6` / `pi-bash-events-v3` / schema 3 producer contract,
+   including `edit_deadline_turn` and durable `client_run_id` starts;
 4. idempotently creates or resumes the Hugin experiment;
 5. runs matched pairs sequentially, counterbalancing which arm runs first;
 6. records only content-blind observations—never diffs, prompts, check output, or seed contents.
@@ -154,9 +156,10 @@ is retried with the exact same request and id; M5 returns the original running o
 instead of starting another paid run. Hugin persists the echoed caller id and request fingerprint
 with the observation, and can consume a recovered terminal result directly after a restart.
 
-The v2 result also records immutable content-blind agent-side check events: check kind, command
+The v3 result also records immutable content-blind agent-side check events: check kind, command
 fingerprint, timing, pass/fail/execution-error, ordering, and event-stream coverage. It never trusts
-the model summary. `none`, `unobservable`, and `partial` remain distinct. Experiments that need to
+the model summary. Unparseable NDJSON and refused or uncorrelated check candidates are counted
+separately; `none`, `unobservable`, and `partial` remain distinct. Experiments that need to
 attribute an improvement to genuine agent-side checking should predeclare
 `gates.minChallengerAgentCheckCoverage`; its default is zero for backward compatibility.
 

--- a/docs/harbor-gate-d-pilot.md
+++ b/docs/harbor-gate-d-pilot.md
@@ -100,7 +100,13 @@ That declaration is now consumed by the recorded no-go run. The verifier
 packaging fix deliberately changes the generated verifier/corpus hashes, so the
 old declaration fails binding before inference and must not be reused.
 
-## Run
+## Future fresh campaign
+
+The v2 declaration above was consumed by the completed historical pilot and is
+immutable. Do not rerun it. The active runner requires an explicit, newly
+reviewed declaration and accepts only the deployed
+`code-loop-pi-2026-07-14-v6` / `pi-bash-events-v3` / schema 3 producer contract.
+The following is a template for a separately declared future campaign.
 
 Create an isolated environment and install the pin:
 
@@ -120,8 +126,8 @@ HARBOR_BIN=/private/tmp/hugin-harbor-pilot/venv/bin/harbor \
   HARBOR_TELEMETRY=off \
   npm run pilot:harbor -- \
   --source-repo /Users/magnus/repos/gille-inference \
-  --campaign-id gate-d-fresh-v2-20260714 \
-  --declaration docs/research/harbor-gate-d-v2-declaration-2026-07-14.json \
+  --campaign-id <new-campaign-id> \
+  --declaration <new-reviewed-declaration.json> \
   --task-ids 11-node-path-containment,12-add-csv-cli-format,13-type-safe-slug-tests,14-shared-handle-validation \
   --holdout-ids 11-node-path-containment,12-add-csv-cli-format \
   --network-mode no-network

--- a/docs/harbor-gate-d-pilot.md
+++ b/docs/harbor-gate-d-pilot.md
@@ -163,10 +163,10 @@ observations:
 npm run pilot:harbor:import -- /path/to/pilot-report.json
 ```
 
-`--commit` is the only mutating mode. It creates or resumes the isolated
-`m5-code-edit-harbor-pilot` experiment and appends idempotent host/replay
-observations. It never imports prompts, diffs, verifier logs, or trajectories,
-and never calls the promotion endpoint.
+`--commit` is the only mutating mode. It creates or resumes an isolated
+`harbor-<campaign-id>` experiment in the `m5-code-edit-harbor-pilot` scope and
+appends idempotent host/replay observations. It never imports prompts, diffs,
+verifier logs, or trajectories, and never calls the promotion endpoint.
 
 ## Fresh four-case outcome (2026-07-14)
 

--- a/scripts/harbor_pilot/import-learning-report.ts
+++ b/scripts/harbor_pilot/import-learning-report.ts
@@ -15,6 +15,7 @@ import { BrokerClient, BrokerHttpError } from "../../src/mcp/broker-client.js";
 import { observeDurably } from "../../src/learning/durable-observation.js";
 import {
   computeConfigurationFingerprint,
+  learningAgentChecksSchema,
   learningExperimentCreateSchema,
   learningExperimentStateSchema,
   learningObservationSchema,
@@ -56,15 +57,15 @@ const liveSchema = z.object({
   holdout: z.boolean(),
   reward: z.union([z.literal(0), z.literal(1)]),
   workId: z.string().min(1),
-  clientRunId: z.string().regex(/^[A-Za-z0-9._:-]{1,128}$/),
+  clientRunId: z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/),
   requestFingerprint: z.string().regex(/^sha256:[a-f0-9]{64}$/),
   startCapabilities: z.object({
     start_idempotency: z.literal("client-run-id-v1"),
-    agent_checks: z.literal("pi-bash-events-v1"),
+    agent_checks: z.literal("pi-bash-events-v3"),
   }).passthrough(),
   execution: z.object({
     model: z.string().min(1),
-    harness_version: z.literal("code-loop-pi-2026-07-14-v4"),
+    harness_version: z.literal("code-loop-pi-2026-07-14-v6"),
     effective_caps: z.object({
       wall_s: z.number().int().positive(),
       turns: z.number().int().positive(),
@@ -72,13 +73,10 @@ const liveSchema = z.object({
     }).passthrough(),
     capabilities: z.object({
       start_idempotency: z.literal("client-run-id-v1"),
-      agent_checks: z.literal("pi-bash-events-v1"),
+      agent_checks: z.literal("pi-bash-events-v3"),
     }).passthrough(),
   }).passthrough(),
-  agentChecks: z.object({
-    source: z.literal("pi-bash-events"),
-    work_id: z.string().min(1),
-  }).passthrough(),
+  agentChecks: learningAgentChecksSchema,
   exceptionType: z.null(),
 }).passthrough();
 const reportSchema = z.object({
@@ -101,7 +99,7 @@ const reportSchema = z.object({
     completion_tokens: z.number().int().positive(),
   }).strict(),
   model: z.string().min(1).max(120),
-  harness_version: z.literal("code-loop-pi-2026-07-14-v4"),
+  harness_version: z.literal("code-loop-pi-2026-07-14-v6"),
   network_mode: z.literal("no-network"),
   network_isolation_met: z.literal(true),
   base_image: z.literal("node:22.17.0-bookworm-slim@sha256:b04ce4ae4e95b522112c2e5c52f781471a5cbc3b594527bcddedee9bc48c03a0"),
@@ -217,7 +215,7 @@ function configuration(
     harness: {
       id: "pi-code-loop",
       version: report.harness_version,
-      configSha256: sha256({ caps: report.caps, capabilities: ["client-run-id-v1", "pi-bash-events-v1"] }),
+      configSha256: sha256({ caps: report.caps, capabilities: ["client-run-id-v1", "pi-bash-events-v3"] }),
       maxTurns: report.caps.turns,
       timeoutMs: report.caps.wall_s * 1_000,
       contextStrategy: "inline-seed-v1",
@@ -231,11 +229,11 @@ function configuration(
         contextWindow: 131_072,
         maxOutputTokens: report.caps.completion_tokens,
         templateVersion: "m5-live-2026-07-14",
-        extraConfigSha256: sha256("client-run-id-v1+pi-bash-events-v1"),
+        extraConfigSha256: sha256("client-run-id-v1+pi-bash-events-v3"),
       },
     },
     logging: {
-      schemaVersion: "code-loop-result-v4",
+      schemaVersion: "code-loop-result-v6",
       requiredFieldsSha256: sha256("execution+telemetry+agent_checks+durable-start"),
     },
     testHarness: kind === "host"

--- a/scripts/harbor_pilot/m5-code-loop-once.ts
+++ b/scripts/harbor_pilot/m5-code-loop-once.ts
@@ -11,7 +11,8 @@ import {
 } from "../../src/learning/m5-code-loop-adapter.js";
 import {
   M5CodeLoopClient,
-  M5CodeLoopError,
+  startM5CodeLoopDurably,
+  supportsM5CodeLoopContract,
   type M5CodeLoopRequest,
   type M5CodeLoopStart,
 } from "../../src/learning/m5-code-loop-client.js";
@@ -32,7 +33,7 @@ const capsSchema = z.object({
 });
 
 const requestSchema = z.object({
-  client_run_id: z.string().regex(/^[A-Za-z0-9._:-]{1,128}$/).optional(),
+  client_run_id: z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/).optional(),
   instruction: z.string().min(1),
   files: z.array(z.object({
     path: z.string().min(1),
@@ -52,7 +53,7 @@ const inputSchema = z.object({
     caps: capsSchema,
     capabilities: z.object({
       startIdempotency: z.literal("client-run-id-v1"),
-      agentChecks: z.literal("pi-bash-events-v1"),
+      agentChecks: z.literal("pi-bash-events-v3"),
     }).strict().optional(),
   }).strict(),
   pollMs: z.number().int().min(250).max(30_000).default(5_000),
@@ -91,37 +92,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
 }
 
-function supportsRequestedContract(
-  tools: Array<Record<string, unknown>>,
-  request: M5CodeLoopRequest,
-): boolean {
-  const start = tools.find((tool) => tool.name === "code_loop_start");
-  if (!start) return false;
-  if (request.client_run_id !== undefined && !JSON.stringify(start).includes("client_run_id")) {
-    return false;
-  }
-  if (request.caps?.edit_deadline_turn === undefined) return true;
-  return JSON.stringify(start).includes("edit_deadline_turn");
-}
-
-async function startDurably(
-  client: M5CodeLoopClient,
-  request: M5CodeLoopRequest,
-): Promise<M5CodeLoopStart> {
-  for (let attempt = 1; ; attempt += 1) {
-    try {
-      return await client.start(request);
-    } catch (err) {
-      const safelyRetryable =
-        request.client_run_id !== undefined &&
-        err instanceof M5CodeLoopError &&
-        err.ambiguousOutcome;
-      if (!safelyRetryable || attempt >= 3) throw err;
-      await sleep(attempt * 500);
-    }
-  }
-}
-
 export async function runCodeLoopOnce(
   rawInput: HarborCodeLoopOnceInput,
 ): Promise<HarborCodeLoopOnceOutput> {
@@ -143,11 +113,15 @@ export async function runCodeLoopOnce(
       bearerToken: requiredEnv("M5_API_KEY"),
     });
     const tools = await client.toolDefinitions();
-    if (!supportsRequestedContract(tools, input.request)) {
-      throw new Error("M5 does not advertise the requested code_loop contract");
+    if (!supportsM5CodeLoopContract(tools)) {
+      throw new Error("M5 does not advertise the exact durable v6/v3 code_loop contract");
     }
 
-    const started = await startDurably(client, input.request);
+    const request = {
+      ...input.request,
+      client_run_id: input.request.client_run_id,
+    } satisfies M5CodeLoopRequest & { client_run_id: string };
+    const started = await startM5CodeLoopDurably(client, request);
     if (started.client_run_id !== input.request.client_run_id) {
       throw new Error("M5 did not echo the declared client_run_id");
     }
@@ -163,9 +137,9 @@ export async function runCodeLoopOnce(
         throw new Error(`M5 result deadline exceeded for ${started.work_id}`);
       }
     }
-    result = await client.result(started.work_id);
-    if (result.work_id !== started.work_id) {
-      throw new Error("M5 result belongs to a different work id than the durable start");
+    result = started.result ?? await client.result(started.work_id);
+    if (result.work_id !== started.work_id || result.status !== status) {
+      throw new Error("M5 result does not match the durable start binding");
     }
     assertM5CodeLoopExecutionBinding(result, input.expected);
     return {

--- a/scripts/harbor_pilot/m5_code_loop_agent.py
+++ b/scripts/harbor_pilot/m5_code_loop_agent.py
@@ -27,7 +27,7 @@ class M5CodeLoopAgent(BaseAgent):
         self,
         logs_dir: Path,
         model_name: str | None = None,
-        expected_harness_version: str = "code-loop-pi-2026-07-14-v4",
+        expected_harness_version: str = "code-loop-pi-2026-07-14-v6",
         wall_s: int | str = 600,
         turns: int | str = 13,
         completion_tokens: int | str = 60_000,
@@ -76,7 +76,7 @@ class M5CodeLoopAgent(BaseAgent):
 
     @override
     def version(self) -> str:
-        return "0.2.0-harbor-0.18.0"
+        return "0.3.0-harbor-0.18.0"
 
     @override
     async def setup(self, environment: BaseEnvironment) -> None:
@@ -270,7 +270,7 @@ class M5CodeLoopAgent(BaseAgent):
                     "caps": self.caps,
                     "capabilities": {
                         "startIdempotency": "client-run-id-v1",
-                        "agentChecks": "pi-bash-events-v1",
+                        "agentChecks": "pi-bash-events-v3",
                     },
                 },
                 "pollMs": self.poll_ms,

--- a/scripts/harbor_pilot/run-pilot.ts
+++ b/scripts/harbor_pilot/run-pilot.ts
@@ -37,11 +37,11 @@ import {
 const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(SCRIPT_DIR, "../..");
 const MODEL = "qwen3-coder-next-80b";
-const HARNESS_VERSION = "code-loop-pi-2026-07-14-v4";
+const HARNESS_VERSION = "code-loop-pi-2026-07-14-v6";
 const CAPS = { wall_s: 600, turns: 13, completion_tokens: 60_000 } as const;
 const EXPECTED_CAPABILITIES = {
   startIdempotency: "client-run-id-v1",
-  agentChecks: "pi-bash-events-v1",
+  agentChecks: "pi-bash-events-v3",
 } as const;
 
 const controlSchema = z.object({
@@ -49,8 +49,8 @@ const controlSchema = z.object({
   holdout: z.boolean(),
   protected: z.array(z.string().min(1)),
   client_run_ids: z.object({
-    baseline: z.string().regex(/^[A-Za-z0-9._:-]{1,128}$/),
-    live: z.string().regex(/^[A-Za-z0-9._:-]{1,128}$/),
+    baseline: z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/),
+    live: z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/),
   }).strict(),
 }).passthrough();
 const gitCommitSchema = z.string().regex(/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/);
@@ -77,7 +77,7 @@ const declarationSchema = z.object({
   }).strict(),
   required_capabilities: z.object({
     start_idempotency: z.literal("client-run-id-v1"),
-    agent_checks: z.literal("pi-bash-events-v1"),
+    agent_checks: z.literal("pi-bash-events-v3"),
   }).strict(),
   network_mode: z.literal("no-network"),
   base_image: z.string().min(1),
@@ -473,10 +473,11 @@ async function main(): Promise<void> {
   const taskIds = csvAfter("--task-ids") ?? [...HARBOR_PILOT_TASK_IDS];
   const holdoutIds = csvAfter("--holdout-ids") ?? [...HARBOR_PILOT_HOLDOUT_IDS];
   const campaignId = valueAfter("--campaign-id") ?? HARBOR_PILOT_CAMPAIGN_ID;
-  const declarationPath = resolve(
-    valueAfter("--declaration") ??
-    join(REPO_ROOT, "docs/research/harbor-gate-d-v2-declaration-2026-07-14.json"),
-  );
+  const declarationArg = valueAfter("--declaration");
+  if (!declarationArg) {
+    throw new Error("--declaration is required; the consumed Gate D v2 declaration must not be reused");
+  }
+  const declarationPath = resolve(declarationArg);
   if (taskIds.length < 4) throw new Error("the larger-corpus pilot requires at least four tasks");
   if (holdoutIds.length < 2) throw new Error("the larger-corpus pilot requires at least two predeclared holdouts");
   const networkModeArg = valueAfter("--network-mode") ?? (process.platform === "darwin" ? "public" : "no-network");
@@ -606,15 +607,17 @@ async function main(): Promise<void> {
       /^sha256:[a-f0-9]{64}$/.test(row.requestFingerprint) &&
       row.holdout === prepared.holdoutIds.includes(row.taskId) &&
       startCapabilities?.start_idempotency === "client-run-id-v1" &&
-      startCapabilities.agent_checks === "pi-bash-events-v1" &&
+      startCapabilities.agent_checks === "pi-bash-events-v3" &&
       execution?.model === MODEL &&
       execution.harness_version === HARNESS_VERSION &&
       effectiveCaps?.wall_s === CAPS.wall_s &&
       effectiveCaps.turns === CAPS.turns &&
       effectiveCaps.completion_tokens === CAPS.completion_tokens &&
       executionCapabilities?.start_idempotency === "client-run-id-v1" &&
-      executionCapabilities.agent_checks === "pi-bash-events-v1" &&
+      executionCapabilities.agent_checks === "pi-bash-events-v3" &&
+      agentChecks?.schema_version === 3 &&
       agentChecks?.source === "pi-bash-events" &&
+      typeof agentChecks.coverage_loss_events === "number" &&
       agentChecks.work_id === row.workId;
   });
   const environmentConditionsMet =

--- a/scripts/run-m5-code-loop-experiment.ts
+++ b/scripts/run-m5-code-loop-experiment.ts
@@ -8,7 +8,6 @@
  *     npm run experiment:m5-code-loop -- ./wave.json
  */
 
-import { createHash } from "node:crypto";
 import {
   cpSync,
   lstatSync,
@@ -39,15 +38,15 @@ import {
 } from "../src/learning/m5-code-loop-prompt.js";
 import {
   M5CodeLoopClient,
-  M5CodeLoopError,
+  m5ClientRunId,
+  startM5CodeLoopDurably,
   type M5CodeLoopRequest,
-  type M5CodeLoopStart,
 } from "../src/learning/m5-code-loop-client.js";
 
-const V4_HARNESS_VERSION = "code-loop-pi-2026-07-14-v4";
-const V4_CAPABILITIES = {
+const DURABLE_HARNESS_VERSION = "code-loop-pi-2026-07-14-v5";
+const DURABLE_CAPABILITIES = {
   startIdempotency: "client-run-id-v1",
-  agentChecks: "pi-bash-events-v1",
+  agentChecks: "pi-bash-events-v2",
 } as const;
 
 const capsSchema = z.object({
@@ -122,11 +121,11 @@ const manifestSchema = z.object({
     if (config.editDeadlineTurn !== caps.edit_deadline_turn) {
       ctx.addIssue({ code: "custom", path: ["arms", arm, "caps", "edit_deadline_turn"], message: "edit deadline differs from the versioned harness config" });
     }
-    if (config.version !== V4_HARNESS_VERSION) {
+    if (config.version !== DURABLE_HARNESS_VERSION) {
       ctx.addIssue({
         code: "custom",
         path: ["experiment", arm, "harness", "version"],
-        message: `live experiments require ${V4_HARNESS_VERSION}`,
+        message: `live experiments require ${DURABLE_HARNESS_VERSION}`,
       });
     }
   }
@@ -296,38 +295,15 @@ function verifyGateD(
   }
 }
 
-function supportsDurableV4(tools: Array<Record<string, unknown>>): boolean {
+function supportsDurableEvidenceContract(tools: Array<Record<string, unknown>>): boolean {
   const start = tools.find((tool) => tool.name === "code_loop_start");
-  const serialized = JSON.stringify(start);
-  return !!start &&
-    serialized.includes("edit_deadline_turn") &&
-    serialized.includes("client_run_id");
+  if (!start) return false;
+  const wire = JSON.stringify(start);
+  return wire.includes("edit_deadline_turn") && wire.includes("client_run_id");
 }
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
-}
-
-function clientRunId(runId: string): string {
-  return `hugin:${createHash("sha256").update(runId).digest("hex")}`;
-}
-
-async function startDurably(
-  m5: M5CodeLoopClient,
-  request: M5CodeLoopRequest,
-): Promise<M5CodeLoopStart> {
-  for (let attempt = 1; ; attempt += 1) {
-    try {
-      return await m5.start(request);
-    } catch (error) {
-      const safelyRetryable =
-        error instanceof M5CodeLoopError &&
-        error.ambiguousOutcome &&
-        request.client_run_id !== undefined;
-      if (!safelyRetryable || attempt >= 3) throw error;
-      await sleep(attempt * 500);
-    }
-  }
 }
 
 async function readOrCreate(
@@ -356,9 +332,8 @@ async function runArm(input: {
   const { m5, broker, manifest, sample, arm, promptPrefix, manifestDir } = input;
   const config = manifest.experiment[arm];
   const runId = `${manifest.experiment.experiment_id}:${sample.id}:${arm}:${config.fingerprint.slice(0, 12)}`;
-  const durableClientRunId = clientRunId(runId);
-  const request: M5CodeLoopRequest = {
-    client_run_id: durableClientRunId,
+  const request: M5CodeLoopRequest & { client_run_id: string } = {
+    client_run_id: m5ClientRunId(runId),
     instruction: applyCodeLoopPromptPrefix(sample.instruction, promptPrefix),
     files: sample.files,
     check_cmd: sample.m5_check_cmd,
@@ -367,37 +342,19 @@ async function runArm(input: {
     caps: manifest.arms[arm].caps,
   };
   process.stdout.write(`[${sample.id}/${arm}] starting\n`);
-  let started: M5CodeLoopStart;
-  try {
-    started = await startDurably(m5, request);
-  } catch (error) {
-    if (error instanceof M5CodeLoopError && error.ambiguousOutcome) {
-      throw new Error(
-        `[${sample.id}/${arm}] M5 start remained unavailable after safe idempotent recovery ` +
-        `for run ${runId}; resume with the same manifest and client binding.`,
-        { cause: error },
-      );
-    }
-    throw error;
-  }
-  if (
-    started.client_run_id !== durableClientRunId ||
-    started.request_fingerprint === null
-  ) {
-    throw new Error(`[${sample.id}/${arm}] M5 omitted the durable start binding`);
-  }
+  const started = await startM5CodeLoopDurably(m5, request);
   const deadline = Date.now() + manifest.result_deadline_s * 1_000;
-  let runStatus = started.status;
-  while (runStatus === "running") {
+  let status = started.status;
+  while (status === "running") {
     await sleep(manifest.poll_ms);
-    runStatus = (await m5.status(started.work_id)).status;
-    if (runStatus === "running" && Date.now() >= deadline) {
+    status = (await m5.status(started.work_id)).status;
+    if (status === "running" && Date.now() >= deadline) {
       throw new Error(`[${sample.id}/${arm}] result deadline exceeded for ${started.work_id}`);
     }
   }
-  const result = await m5.result(started.work_id);
-  if (result.work_id !== started.work_id) {
-    throw new Error(`[${sample.id}/${arm}] M5 result belongs to a different work id`);
+  const result = started.result ?? await m5.result(started.work_id);
+  if (result.work_id !== started.work_id || result.status !== status) {
+    throw new Error(`[${sample.id}/${arm}] M5 result does not match the durable start binding`);
   }
   const externalVerification = verifyGateD(
     result,
@@ -416,10 +373,10 @@ async function runArm(input: {
       model: config.model.id,
       harnessVersion: config.harness.version,
       caps: manifest.arms[arm].caps,
-      capabilities: config.harness.version === V4_HARNESS_VERSION
-        ? V4_CAPABILITIES
-        : undefined,
+      capabilities: DURABLE_CAPABILITIES,
     },
+    clientRunId: started.client_run_id,
+    requestFingerprint: started.request_fingerprint,
     externalVerification,
   });
   const persisted = await observeDurably(broker, observation);
@@ -489,8 +446,11 @@ async function main(): Promise<void> {
     baseUrl: requiredEnv("HUGIN_BROKER_URL"),
     bearerToken: requiredEnv("HUGIN_BROKER_TOKEN"),
   });
-  if (!supportsDurableV4(await m5.toolDefinitions())) {
-    throw new Error("M5 code_loop does not advertise the durable v4 experiment contract");
+  if (!supportsDurableEvidenceContract(await m5.toolDefinitions())) {
+    throw new Error(
+      "M5 code_loop does not advertise durable client_run_id plus edit_deadline_turn; " +
+      "deploy the reviewed gille-inference contract before creating the experiment",
+    );
   }
 
   let state = await readOrCreate(broker, manifest.experiment);

--- a/scripts/run-m5-code-loop-experiment.ts
+++ b/scripts/run-m5-code-loop-experiment.ts
@@ -40,13 +40,14 @@ import {
   M5CodeLoopClient,
   m5ClientRunId,
   startM5CodeLoopDurably,
+  supportsM5CodeLoopContract,
   type M5CodeLoopRequest,
 } from "../src/learning/m5-code-loop-client.js";
 
-const DURABLE_HARNESS_VERSION = "code-loop-pi-2026-07-14-v5";
+const DURABLE_HARNESS_VERSION = "code-loop-pi-2026-07-14-v6";
 const DURABLE_CAPABILITIES = {
   startIdempotency: "client-run-id-v1",
-  agentChecks: "pi-bash-events-v2",
+  agentChecks: "pi-bash-events-v3",
 } as const;
 
 const capsSchema = z.object({
@@ -295,13 +296,6 @@ function verifyGateD(
   }
 }
 
-function supportsDurableEvidenceContract(tools: Array<Record<string, unknown>>): boolean {
-  const start = tools.find((tool) => tool.name === "code_loop_start");
-  if (!start) return false;
-  const wire = JSON.stringify(start);
-  return wire.includes("edit_deadline_turn") && wire.includes("client_run_id");
-}
-
 function sleep(ms: number): Promise<void> {
   return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
 }
@@ -446,9 +440,9 @@ async function main(): Promise<void> {
     baseUrl: requiredEnv("HUGIN_BROKER_URL"),
     bearerToken: requiredEnv("HUGIN_BROKER_TOKEN"),
   });
-  if (!supportsDurableEvidenceContract(await m5.toolDefinitions())) {
+  if (!supportsM5CodeLoopContract(await m5.toolDefinitions())) {
     throw new Error(
-      "M5 code_loop does not advertise durable client_run_id plus edit_deadline_turn; " +
+      "M5 code_loop does not advertise the exact durable v6/v3 evidence contract; " +
       "deploy the reviewed gille-inference contract before creating the experiment",
     );
   }

--- a/src/learning/experiment-evaluator.ts
+++ b/src/learning/experiment-evaluator.ts
@@ -60,6 +60,13 @@ function summarize(observations: RecordedLearningObservation[]): LearningArmSumm
   const infra = observations.filter(
     (observation) => observation.quality_outcome === "infra-error",
   ).length;
+  const agentCheckSamples = observations.filter(
+    (observation) =>
+      observation.agent_checks?.state === "attempted" &&
+      observation.agent_checks.attempts.some(
+        (attempt) => attempt.status === "passed" || attempt.status === "failed",
+      ),
+  ).length;
 
   return {
     samples,
@@ -83,6 +90,8 @@ function summarize(observations: RecordedLearningObservation[]): LearningArmSumm
     verifierScoreMean: mean(
       observations.map((observation) => observation.verifier_score),
     ),
+    agentCheckSamples,
+    agentCheckCoverage: samples > 0 ? agentCheckSamples / samples : 0,
   };
 }
 
@@ -185,6 +194,15 @@ function collectFailureSignals(
     if (observation.edit_start_ms === undefined && observation.phase_ms?.inspect !== undefined) {
       add("edit-start-unobserved");
     }
+    if (observation.agent_checks?.state === "none") add("agent-check-not-observed");
+    if (observation.agent_checks?.state === "unobservable") add("agent-check-unobservable");
+    if (observation.agent_checks?.state === "partial") add("agent-check-partial");
+    if (observation.agent_checks?.attempts.some((attempt) => attempt.status === "failed")) {
+      add("agent-check-failed");
+    }
+    if (observation.agent_checks?.attempts.some((attempt) => attempt.status === "execution-error")) {
+      add("agent-check-execution-error");
+    }
   }
 
   return [...counts.entries()]
@@ -211,6 +229,14 @@ function addCoverageRequirements(
     materiallyLessThan(challenger.ratedCoverage, gates.minRatedCoverage)
   ) {
     missing.push(`rated coverage must be >= ${gates.minRatedCoverage} on both arms`);
+  }
+  if (materiallyLessThan(
+    challenger.agentCheckCoverage,
+    gates.minChallengerAgentCheckCoverage,
+  )) {
+    missing.push(
+      `challenger agent-check coverage must be >= ${gates.minChallengerAgentCheckCoverage}`,
+    );
   }
 }
 

--- a/src/learning/experiment-schema.ts
+++ b/src/learning/experiment-schema.ts
@@ -12,6 +12,8 @@ import { z } from "zod";
 import { taskTypeSchema } from "../broker/types.js";
 
 export const sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
+export const prefixedSha256Schema = z.string().regex(/^sha256:[a-f0-9]{64}$/);
+export const clientRunIdSchema = z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/);
 const versionSchema = z.string().min(1).max(120);
 const slugSchema = z.string().regex(/^[a-z0-9][a-z0-9-]{1,79}$/);
 
@@ -166,6 +168,8 @@ export const learningExperimentGatesSchema = z.object({
   minHoldoutPairs: z.number().int().min(1).max(100).default(2),
   minVerifiedCoverage: z.number().min(0).max(1).default(0.8),
   minRatedCoverage: z.number().min(0).max(1).default(0.5),
+  /** Optional fail-closed attribution gate for genuine, fully observed agent-side checks. */
+  minChallengerAgentCheckCoverage: z.number().min(0).max(1).default(0),
   maxQualityRegression: z.number().min(0).max(1).default(0),
   maxUsefulRegression: z.number().min(0).max(1).default(0),
   maxRescueRateIncrease: z.number().min(0).max(1).default(0),
@@ -234,6 +238,49 @@ export const learningVerifierSchema = z.object({
   version: versionSchema.optional(),
 }).strict();
 
+export const learningAgentCheckAttemptSchema = z.object({
+  order: z.number().int().positive(),
+  kind: z.enum(["typescript", "test", "lint", "build", "validation"]),
+  command_fingerprint: prefixedSha256Schema,
+  started_ms: z.number().int().nonnegative(),
+  ended_ms: z.number().int().nonnegative(),
+  status: z.enum(["passed", "failed", "execution-error"]),
+  exit_code: z.number().int().nullable(),
+}).strict().superRefine((value, ctx) => {
+  if (value.ended_ms < value.started_ms) {
+    ctx.addIssue({ code: "custom", path: ["ended_ms"], message: "check ended before it started" });
+  }
+  if (value.status === "failed" && (value.exit_code === null || value.exit_code <= 0)) {
+    ctx.addIssue({ code: "custom", path: ["exit_code"], message: "failed checks require a positive exit code" });
+  }
+  if (value.status !== "failed" && value.exit_code !== null) {
+    ctx.addIssue({ code: "custom", path: ["exit_code"], message: "only failed checks carry a numeric exit code" });
+  }
+});
+
+export const learningAgentChecksSchema = z.object({
+  schema_version: z.literal(2),
+  source: z.literal("pi-bash-events"),
+  state: z.enum(["none", "attempted", "unobservable", "partial"]),
+  unparseable_lines: z.number().int().nonnegative(),
+  work_id: z.string().min(1).max(200),
+  attempts: z.array(learningAgentCheckAttemptSchema).max(1_000),
+}).strict().superRefine((value, ctx) => {
+  const hasAttempts = value.attempts.length > 0;
+  if ((value.state === "attempted" || value.state === "partial") !== hasAttempts) {
+    ctx.addIssue({ code: "custom", path: ["attempts"], message: "agent-check state disagrees with attempts" });
+  }
+  const hasParseLoss = value.unparseable_lines > 0;
+  if ((value.state === "unobservable" || value.state === "partial") !== hasParseLoss) {
+    ctx.addIssue({ code: "custom", path: ["unparseable_lines"], message: "agent-check state disagrees with parse coverage" });
+  }
+  for (let index = 0; index < value.attempts.length; index += 1) {
+    if (value.attempts[index]?.order !== index + 1) {
+      ctx.addIssue({ code: "custom", path: ["attempts", index, "order"], message: "check order must be contiguous" });
+    }
+  }
+});
+
 export const learningObservationInputShape = {
   experiment_id: slugSchema,
   run_id: z.string().min(1).max(200),
@@ -262,17 +309,48 @@ export const learningObservationInputShape = {
   task_id: z.string().min(1).max(200).optional(),
   ledger_id: z.string().min(1).max(200).optional(),
   work_id: z.string().min(1).max(200).optional(),
+  client_run_id: clientRunIdSchema.optional(),
+  request_fingerprint: prefixedSha256Schema.optional(),
+  agent_checks: learningAgentChecksSchema.optional(),
 };
 
-export const learningObservationSchema = z.object(learningObservationInputShape).strict();
+function validateObservationBindings(
+  value: {
+    work_id?: string;
+    client_run_id?: string;
+    request_fingerprint?: string;
+    agent_checks?: z.infer<typeof learningAgentChecksSchema>;
+  },
+  ctx: z.RefinementCtx,
+): void {
+  if ((value.client_run_id === undefined) !== (value.request_fingerprint === undefined)) {
+    ctx.addIssue({
+      code: "custom",
+      path: [value.client_run_id === undefined ? "client_run_id" : "request_fingerprint"],
+      message: "durable observations require both client run id and request fingerprint",
+    });
+  }
+  if (value.agent_checks && value.agent_checks.work_id !== value.work_id) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["agent_checks", "work_id"],
+      message: "agent-check evidence must match the observation work id",
+    });
+  }
+}
+
+export const learningObservationSchema = z.object(learningObservationInputShape)
+  .strict()
+  .superRefine(validateObservationBindings);
 export type LearningObservationInput = z.infer<typeof learningObservationSchema>;
 
-export const recordedLearningObservationSchema = learningObservationSchema.extend({
+export const recordedLearningObservationSchema = z.object({
+  ...learningObservationInputShape,
   recorded_at: z.string().min(1),
   recorded_by: z.string().min(1),
   product_rated_at: z.string().min(1).optional(),
   product_rated_by: z.string().min(1).optional(),
-}).strict();
+}).strict().superRefine(validateObservationBindings);
 export type RecordedLearningObservation = z.infer<typeof recordedLearningObservationSchema>;
 
 const ratedProductOutcomeSchema = z.enum([
@@ -319,6 +397,8 @@ export const learningArmSummarySchema = z.object({
   editStartMeanMs: z.number().nonnegative().nullable(),
   observabilityCoverageMean: z.number().min(0).max(1).nullable(),
   verifierScoreMean: z.number().min(0).max(1).nullable(),
+  agentCheckSamples: z.number().int().nonnegative().default(0),
+  agentCheckCoverage: z.number().min(0).max(1).default(0),
 }).strict();
 export type LearningArmSummary = z.infer<typeof learningArmSummarySchema>;
 

--- a/src/learning/experiment-schema.ts
+++ b/src/learning/experiment-schema.ts
@@ -259,10 +259,11 @@ export const learningAgentCheckAttemptSchema = z.object({
 });
 
 export const learningAgentChecksSchema = z.object({
-  schema_version: z.literal(2),
+  schema_version: z.literal(3),
   source: z.literal("pi-bash-events"),
   state: z.enum(["none", "attempted", "unobservable", "partial"]),
   unparseable_lines: z.number().int().nonnegative(),
+  coverage_loss_events: z.number().int().nonnegative(),
   work_id: z.string().min(1).max(200),
   attempts: z.array(learningAgentCheckAttemptSchema).max(1_000),
 }).strict().superRefine((value, ctx) => {
@@ -270,9 +271,9 @@ export const learningAgentChecksSchema = z.object({
   if ((value.state === "attempted" || value.state === "partial") !== hasAttempts) {
     ctx.addIssue({ code: "custom", path: ["attempts"], message: "agent-check state disagrees with attempts" });
   }
-  const hasParseLoss = value.unparseable_lines > 0;
-  if ((value.state === "unobservable" || value.state === "partial") !== hasParseLoss) {
-    ctx.addIssue({ code: "custom", path: ["unparseable_lines"], message: "agent-check state disagrees with parse coverage" });
+  const hasCoverageLoss = value.unparseable_lines > 0 || value.coverage_loss_events > 0;
+  if ((value.state === "unobservable" || value.state === "partial") !== hasCoverageLoss) {
+    ctx.addIssue({ code: "custom", path: ["state"], message: "agent-check state disagrees with event coverage" });
   }
   for (let index = 0; index < value.attempts.length; index += 1) {
     if (value.attempts[index]?.order !== index + 1) {

--- a/src/learning/m5-code-loop-adapter.ts
+++ b/src/learning/m5-code-loop-adapter.ts
@@ -91,7 +91,7 @@ export const m5CodeLoopResultSchema = z.object({
     }).strict(),
     capabilities: z.object({
       start_idempotency: z.literal("client-run-id-v1"),
-      agent_checks: z.literal("pi-bash-events-v2"),
+      agent_checks: z.literal("pi-bash-events-v3"),
     }).strict().optional(),
   }).strict().optional(),
   telemetry: m5CodeLoopTelemetrySchema.optional(),
@@ -125,7 +125,7 @@ export interface M5CodeLoopObservationContext {
     };
     capabilities?: {
       startIdempotency: "client-run-id-v1";
-      agentChecks: "pi-bash-events-v2";
+      agentChecks: "pi-bash-events-v3";
     };
   };
   externalVerification?: {

--- a/src/learning/m5-code-loop-adapter.ts
+++ b/src/learning/m5-code-loop-adapter.ts
@@ -7,6 +7,8 @@
 
 import { z } from "zod";
 import {
+  learningAgentCheckAttemptSchema,
+  learningAgentChecksSchema,
   learningObservationSchema,
   sha256Schema,
   type LearningObservationInput,
@@ -52,38 +54,8 @@ export const m5CodeLoopTelemetrySchema = z.object({
   }
 });
 
-const m5CodeLoopAgentChecksSchema = z.object({
-  schema_version: z.literal(1),
-  source: z.literal("pi-bash-events"),
-  state: z.enum(["none", "attempted"]),
-  work_id: z.string().min(1).max(200),
-  attempts: z.array(z.object({
-    order: z.number().int().positive(),
-    kind: z.enum(["typescript", "test", "lint", "build", "validation"]),
-    command_fingerprint: z.string().regex(/^sha256:[a-f0-9]{64}$/),
-    started_ms: z.number().int().nonnegative(),
-    ended_ms: z.number().int().nonnegative(),
-    status: z.enum(["passed", "failed", "execution-error"]),
-    exit_code: z.number().int().nullable(),
-  }).strict()).max(1_000),
-}).strict().superRefine((value, ctx) => {
-  if ((value.state === "none") !== (value.attempts.length === 0)) {
-    ctx.addIssue({
-      code: "custom",
-      path: ["state"],
-      message: "agent check state must agree with the attempt list",
-    });
-  }
-  for (const [index, attempt] of value.attempts.entries()) {
-    if (attempt.ended_ms < attempt.started_ms) {
-      ctx.addIssue({
-        code: "custom",
-        path: ["attempts", index, "ended_ms"],
-        message: "agent check cannot end before it starts",
-      });
-    }
-  }
-});
+export const m5AgentCheckAttemptSchema = learningAgentCheckAttemptSchema;
+export const m5AgentChecksSchema = learningAgentChecksSchema;
 
 export const m5CodeLoopResultSchema = z.object({
   status: codeLoopStatusSchema,
@@ -119,12 +91,16 @@ export const m5CodeLoopResultSchema = z.object({
     }).strict(),
     capabilities: z.object({
       start_idempotency: z.literal("client-run-id-v1"),
-      agent_checks: z.literal("pi-bash-events-v1"),
+      agent_checks: z.literal("pi-bash-events-v2"),
     }).strict().optional(),
   }).strict().optional(),
   telemetry: m5CodeLoopTelemetrySchema.optional(),
-  agent_checks: m5CodeLoopAgentChecksSchema.optional(),
-}).strict();
+  agent_checks: m5AgentChecksSchema.optional(),
+}).strict().superRefine((value, ctx) => {
+  if (value.agent_checks && value.agent_checks.work_id !== value.work_id) {
+    ctx.addIssue({ code: "custom", path: ["agent_checks", "work_id"], message: "agent-check evidence belongs to another work id" });
+  }
+});
 export type M5CodeLoopResult = z.infer<typeof m5CodeLoopResultSchema>;
 
 export interface M5CodeLoopObservationContext {
@@ -134,6 +110,8 @@ export interface M5CodeLoopObservationContext {
   arm: "champion" | "challenger";
   holdout: boolean;
   configurationFingerprint: string;
+  clientRunId?: string;
+  requestFingerprint?: string;
   taskId?: string;
   ledgerId?: string;
   expectedExecution?: {
@@ -147,7 +125,7 @@ export interface M5CodeLoopObservationContext {
     };
     capabilities?: {
       startIdempotency: "client-run-id-v1";
-      agentChecks: "pi-bash-events-v1";
+      agentChecks: "pi-bash-events-v2";
     };
   };
   externalVerification?: {
@@ -219,21 +197,17 @@ export function assertM5CodeLoopExecutionBinding(
     }
   }
   if (expected.capabilities) {
-    const actualCapabilities = result.execution.capabilities;
-    if (!actualCapabilities) {
+    if (!result.execution.capabilities) {
       throw new Error("M5 result omitted the declared execution capabilities");
     }
-    if (actualCapabilities.start_idempotency !== expected.capabilities.startIdempotency) {
-      throw new Error("M5 start idempotency capability does not match the declared experiment");
+    if (result.execution.capabilities.start_idempotency !== expected.capabilities.startIdempotency) {
+      throw new Error("M5 start-idempotency capability does not match the declared experiment");
     }
-    if (actualCapabilities.agent_checks !== expected.capabilities.agentChecks) {
+    if (result.execution.capabilities.agent_checks !== expected.capabilities.agentChecks) {
       throw new Error("M5 agent-check capability does not match the declared experiment");
     }
     if (!result.agent_checks) {
       throw new Error("M5 result omitted declared agent-side check evidence");
-    }
-    if (result.agent_checks.work_id !== result.work_id) {
-      throw new Error("M5 agent-side check evidence belongs to a different work id");
     }
   }
 }
@@ -246,6 +220,9 @@ export function observationFromM5CodeLoop(
   assertM5CodeLoopExecutionBinding(result, context.expectedExecution);
   const fingerprint = sha256Schema.parse(context.configurationFingerprint);
   const external = context.externalVerification;
+  if ((context.clientRunId === undefined) !== (context.requestFingerprint === undefined)) {
+    throw new Error("durable M5 observation requires both client run id and request fingerprint");
+  }
   const authoritativeCheck =
     result.protected_violations.length === 0 &&
     (external?.ran === true || result.check.ran);
@@ -294,5 +271,8 @@ export function observationFromM5CodeLoop(
     task_id: context.taskId,
     ledger_id: context.ledgerId,
     work_id: result.work_id,
+    client_run_id: context.clientRunId,
+    request_fingerprint: context.requestFingerprint,
+    agent_checks: result.agent_checks,
   });
 }

--- a/src/learning/m5-code-loop-client.ts
+++ b/src/learning/m5-code-loop-client.ts
@@ -242,13 +242,13 @@ export class M5CodeLoopClient {
         throw new M5CodeLoopError(
           `M5 JSON-RPC timed out after ${this.timeoutMs}ms`,
           undefined,
-          true,
+          mutating,
         );
       }
       throw new M5CodeLoopError(
         `M5 JSON-RPC request failed: ${err instanceof Error ? err.message : String(err)}`,
         undefined,
-        true,
+        mutating,
       );
     } finally {
       clearTimeout(timer);

--- a/src/learning/m5-code-loop-client.ts
+++ b/src/learning/m5-code-loop-client.ts
@@ -1,5 +1,6 @@
 /** Minimal owner-authenticated JSON-RPC client for M5's async code_loop tools. */
 
+import { createHash } from "node:crypto";
 import { z } from "zod";
 import {
   m5CodeLoopResultSchema,
@@ -30,9 +31,9 @@ export interface M5CodeLoopRequest {
   };
 }
 
-const codeLoopCapabilitiesSchema = z.object({
+export const codeLoopCapabilitiesSchema = z.object({
   start_idempotency: z.literal("client-run-id-v1"),
-  agent_checks: z.literal("pi-bash-events-v1"),
+  agent_checks: z.literal("pi-bash-events-v2"),
 }).strict();
 
 const jobStatusSchema = z.enum([
@@ -47,13 +48,24 @@ const jobStatusSchema = z.enum([
 const startSchema = z.object({
   work_id: z.string().min(1),
   status: jobStatusSchema,
-  client_run_id: z.string().min(1).nullable(),
+  client_run_id: z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/).nullable(),
   request_fingerprint: z.string().regex(/^sha256:[a-f0-9]{64}$/).nullable(),
   recovered: z.boolean(),
   capabilities: codeLoopCapabilitiesSchema,
   result: m5CodeLoopResultSchema.optional(),
-}).strict();
+}).strict().superRefine((value, ctx) => {
+  if (value.result && value.result.work_id !== value.work_id) {
+    ctx.addIssue({ code: "custom", path: ["result", "work_id"], message: "recovered result belongs to another work id" });
+  }
+  if (value.result && value.result.status !== value.status) {
+    ctx.addIssue({ code: "custom", path: ["result", "status"], message: "recovered result status disagrees with start status" });
+  }
+});
 export type M5CodeLoopStart = z.infer<typeof startSchema>;
+export type DurableM5CodeLoopStart = M5CodeLoopStart & {
+  client_run_id: string;
+  request_fingerprint: string;
+};
 
 const statusSchema = z.object({
   status: jobStatusSchema,
@@ -103,9 +115,15 @@ export class M5CodeLoopClient {
   }
 
   async start(request: M5CodeLoopRequest): Promise<M5CodeLoopStart> {
-    return startSchema.parse(
-      await this.call("code_loop_start", { ...request }),
-    );
+    const raw = await this.call("code_loop_start", { ...request }, true);
+    const parsed = startSchema.safeParse(raw);
+    if (!parsed.success) {
+      throw new M5CodeLoopError(
+        "M5 code_loop_start returned an invalid durable-start contract",
+        parsed.error.flatten(),
+      );
+    }
+    return parsed.data;
   }
 
   async status(workId: string): Promise<z.infer<typeof statusSchema>> {
@@ -126,14 +144,18 @@ export class M5CodeLoopClient {
     return (response as { tools: Array<Record<string, unknown>> }).tools;
   }
 
-  private async call(name: string, args: Record<string, unknown>): Promise<unknown> {
-    const response = await this.rpc("tools/call", { name, arguments: args });
+  private async call(
+    name: string,
+    args: Record<string, unknown>,
+    mutating = false,
+  ): Promise<unknown> {
+    const response = await this.rpc("tools/call", { name, arguments: args }, mutating);
     if (!response || typeof response !== "object") {
-      throw new M5CodeLoopError(`M5 ${name} returned an invalid result`);
+      throw new M5CodeLoopError(`M5 ${name} returned an invalid result`, undefined, mutating);
     }
     const result = response as { isError?: unknown; content?: unknown };
     if (!Array.isArray(result.content)) {
-      throw new M5CodeLoopError(`M5 ${name} returned no content`);
+      throw new M5CodeLoopError(`M5 ${name} returned no content`, undefined, mutating);
     }
     const text = result.content.find(
       (item): item is { type: "text"; text: string } =>
@@ -141,12 +163,14 @@ export class M5CodeLoopClient {
         (item as { type?: unknown }).type === "text" &&
         typeof (item as { text?: unknown }).text === "string",
     )?.text;
-    if (text === undefined) throw new M5CodeLoopError(`M5 ${name} returned no text content`);
+    if (text === undefined) {
+      throw new M5CodeLoopError(`M5 ${name} returned no text content`, undefined, mutating);
+    }
     let parsed: unknown;
     try {
       parsed = JSON.parse(text);
     } catch {
-      throw new M5CodeLoopError(`M5 ${name} returned non-JSON text`);
+      throw new M5CodeLoopError(`M5 ${name} returned non-JSON text`, undefined, mutating);
     }
     if (result.isError === true) {
       throw new M5CodeLoopError(`M5 ${name} refused or failed`, parsed);
@@ -154,7 +178,11 @@ export class M5CodeLoopClient {
     return parsed;
   }
 
-  private async rpc(method: string, params: Record<string, unknown>): Promise<unknown> {
+  private async rpc(
+    method: string,
+    params: Record<string, unknown>,
+    mutating = false,
+  ): Promise<unknown> {
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), this.timeoutMs);
     try {
@@ -169,7 +197,11 @@ export class M5CodeLoopClient {
         signal: controller.signal,
       });
       if (!response.ok) {
-        throw new M5CodeLoopError(`M5 JSON-RPC returned HTTP ${response.status}`);
+        throw new M5CodeLoopError(
+          `M5 JSON-RPC returned HTTP ${response.status}`,
+          undefined,
+          mutating && response.status >= 500,
+        );
       }
       const body = await response.json() as {
         error?: { code?: unknown; message?: unknown };
@@ -199,4 +231,52 @@ export class M5CodeLoopClient {
       clearTimeout(timer);
     }
   }
+}
+
+/** Stable, content-blind caller id for one immutable Hugin experiment run. */
+export function m5ClientRunId(runId: string): string {
+  return `hugin:${createHash("sha256").update(runId, "utf8").digest("hex")}`;
+}
+
+export async function startM5CodeLoopDurably(
+  client: Pick<M5CodeLoopClient, "start">,
+  request: M5CodeLoopRequest & { client_run_id: string },
+  options: {
+    maxAttempts?: number;
+    sleep?: (ms: number) => Promise<void>;
+  } = {},
+): Promise<DurableM5CodeLoopStart> {
+  // A lost response can race the original request while it is still waiting on M5's 60 s GPU
+  // admission. Twelve bounded retries cover the remaining half of that window after the client's
+  // default 30 s timeout without ever changing the caller id or request bytes.
+  const maxAttempts = options.maxAttempts ?? 12;
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1 || maxAttempts > 20) {
+    throw new Error("durable M5 start attempts must be an integer from 1 to 20");
+  }
+  const pause = options.sleep ?? ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  let sawAmbiguousOutcome = false;
+  let lastError: unknown = new Error("durable M5 start did not run");
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const started = await client.start(request);
+      if (started.client_run_id !== request.client_run_id || started.request_fingerprint === null) {
+        throw new M5CodeLoopError(
+          "M5 did not echo the durable caller id and canonical request fingerprint",
+        );
+      }
+      return started as DurableM5CodeLoopStart;
+    } catch (err) {
+      lastError = err;
+      const refusal = err instanceof M5CodeLoopError && err.detail && typeof err.detail === "object"
+        ? (err.detail as { refusal?: unknown }).refusal
+        : undefined;
+      const retryable = err instanceof M5CodeLoopError && (
+        err.ambiguousOutcome || (sawAmbiguousOutcome && refusal === "busy")
+      );
+      if (err instanceof M5CodeLoopError && err.ambiguousOutcome) sawAmbiguousOutcome = true;
+      if (!retryable || attempt === maxAttempts) throw err;
+      await pause(attempt * 500);
+    }
+  }
+  throw lastError;
 }

--- a/src/learning/m5-code-loop-client.ts
+++ b/src/learning/m5-code-loop-client.ts
@@ -31,9 +31,28 @@ export interface M5CodeLoopRequest {
   };
 }
 
+export const M5_CODE_LOOP_TOOL_CONTRACT_ADVERTISEMENT =
+  "contract[harness=code-loop-pi-2026-07-14-v6;agent_checks=pi-bash-events-v3;schema=3;max_attempts=1000]";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Fail before a paid start unless tools/list advertises the exact producer contract we parse. */
+export function supportsM5CodeLoopContract(tools: Array<Record<string, unknown>>): boolean {
+  const start = tools.find((tool) => tool.name === "code_loop_start");
+  if (!start || typeof start.description !== "string") return false;
+  if (!isRecord(start.inputSchema) || !isRecord(start.inputSchema.properties)) return false;
+  const properties = start.inputSchema.properties;
+  if (!Object.hasOwn(properties, "client_run_id") || !isRecord(properties.caps)) return false;
+  if (!isRecord(properties.caps.properties)) return false;
+  return start.description.includes(M5_CODE_LOOP_TOOL_CONTRACT_ADVERTISEMENT) &&
+    Object.hasOwn(properties.caps.properties, "edit_deadline_turn");
+}
+
 export const codeLoopCapabilitiesSchema = z.object({
   start_idempotency: z.literal("client-run-id-v1"),
-  agent_checks: z.literal("pi-bash-events-v2"),
+  agent_checks: z.literal("pi-bash-events-v3"),
 }).strict();
 
 const jobStatusSchema = z.enum([
@@ -121,6 +140,10 @@ export class M5CodeLoopClient {
       throw new M5CodeLoopError(
         "M5 code_loop_start returned an invalid durable-start contract",
         parsed.error.flatten(),
+        // The mutating call reached M5 and returned a tool result. Even when that result is
+        // malformed, the run may already have been accepted; retry only through the same
+        // client_run_id so response-shape faults cannot strand paid work.
+        true,
       );
     }
     return parsed.data;
@@ -262,6 +285,11 @@ export async function startM5CodeLoopDurably(
       if (started.client_run_id !== request.client_run_id || started.request_fingerprint === null) {
         throw new M5CodeLoopError(
           "M5 did not echo the durable caller id and canonical request fingerprint",
+          undefined,
+          // The mutating call returned after it may have committed the paid run. A schema-valid
+          // but incomplete/wrong binding is no safer than a malformed response: recover only by
+          // retrying the exact request under the same caller id.
+          true,
         );
       }
       return started as DurableM5CodeLoopStart;

--- a/tests/harbor-pilot.test.ts
+++ b/tests/harbor-pilot.test.ts
@@ -27,6 +27,16 @@ import {
 } from "../scripts/harbor_pilot/run-pilot.js";
 
 const roots: string[] = [];
+const advertisedCodeLoopStart = {
+  name: "code_loop_start",
+  description: "Start work. contract[harness=code-loop-pi-2026-07-14-v6;agent_checks=pi-bash-events-v3;schema=3;max_attempts=1000]",
+  inputSchema: {
+    properties: {
+      client_run_id: {},
+      caps: { properties: { edit_deadline_turn: {} } },
+    },
+  },
+};
 
 afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
@@ -221,11 +231,11 @@ describe("Harbor Gate D pilot", () => {
       verifier_sha256: prepared.verifierSha256,
       harbor_verifier_sha256: prepared.harborVerifierSha256,
       model: "qwen3-coder-next-80b",
-      harness_version: "code-loop-pi-2026-07-14-v4",
+      harness_version: "code-loop-pi-2026-07-14-v6",
       caps: { wall_s: 600, turns: 13, completion_tokens: 60_000 },
       required_capabilities: {
         start_idempotency: "client-run-id-v1",
-        agent_checks: "pi-bash-events-v1",
+        agent_checks: "pi-bash-events-v3",
       },
       network_mode: "no-network",
       base_image: prepared.baseImage,
@@ -310,11 +320,11 @@ describe("Harbor Gate D pilot", () => {
         schema_version: 1,
         model: "qwen3-coder-next-80b",
         engine: "pi",
-        harness_version: "code-loop-pi-2026-07-14-v4",
+        harness_version: "code-loop-pi-2026-07-14-v6",
         effective_caps: caps,
         capabilities: {
           start_idempotency: "client-run-id-v1",
-          agent_checks: "pi-bash-events-v1",
+          agent_checks: "pi-bash-events-v3",
         },
       },
       telemetry: {
@@ -324,9 +334,11 @@ describe("Harbor Gate D pilot", () => {
         observability_coverage: 0.5,
       },
       agent_checks: {
-        schema_version: 1,
+        schema_version: 3,
         source: "pi-bash-events",
         state: "none",
+        unparseable_lines: 0,
+        coverage_loss_events: 0,
         work_id: "cl-durable",
         attempts: [],
       },
@@ -342,7 +354,7 @@ describe("Harbor Gate D pilot", () => {
         return new Response(JSON.stringify({
           jsonrpc: "2.0",
           id: body.id,
-          result: { tools: [{ name: "code_loop_start", inputSchema: { properties: { client_run_id: {} } } }] },
+          result: { tools: [advertisedCodeLoopStart] },
         }));
       }
       const tool = body.params.name;
@@ -361,7 +373,7 @@ describe("Harbor Gate D pilot", () => {
               recovered: true,
               capabilities: {
                 start_idempotency: "client-run-id-v1",
-                agent_checks: "pi-bash-events-v1",
+                agent_checks: "pi-bash-events-v3",
               },
               result,
             }) }],
@@ -390,11 +402,11 @@ describe("Harbor Gate D pilot", () => {
       },
       expected: {
         model: "qwen3-coder-next-80b",
-        harnessVersion: "code-loop-pi-2026-07-14-v4",
+        harnessVersion: "code-loop-pi-2026-07-14-v6",
         caps,
         capabilities: {
           startIdempotency: "client-run-id-v1",
-          agentChecks: "pi-bash-events-v1",
+          agentChecks: "pi-bash-events-v3",
         },
       },
       pollMs: 250,
@@ -424,7 +436,7 @@ describe("Harbor Gate D pilot", () => {
         return new Response(JSON.stringify({
           jsonrpc: "2.0",
           id: body.id,
-          result: { tools: [{ name: "code_loop_start", inputSchema: { properties: { client_run_id: {} } } }] },
+          result: { tools: [advertisedCodeLoopStart] },
         }));
       }
       const tool = body.params.name;
@@ -437,7 +449,7 @@ describe("Harbor Gate D pilot", () => {
             recovered: false,
             capabilities: {
               start_idempotency: "client-run-id-v1",
-              agent_checks: "pi-bash-events-v1",
+              agent_checks: "pi-bash-events-v3",
             },
           }
         : {
@@ -455,17 +467,19 @@ describe("Harbor Gate D pilot", () => {
               schema_version: 1,
               model: "qwen3-coder-next-80b",
               engine: "pi",
-              harness_version: "code-loop-pi-2026-07-14-v4",
+              harness_version: "code-loop-pi-2026-07-14-v6",
               effective_caps: caps,
               capabilities: {
                 start_idempotency: "client-run-id-v1",
-                agent_checks: "pi-bash-events-v1",
+                agent_checks: "pi-bash-events-v3",
               },
             },
             agent_checks: {
-              schema_version: 1,
+              schema_version: 3,
               source: "pi-bash-events",
               state: "none",
+              unparseable_lines: 0,
+              coverage_loss_events: 0,
               work_id: "cl-other",
               attempts: [],
             },
@@ -489,16 +503,16 @@ describe("Harbor Gate D pilot", () => {
       },
       expected: {
         model: "qwen3-coder-next-80b",
-        harnessVersion: "code-loop-pi-2026-07-14-v4",
+        harnessVersion: "code-loop-pi-2026-07-14-v6",
         caps,
         capabilities: {
           startIdempotency: "client-run-id-v1",
-          agentChecks: "pi-bash-events-v1",
+          agentChecks: "pi-bash-events-v3",
         },
       },
       pollMs: 250,
       resultDeadlineS: 60,
-    })).rejects.toThrow(/different work id/);
+    })).rejects.toThrow(/durable start binding/);
   });
 
   it("summarizes Harbor rewards without importing prompts, diffs, or verifier logs", () => {
@@ -579,18 +593,26 @@ describe("Harbor Gate D pilot", () => {
       requestFingerprint: `sha256:${String(index).padStart(64, "0")}`,
       startCapabilities: {
         start_idempotency: "client-run-id-v1",
-        agent_checks: "pi-bash-events-v1",
+        agent_checks: "pi-bash-events-v3",
       },
       execution: {
         model: "qwen3-coder-next-80b",
-        harness_version: "code-loop-pi-2026-07-14-v4",
+        harness_version: "code-loop-pi-2026-07-14-v6",
         effective_caps: { wall_s: 600, turns: 13, completion_tokens: 60_000 },
         capabilities: {
           start_idempotency: "client-run-id-v1",
-          agent_checks: "pi-bash-events-v1",
+          agent_checks: "pi-bash-events-v3",
         },
       },
-      agentChecks: { source: "pi-bash-events", work_id: `cl-live-${index}` },
+      agentChecks: {
+        schema_version: 3,
+        source: "pi-bash-events",
+        state: "none",
+        unparseable_lines: 0,
+        coverage_loss_events: 0,
+        work_id: `cl-live-${index}`,
+        attempts: [],
+      },
       exceptionType: null,
     }));
     const payload = harborLearningImportFromReport({
@@ -609,7 +631,7 @@ describe("Harbor Gate D pilot", () => {
       harbor_verifier_sha256: "d".repeat(64),
       caps: { wall_s: 600, turns: 13, completion_tokens: 60_000 },
       model: "qwen3-coder-next-80b",
-      harness_version: "code-loop-pi-2026-07-14-v4",
+      harness_version: "code-loop-pi-2026-07-14-v6",
       network_mode: "no-network",
       network_isolation_met: true,
       base_image: "node:22.17.0-bookworm-slim@sha256:b04ce4ae4e95b522112c2e5c52f781471a5cbc3b594527bcddedee9bc48c03a0",

--- a/tests/learning-experiment.test.ts
+++ b/tests/learning-experiment.test.ts
@@ -83,10 +83,11 @@ describe("evaluateLearningExperiment", () => {
     const observedCheck = (sample: string) => ({
       work_id: `work-${sample}`,
       agent_checks: {
-        schema_version: 2 as const,
+        schema_version: 3 as const,
         source: "pi-bash-events" as const,
         state: "attempted" as const,
         unparseable_lines: 0,
+        coverage_loss_events: 0,
         work_id: `work-${sample}`,
         attempts: [{
           order: 1,
@@ -106,10 +107,11 @@ describe("evaluateLearningExperiment", () => {
         : {
             work_id: `work-${sample}`,
             agent_checks: {
-              schema_version: 2,
+              schema_version: 3,
               source: "pi-bash-events",
               state: "attempted",
               unparseable_lines: 0,
+              coverage_loss_events: 0,
               work_id: `work-${sample}`,
               attempts: [{
                 order: 1,

--- a/tests/learning-experiment.test.ts
+++ b/tests/learning-experiment.test.ts
@@ -73,6 +73,71 @@ describe("evaluateLearningExperiment", () => {
     expect(evaluation.guardFailures).toEqual([]);
   });
 
+  it("fails attribution closed when predeclared challenger agent-check coverage is missing", () => {
+    const input = makeExperimentInput({
+      gates: {
+        ...makeExperimentInput().gates,
+        minChallengerAgentCheckCoverage: 1,
+      },
+    });
+    const observedCheck = (sample: string) => ({
+      work_id: `work-${sample}`,
+      agent_checks: {
+        schema_version: 2 as const,
+        source: "pi-bash-events" as const,
+        state: "attempted" as const,
+        unparseable_lines: 0,
+        work_id: `work-${sample}`,
+        attempts: [{
+          order: 1,
+          kind: "test" as const,
+          command_fingerprint: `sha256:${"a".repeat(64)}`,
+          started_ms: 10,
+          ended_ms: 20,
+          status: "passed" as const,
+          exit_code: null,
+        }],
+      },
+    });
+    const observations = ["case-1", "case-2"].flatMap((sample) => [
+      recorded(makeObservation(sample, "champion")),
+      recorded(makeObservation(sample, "challenger", sample === "case-1"
+        ? observedCheck(sample)
+        : {
+            work_id: `work-${sample}`,
+            agent_checks: {
+              schema_version: 2,
+              source: "pi-bash-events",
+              state: "attempted",
+              unparseable_lines: 0,
+              work_id: `work-${sample}`,
+              attempts: [{
+                order: 1,
+                kind: "test",
+                command_fingerprint: `sha256:${"b".repeat(64)}`,
+                started_ms: 10,
+                ended_ms: 20,
+                status: "execution-error",
+                exit_code: null,
+              }],
+            },
+          })),
+    ]);
+    const gathering = evaluateLearningExperiment({ observations, gates: input.gates });
+    expect(gathering.decision).toBe("gathering");
+    expect(gathering.challenger.agentCheckCoverage).toBe(0.5);
+    expect(gathering.missingRequirements.join(" ")).toMatch(/agent-check coverage/);
+    expect(gathering.failureSignals).toContainEqual({ signal: "agent-check-execution-error", count: 1 });
+
+    const complete = observations.map((observation) =>
+      observation.arm === "challenger" && observation.sample_id === "case-2"
+        ? recorded(makeObservation("case-2", "challenger", observedCheck("case-2")))
+        : observation
+    );
+    expect(evaluateLearningExperiment({ observations: complete, gates: input.gates }).decision)
+      .toBe("promotion-ready");
+  });
+
   it("rejects a faster challenger when correctness regresses", () => {
     const input = makeExperimentInput();
     const observations = ["case-1", "case-2"].flatMap((sample) => [

--- a/tests/m5-code-loop-adapter.test.ts
+++ b/tests/m5-code-loop-adapter.test.ts
@@ -63,6 +63,36 @@ describe("M5 code-loop experiment adapter", () => {
     expect(JSON.stringify(observation)).not.toContain("done");
   });
 
+  it("persists durable binding and immutable content-blind agent-check evidence", () => {
+    const evidence = {
+      schema_version: 2 as const,
+      source: "pi-bash-events" as const,
+      state: "attempted" as const,
+      unparseable_lines: 0,
+      work_id: "cl-20260713-abcdef12",
+      attempts: [{
+        order: 1,
+        kind: "test" as const,
+        command_fingerprint: `sha256:${"b".repeat(64)}`,
+        started_ms: 100,
+        ended_ms: 300,
+        status: "passed" as const,
+        exit_code: null,
+      }],
+    };
+    const observation = observationFromM5CodeLoop(result({ agent_checks: evidence }), {
+      ...context,
+      clientRunId: "hugin:run-1",
+      requestFingerprint: `sha256:${"c".repeat(64)}`,
+    });
+    expect(observation).toMatchObject({
+      client_run_id: "hugin:run-1",
+      request_fingerprint: `sha256:${"c".repeat(64)}`,
+      agent_checks: evidence,
+    });
+    expect(JSON.stringify(observation.agent_checks)).not.toContain("npm test");
+  });
+
   it("keeps old gateway results honest by leaving edit timing unmeasured", () => {
     const observation = observationFromM5CodeLoop(result(), context);
     expect(observation.edited).toBe(true);
@@ -145,17 +175,17 @@ describe("M5 code-loop experiment adapter", () => {
     }).configuration_fingerprint).toBe("a".repeat(64));
   });
 
-  it("binds v4 capability evidence and refuses a prose-only result", () => {
+  it("binds v5 capability evidence and refuses a prose-only result", () => {
     const caps = { wall_s: 600, turns: 13, completion_tokens: 60_000 };
     const execution = {
       schema_version: 1 as const,
       model: "qwen3-coder-next-80b",
       engine: "pi",
-      harness_version: "code-loop-pi-2026-07-14-v4",
+      harness_version: "code-loop-pi-2026-07-14-v5",
       effective_caps: caps,
       capabilities: {
-        start_idempotency: "client-run-id-v1",
-        agent_checks: "pi-bash-events-v1",
+        start_idempotency: "client-run-id-v1" as const,
+        agent_checks: "pi-bash-events-v2" as const,
       },
     };
     const expectedExecution = {
@@ -164,19 +194,20 @@ describe("M5 code-loop experiment adapter", () => {
       caps,
       capabilities: {
         startIdempotency: "client-run-id-v1" as const,
-        agentChecks: "pi-bash-events-v1" as const,
+        agentChecks: "pi-bash-events-v2" as const,
       },
     };
     expect(() => observationFromM5CodeLoop(result({ execution }), {
       ...context,
       expectedExecution,
-    })).toThrow(/agent-side check evidence/);
+    })).toThrow(/omitted declared agent-side check evidence/);
     expect(observationFromM5CodeLoop(result({
       execution,
       agent_checks: {
-        schema_version: 1,
+        schema_version: 2,
         source: "pi-bash-events",
         state: "none",
+        unparseable_lines: 0,
         work_id: "cl-20260713-abcdef12",
         attempts: [],
       },

--- a/tests/m5-code-loop-adapter.test.ts
+++ b/tests/m5-code-loop-adapter.test.ts
@@ -65,10 +65,11 @@ describe("M5 code-loop experiment adapter", () => {
 
   it("persists durable binding and immutable content-blind agent-check evidence", () => {
     const evidence = {
-      schema_version: 2 as const,
+      schema_version: 3 as const,
       source: "pi-bash-events" as const,
       state: "attempted" as const,
       unparseable_lines: 0,
+      coverage_loss_events: 0,
       work_id: "cl-20260713-abcdef12",
       attempts: [{
         order: 1,
@@ -91,6 +92,23 @@ describe("M5 code-loop experiment adapter", () => {
       agent_checks: evidence,
     });
     expect(JSON.stringify(observation.agent_checks)).not.toContain("npm test");
+  });
+
+  it("keeps refused or uncorrelated check events distinct from affirmative no-check evidence", () => {
+    const evidence = {
+      schema_version: 3 as const,
+      source: "pi-bash-events" as const,
+      state: "unobservable" as const,
+      unparseable_lines: 0,
+      coverage_loss_events: 1,
+      work_id: "cl-20260713-abcdef12",
+      attempts: [],
+    };
+    expect(observationFromM5CodeLoop(result({ agent_checks: evidence }), context).agent_checks)
+      .toEqual(evidence);
+    expect(() => observationFromM5CodeLoop(result({
+      agent_checks: { ...evidence, state: "none" },
+    }), context)).toThrow(/event coverage/);
   });
 
   it("keeps old gateway results honest by leaving edit timing unmeasured", () => {
@@ -181,11 +199,11 @@ describe("M5 code-loop experiment adapter", () => {
       schema_version: 1 as const,
       model: "qwen3-coder-next-80b",
       engine: "pi",
-      harness_version: "code-loop-pi-2026-07-14-v5",
+      harness_version: "code-loop-pi-2026-07-14-v6",
       effective_caps: caps,
       capabilities: {
         start_idempotency: "client-run-id-v1" as const,
-        agent_checks: "pi-bash-events-v2" as const,
+        agent_checks: "pi-bash-events-v3" as const,
       },
     };
     const expectedExecution = {
@@ -194,7 +212,7 @@ describe("M5 code-loop experiment adapter", () => {
       caps,
       capabilities: {
         startIdempotency: "client-run-id-v1" as const,
-        agentChecks: "pi-bash-events-v2" as const,
+        agentChecks: "pi-bash-events-v3" as const,
       },
     };
     expect(() => observationFromM5CodeLoop(result({ execution }), {
@@ -204,10 +222,11 @@ describe("M5 code-loop experiment adapter", () => {
     expect(observationFromM5CodeLoop(result({
       execution,
       agent_checks: {
-        schema_version: 2,
+        schema_version: 3,
         source: "pi-bash-events",
         state: "none",
         unparseable_lines: 0,
+        coverage_loss_events: 0,
         work_id: "cl-20260713-abcdef12",
         attempts: [],
       },

--- a/tests/m5-code-loop-client.test.ts
+++ b/tests/m5-code-loop-client.test.ts
@@ -104,6 +104,20 @@ describe("M5CodeLoopClient", () => {
       });
   });
 
+  it("does not label read-only transport failures as ambiguous mutations", async () => {
+    const client = new M5CodeLoopClient({
+      endpoint: "http://m5.test:8080/mcp",
+      bearerToken: "x",
+      fetchImpl: (async () => {
+        throw new TypeError("connection reset");
+      }) as typeof fetch,
+    });
+    await expect(client.status("cl-1")).rejects.toMatchObject({
+      name: "M5CodeLoopError",
+      ambiguousOutcome: false,
+    });
+  });
+
   it("marks an invalid start envelope ambiguous after the mutating call reached M5", async () => {
     const client = new M5CodeLoopClient({
       endpoint: "http://m5.test:8080/mcp",

--- a/tests/m5-code-loop-client.test.ts
+++ b/tests/m5-code-loop-client.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
-import { M5CodeLoopClient, M5CodeLoopError } from "../src/learning/m5-code-loop-client.js";
+import {
+  M5CodeLoopClient,
+  M5CodeLoopError,
+  m5ClientRunId,
+  startM5CodeLoopDurably,
+  type M5CodeLoopRequest,
+} from "../src/learning/m5-code-loop-client.js";
 
 function rpcResult(value: unknown, isError = false): Response {
   return new Response(JSON.stringify({
@@ -12,19 +18,39 @@ function rpcResult(value: unknown, isError = false): Response {
   }), { status: 200, headers: { "content-type": "application/json" } });
 }
 
+function startResult(overrides: Record<string, unknown> = {}) {
+  return {
+    work_id: "cl-1",
+    status: "running",
+    client_run_id: "hugin:run-1",
+    request_fingerprint: `sha256:${"a".repeat(64)}`,
+    recovered: false,
+    capabilities: {
+      start_idempotency: "client-run-id-v1",
+      agent_checks: "pi-bash-events-v2",
+    },
+    ...overrides,
+  };
+}
+
+function terminalResult() {
+  return {
+    status: "completed",
+    diff: "",
+    diff_truncated: false,
+    changed_files: [],
+    protected_violations: [],
+    summary: "",
+    check: { ran: false, exit_code: null, output_tail: "" },
+    usage: { turns: 1, wall_ms: 2, prompt_tokens: 3, completion_tokens: 4 },
+    work_id: "cl-1",
+    detail: "",
+  };
+}
+
 describe("M5CodeLoopClient", () => {
   it("calls the owner-gated tool without leaking the token into the body", async () => {
-    const fetchImpl = vi.fn(async () => rpcResult({
-      work_id: "cl-1",
-      status: "running",
-      client_run_id: "harbor:campaign:task:live",
-      request_fingerprint: `sha256:${"a".repeat(64)}`,
-      recovered: false,
-      capabilities: {
-        start_idempotency: "client-run-id-v1",
-        agent_checks: "pi-bash-events-v1",
-      },
-    }));
+    const fetchImpl = vi.fn(async () => rpcResult(startResult()));
     const client = new M5CodeLoopClient({
       endpoint: "http://m5.test:8080/mcp",
       bearerToken: "owner-secret",
@@ -32,15 +58,10 @@ describe("M5CodeLoopClient", () => {
     });
 
     expect(await client.start({
-      client_run_id: "harbor:campaign:task:live",
+      client_run_id: "hugin:run-1",
       instruction: "fix",
       files: [{ path: "a.ts", content: "x" }],
-    })).toMatchObject({
-      work_id: "cl-1",
-      status: "running",
-      client_run_id: "harbor:campaign:task:live",
-      recovered: false,
-    });
+    })).toEqual(startResult());
     const [, init] = fetchImpl.mock.calls[0]!;
     expect((init?.headers as Record<string, string>).authorization).toBe("Bearer owner-secret");
     expect(String(init?.body)).not.toContain("owner-secret");
@@ -48,7 +69,7 @@ describe("M5CodeLoopClient", () => {
       method: "tools/call",
       params: {
         name: "code_loop_start",
-        arguments: { client_run_id: "harbor:campaign:task:live" },
+        arguments: { client_run_id: "hugin:run-1" },
       },
     });
   });
@@ -80,6 +101,51 @@ describe("M5CodeLoopClient", () => {
         name: "M5CodeLoopError",
         ambiguousOutcome: true,
       });
+  });
+
+  it("parses a recovered terminal result without requiring a second result call", async () => {
+    const recovered = startResult({
+      status: "completed",
+      recovered: true,
+      result: terminalResult(),
+    });
+    const client = new M5CodeLoopClient({
+      endpoint: "http://m5.test:8080/mcp",
+      bearerToken: "x",
+      fetchImpl: (async () => rpcResult(recovered)) as typeof fetch,
+    });
+    expect((await client.start({
+      client_run_id: "hugin:run-1",
+      instruction: "fix",
+      files: [{ path: "a", content: "b" }],
+    })).result).toEqual(terminalResult());
+  });
+
+  it("retries the byte-identical durable request after ambiguity and an admission busy", async () => {
+    const request: M5CodeLoopRequest & { client_run_id: string } = {
+      client_run_id: "hugin:run-1",
+      instruction: "fix",
+      files: [{ path: "a", content: "b" }],
+    };
+    const start = vi.fn()
+      .mockRejectedValueOnce(new M5CodeLoopError("lost", undefined, true))
+      .mockRejectedValueOnce(new M5CodeLoopError("busy", { refusal: "busy" }))
+      .mockResolvedValueOnce(startResult());
+    const sleeps: number[] = [];
+    const recovered = await startM5CodeLoopDurably({ start }, request, {
+      sleep: async (ms) => { sleeps.push(ms); },
+    });
+    expect(recovered.work_id).toBe("cl-1");
+    expect(start).toHaveBeenCalledTimes(3);
+    expect(start.mock.calls.every(([actual]) => actual === request)).toBe(true);
+    expect(sleeps).toEqual([500, 1_000]);
+  });
+
+  it("derives a stable bounded client id without embedding the experiment run id", () => {
+    const runId = "experiment:sample:challenger:abcdef";
+    expect(m5ClientRunId(runId)).toMatch(/^hugin:[a-f0-9]{64}$/);
+    expect(m5ClientRunId(runId)).toBe(m5ClientRunId(runId));
+    expect(m5ClientRunId(runId)).not.toContain("sample");
   });
 
   it("rejects unsafe or wrong-path endpoints", () => {

--- a/tests/m5-code-loop-client.test.ts
+++ b/tests/m5-code-loop-client.test.ts
@@ -4,6 +4,7 @@ import {
   M5CodeLoopError,
   m5ClientRunId,
   startM5CodeLoopDurably,
+  supportsM5CodeLoopContract,
   type M5CodeLoopRequest,
 } from "../src/learning/m5-code-loop-client.js";
 
@@ -27,7 +28,7 @@ function startResult(overrides: Record<string, unknown> = {}) {
     recovered: false,
     capabilities: {
       start_idempotency: "client-run-id-v1",
-      agent_checks: "pi-bash-events-v2",
+      agent_checks: "pi-bash-events-v3",
     },
     ...overrides,
   };
@@ -103,6 +104,50 @@ describe("M5CodeLoopClient", () => {
       });
   });
 
+  it("marks an invalid start envelope ambiguous after the mutating call reached M5", async () => {
+    const client = new M5CodeLoopClient({
+      endpoint: "http://m5.test:8080/mcp",
+      bearerToken: "x",
+      fetchImpl: (async () => rpcResult(startResult({
+        capabilities: {
+          start_idempotency: "client-run-id-v1",
+          agent_checks: "pi-bash-events-v2",
+        },
+      }))) as typeof fetch,
+    });
+    await expect(client.start({
+      client_run_id: "hugin:run-1",
+      instruction: "fix",
+      files: [{ path: "a", content: "b" }],
+    })).rejects.toMatchObject({
+      name: "M5CodeLoopError",
+      ambiguousOutcome: true,
+    });
+  });
+
+  it("recovers a schema-valid start that omitted its durable binding", async () => {
+    let calls = 0;
+    const request: M5CodeLoopRequest & { client_run_id: string } = {
+      client_run_id: "hugin:run-1",
+      instruction: "fix",
+      files: [{ path: "a", content: "b" }],
+    };
+    const client = {
+      start: async () => {
+        calls += 1;
+        return calls === 1
+          ? startResult({ client_run_id: null, request_fingerprint: null })
+          : startResult({ recovered: true });
+      },
+    };
+    const result = await startM5CodeLoopDurably(client, request, {
+      maxAttempts: 2,
+      sleep: async () => {},
+    });
+    expect(calls).toBe(2);
+    expect(result).toMatchObject({ client_run_id: request.client_run_id, recovered: true });
+  });
+
   it("parses a recovered terminal result without requiring a second result call", async () => {
     const recovered = startResult({
       status: "completed",
@@ -146,6 +191,18 @@ describe("M5CodeLoopClient", () => {
     expect(m5ClientRunId(runId)).toMatch(/^hugin:[a-f0-9]{64}$/);
     expect(m5ClientRunId(runId)).toBe(m5ClientRunId(runId));
     expect(m5ClientRunId(runId)).not.toContain("sample");
+  });
+
+  it("preflights the exact advertised producer contract before a paid start", () => {
+    const tool = {
+      name: "code_loop_start",
+      description: "Start work. contract[harness=code-loop-pi-2026-07-14-v6;agent_checks=pi-bash-events-v3;schema=3;max_attempts=1000]",
+      inputSchema: { properties: { client_run_id: {}, caps: { properties: { edit_deadline_turn: {} } } } },
+    };
+    expect(supportsM5CodeLoopContract([tool])).toBe(true);
+    expect(supportsM5CodeLoopContract([{ ...tool, description: tool.description.replace("v3", "v2") }])).toBe(false);
+    expect(supportsM5CodeLoopContract([{ ...tool, inputSchema: { properties: { caps: { properties: { edit_deadline_turn: {} } } } } }])).toBe(false);
+    expect(supportsM5CodeLoopContract([{ ...tool, inputSchema: { properties: { client_run_id: {} } } }])).toBe(false);
   });
 
   it("rejects unsafe or wrong-path endpoints", () => {


### PR DESCRIPTION
## Summary
- require the exact deployed M5 v6/v3 producer contract before paid work
- recover ambiguous starts through a durable caller ID and persist request/work/check bindings
- add conservative agent-check coverage to the learning gate
- keep the consumed Harbor v2 declaration immutable and require a fresh declaration for future campaigns

## Validation
- npm run build
- npm test (108 files, 1777 tests before the final one-test review addition)
- focused learning/M5/Harbor tests
- deploy and bootstrap shell suites
- Python syntax, historical JSON parse, git diff --check

## Review
- native exact-head review completed; fixed structural preflight, declaration reuse, and read-only ambiguity classification findings
- external Claude/Opus review unavailable because private-repository disclosure is blocked by execution policy

No model campaign, learning import, routing change, or promotion is part of this PR.