### PR TITLE
Consume cross-client M5 exposure in daily exams

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,7 @@ hugin/
 │       ├── experiment-store.ts   # Principal-isolated Munin state + CAS/idempotency
 │       ├── experiment-handlers.ts # Authenticated Broker learning endpoints
 │       ├── daily-task-exam-factory.ts # Content-blind daily task → holdout/regression/quarantine candidates
+│       ├── task-exposure-client.ts # Owner-authenticated, content-blind M5 freshness lookup
 │       ├── m5-code-loop-adapter.ts # Honest M5 result → content-blind observation mapping
 │       └── m5-code-loop-client.ts  # Owner-gated async code_loop JSON-RPC client
 ├── tests/
@@ -208,6 +209,9 @@ MUNIN_API_KEY=<same key Munin uses>
 | `OLLAMA_PI_URL` | `http://127.0.0.1:11434` | Ollama endpoint on Pi (local) |
 | `OLLAMA_LAPTOP_URL` | — | Ollama endpoint on laptop (via Tailscale, empty = disabled) |
 | `OLLAMA_DEFAULT_MODEL` | `qwen2.5:3b` | Default model for ollama tasks without explicit Model field |
+| `HOMESERVER_GATEWAY_URL` | — | Sovereign M5 gateway root URL. Also used by the daily exam factory for the read-only cross-client exposure lookup. |
+| `HOMESERVER_GATEWAY_API_KEY` | — | Gateway bearer token. The daily exam factory may use it for exposure lookup when it is a minted owner credential. |
+| `M5_TASK_EXPOSURE_API_KEY` | — | Optional dedicated minted owner credential for the read-only task-exposure lookup; takes precedence over `HOMESERVER_GATEWAY_API_KEY`. |
 | `HUGIN_INJECTION_POLICY` | `warn` | Prompt-injection policy for context-refs: `off` (no scan), `warn` (prepend warning banner), `block` (quarantine high-severity refs, task continues), `fail` (reject task). See `docs/security/prompt-injection-scanner.md`. |
 | `HUGIN_EXFIL_POLICY` | `warn` | Exfiltration scanner policy for task results: `off` / `warn` / `flag` / `redact`. See `docs/security/exfiltration-scanner.md`. |
 | `HUGIN_EXTERNAL_POLICY` | `warn` | Provenance policy for externally sourced context-refs (entries tagged `source:external` or under `signals/`): `allow` / `warn` / `block` / `fail`. See `docs/security/provenance-enforcement.md`. |

--- a/docs/daily-exam-factory.md
+++ b/docs/daily-exam-factory.md
@@ -26,9 +26,9 @@ classifies them without running a model or writing any learning state:
 
 | Lane | Meaning |
 |---|---|
-| `provisional-holdout` | Hugin has no evidence that M5 saw the task. A cross-client exposure check and an independent verifier are still required before sealing it. |
-| `regression` | Hugin has evidence that the task reached an M5 runtime or leaf. It may test non-regression, but it is not fresh. |
-| `quarantine` | Reproducibility, privacy, completion, repository, PR, or exposure evidence is incomplete. |
+| `provisional-holdout` | Hugin-local provenance is negative, M5's owner lookup returned `seen:false`, the task was created inside a complete live all-lane coverage window, and an independent verifier is still required. |
+| `regression` | Hugin-local provenance or M5's cross-client registry proves exposure. It may test non-regression, but it is not fresh. |
+| `quarantine` | Reproducibility, privacy, completion, repository, PR, lookup availability, coverage window, or exposure evidence is incomplete. |
 
 Every non-quarantined candidate still has readiness
 `needs-independent-verifier`. Agent prose and a changed test file are not an
@@ -37,7 +37,10 @@ independent grading oracle.
 ## Run it
 
 ```bash
-MUNIN_API_KEY=... npm run harvest:daily-exams -- \
+MUNIN_API_KEY=... \
+HOMESERVER_GATEWAY_URL=http://100.76.72.59:8080 \
+M5_TASK_EXPOSURE_API_KEY=... \
+npm run harvest:daily-exams -- \
   --since 2026-07-14T00:00:00Z \
   --limit 500 \
   --output /private/tmp/hugin-daily-exam-candidates.json
@@ -47,28 +50,48 @@ The output file is created mode `0600`. Omit `--output` to write JSON to stdout.
 The command reports `historyComplete:false` whenever Munin pagination or the
 caller limit prevents it from proving that the selected history is complete.
 
+Before classification, the CLI applies the shared
+`trim-utf8-sha256-v1` contract to each exact `### Prompt` and sends only the
+unique SHA-256 digests to M5's owner-authenticated batch lookup. The manifest is
+schema v2 and records bounded coverage metadata plus per-candidate timestamps,
+lanes, model IDs, and harness IDs; it never records lookup prose or raw task
+text. A dedicated `M5_TASK_EXPOSURE_API_KEY` is preferred and falls back to
+`HOMESERVER_GATEWAY_API_KEY` only when that is a real minted owner credential.
+Redirects are denied so the owner token cannot leave the configured sovereign
+gateway.
+
+Positive matches are regression evidence even for older tasks. A negative is
+usable only when live coverage is complete, all six gateway-controlled lanes
+are present, and the earliest task creation/submission timestamp is inside the
+reported window. Missing credentials, lookup failures, incomplete coverage,
+old tasks, and contract drift fail closed to quarantine. The harvester still
+completes and exposes `exposureLookup.status`; deployment acceptance rejects an
+`unavailable` production lookup rather than stamping a partially wired release.
+
 Production runs the same compiled CLI from
 `hugin-daily-exam-factory.timer` once per day. It inspects a rolling 48-hour
 window and atomically replaces the private manifest at
 `~/.hugin/daily-exam-candidates/latest.json`. Deployment installs the timer and
-runs one acceptance sweep; the timer never invokes Harbor or a model.
+runs one acceptance sweep, including the read-only M5 lookup; the timer never
+invokes Harbor or a model.
 
 ## Safety boundary and next stage
 
 The factory does not:
 
-- claim that absence of Hugin-local M5 provenance proves global freshness;
+- claim that an unbound, incomplete, or out-of-window negative proves freshness;
 - copy private tasks into an evaluation package;
 - invent or trust a verifier;
-- run Harbor or M5;
+- run Harbor or M5 inference;
 - import a learning observation; or
 - promote a model, harness, prompt, or route.
 
-The next stage consumes a reviewed candidate, checks a shared exposure registry,
-reconstructs the base tree, derives and validates an independent verifier, and
-only then creates a frozen Harbor declaration. The reusable Gate D corpus and
-M5 capability ledger remain owned by `gille-inference`; this Hugin-side factory
-owns daily task discovery and reproducibility evidence.
+The next stage consumes a reviewed candidate, reconstructs the base tree,
+derives and validates an independent verifier, rechecks exposure immediately
+before sealing, and only then creates a frozen Harbor declaration. The reusable
+Gate D corpus and M5 capability ledger remain owned by `gille-inference`; this
+Hugin-side factory owns daily task discovery and reproducibility evidence.
 
-The owner-side exposure lookup is tracked in
-[`gille-inference#257`](https://github.com/Magnus-Gille/gille-inference/issues/257).
+The owner-side exposure contract shipped in
+[`gille-inference#257`](https://github.com/Magnus-Gille/gille-inference/issues/257)
+and is documented in that repository's `docs/task-exposure-contract.md`.

--- a/scripts/deploy-pi.sh
+++ b/scripts/deploy-pi.sh
@@ -239,7 +239,7 @@ echo "==> Daily exam factory acceptance..."
 ssh "$REMOTE" "
   XDG_RUNTIME_DIR=/run/user/1000 systemctl --user start hugin-daily-exam-factory.service
   test -s /home/$DEPLOY_USER/.hugin/daily-exam-candidates/latest.json
-  /usr/bin/node -e 'const m=JSON.parse(require(\"node:fs\").readFileSync(process.argv[1],\"utf8\")); process.stdout.write(JSON.stringify({generatedAt:m.generatedAt,inspectedTasks:m.inspectedTasks,historyComplete:m.historyComplete,counts:m.counts})+\"\\n\")' /home/$DEPLOY_USER/.hugin/daily-exam-candidates/latest.json
+  /usr/bin/node -e 'const m=JSON.parse(require(\"node:fs\").readFileSync(process.argv[1],\"utf8\")); if(m.exposureLookup?.status===\"unavailable\") throw new Error(\"cross-client exposure lookup unavailable: \"+(m.exposureLookup.failureKind??\"unknown\")); process.stdout.write(JSON.stringify({generatedAt:m.generatedAt,inspectedTasks:m.inspectedTasks,historyComplete:m.historyComplete,exposureLookup:{status:m.exposureLookup?.status,queriedFingerprints:m.exposureLookup?.queriedFingerprints,coverageComplete:m.exposureLookup?.coverage?.coverageComplete},counts:m.counts})+\"\\n\")' /home/$DEPLOY_USER/.hugin/daily-exam-candidates/latest.json
 "
 
 echo ""

--- a/scripts/deploy-pi.test.sh
+++ b/scripts/deploy-pi.test.sh
@@ -248,6 +248,7 @@ assert_not_contains "$full_calls" "npm install --omit=dev" "deployment never rew
 assert_contains "$full_calls" "curl -fsS http://127.0.0.1:3032/health" "deployment retains the health acceptance gate"
 assert_contains "$full_calls" "enable --now hugin-daily-exam-factory.timer" "deployment enables the automatic daily factory"
 assert_contains "$full_calls" "start hugin-daily-exam-factory.service" "deployment runs a factory acceptance sweep"
+assert_contains "$full_calls" "exposureLookup?.status" "deployment validates cross-client lookup availability"
 assert_contains "$full_calls" "$full_sha" "deployment stamps the exact local full SHA"
 assert_order "$full_calls" "curl -fsS http://127.0.0.1:3032/health" "mv '/home/magnus/repos/hugin/.deployed-commit.tmp' '/home/magnus/repos/hugin/.deployed-commit'" "health acceptance precedes atomic marker stamp"
 assert_order "$full_calls" "start hugin-daily-exam-factory.service" "mv '/home/magnus/repos/hugin/.deployed-commit.tmp' '/home/magnus/repos/hugin/.deployed-commit'" "factory acceptance precedes atomic marker stamp"

--- a/src/daily-exam-harvest-cli.ts
+++ b/src/daily-exam-harvest-cli.ts
@@ -16,8 +16,15 @@ import { MuninClient, type MuninEntry } from "./munin-client.js";
 import { queryAllMuninEntries } from "./munin-pagination.js";
 import {
   buildDailyExamManifest,
+  dailyTaskExposureFingerprint,
+  type DailyExamExposureLookupInput,
   type DailyTaskHarvestSource,
 } from "./learning/daily-task-exam-factory.js";
+import {
+  TaskExposureClient,
+  TaskExposureLookupError,
+} from "./learning/task-exposure-client.js";
+import { resolveGatewayRootUrl } from "./orchestrator/provider-config.js";
 
 interface CliOptions {
   since?: string;
@@ -30,9 +37,9 @@ function usage(): string {
   return [
     "Usage: npm run harvest:daily-exams -- [options]",
     "",
-    "Read completed Hugin tasks from Munin and emit a content-blind, quarantined",
-    "exam-candidate manifest. This command never runs a model, writes Munin, or",
-    "imports/promotes learning evidence.",
+    "Read completed Hugin tasks from Munin, query M5 with content-blind prompt",
+    "fingerprints, and emit a quarantined exam-candidate manifest. This command",
+    "never runs a model, writes Munin/M5, or imports/promotes learning evidence.",
     "",
     "Options:",
     "  --since <ISO>    Only inspect tasks updated at/after this timestamp",
@@ -158,6 +165,42 @@ async function loadSources(
   return { sources, historyComplete: !queried.truncated };
 }
 
+export async function lookupCrossClientExposure(
+  sources: DailyTaskHarvestSource[],
+  env: NodeJS.ProcessEnv = process.env,
+  fetchImpl: typeof fetch = fetch,
+): Promise<DailyExamExposureLookupInput> {
+  const fingerprints = [...new Set(
+    sources
+      .map(dailyTaskExposureFingerprint)
+      .filter((fingerprint): fingerprint is string => fingerprint !== undefined),
+  )].sort();
+  if (fingerprints.length === 0) return { status: "not-needed" };
+
+  const gateway = resolveGatewayRootUrl(env, "HOMESERVER_GATEWAY_URL");
+  const bearerToken = (
+    env.M5_TASK_EXPOSURE_API_KEY?.trim() ||
+    env.HOMESERVER_GATEWAY_API_KEY?.trim() ||
+    ""
+  );
+  if (!gateway.ok || bearerToken === "") {
+    return { status: "unavailable", failureKind: "configuration" };
+  }
+  try {
+    const client = new TaskExposureClient({
+      baseUrl: gateway.baseUrl,
+      bearerToken,
+      fetchImpl,
+    });
+    return { status: "queried", evidence: await client.lookup(fingerprints) };
+  } catch (error) {
+    return {
+      status: "unavailable",
+      failureKind: error instanceof TaskExposureLookupError ? error.kind : "contract",
+    };
+  }
+}
+
 export async function main(argv = process.argv.slice(2)): Promise<void> {
   const options = parseArgs(argv);
   const apiKey = process.env.MUNIN_API_KEY?.trim();
@@ -167,10 +210,18 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     apiKey,
   });
   const loaded = await loadSources(munin, options);
+  const exposureLookup = await lookupCrossClientExposure(loaded.sources);
+  if (exposureLookup.status === "unavailable") {
+    process.stderr.write(
+      `Cross-client exposure lookup unavailable (${exposureLookup.failureKind}); ` +
+      "eligible negative candidates will be quarantined\n",
+    );
+  }
   const manifest = buildDailyExamManifest({
     generatedAt: new Date().toISOString(),
     historyComplete: loaded.historyComplete,
     sources: loaded.sources,
+    exposureLookup,
   });
   const json = `${JSON.stringify(manifest, null, 2)}\n`;
   if (options.output) {

--- a/src/learning/daily-task-exam-factory.ts
+++ b/src/learning/daily-task-exam-factory.ts
@@ -5,17 +5,26 @@ import {
   structuredTaskResultSchema,
   type StructuredTaskResult,
 } from "../task-result-schema.js";
+import {
+  TASK_EXPOSURE_FINGERPRINT_VERSION,
+  TASK_EXPOSURE_REQUIRED_LANES,
+  type TaskExposureLookupEvidence,
+  type TaskExposureLookupFailureKind,
+  type TaskExposureLookupResult,
+} from "./task-exposure-client.js";
 
 const sha256Schema = z.string().regex(/^[0-9a-f]{64}$/);
 const gitCommitSchema = z.string().regex(/^[0-9a-f]{40,64}$/);
+const isoTimestampSchema = z.string().datetime({ offset: true });
 
 export const dailyExamCandidateSchema = z.object({
-  schemaVersion: z.literal(1),
+  schemaVersion: z.literal(2),
   candidateId: z.string().regex(/^daily-[0-9a-f]{24}$/),
   source: z.object({
     taskNamespace: z.string().startsWith("tasks/"),
     taskId: z.string().min(1),
-    statusUpdatedAt: z.string().min(1),
+    taskCreatedAt: isoTimestampSchema.optional(),
+    statusUpdatedAt: isoTimestampSchema,
     taskDocumentSha256: sha256Schema,
     promptSha256: sha256Schema.optional(),
     structuredResultSha256: sha256Schema.optional(),
@@ -36,19 +45,135 @@ export const dailyExamCandidateSchema = z.object({
     state: z.enum(["no-m5-evidence", "m5-exposed", "unknown"]),
     models: z.array(z.string().min(1)),
     evidence: z.array(z.string().min(1)),
+    crossClient: z.object({
+      fingerprintVersion: z.literal(TASK_EXPOSURE_FINGERPRINT_VERSION),
+      fingerprintSha256: sha256Schema,
+      seen: z.boolean(),
+      firstSeenAt: isoTimestampSchema.nullable(),
+      lastSeenAt: isoTimestampSchema.nullable(),
+      lanes: z.array(z.enum(TASK_EXPOSURE_REQUIRED_LANES)).max(TASK_EXPOSURE_REQUIRED_LANES.length),
+      modelIds: z.array(z.string().min(1).max(160)).max(1_000),
+      harnessIds: z.array(z.string().min(1).max(160)).max(1_000),
+    }).strict().superRefine((crossClient, ctx) => {
+      if (!crossClient.seen && (
+        crossClient.firstSeenAt !== null ||
+        crossClient.lastSeenAt !== null ||
+        crossClient.lanes.length > 0 ||
+        crossClient.modelIds.length > 0 ||
+        crossClient.harnessIds.length > 0
+      )) {
+        ctx.addIssue({ code: "custom", path: ["seen"], message: "unseen results cannot carry exposure metadata" });
+      }
+      if (crossClient.seen && (
+        crossClient.firstSeenAt === null ||
+        crossClient.lastSeenAt === null ||
+        crossClient.lanes.length === 0
+      )) {
+        ctx.addIssue({ code: "custom", path: ["seen"], message: "seen results require timestamps and lanes" });
+      }
+    }).optional(),
   }).strict(),
   lane: z.enum(["provisional-holdout", "regression", "quarantine"]),
   readiness: z.enum(["needs-independent-verifier", "quarantined"]),
   reasons: z.array(z.string().min(1)),
   contentPolicy: z.literal("content-blind-references-only"),
-}).strict();
+}).strict().superRefine((value, ctx) => {
+  if (
+    value.exposure.crossClient &&
+    value.exposure.crossClient.fingerprintSha256 !== value.source.promptSha256
+  ) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["exposure", "crossClient", "fingerprintSha256"],
+      message: "cross-client result must bind to the candidate prompt fingerprint",
+    });
+  }
+  if (value.exposure.crossClient?.seen && value.exposure.state !== "m5-exposed") {
+    ctx.addIssue({
+      code: "custom",
+      path: ["exposure", "state"],
+      message: "a positive cross-client result must classify as M5-exposed",
+    });
+  }
+  if (value.lane === "provisional-holdout" && (
+    value.exposure.state !== "no-m5-evidence" ||
+    value.exposure.crossClient?.seen !== false
+  )) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["lane"],
+      message: "provisional holdouts require a bound negative cross-client result",
+    });
+  }
+  if (value.lane === "regression" && value.exposure.state !== "m5-exposed") {
+    ctx.addIssue({ code: "custom", path: ["lane"], message: "regressions require M5 exposure" });
+  }
+  if ((value.lane === "quarantine") !== (value.readiness === "quarantined")) {
+    ctx.addIssue({ code: "custom", path: ["readiness"], message: "quarantine lane/readiness must agree" });
+  }
+});
 export type DailyExamCandidate = z.infer<typeof dailyExamCandidateSchema>;
 
+const dailyExamExposureCoverageSchema = z.object({
+  coverageComplete: z.boolean(),
+  from: z.string().refine((value) => !Number.isNaN(Date.parse(value))),
+  through: z.string().refine((value) => !Number.isNaN(Date.parse(value))),
+  lanes: z.array(z.enum(TASK_EXPOSURE_REQUIRED_LANES)).max(TASK_EXPOSURE_REQUIRED_LANES.length),
+  historicalBackfillComplete: z.literal(false),
+  incompleteBefore: z.string().min(1),
+  incompleteReasonCount: z.number().int().nonnegative(),
+}).strict().superRefine((value, ctx) => {
+  if (Date.parse(value.from) > Date.parse(value.through)) {
+    ctx.addIssue({ code: "custom", path: ["through"], message: "coverage window is inverted" });
+  }
+  if (new Set(value.lanes).size !== value.lanes.length) {
+    ctx.addIssue({ code: "custom", path: ["lanes"], message: "coverage lanes must be unique" });
+  }
+  if (Date.parse(value.incompleteBefore) !== Date.parse(value.from)) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["incompleteBefore"],
+      message: "incomplete-before boundary must match live coverage start",
+    });
+  }
+});
+
+const dailyExamExposureLookupSchema = z.object({
+  status: z.enum(["queried", "unavailable", "not-needed"]),
+  fingerprintVersion: z.literal(TASK_EXPOSURE_FINGERPRINT_VERSION),
+  queriedFingerprints: z.number().int().nonnegative(),
+  coverage: dailyExamExposureCoverageSchema.optional(),
+  failureKind: z.enum([
+    "configuration",
+    "authentication",
+    "transport",
+    "server",
+    "contract",
+  ]).optional(),
+}).strict().superRefine((value, ctx) => {
+  if (value.status === "queried" && (!value.coverage || value.queriedFingerprints < 1)) {
+    ctx.addIssue({ code: "custom", path: ["coverage"], message: "queried lookups require coverage" });
+  }
+  if (value.status === "unavailable" && !value.failureKind) {
+    ctx.addIssue({ code: "custom", path: ["failureKind"], message: "unavailable lookups require a failure kind" });
+  }
+  if (value.status === "not-needed" && value.queriedFingerprints !== 0) {
+    ctx.addIssue({ code: "custom", path: ["queriedFingerprints"], message: "not-needed lookups query nothing" });
+  }
+  if (value.status === "queried" && value.failureKind) {
+    ctx.addIssue({ code: "custom", path: ["failureKind"], message: "queried lookups cannot carry a failure" });
+  }
+  if (value.status !== "queried" && value.coverage) {
+    ctx.addIssue({ code: "custom", path: ["coverage"], message: "only queried lookups carry coverage" });
+  }
+});
+
 export const dailyExamManifestSchema = z.object({
-  schemaVersion: z.literal(1),
-  generatedAt: z.string().min(1),
+  schemaVersion: z.literal(2),
+  generatedAt: isoTimestampSchema,
   source: z.literal("hugin-munin-daily-tasks"),
   contentPolicy: z.literal("content-blind-references-only"),
+  exposureLookup: dailyExamExposureLookupSchema,
   historyComplete: z.boolean(),
   inspectedTasks: z.number().int().nonnegative(),
   counts: z.object({
@@ -57,13 +182,54 @@ export const dailyExamManifestSchema = z.object({
     quarantine: z.number().int().nonnegative(),
   }).strict(),
   candidates: z.array(dailyExamCandidateSchema),
-}).strict();
+}).strict().superRefine((value, ctx) => {
+  if (value.inspectedTasks !== value.candidates.length) {
+    ctx.addIssue({ code: "custom", path: ["inspectedTasks"], message: "candidate count disagrees with inspected tasks" });
+  }
+  const actualCounts = {
+    provisionalHoldout: value.candidates.filter((candidate) => candidate.lane === "provisional-holdout").length,
+    regression: value.candidates.filter((candidate) => candidate.lane === "regression").length,
+    quarantine: value.candidates.filter((candidate) => candidate.lane === "quarantine").length,
+  };
+  for (const key of ["provisionalHoldout", "regression", "quarantine"] as const) {
+    if (value.counts[key] !== actualCounts[key]) {
+      ctx.addIssue({ code: "custom", path: ["counts", key], message: "manifest lane count is dishonest" });
+    }
+  }
+  if (new Set(value.candidates.map((candidate) => candidate.candidateId)).size !== value.candidates.length) {
+    ctx.addIssue({ code: "custom", path: ["candidates"], message: "candidate IDs must be unique" });
+  }
+  for (let index = 0; index < value.candidates.length; index += 1) {
+    const candidate = value.candidates[index]!;
+    if (candidate.lane !== "provisional-holdout") continue;
+    const coverage = value.exposureLookup.coverage;
+    const safeNegative =
+      value.exposureLookup.status === "queried" &&
+      coverage?.coverageComplete === true &&
+      TASK_EXPOSURE_REQUIRED_LANES.every((lane) => coverage.lanes.includes(lane)) &&
+      candidate.source.taskCreatedAt !== undefined &&
+      candidate.source.taskCreatedAt >= coverage.from &&
+      candidate.source.taskCreatedAt <= coverage.through;
+    if (!safeNegative) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["candidates", index, "lane"],
+        message: "provisional holdout is not bound to complete live cross-client coverage",
+      });
+    }
+  }
+});
 export type DailyExamManifest = z.infer<typeof dailyExamManifestSchema>;
 
 export interface DailyTaskHarvestSource {
   status: MuninEntry;
   resultStructured?: MuninEntry | null;
 }
+
+export type DailyExamExposureLookupInput =
+  | { status: "queried"; evidence: TaskExposureLookupEvidence }
+  | { status: "unavailable"; failureKind: TaskExposureLookupFailureKind }
+  | { status: "not-needed" };
 
 function sha256(value: string | Buffer): string {
   return createHash("sha256").update(value).digest("hex");
@@ -77,6 +243,25 @@ function field(content: string, label: string): string | undefined {
 function promptFromTask(content: string): string | undefined {
   const prompt = content.match(/###\s*Prompt\s*\n([\s\S]+)$/i)?.[1]?.trim();
   return prompt || undefined;
+}
+
+export function dailyTaskExposureFingerprint(source: DailyTaskHarvestSource): string | undefined {
+  const prompt = promptFromTask(source.status.content);
+  return prompt ? sha256(prompt) : undefined;
+}
+
+function normalizedIso(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? undefined : new Date(parsed).toISOString();
+}
+
+function taskCreatedAt(source: DailyTaskHarvestSource): string | undefined {
+  const candidates = [
+    normalizedIso(field(source.status.content, "Submitted at")),
+    normalizedIso(source.status.created_at),
+  ].filter((value): value is string => value !== undefined);
+  return candidates.sort()[0];
 }
 
 function contextAliasFromTask(content: string): string | undefined {
@@ -147,6 +332,119 @@ function exposureFor(result: StructuredTaskResult | undefined): DailyExamCandida
   return { state: "unknown", models: [...models].sort(), evidence: ["runtime-exposure-ambiguous"] };
 }
 
+function crossClientRecord(result: TaskExposureLookupResult) {
+  return {
+    fingerprintVersion: TASK_EXPOSURE_FINGERPRINT_VERSION,
+    fingerprintSha256: result.fingerprintSha256,
+    seen: result.seen,
+    firstSeenAt: result.firstSeenAt,
+    lastSeenAt: result.lastSeenAt,
+    lanes: result.lanes,
+    modelIds: result.modelIds,
+    harnessIds: result.harnessIds,
+  };
+}
+
+function resolveExposure(input: {
+  local: DailyExamCandidate["exposure"];
+  fingerprint?: string;
+  createdAt?: string;
+  lookup: DailyExamExposureLookupInput;
+  results: Map<string, TaskExposureLookupResult>;
+}): { exposure: DailyExamCandidate["exposure"]; reason?: string } {
+  const { local, fingerprint, createdAt, lookup, results } = input;
+  if (local.state === "m5-exposed") {
+    const result = fingerprint ? results.get(fingerprint) : undefined;
+    return {
+      exposure: result ? { ...local, crossClient: crossClientRecord(result) } : local,
+    };
+  }
+  if (local.state === "unknown") {
+    const result = fingerprint ? results.get(fingerprint) : undefined;
+    if (result?.seen) {
+      return {
+        exposure: {
+          state: "m5-exposed",
+          models: [...new Set([...local.models, ...result.modelIds])].sort(),
+          evidence: [...new Set([...local.evidence, "cross-client-registry-seen"])].sort(),
+          crossClient: crossClientRecord(result),
+        },
+      };
+    }
+    return {
+      exposure: result ? { ...local, crossClient: crossClientRecord(result) } : local,
+    };
+  }
+  if (!fingerprint) {
+    return {
+      exposure: { ...local, state: "unknown", evidence: [...local.evidence, "cross-client-fingerprint-unavailable"] },
+      reason: "cross-client-fingerprint-unavailable",
+    };
+  }
+  if (lookup.status !== "queried") {
+    return {
+      exposure: { ...local, state: "unknown", evidence: [...local.evidence, "cross-client-lookup-unavailable"] },
+      reason: "cross-client-exposure-lookup-unavailable",
+    };
+  }
+  const result = results.get(fingerprint);
+  if (!result) {
+    return {
+      exposure: { ...local, state: "unknown", evidence: [...local.evidence, "cross-client-result-missing"] },
+      reason: "cross-client-exposure-result-missing",
+    };
+  }
+  const crossClient = crossClientRecord(result);
+  if (result.seen) {
+    return {
+      exposure: {
+        state: "m5-exposed",
+        models: [...new Set([...local.models, ...result.modelIds])].sort(),
+        evidence: [...new Set([...local.evidence, "cross-client-registry-seen"])].sort(),
+        crossClient,
+      },
+    };
+  }
+  const coverage = lookup.evidence.coverage;
+  if (!coverage.coverageComplete) {
+    return {
+      exposure: { ...local, state: "unknown", evidence: [...local.evidence, "cross-client-coverage-incomplete"], crossClient },
+      reason: "cross-client-coverage-incomplete",
+    };
+  }
+  if (!TASK_EXPOSURE_REQUIRED_LANES.every((lane) => coverage.lanes.includes(lane))) {
+    return {
+      exposure: { ...local, state: "unknown", evidence: [...local.evidence, "cross-client-coverage-lanes-incomplete"], crossClient },
+      reason: "cross-client-coverage-lanes-incomplete",
+    };
+  }
+  if (!createdAt) {
+    return {
+      exposure: { ...local, state: "unknown", evidence: [...local.evidence, "task-created-at-unavailable"], crossClient },
+      reason: "task-created-at-unavailable",
+    };
+  }
+  if (createdAt < coverage.from) {
+    return {
+      exposure: { ...local, state: "unknown", evidence: [...local.evidence, "candidate-before-cross-client-coverage"], crossClient },
+      reason: "candidate-before-cross-client-coverage-window",
+    };
+  }
+  if (createdAt > coverage.through) {
+    return {
+      exposure: { ...local, state: "unknown", evidence: [...local.evidence, "candidate-after-cross-client-coverage"], crossClient },
+      reason: "candidate-after-cross-client-coverage-window",
+    };
+  }
+  return {
+    exposure: {
+      ...local,
+      evidence: [...new Set([...local.evidence, "cross-client-registry-unseen-complete"])].sort(),
+      crossClient,
+    },
+  };
+}
+
 function taskTypeFromTags(tags: readonly string[]): string | undefined {
   return tags
     .find((tag) => tag.startsWith("type:") && !tag.startsWith("type:task-result"))
@@ -155,16 +453,32 @@ function taskTypeFromTags(tags: readonly string[]): string | undefined {
 
 /**
  * Convert one completed daily task into content-blind exam-candidate metadata.
- * "No M5 evidence" is intentionally only provisional: Hugin cannot prove the
- * same prompt was not shown through another client, so a later exposure-ledger
- * check remains mandatory before a candidate is sealed as a holdout.
+ * "No M5 evidence" becomes provisional only after a bound negative lookup in
+ * the complete live cross-client coverage window. Missing or incomplete lookup
+ * evidence fails closed to quarantine.
  */
-export function buildDailyExamCandidate(source: DailyTaskHarvestSource): DailyExamCandidate {
+export function buildDailyExamCandidate(
+  source: DailyTaskHarvestSource,
+  exposureLookup: DailyExamExposureLookupInput = { status: "unavailable", failureKind: "configuration" },
+): DailyExamCandidate {
   const taskDocument = source.status.content;
   const prompt = promptFromTask(taskDocument);
   const resultContent = source.resultStructured?.content;
   const result = parseStructuredResult(resultContent);
-  const exposure = exposureFor(result);
+  const localExposure = exposureFor(result);
+  const promptFingerprint = prompt ? sha256(prompt) : undefined;
+  const createdAt = taskCreatedAt(source);
+  const lookupResults = exposureLookup.status === "queried"
+    ? new Map(exposureLookup.evidence.results.map((row) => [row.fingerprintSha256, row]))
+    : new Map<string, TaskExposureLookupResult>();
+  const resolvedExposure = resolveExposure({
+    local: localExposure,
+    fingerprint: promptFingerprint,
+    createdAt,
+    lookup: exposureLookup,
+    results: lookupResults,
+  });
+  const exposure = resolvedExposure.exposure;
   const contextAlias = contextAliasFromTask(taskDocument);
   const githubRepository = githubRepositoryFromPr(result?.prUrl);
   const change = result?.repositoryChange;
@@ -188,6 +502,7 @@ export function buildDailyExamCandidate(source: DailyTaskHarvestSource): DailyEx
   if (sensitivity === "private") reasons.push("private-task-not-eligible-for-automatic-packaging");
   if (sourceClassificationIsPrivate) reasons.push("source-classification-not-eligible-for-automatic-packaging");
   if (exposure.state === "unknown") reasons.push("m5-exposure-unknown");
+  if (resolvedExposure.reason) reasons.push(resolvedExposure.reason);
 
   const repository = sensitivity !== "private" && !sourceClassificationIsPrivate && change && result?.prUrl && githubRepository
     ? {
@@ -207,7 +522,7 @@ export function buildDailyExamCandidate(source: DailyTaskHarvestSource): DailyEx
   if (!quarantine) reasons.push(
     lane === "regression"
       ? "already-exposed-to-m5-use-only-as-regression"
-      : "requires-cross-client-exposure-check-before-holdout-seal",
+      : "cross-client-exposure-check-passed",
     "independent-verifier-required",
   );
 
@@ -220,11 +535,12 @@ export function buildDailyExamCandidate(source: DailyTaskHarvestSource): DailyEx
     diffSha256: change?.diffSha256 ?? null,
   });
   const candidate: DailyExamCandidate = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     candidateId: `daily-${sha256(identity).slice(0, 24)}`,
     source: {
       taskNamespace: source.status.namespace,
       taskId: result?.taskId ?? source.status.namespace.replace(/^tasks\//, ""),
+      ...(createdAt ? { taskCreatedAt: createdAt } : {}),
       statusUpdatedAt: source.status.updated_at,
       taskDocumentSha256: sha256(taskDocument),
       ...(prompt ? { promptSha256: sha256(prompt) } : {}),
@@ -249,15 +565,37 @@ export function buildDailyExamManifest(input: {
   generatedAt: string;
   historyComplete: boolean;
   sources: DailyTaskHarvestSource[];
+  exposureLookup?: DailyExamExposureLookupInput;
 }): DailyExamManifest {
+  const exposureLookup = input.exposureLookup ?? { status: "unavailable", failureKind: "configuration" };
   const candidates = input.sources
-    .map(buildDailyExamCandidate)
+    .map((source) => buildDailyExamCandidate(source, exposureLookup))
     .sort((a, b) => a.candidateId.localeCompare(b.candidateId));
+  const lookupManifest = exposureLookup.status === "queried"
+    ? {
+        status: exposureLookup.status,
+        fingerprintVersion: TASK_EXPOSURE_FINGERPRINT_VERSION,
+        queriedFingerprints: exposureLookup.evidence.results.length,
+        coverage: exposureLookup.evidence.coverage,
+      }
+    : exposureLookup.status === "unavailable"
+      ? {
+          status: exposureLookup.status,
+          fingerprintVersion: TASK_EXPOSURE_FINGERPRINT_VERSION,
+          queriedFingerprints: 0,
+          failureKind: exposureLookup.failureKind,
+        }
+      : {
+          status: exposureLookup.status,
+          fingerprintVersion: TASK_EXPOSURE_FINGERPRINT_VERSION,
+          queriedFingerprints: 0,
+        };
   return dailyExamManifestSchema.parse({
-    schemaVersion: 1,
+    schemaVersion: 2,
     generatedAt: input.generatedAt,
     source: "hugin-munin-daily-tasks",
     contentPolicy: "content-blind-references-only",
+    exposureLookup: lookupManifest,
     historyComplete: input.historyComplete,
     inspectedTasks: input.sources.length,
     counts: {

--- a/src/learning/task-exposure-client.ts
+++ b/src/learning/task-exposure-client.ts
@@ -1,0 +1,319 @@
+import { z } from "zod";
+import { resolveGatewayRootUrl } from "../orchestrator/provider-config.js";
+
+export const TASK_EXPOSURE_FINGERPRINT_VERSION = "trim-utf8-sha256-v1" as const;
+export const TASK_EXPOSURE_REQUIRED_LANES = [
+  "chat",
+  "mcp-ask",
+  "delegate",
+  "delegate-disagreement",
+  "delegate-shadow",
+  "code-loop",
+] as const;
+
+const sha256Schema = z.string().regex(/^[0-9a-f]{64}$/);
+const isoTimestampSchema = z.string().datetime({ offset: true });
+const taskExposureLaneSchema = z.enum(TASK_EXPOSURE_REQUIRED_LANES);
+
+const rawCoverageSchema = z.object({
+  coverage_complete: z.boolean(),
+  from: isoTimestampSchema,
+  through: isoTimestampSchema,
+  lanes: z.array(taskExposureLaneSchema).max(TASK_EXPOSURE_REQUIRED_LANES.length),
+  historical_backfill_complete: z.literal(false),
+  historical_backfill_from: isoTimestampSchema.nullable(),
+  historical_backfill_through: isoTimestampSchema.nullable(),
+  historical_events_imported: z.number().int().nonnegative(),
+  historical_rows_skipped_inexact: z.number().int().nonnegative(),
+  incomplete_before: isoTimestampSchema,
+  incomplete_reasons: z.array(z.string().min(1).max(500)).max(50),
+}).strict().superRefine((value, ctx) => {
+  if (Date.parse(value.from) > Date.parse(value.through)) {
+    ctx.addIssue({ code: "custom", path: ["through"], message: "coverage window is inverted" });
+  }
+  if (new Set(value.lanes).size !== value.lanes.length) {
+    ctx.addIssue({ code: "custom", path: ["lanes"], message: "coverage lanes must be unique" });
+  }
+  if (Date.parse(value.incomplete_before) !== Date.parse(value.from)) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["incomplete_before"],
+      message: "incomplete-before boundary must match live coverage start",
+    });
+  }
+});
+
+const rawResultSchema = z.object({
+  fingerprint_sha256: sha256Schema,
+  seen: z.boolean(),
+  first_seen_at: isoTimestampSchema.nullable(),
+  last_seen_at: isoTimestampSchema.nullable(),
+  lanes: z.array(taskExposureLaneSchema).max(TASK_EXPOSURE_REQUIRED_LANES.length),
+  model_ids: z.array(z.string().min(1).max(160)).max(1_000),
+  harness_ids: z.array(z.string().min(1).max(160)).max(1_000),
+}).strict().superRefine((value, ctx) => {
+  if (!value.seen && (
+    value.first_seen_at !== null ||
+    value.last_seen_at !== null ||
+    value.lanes.length > 0 ||
+    value.model_ids.length > 0 ||
+    value.harness_ids.length > 0
+  )) {
+    ctx.addIssue({ code: "custom", path: ["seen"], message: "unseen results must not carry exposure metadata" });
+  }
+  if (value.seen && (value.first_seen_at === null || value.last_seen_at === null || value.lanes.length === 0)) {
+    ctx.addIssue({ code: "custom", path: ["seen"], message: "seen results require timestamps and lanes" });
+  }
+  if (
+    value.first_seen_at &&
+    value.last_seen_at &&
+    Date.parse(value.first_seen_at) > Date.parse(value.last_seen_at)
+  ) {
+    ctx.addIssue({ code: "custom", path: ["last_seen_at"], message: "exposure window is inverted" });
+  }
+});
+
+const rawResponseSchema = z.object({
+  schema_version: z.literal(1),
+  fingerprint_version: z.literal(TASK_EXPOSURE_FINGERPRINT_VERSION),
+  coverage: rawCoverageSchema,
+  results: z.array(rawResultSchema).min(1).max(100),
+}).strict();
+
+export interface TaskExposureCoverageEvidence {
+  coverageComplete: boolean;
+  from: string;
+  through: string;
+  lanes: Array<(typeof TASK_EXPOSURE_REQUIRED_LANES)[number]>;
+  historicalBackfillComplete: false;
+  incompleteBefore: string;
+  incompleteReasonCount: number;
+}
+
+export interface TaskExposureLookupResult {
+  fingerprintSha256: string;
+  seen: boolean;
+  firstSeenAt: string | null;
+  lastSeenAt: string | null;
+  lanes: Array<(typeof TASK_EXPOSURE_REQUIRED_LANES)[number]>;
+  modelIds: string[];
+  harnessIds: string[];
+}
+
+export interface TaskExposureLookupEvidence {
+  coverage: TaskExposureCoverageEvidence;
+  results: TaskExposureLookupResult[];
+}
+
+export type TaskExposureLookupFailureKind =
+  | "configuration"
+  | "authentication"
+  | "transport"
+  | "server"
+  | "contract";
+
+export class TaskExposureLookupError extends Error {
+  constructor(
+    message: string,
+    public readonly kind: TaskExposureLookupFailureKind,
+  ) {
+    super(message);
+    this.name = "TaskExposureLookupError";
+  }
+}
+
+export interface TaskExposureClientConfig {
+  baseUrl: string;
+  bearerToken: string;
+  requestTimeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}
+
+function intersectLanes(
+  left: TaskExposureCoverageEvidence["lanes"],
+  right: TaskExposureCoverageEvidence["lanes"],
+): TaskExposureCoverageEvidence["lanes"] {
+  const rightSet = new Set(right);
+  return left.filter((lane) => rightSet.has(lane));
+}
+
+function normalizeCoverage(
+  raw: z.infer<typeof rawCoverageSchema>,
+): TaskExposureCoverageEvidence {
+  return {
+    coverageComplete: raw.coverage_complete,
+    from: new Date(raw.from).toISOString(),
+    through: new Date(raw.through).toISOString(),
+    lanes: [...raw.lanes].sort(),
+    historicalBackfillComplete: raw.historical_backfill_complete,
+    incompleteBefore: new Date(raw.incomplete_before).toISOString(),
+    incompleteReasonCount: raw.incomplete_reasons.length,
+  };
+}
+
+function normalizeResult(raw: z.infer<typeof rawResultSchema>): TaskExposureLookupResult {
+  return {
+    fingerprintSha256: raw.fingerprint_sha256,
+    seen: raw.seen,
+    firstSeenAt: raw.first_seen_at ? new Date(raw.first_seen_at).toISOString() : null,
+    lastSeenAt: raw.last_seen_at ? new Date(raw.last_seen_at).toISOString() : null,
+    lanes: [...new Set(raw.lanes)].sort(),
+    modelIds: [...new Set(raw.model_ids)].sort(),
+    harnessIds: [...new Set(raw.harness_ids)].sort(),
+  };
+}
+
+export class TaskExposureClient {
+  private readonly endpoint: string;
+  private readonly token: string;
+  private readonly timeoutMs: number;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(config: TaskExposureClientConfig) {
+    const sovereign = resolveGatewayRootUrl(
+      { HOMESERVER_GATEWAY_URL: config.baseUrl },
+      "HOMESERVER_GATEWAY_URL",
+    );
+    if (!sovereign.ok) {
+      throw new TaskExposureLookupError("task exposure gateway is not sovereign", "configuration");
+    }
+    let base: URL;
+    try {
+      base = new URL(sovereign.baseUrl);
+    } catch {
+      throw new TaskExposureLookupError("task exposure gateway URL is invalid", "configuration");
+    }
+    if (base.protocol !== "http:" && base.protocol !== "https:") {
+      throw new TaskExposureLookupError("task exposure gateway must use http(s)", "configuration");
+    }
+    if (base.username || base.password || base.search || base.hash) {
+      throw new TaskExposureLookupError(
+        "task exposure gateway URL must not contain credentials, query, or fragment",
+        "configuration",
+      );
+    }
+    if (base.pathname !== "/" && base.pathname !== "") {
+      throw new TaskExposureLookupError("task exposure gateway URL must be a root URL", "configuration");
+    }
+    if (config.bearerToken.trim() === "") {
+      throw new TaskExposureLookupError("task exposure owner credential is required", "configuration");
+    }
+    this.endpoint = new URL("/admin/task-exposures/lookup", base).toString();
+    this.token = config.bearerToken;
+    const timeoutMs = config.requestTimeoutMs ?? 15_000;
+    if (!Number.isInteger(timeoutMs) || timeoutMs < 1_000 || timeoutMs > 60_000) {
+      throw new TaskExposureLookupError(
+        "task exposure timeout must be an integer from 1000 to 60000 ms",
+        "configuration",
+      );
+    }
+    this.timeoutMs = timeoutMs;
+    this.fetchImpl = config.fetchImpl ?? fetch;
+  }
+
+  private async lookupBatch(fingerprints: string[]): Promise<z.infer<typeof rawResponseSchema>> {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const response = await this.fetchImpl(this.endpoint, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${this.token}`,
+          "content-type": "application/json",
+          accept: "application/json",
+        },
+        body: JSON.stringify({
+          fingerprint_version: TASK_EXPOSURE_FINGERPRINT_VERSION,
+          fingerprints,
+        }),
+        redirect: "error",
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        const kind = response.status === 401 || response.status === 403
+          ? "authentication"
+          : response.status >= 500
+            ? "server"
+            : "contract";
+        throw new TaskExposureLookupError(
+          `task exposure lookup returned HTTP ${response.status}`,
+          kind,
+        );
+      }
+      let text: string;
+      try {
+        text = await response.text();
+      } catch {
+        throw new TaskExposureLookupError("task exposure lookup response transport failed", "transport");
+      }
+      if (text.length > 1_000_000) {
+        throw new TaskExposureLookupError("task exposure lookup response is too large", "contract");
+      }
+      let raw: unknown;
+      try {
+        raw = JSON.parse(text);
+      } catch {
+        throw new TaskExposureLookupError("task exposure lookup returned invalid JSON", "contract");
+      }
+      const parsed = rawResponseSchema.safeParse(raw);
+      if (!parsed.success) {
+        throw new TaskExposureLookupError("task exposure lookup violated its schema", "contract");
+      }
+      const actual = parsed.data.results.map((result) => result.fingerprint_sha256);
+      if (JSON.stringify(actual) !== JSON.stringify(fingerprints)) {
+        throw new TaskExposureLookupError("task exposure lookup result order/binding drifted", "contract");
+      }
+      return parsed.data;
+    } catch (error) {
+      if (error instanceof TaskExposureLookupError) throw error;
+      const detail = error instanceof Error && error.name === "AbortError" ? "timed out" : "failed";
+      throw new TaskExposureLookupError(`task exposure lookup transport ${detail}`, "transport");
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async lookup(fingerprints: string[]): Promise<TaskExposureLookupEvidence> {
+    const unique = [...new Set(fingerprints)];
+    if (unique.length !== fingerprints.length || unique.length === 0) {
+      throw new TaskExposureLookupError(
+        "task exposure lookup requires unique non-empty fingerprints",
+        "configuration",
+      );
+    }
+    if (!unique.every((fingerprint) => sha256Schema.safeParse(fingerprint).success)) {
+      throw new TaskExposureLookupError("task exposure lookup received an invalid fingerprint", "configuration");
+    }
+
+    let coverage: TaskExposureCoverageEvidence | undefined;
+    const results: TaskExposureLookupResult[] = [];
+    for (let offset = 0; offset < unique.length; offset += 100) {
+      const batch = unique.slice(offset, offset + 100);
+      const response = await this.lookupBatch(batch);
+      const current = normalizeCoverage(response.coverage);
+      if (!coverage) {
+        coverage = current;
+      } else {
+        coverage = {
+          coverageComplete: coverage.coverageComplete && current.coverageComplete,
+          from: coverage.from > current.from ? coverage.from : current.from,
+          through: coverage.through < current.through ? coverage.through : current.through,
+          lanes: intersectLanes(coverage.lanes, current.lanes),
+          historicalBackfillComplete: false,
+          incompleteBefore: coverage.incompleteBefore > current.incompleteBefore
+            ? coverage.incompleteBefore
+            : current.incompleteBefore,
+          incompleteReasonCount: Math.max(
+            coverage.incompleteReasonCount,
+            current.incompleteReasonCount,
+          ),
+        };
+      }
+      results.push(...response.results.map(normalizeResult));
+    }
+    if (!coverage || coverage.from > coverage.through) {
+      throw new TaskExposureLookupError("task exposure batch coverage has no common window", "contract");
+    }
+    return { coverage, results };
+  }
+}

--- a/systemd/hugin-daily-exam-factory.service
+++ b/systemd/hugin-daily-exam-factory.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Hugin daily-use exam candidate factory (read-only Munin sweep)
+Description=Hugin daily-use exam candidate factory (read-only Munin and M5 exposure sweep)
 After=network-online.target munin-memory.service
 Wants=network-online.target
 

--- a/tests/daily-exam-cli.test.ts
+++ b/tests/daily-exam-cli.test.ts
@@ -11,11 +11,30 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+  lookupCrossClientExposure,
   parseArgs,
   writeManifestFile,
 } from "../src/daily-exam-harvest-cli.js";
+import {
+  TASK_EXPOSURE_FINGERPRINT_VERSION,
+  TASK_EXPOSURE_REQUIRED_LANES,
+} from "../src/learning/task-exposure-client.js";
+import type { DailyTaskHarvestSource } from "../src/learning/daily-task-exam-factory.js";
 
 describe("daily exam factory CLI", () => {
+  const lookupSource: DailyTaskHarvestSource = {
+    status: {
+      id: "tasks/lookup/status",
+      namespace: "tasks/lookup",
+      key: "status",
+      content: "## Task: Lookup\n\n- **Submitted at:** 2026-07-14T10:00:00Z\n\n### Prompt\nExact private task text",
+      tags: ["completed"],
+      classification: "internal",
+      created_at: "2026-07-14T10:00:00.000Z",
+      updated_at: "2026-07-14T11:00:00.000Z",
+    },
+  };
+
   it("normalizes timestamps and keeps a bounded default", () => {
     expect(parseArgs(["--since", "2026-07-14T10:00:00+02:00"])).toEqual({
       since: "2026-07-14T08:00:00.000Z",
@@ -64,5 +83,61 @@ describe("daily exam factory CLI", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
+  });
+
+  it("looks up only the content-blind task fingerprint through the sovereign gateway", async () => {
+    const lookup = await lookupCrossClientExposure(
+      [lookupSource],
+      {
+        HOMESERVER_GATEWAY_URL: "http://100.76.72.59:8080",
+        HOMESERVER_GATEWAY_API_KEY: "owner-token",
+      },
+      (async (_url, init) => {
+        const body = JSON.parse(String(init?.body)) as {
+          fingerprint_version: string;
+          fingerprints: string[];
+        };
+        expect(body.fingerprint_version).toBe(TASK_EXPOSURE_FINGERPRINT_VERSION);
+        expect(body.fingerprints).toHaveLength(1);
+        expect(String(init?.body)).not.toContain("Exact private task text");
+        return new Response(JSON.stringify({
+          schema_version: 1,
+          fingerprint_version: TASK_EXPOSURE_FINGERPRINT_VERSION,
+          coverage: {
+            coverage_complete: true,
+            from: "2026-07-14T09:00:00.000Z",
+            through: "2026-07-14T12:00:00.000Z",
+            lanes: TASK_EXPOSURE_REQUIRED_LANES,
+            historical_backfill_complete: false,
+            historical_backfill_from: null,
+            historical_backfill_through: null,
+            historical_events_imported: 0,
+            historical_rows_skipped_inexact: 1,
+            incomplete_before: "2026-07-14T09:00:00.000Z",
+            incomplete_reasons: ["legacy history incomplete"],
+          },
+          results: [{
+            fingerprint_sha256: body.fingerprints[0],
+            seen: false,
+            first_seen_at: null,
+            last_seen_at: null,
+            lanes: [],
+            model_ids: [],
+            harness_ids: [],
+          }],
+        }), { status: 200 });
+      }) as typeof fetch,
+    );
+    expect(lookup).toMatchObject({ status: "queried" });
+  });
+
+  it("fails lookup configuration closed and skips only when no prompt can be fingerprinted", async () => {
+    expect(await lookupCrossClientExposure([lookupSource], {})).toEqual({
+      status: "unavailable",
+      failureKind: "configuration",
+    });
+    const withoutPrompt = structuredClone(lookupSource);
+    withoutPrompt.status.content = "## Task: no prompt section";
+    expect(await lookupCrossClientExposure([withoutPrompt], {})).toEqual({ status: "not-needed" });
   });
 });

--- a/tests/daily-task-exam-factory.test.ts
+++ b/tests/daily-task-exam-factory.test.ts
@@ -3,7 +3,14 @@ import type { MuninEntry } from "../src/munin-client.js";
 import {
   buildDailyExamCandidate,
   buildDailyExamManifest,
+  dailyExamManifestSchema,
+  dailyTaskExposureFingerprint,
+  type DailyExamExposureLookupInput,
 } from "../src/learning/daily-task-exam-factory.js";
+import {
+  TASK_EXPOSURE_FINGERPRINT_VERSION,
+  TASK_EXPOSURE_REQUIRED_LANES,
+} from "../src/learning/task-exposure-client.js";
 import { buildStructuredTaskResult } from "../src/task-result-schema.js";
 
 const BASE = "a".repeat(40);
@@ -88,9 +95,47 @@ function source(runtime: "claude" | "homeserver" = "claude") {
   };
 }
 
+function lookupFor(
+  task = source("claude"),
+  input: {
+    seen?: boolean;
+    coverageComplete?: boolean;
+    from?: string;
+    through?: string;
+    lanes?: string[];
+  } = {},
+): DailyExamExposureLookupInput {
+  const fingerprint = dailyTaskExposureFingerprint(task)!;
+  const seen = input.seen ?? false;
+  return {
+    status: "queried",
+    evidence: {
+      coverage: {
+        coverageComplete: input.coverageComplete ?? true,
+        from: input.from ?? "2026-07-14T09:00:00.000Z",
+        through: input.through ?? "2026-07-14T12:00:00.000Z",
+        lanes: (input.lanes ?? [...TASK_EXPOSURE_REQUIRED_LANES]) as typeof TASK_EXPOSURE_REQUIRED_LANES[number][],
+        historicalBackfillComplete: false,
+        incompleteBefore: input.from ?? "2026-07-14T09:00:00.000Z",
+        incompleteReasonCount: 1,
+      },
+      results: [{
+        fingerprintSha256: fingerprint,
+        seen,
+        firstSeenAt: seen ? "2026-07-14T10:30:00.000Z" : null,
+        lastSeenAt: seen ? "2026-07-14T10:30:00.000Z" : null,
+        lanes: seen ? ["chat"] : [],
+        modelIds: seen ? ["qwen3-coder-next-80b"] : [],
+        harnessIds: seen ? ["openai-chat"] : [],
+      }],
+    },
+  };
+}
+
 describe("daily task exam factory", () => {
   it("turns cloud-completed repository work into a provisional, content-blind holdout candidate", () => {
-    const candidate = buildDailyExamCandidate(source("claude"));
+    const cloud = source("claude");
+    const candidate = buildDailyExamCandidate(cloud, lookupFor(cloud));
     expect(candidate.lane).toBe("provisional-holdout");
     expect(candidate.readiness).toBe("needs-independent-verifier");
     expect(candidate.exposure.state).toBe("no-m5-evidence");
@@ -104,7 +149,33 @@ describe("daily task exam factory", () => {
     const serialized = JSON.stringify(candidate);
     expect(serialized).not.toContain("Fix the parser");
     expect(serialized).not.toContain("Sensitive answer text");
-    expect(candidate.reasons).toContain("requires-cross-client-exposure-check-before-holdout-seal");
+    expect(candidate.exposure.crossClient).toEqual(expect.objectContaining({
+      fingerprintVersion: TASK_EXPOSURE_FINGERPRINT_VERSION,
+      seen: false,
+    }));
+    expect(candidate.reasons).toContain("cross-client-exposure-check-passed");
+  });
+
+  it("routes a cross-client positive to regression even when Hugin ran it in cloud", () => {
+    const cloud = source("claude");
+    const candidate = buildDailyExamCandidate(cloud, lookupFor(cloud, { seen: true }));
+    expect(candidate.lane).toBe("regression");
+    expect(candidate.exposure.state).toBe("m5-exposed");
+    expect(candidate.exposure.models).toContain("qwen3-coder-next-80b");
+    expect(candidate.exposure.evidence).toContain("cross-client-registry-seen");
+  });
+
+  it("fails unseen candidates closed outside complete all-lane coverage", () => {
+    const cloud = source("claude");
+    expect(buildDailyExamCandidate(cloud, lookupFor(cloud, { coverageComplete: false })))
+      .toMatchObject({ lane: "quarantine", readiness: "quarantined" });
+    expect(buildDailyExamCandidate(cloud, lookupFor(cloud, { from: "2026-07-14T10:30:00.000Z" })).reasons)
+      .toContain("candidate-before-cross-client-coverage-window");
+    expect(buildDailyExamCandidate(cloud, lookupFor(cloud, {
+      lanes: TASK_EXPOSURE_REQUIRED_LANES.filter((lane) => lane !== "code-loop"),
+    })).reasons).toContain("cross-client-coverage-lanes-incomplete");
+    expect(buildDailyExamCandidate(cloud).reasons)
+      .toContain("cross-client-exposure-lookup-unavailable");
   });
 
   it("routes a task already seen by M5 to regression rather than a holdout", () => {
@@ -133,6 +204,15 @@ describe("daily task exam factory", () => {
     expect(candidate.lane).toBe("quarantine");
     expect(candidate.exposure.state).toBe("unknown");
     expect(candidate.reasons).toContain("valid-result-structured-missing");
+  });
+
+  it("keeps malformed results quarantined while preserving a positive registry match", () => {
+    const malformed = source("claude");
+    malformed.resultStructured.content = "not json";
+    const candidate = buildDailyExamCandidate(malformed, lookupFor(malformed, { seen: true }));
+    expect(candidate.lane).toBe("quarantine");
+    expect(candidate.exposure.state).toBe("m5-exposed");
+    expect(candidate.exposure.crossClient?.seen).toBe(true);
   });
 
   it("omits repository metadata when quarantining a private task", () => {
@@ -175,8 +255,17 @@ describe("daily task exam factory", () => {
       generatedAt: "2026-07-14T12:00:00.000Z",
       historyComplete: false,
       sources: [cloud, m5],
+      exposureLookup: lookupFor(cloud),
     });
     expect(manifest.historyComplete).toBe(false);
     expect(manifest.counts).toEqual({ provisionalHoldout: 1, regression: 1, quarantine: 0 });
+    expect(manifest.exposureLookup).toMatchObject({
+      status: "queried",
+      fingerprintVersion: TASK_EXPOSURE_FINGERPRINT_VERSION,
+      queriedFingerprints: 1,
+    });
+    const forged = structuredClone(manifest);
+    forged.exposureLookup.coverage!.coverageComplete = false;
+    expect(dailyExamManifestSchema.safeParse(forged).success).toBe(false);
   });
 });

--- a/tests/task-exposure-client.test.ts
+++ b/tests/task-exposure-client.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  TASK_EXPOSURE_FINGERPRINT_VERSION,
+  TASK_EXPOSURE_REQUIRED_LANES,
+  TaskExposureClient,
+} from "../src/learning/task-exposure-client.js";
+
+const A = "a".repeat(64);
+const B = "b".repeat(64);
+
+function responseFor(
+  fingerprints: string[],
+  input: {
+    from?: string;
+    through?: string;
+    coverageComplete?: boolean;
+    lanes?: string[];
+    results?: unknown[];
+  } = {},
+): Response {
+  return new Response(JSON.stringify({
+    schema_version: 1,
+    fingerprint_version: TASK_EXPOSURE_FINGERPRINT_VERSION,
+    coverage: {
+      coverage_complete: input.coverageComplete ?? true,
+      from: input.from ?? "2026-07-14T10:00:00.000Z",
+      through: input.through ?? "2026-07-14T12:00:00.000Z",
+      lanes: input.lanes ?? TASK_EXPOSURE_REQUIRED_LANES,
+      historical_backfill_complete: false,
+      historical_backfill_from: null,
+      historical_backfill_through: null,
+      historical_events_imported: 0,
+      historical_rows_skipped_inexact: 7,
+      incomplete_before: input.from ?? "2026-07-14T10:00:00.000Z",
+      incomplete_reasons: ["legacy history is incomplete"],
+    },
+    results: input.results ?? fingerprints.map((fingerprint) => ({
+      fingerprint_sha256: fingerprint,
+      seen: false,
+      first_seen_at: null,
+      last_seen_at: null,
+      lanes: [],
+      model_ids: [],
+      harness_ids: [],
+    })),
+  }), { status: 200, headers: { "content-type": "application/json" } });
+}
+
+describe("TaskExposureClient", () => {
+  it("sends only content-blind fingerprints and binds ordered results", async () => {
+    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      expect(String(_url)).toBe("http://100.76.72.59:8080/admin/task-exposures/lookup");
+      expect((init?.headers as Record<string, string>).authorization).toBe("Bearer owner-token");
+      expect(init?.redirect).toBe("error");
+      expect(String(init?.body)).not.toContain("owner-token");
+      expect(JSON.parse(String(init?.body))).toEqual({
+        fingerprint_version: TASK_EXPOSURE_FINGERPRINT_VERSION,
+        fingerprints: [A, B],
+      });
+      return responseFor([A, B]);
+    });
+    const client = new TaskExposureClient({
+      baseUrl: "http://100.76.72.59:8080",
+      bearerToken: "owner-token",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+    const evidence = await client.lookup([A, B]);
+    expect(evidence.results.map((result) => result.fingerprintSha256)).toEqual([A, B]);
+    expect(evidence.coverage.coverageComplete).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("batches more than 100 fingerprints and uses the safe coverage intersection", async () => {
+    const fingerprints = Array.from({ length: 101 }, (_, index) =>
+      index.toString(16).padStart(64, "0"));
+    let call = 0;
+    const client = new TaskExposureClient({
+      baseUrl: "http://100.76.72.59:8080",
+      bearerToken: "owner-token",
+      fetchImpl: (async (_url, init) => {
+        const batch = JSON.parse(String(init?.body)).fingerprints as string[];
+        call += 1;
+        return responseFor(batch, {
+          from: call === 1 ? "2026-07-14T10:00:00.000Z" : "2026-07-14T10:05:00.000Z",
+          through: call === 1 ? "2026-07-14T12:00:00.000Z" : "2026-07-14T11:55:00.000Z",
+        });
+      }) as typeof fetch,
+    });
+    const evidence = await client.lookup(fingerprints);
+    expect(call).toBe(2);
+    expect(evidence.results).toHaveLength(101);
+    expect(evidence.coverage.from).toBe("2026-07-14T10:05:00.000Z");
+    expect(evidence.coverage.through).toBe("2026-07-14T11:55:00.000Z");
+  });
+
+  it("rejects reordered results and dishonest unseen metadata", async () => {
+    const reordered = new TaskExposureClient({
+      baseUrl: "http://100.76.72.59:8080",
+      bearerToken: "owner-token",
+      fetchImpl: (async () => responseFor([B, A])) as typeof fetch,
+    });
+    await expect(reordered.lookup([A, B])).rejects.toMatchObject({ kind: "contract" });
+
+    const dishonest = new TaskExposureClient({
+      baseUrl: "http://100.76.72.59:8080",
+      bearerToken: "owner-token",
+      fetchImpl: (async () => responseFor([A], { results: [{
+        fingerprint_sha256: A,
+        seen: false,
+        first_seen_at: "2026-07-14T10:00:00.000Z",
+        last_seen_at: null,
+        lanes: [],
+        model_ids: [],
+        harness_ids: [],
+      }] })) as typeof fetch,
+    });
+    await expect(dishonest.lookup([A])).rejects.toMatchObject({ kind: "contract" });
+  });
+
+  it("classifies authorization and transport failures without exposing credentials", async () => {
+    const denied = new TaskExposureClient({
+      baseUrl: "http://100.76.72.59:8080",
+      bearerToken: "owner-token",
+      fetchImpl: (async () => new Response("denied", { status: 403 })) as typeof fetch,
+    });
+    await expect(denied.lookup([A])).rejects.toMatchObject({ kind: "authentication" });
+
+    const offline = new TaskExposureClient({
+      baseUrl: "http://100.76.72.59:8080",
+      bearerToken: "owner-token",
+      fetchImpl: (async () => { throw new TypeError("owner-token network failure"); }) as typeof fetch,
+    });
+    await expect(offline.lookup([A])).rejects.toMatchObject({
+      kind: "transport",
+      message: "task exposure lookup transport failed",
+    });
+    expect(() => new TaskExposureClient({
+      baseUrl: "https://public.example.com",
+      bearerToken: "owner-token",
+    })).toThrow(/sovereign/);
+  });
+});


### PR DESCRIPTION
## Summary
- hash each exact daily task prompt with the deployed trim-utf8-sha256-v1 contract and query M5 in batches of 100
- classify positive matches as regressions and permit negative provisional holdouts only inside complete live all-lane coverage
- fail missing credentials, transport/schema drift, incomplete coverage, missing lanes, and old/future tasks closed to quarantine
- emit content-blind schema-v2 evidence; deny redirects and drop free-form lookup prose
- make deployment acceptance verify that the production lookup is wired

## Validation
- live read-only production probe: HTTP 200, schema 1, coverage complete, six lanes
- npm run build
- focused: 3 files / 21 tests
- full: 109 files / 1,787 tests
- both CI shell suites
- bash syntax and git diff --check

No model, Harbor run, learning import, route change, or promotion is performed.