### PR TITLE
Expose shared friction reporting and restore PR CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,7 @@ hugin/
 │   ├── ollama-hosts.ts    # Lazy host resolution with negative caching
 │   ├── context-loader.ts  # Context-refs resolver (fetch Munin entries for prompt injection)
 │   ├── daily-exam-harvest-cli.ts # Production-built, read-only Munin sweep → mode-0600 candidate manifest
+│   ├── friction-cli.ts    # Authenticated Broker CLI for writing shared friction events
 │   ├── prompt-injection-scanner.ts # Regex scanner for adversarial patterns in context-ref content
 │   ├── exfiltration-scanner.ts   # Regex scanner for data-leak patterns in task output
 │   ├── provenance.ts               # External-vs-trusted provenance detection for context-refs
@@ -124,8 +125,8 @@ hugin/
 │   ├── artifact-delivery.ts      # Runtime-owned artefact delivery (#68): manifest parse/validate, target allowlist, symlink guard, rsync→sha256→mv deliver+verify
 │   ├── mcp-server.ts             # hugin-mcp stdio entrypoint (orchestrator-side, on the laptop)
 │   ├── mcp/                      # hugin-mcp internals (broker client + tool definitions)
-│   │   ├── broker-client.ts      # HTTP client for /v1/delegate/* (bearer auth, AbortController timeout)
-│   │   └── tools.ts              # 5 delegation + 5 learning-loop MCP tools
+│   │   ├── broker-client.ts      # HTTP client for delegate/friction/learning APIs (bearer auth, AbortController timeout)
+│   │   └── tools.ts              # 5 delegation + 5 learning-loop + friction MCP tools
 │   ├── broker/                   # MCP durable-delegation API (Tailscale-only HTTP, /v1/delegate/*)
 │   │   ├── server.ts             # Express app + opt-in startup (HUGIN_BROKER_KEYS)
 │   │   ├── handlers.ts           # submit/await/rate/list/models endpoint handlers
@@ -152,6 +153,16 @@ hugin/
     ├── sync-claude-config.sh     # DEPRECATED — config now lives in the claude-config repo (bootstrap.sh)
     └── update-cli.sh             # Auto-update CLI tools (daily cron)
 ```
+
+### Lifecycle, quality, and friction
+
+`completed` means the executor exited successfully. It does not by itself mean
+that the requested change was correct, useful, or accepted. `hugin_rate` stores
+product-usefulness feedback for owned terminal Broker tasks. Friction is an
+orthogonal signal: use the standalone `report_friction` MCP tool, Broker
+`POST /v1/friction/report`, main-MCP `hugin_report_friction`, or the
+`hugin-friction` CLI to record capability, environment, or specification
+problems in `signals/friction`. See `docs/friction-reporting.md`.
 
 ## How to build
 

--- a/docs/daily-exam-factory.md
+++ b/docs/daily-exam-factory.md
@@ -44,6 +44,13 @@ Every non-quarantined candidate still has readiness
 `needs-independent-verifier`. Agent prose and a changed test file are not an
 independent grading oracle.
 
+`completed` means that the executor lifecycle finished successfully; it is not
+proof that the solution was accepted. The schema-v2 factory does not yet join
+general post-run reviewer feedback. Hugin
+[#216](https://github.com/Magnus-Gille/hugin/issues/216) tracks binding semantic
+acceptance to the exact result/diff and carrying it into harvesting. Until then,
+neither a candidate record nor a green task lifecycle is a golden answer.
+
 ## Cross-client exposure snapshot
 
 Hugin computes the exact M5 fingerprint contract:

--- a/docs/friction-reporting.md
+++ b/docs/friction-reporting.md
@@ -30,9 +30,13 @@ write returns an error so the caller knows the evidence was not recorded.
 The Broker endpoint is available only when the authenticated Broker is enabled.
 It defaults `model_id` to the authenticated principal and adds
 `source:broker-api` plus `reporter:<principal>` tags. A caller may provide a
-more precise `model_id`, but the authenticated reporter tag remains. The
-`source:*` and `reporter:*` prefixes are server-owned; caller-supplied tags with
-either prefix are discarded.
+more precise `model_id`, but the authenticated reporter tag remains. Taxonomy,
+model, task, tool, classification, and provenance tag prefixes are server-owned;
+caller-supplied tags with those prefixes are discarded. Routing tags such as
+`repo:*`, `issue:*`, and `phase:*` remain available to callers.
+
+When `task_id` resolves to a private Munin task, the friction event inherits its
+restricted classification. Reports without a linked task remain `internal`.
 
 Broker writes are retry-safe without losing recurrence frequency. Each event
 has an `event_id`: the MCP and CLI clients generate one automatically and reuse

--- a/docs/friction-reporting.md
+++ b/docs/friction-reporting.md
@@ -30,7 +30,15 @@ write returns an error so the caller knows the evidence was not recorded.
 The Broker endpoint is available only when the authenticated Broker is enabled.
 It defaults `model_id` to the authenticated principal and adds
 `source:broker-api` plus `reporter:<principal>` tags. A caller may provide a
-more precise `model_id`, but the authenticated reporter tag remains.
+more precise `model_id`, but the authenticated reporter tag remains. The
+`source:*` and `reporter:*` prefixes are server-owned; caller-supplied tags with
+either prefix are discarded.
+
+Broker writes are retry-safe. The server derives the Munin key from the
+authenticated reporter and normalized event payload, so submitting the same
+event again returns the existing key with `deduplicated: true` instead of
+adding a second corpus entry. A materially different report gets a different
+key.
 
 ## CLI example
 
@@ -70,5 +78,6 @@ Content-Type: application/json
 }
 ```
 
-A successful write returns HTTP `201` with the durable Munin namespace and key.
+A successful write returns HTTP `201` with the durable Munin namespace, key,
+and a `deduplicated` boolean.
 Use `npm run friction-report` for the existing aggregate readout.

--- a/docs/friction-reporting.md
+++ b/docs/friction-reporting.md
@@ -1,0 +1,74 @@
+# Friction reporting
+
+Hugin stores concrete task-solving friction as schema-v1 events in the flat
+Munin namespace `signals/friction`. A friction event says that the model,
+environment, or task specification made execution harder than it should have
+been. It is operational evidence; it is not a verdict on the final answer.
+
+Use `hugin_rate` for product usefulness of a terminal Broker task. Use friction
+reporting for events such as a missing tool, a sandbox failure, an unclear
+prerequisite, or a model hitting a reasoning limit. One task can legitimately
+have both kinds of evidence.
+
+## Submission surfaces
+
+All submission surfaces use the same taxonomy, payload, tags, and Munin
+namespace:
+
+| Surface | Entry point | Intended caller |
+|---|---|---|
+| Injected standalone MCP | `report_friction` | Claude SDK tasks running inside Hugin |
+| Broker HTTP API | `POST /v1/friction/report` | Authenticated integrations |
+| Main Hugin MCP | `hugin_report_friction` | Codex/Claude orchestrator sessions |
+| CLI | `hugin-friction` or `npm run friction-submit --` | Humans, scripts, and quality gates |
+
+The standalone MCP remains deliberately lossy: a Munin timeout is reported as
+`dropped: true` and never blocks the task that encountered the friction. The
+Broker API and its MCP/CLI clients are explicit post-run operations; a failed
+write returns an error so the caller knows the evidence was not recorded.
+
+The Broker endpoint is available only when the authenticated Broker is enabled.
+It defaults `model_id` to the authenticated principal and adds
+`source:broker-api` plus `reporter:<principal>` tags. A caller may provide a
+more precise `model_id`, but the authenticated reporter tag remains.
+
+## CLI example
+
+```bash
+export HUGIN_BROKER_URL=http://huginmunin:3033
+export HUGIN_BROKER_TOKEN="$(your-keychain-helper)"
+
+hugin-friction \
+  --friction-type tool_failure \
+  --severity blocking \
+  --summary "Codex sandbox could not start" \
+  --detail "The outer systemd sandbox did not allow AF_NETLINK." \
+  --task-id 20260714t214415z-dogfood-cassette3 \
+  --tool-name codex-exec \
+  --tag repo:cassette-ai \
+  --tag issue:hugin-218
+```
+
+Never include credentials, tokens, private source text, or unnecessary task
+content in `summary`, `detail`, or tags. Describe the failure and remediation,
+not the sensitive payload being processed.
+
+## API example
+
+```http
+POST /v1/friction/report
+Authorization: Bearer <broker token>
+Content-Type: application/json
+
+{
+  "friction_type": "prerequisite_missing",
+  "severity": "high",
+  "summary": "Managed repository assumed the wrong default branch",
+  "detail": "The repository uses master, while the workflow assumed origin/main.",
+  "task_id": "20260714t214415z-dogfood-cassette3",
+  "tags": ["repo:cassette-ai", "issue:hugin-217"]
+}
+```
+
+A successful write returns HTTP `201` with the durable Munin namespace and key.
+Use `npm run friction-report` for the existing aggregate readout.

--- a/docs/friction-reporting.md
+++ b/docs/friction-reporting.md
@@ -34,11 +34,13 @@ more precise `model_id`, but the authenticated reporter tag remains. The
 `source:*` and `reporter:*` prefixes are server-owned; caller-supplied tags with
 either prefix are discarded.
 
-Broker writes are retry-safe. The server derives the Munin key from the
-authenticated reporter and normalized event payload, so submitting the same
-event again returns the existing key with `deduplicated: true` instead of
-adding a second corpus entry. A materially different report gets a different
-key.
+Broker writes are retry-safe without losing recurrence frequency. Each event
+has an `event_id`: the MCP and CLI clients generate one automatically and reuse
+it for an automatic transport retry. Raw API callers must supply a UUID and
+reuse it only when retrying the same occurrence. The same event and payload
+returns the existing key with `deduplicated: true`; reusing an ID with different
+evidence returns HTTP `409`. A genuinely later recurrence gets a new ID and a
+new corpus entry.
 
 ## CLI example
 
@@ -51,6 +53,7 @@ hugin-friction \
   --severity blocking \
   --summary "Codex sandbox could not start" \
   --detail "The outer systemd sandbox did not allow AF_NETLINK." \
+  --event-id 11111111-2222-4333-8444-555555555555 \
   --task-id 20260714t214415z-dogfood-cassette3 \
   --tool-name codex-exec \
   --tag repo:cassette-ai \
@@ -69,6 +72,7 @@ Authorization: Bearer <broker token>
 Content-Type: application/json
 
 {
+  "event_id": "11111111-2222-4333-8444-555555555555",
   "friction_type": "prerequisite_missing",
   "severity": "high",
   "summary": "Managed repository assumed the wrong default branch",

--- a/docs/research/m5-task-solver-dogfood-2026-07.md
+++ b/docs/research/m5-task-solver-dogfood-2026-07.md
@@ -1,0 +1,92 @@
+# M5 task-solver dogfood finding — July 2026
+
+Status: evidence note, not a production routing policy.
+
+## Finding
+
+M5/OpenCode is a promising lane for bounded coding tasks whose result can be
+checked cheaply and mechanically. The current evidence does not justify sending
+complex repair or review-convergence work to it autonomously.
+
+This is deliberately narrower than “M5 can solve coding tasks.” The observed
+unit is one attempt under one harness, prompt, repository state, model route,
+and verifier—not an enduring property of the machine or model family.
+
+## Observed runs
+
+| Task | Lane | Result | Independent quality gate | Interpretation |
+|---|---|---|---|---|
+| Heimdall #88 | M5/OpenCode | PR [#122](https://github.com/Magnus-Gille/heimdall/pull/122) | 45 focused tests, 943 full Node tests, 29 Python tests, and lint passed | Positive evidence for bounded, well-specified, mechanically verifiable work |
+| Munin #170 repair, attempt 1 | M5/OpenCode | Exit 0 after operating in the wrong path; no repository change | Rejected | Harness completion is not semantic completion |
+| Munin #170 repair, attempt 2 | M5/OpenCode | Unsafe partial result after about 19 minutes | Rejected | Negative evidence for complex transactional repair/review convergence |
+| Munin #170 continuation | cloud Claude | PR [#206](https://github.com/Magnus-Gille/munin-memory/pull/206) | Implementation worked under an added adversarial test, but the submitted PR still lacked required regression coverage and needed cleanup | Even cloud completion requires an independent quality gate |
+| Cassette #3 | Codex under Hugin | No commands could run because the service sandbox blocked `AF_NETLINK` | Invalid capability evidence | Infrastructure failure must be excluded from model-quality conclusions; tracked by Hugin [#218](https://github.com/Magnus-Gille/hugin/issues/218) |
+
+## Provisional routing hypothesis
+
+Admit an M5 coding attempt when all of these are observable before execution:
+
+- the requested outcome and repository scope are explicit;
+- the likely change is bounded rather than an open-ended architectural repair;
+- deterministic tests, type checks, lint, or another cheap verifier can reject a bad result;
+- the harness has a clean, isolated worktree and passes an infrastructure preflight;
+- a cloud/human quality gate remains responsible for acceptance while the lane is being evaluated.
+
+Abstain or route to the stronger harness when any of these apply:
+
+- correctness depends on concurrency, transactions, migrations, security
+  boundaries, or other adversarial invariants not covered by a mechanical test;
+- the task is primarily diagnosis plus iterative review convergence;
+- no independent verifier can cheaply distinguish a plausible answer from a
+  correct one;
+- repository path, base branch, tool permissions, or sandbox readiness is
+  ambiguous;
+- a prior attempt produced a no-op, unsafe partial result, or repeated review
+  rejection and the new attempt does not materially change the harness or
+  acceptance contract.
+
+Confidence is **low**. There are only two valid M5/OpenCode coding observations
+in this dogfood slice: one accepted bounded task and one complex task with two
+rejected attempts. The Cassette run is infrastructure evidence, not model
+evidence.
+
+## What should enter the learning loop
+
+Record these dimensions separately:
+
+1. **Execution lifecycle:** did the harness start and finish? Hugin's
+   `completed` state currently answers only this question.
+2. **Repository evidence:** did the attempt produce the expected diff in the
+   correct repository and base state?
+3. **Mechanical verification:** which declared checks ran, and did they pass?
+4. **Independent acceptance:** `pass | partial | redo | wrong`, with reviewer
+   provenance and binding to the exact result/diff.
+5. **Friction:** did infrastructure, tooling, model capability, or task
+   specification interfere with the attempt?
+
+Do not train routing from exit code, PR existence, or green repository tests
+alone. Hugin [#216](https://github.com/Magnus-Gille/hugin/issues/216) tracks the
+missing general semantic-acceptance contract.
+
+## M5 meta-check of this finding
+
+A bounded M5 `mellum` classification call was run against the evidence summary
+on 2026-07-15 (ledger `e2ca23ad-9f0f-43ff-84c5-e8e2ddd1961f`). It returned in
+8.28 seconds using 600 tokens and proposed essentially the same
+eligible/abstain split. The gateway correctly marked it `unverified` and its
+delegate policy remained `shadow` because no verifier-backed lane existed.
+
+The quality-gate rating for that draft is **partial**: the condition lists were
+useful, but its one-sentence hypothesis said “reliably” and assigned medium
+confidence from this tiny sample, and one proposed falsifier incorrectly treated
+the infrastructure-blocked Cassette run as valid model evidence. The edits in
+this note narrow those claims and downgrade confidence.
+
+## Next falsifiable evaluation
+
+Build a stratified corpus of fresh managed-repository tasks, preclassify each as
+bounded/mechanically-verifiable or complex/review-heavy, and run matched M5 and
+cloud attempts from the same base commit. A reviewer who does not know the lane
+should rate the exact diffs. Promote a routing rule only through the existing
+champion/challenger gate with predeclared sample, verifier-coverage, quality,
+latency, and regression thresholds.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "bin": {
         "friction-mcp": "dist/friction-mcp.js",
+        "hugin-friction": "dist/friction-cli.js",
         "hugin-mcp": "dist/mcp-server.js"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "bin": {
     "hugin-mcp": "dist/mcp-server.js",
-    "friction-mcp": "dist/friction-mcp.js"
+    "friction-mcp": "dist/friction-mcp.js",
+    "hugin-friction": "dist/friction-cli.js"
   },
   "scripts": {
     "build": "tsc",
@@ -14,6 +15,7 @@
     "start:mcp": "node dist/mcp-server.js",
     "start:friction-mcp": "node dist/friction-mcp.js",
     "friction-report": "node scripts/friction-report.mjs",
+    "friction-submit": "node dist/friction-cli.js",
     "build:pii-fixtures": "tsx scripts/build-pii-fixtures.ts",
     "eval:pii": "tsx scripts/run-pii-eval.ts",
     "experiment:m5-code-loop": "tsx scripts/run-m5-code-loop-experiment.ts",

--- a/src/broker/handlers.ts
+++ b/src/broker/handlers.ts
@@ -51,7 +51,7 @@ import { reportFrictionInputSchema } from "../friction/schema.js";
 
 const brokerFrictionInputSchema = reportFrictionInputSchema.extend({
   event_id: z.string().uuid(),
-});
+}).strict();
 
 export interface BrokerHandlerDependencies {
   taskStore: BrokerTaskStore;
@@ -516,8 +516,9 @@ export function createFrictionHandler(deps: BrokerHandlerDependencies) {
       }
       res.status(500).json({
         error: "internal",
-        message: `friction write failed: ${err instanceof Error ? err.message : String(err)}`,
+        message: "friction write failed",
       });
+      console.error("[broker] friction write failed:", err);
     }
   };
 }

--- a/src/broker/handlers.ts
+++ b/src/broker/handlers.ts
@@ -7,8 +7,9 @@
  *   - rate    (§5)
  *   - list    (§5 projection)
  *   - models  (§2 alias map + §6 registry view)
+ *   - friction (shared operational evidence corpus)
  *
- * All five endpoints assume `brokerAuthMiddleware` has already populated
+ * All handlers assume `brokerAuthMiddleware` has already populated
  * `req.brokerPrincipal`.
  */
 
@@ -41,6 +42,7 @@ import {
 import type { AwaitLifecycle } from "./await-observation.js";
 import type { AuthenticatedRequest } from "./auth.js";
 import { computeSubmitWarnings } from "./submit-warnings.js";
+import { reportFrictionInputSchema } from "../friction/schema.js";
 
 export interface BrokerHandlerDependencies {
   taskStore: BrokerTaskStore;
@@ -469,6 +471,38 @@ export function createRateHandler(deps: BrokerHandlerDependencies) {
     }
 
     res.status(204).send();
+  };
+}
+
+export function createFrictionHandler(deps: BrokerHandlerDependencies) {
+  return async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    const principal = req.brokerPrincipal;
+    if (!principal) {
+      res.status(500).json({ error: "internal", message: "principal missing" });
+      return;
+    }
+
+    let parsed;
+    try {
+      parsed = reportFrictionInputSchema.parse(req.body);
+    } catch (err) {
+      respondZodError(res, err);
+      return;
+    }
+
+    try {
+      const result = await deps.taskStore.writeFriction(
+        parsed,
+        principal,
+        nowFn(deps)(),
+      );
+      res.status(201).json(result);
+    } catch (err) {
+      res.status(500).json({
+        error: "internal",
+        message: `friction write failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
   };
 }
 

--- a/src/broker/handlers.ts
+++ b/src/broker/handlers.ts
@@ -14,7 +14,7 @@
  */
 
 import type { Request, Response } from "express";
-import { ZodError } from "zod";
+import { z, ZodError } from "zod";
 import {
   ACTIVE_ALIAS_MAP,
   RUNTIME_REGISTRY,
@@ -31,7 +31,12 @@ import { projectDelegations } from "./journal.js";
 import type { IdempotencyIndex } from "./idempotency.js";
 import { hashPayload } from "./idempotency.js";
 import type { BrokerTaskStore } from "./task-store.js";
-import { generateBrokerTaskId, parseCanonicalEnvelope, parseStoredEnvelope } from "./task-store.js";
+import {
+  FrictionIdempotencyConflictError,
+  generateBrokerTaskId,
+  parseCanonicalEnvelope,
+  parseStoredEnvelope,
+} from "./task-store.js";
 import {
   awaitRequestSchema,
   delegationRequestSchema,
@@ -43,6 +48,10 @@ import type { AwaitLifecycle } from "./await-observation.js";
 import type { AuthenticatedRequest } from "./auth.js";
 import { computeSubmitWarnings } from "./submit-warnings.js";
 import { reportFrictionInputSchema } from "../friction/schema.js";
+
+const brokerFrictionInputSchema = reportFrictionInputSchema.extend({
+  event_id: z.string().uuid(),
+});
 
 export interface BrokerHandlerDependencies {
   taskStore: BrokerTaskStore;
@@ -484,7 +493,7 @@ export function createFrictionHandler(deps: BrokerHandlerDependencies) {
 
     let parsed;
     try {
-      parsed = reportFrictionInputSchema.parse(req.body);
+      parsed = brokerFrictionInputSchema.parse(req.body);
     } catch (err) {
       respondZodError(res, err);
       return;
@@ -498,6 +507,13 @@ export function createFrictionHandler(deps: BrokerHandlerDependencies) {
       );
       res.status(201).json(result);
     } catch (err) {
+      if (err instanceof FrictionIdempotencyConflictError) {
+        res.status(409).json({
+          error: "idempotency_collision",
+          message: err.message,
+        });
+        return;
+      }
       res.status(500).json({
         error: "internal",
         message: `friction write failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/broker/server.ts
+++ b/src/broker/server.ts
@@ -1,8 +1,9 @@
 /**
  * Broker HTTP server (orchestrator v1).
  *
- * Mounts the five `/v1/delegate/*` handlers and optional versioned-learning
- * handlers behind the bearer-token middleware on a separate Express app. The default bind is loopback only;
+ * Mounts the five `/v1/delegate/*` handlers, the shared friction endpoint, and
+ * optional versioned-learning handlers behind the bearer-token middleware on a
+ * separate Express app. The default bind is loopback only;
  * production deployments override `HUGIN_BROKER_HOST` to the Tailscale
  * interface IP. Health is unauthenticated; everything else requires a
  * known principal.
@@ -23,6 +24,7 @@ import {
 } from "./auth.js";
 import {
   createAwaitHandler,
+  createFrictionHandler,
   createListHandler,
   createModelsHandler,
   createRateHandler,
@@ -62,6 +64,7 @@ export function buildBrokerApp(config: BrokerServerConfig): Express {
   app.post("/v1/delegate/submit", auth, createSubmitHandler(config.deps));
   app.post("/v1/delegate/await", auth, createAwaitHandler(config.deps));
   app.post("/v1/delegate/rate", auth, createRateHandler(config.deps));
+  app.post("/v1/friction/report", auth, createFrictionHandler(config.deps));
   app.post("/v1/delegate/list", auth, createListHandler(config.deps));
   app.get("/v1/delegate/list", auth, createListHandler(config.deps));
   app.get(

--- a/src/broker/task-store.ts
+++ b/src/broker/task-store.ts
@@ -27,6 +27,14 @@ import { hashPayload } from "./idempotency.js";
 import { deriveAwaitObservation } from "./await-observation.js";
 import type { AwaitEvent, AwaitObservation } from "./await-observation.js";
 import { queryAllMuninEntries } from "../munin-pagination.js";
+import type { ReportFrictionInput } from "../friction/schema.js";
+import {
+  buildFrictionContent,
+  buildFrictionKey,
+  buildFrictionNamespace,
+  buildFrictionTags,
+  sanitiseTaskId,
+} from "../friction/munin-key.js";
 
 export { MUNIN_QUERY_MAX } from "../munin-pagination.js";
 
@@ -59,6 +67,13 @@ export interface CanonicalListResult {
   rows: CanonicalListRow[];
   /** True when a Munin ambiguity or the bounded history budget may omit matches. */
   truncated: boolean;
+}
+
+export interface FrictionWriteResult {
+  ok: true;
+  dropped: false;
+  namespace: string;
+  key: string;
 }
 
 /**
@@ -225,6 +240,51 @@ export class BrokerTaskStore {
       undefined,
       envelope?.sensitivity === "private" ? "client-restricted" : "internal",
     );
+  }
+
+  /**
+   * Persist a friction signal through the authenticated Broker surface.
+   *
+   * This deliberately reuses the standalone friction MCP's schema and Munin
+   * shape so API, MCP and CLI reports land in one corpus. The Broker principal
+   * is retained as a tag even when the caller supplies a more specific model id.
+   */
+  async writeFriction(
+    input: ReportFrictionInput,
+    reporter: string,
+    recordedAt: Date,
+  ): Promise<FrictionWriteResult> {
+    // `reporter:*` is authenticated server provenance. Drop caller attempts to
+    // add another reporter tag so consumers never have to guess which one wins.
+    const trustedInput: ReportFrictionInput = {
+      ...input,
+      ...(input.tags
+        ? { tags: input.tags.filter((tag) => !tag.startsWith("reporter:")) }
+        : {}),
+    };
+    const resolvedTaskId = trustedInput.task_id?.trim()
+      ? sanitiseTaskId(trustedInput.task_id)
+      : undefined;
+    const modelId = trustedInput.model_id?.trim() || reporter.trim() || "unknown";
+    const namespace = buildFrictionNamespace();
+    const key = buildFrictionKey(resolvedTaskId, recordedAt);
+    const reporterTag = reporter
+      .trim()
+      .replace(/[^A-Za-z0-9._-]/g, "_")
+      .slice(0, 64) || "unknown";
+    const tags = [...new Set([
+      ...buildFrictionTags({ input: trustedInput, modelId, resolvedTaskId }),
+      "source:broker-api",
+      `reporter:${reporterTag}`,
+    ])];
+    const content = buildFrictionContent({
+      input: trustedInput,
+      modelId,
+      resolvedTaskId,
+      recordedAt,
+    });
+    await this.munin.write(namespace, key, content, tags, undefined, "internal");
+    return { ok: true, dropped: false, namespace, key };
   }
 
   /**

--- a/src/broker/task-store.ts
+++ b/src/broker/task-store.ts
@@ -30,7 +30,6 @@ import { queryAllMuninEntries } from "../munin-pagination.js";
 import type { ReportFrictionInput } from "../friction/schema.js";
 import {
   buildFrictionContent,
-  buildFrictionKey,
   buildFrictionNamespace,
   buildFrictionTags,
   sanitiseTaskId,
@@ -74,6 +73,36 @@ export interface FrictionWriteResult {
   dropped: false;
   namespace: string;
   key: string;
+  deduplicated: boolean;
+}
+
+function buildBrokerFrictionKey(
+  input: ReportFrictionInput,
+  reporterTag: string,
+  resolvedTaskId: string | undefined,
+  modelId: string,
+): string {
+  // A friction report describes a semantic event, not an HTTP attempt. Hash
+  // the normalized event so an ambiguous client retry reuses one Munin key.
+  // Tags are set-like metadata, so their order must not change the identity.
+  const normalized = {
+    reporter: reporterTag,
+    model_id: modelId,
+    task_id: resolvedTaskId ?? null,
+    friction_type: input.friction_type,
+    severity: input.severity,
+    summary: input.summary,
+    detail: input.detail,
+    resource_assessment: input.resource_assessment ?? null,
+    alias_suggested: input.alias_suggested ?? null,
+    tool_name: input.tool_name ?? null,
+    tags: [...new Set(input.tags ?? [])].sort(),
+  };
+  const digest = createHash("sha256")
+    .update(JSON.stringify(normalized))
+    .digest("hex")
+    .slice(0, 32);
+  return `${sanitiseTaskId(resolvedTaskId)}-broker-${digest}`;
 }
 
 /**
@@ -254,12 +283,16 @@ export class BrokerTaskStore {
     reporter: string,
     recordedAt: Date,
   ): Promise<FrictionWriteResult> {
-    // `reporter:*` is authenticated server provenance. Drop caller attempts to
-    // add another reporter tag so consumers never have to guess which one wins.
+    // `reporter:*` and `source:*` are server-owned provenance. Drop caller
+    // attempts to add either so consumers never have to guess which one wins.
     const trustedInput: ReportFrictionInput = {
       ...input,
       ...(input.tags
-        ? { tags: input.tags.filter((tag) => !tag.startsWith("reporter:")) }
+        ? {
+            tags: input.tags.filter(
+              (tag) => !tag.startsWith("reporter:") && !tag.startsWith("source:"),
+            ),
+          }
         : {}),
     };
     const resolvedTaskId = trustedInput.task_id?.trim()
@@ -267,11 +300,19 @@ export class BrokerTaskStore {
       : undefined;
     const modelId = trustedInput.model_id?.trim() || reporter.trim() || "unknown";
     const namespace = buildFrictionNamespace();
-    const key = buildFrictionKey(resolvedTaskId, recordedAt);
     const reporterTag = reporter
       .trim()
       .replace(/[^A-Za-z0-9._-]/g, "_")
       .slice(0, 64) || "unknown";
+    const key = buildBrokerFrictionKey(
+      trustedInput,
+      reporterTag,
+      resolvedTaskId,
+      modelId,
+    );
+    if (await this.munin.read(namespace, key)) {
+      return { ok: true, dropped: false, namespace, key, deduplicated: true };
+    }
     const tags = [...new Set([
       ...buildFrictionTags({ input: trustedInput, modelId, resolvedTaskId }),
       "source:broker-api",
@@ -284,7 +325,7 @@ export class BrokerTaskStore {
       recordedAt,
     });
     await this.munin.write(namespace, key, content, tags, undefined, "internal");
-    return { ok: true, dropped: false, namespace, key };
+    return { ok: true, dropped: false, namespace, key, deduplicated: false };
   }
 
   /**

--- a/src/broker/task-store.ts
+++ b/src/broker/task-store.ts
@@ -28,6 +28,7 @@ import { deriveAwaitObservation } from "./await-observation.js";
 import type { AwaitEvent, AwaitObservation } from "./await-observation.js";
 import { queryAllMuninEntries } from "../munin-pagination.js";
 import type { ReportFrictionInput } from "../friction/schema.js";
+import { muninClassificationToSensitivity } from "../sensitivity.js";
 import {
   buildFrictionContent,
   buildFrictionNamespace,
@@ -74,6 +75,41 @@ export interface FrictionWriteResult {
   namespace: string;
   key: string;
   deduplicated: boolean;
+}
+
+const SERVER_OWNED_FRICTION_TAG_PREFIXES = [
+  "friction:",
+  "friction-category:",
+  "severity:",
+  "model:",
+  "source:",
+  "schema:",
+  "task:",
+  "resource:",
+  "alias-suggested:",
+  "tool:",
+  "reporter:",
+  "classification:",
+] as const;
+
+function keepCallerFrictionTags(tags: string[] | undefined): string[] | undefined {
+  if (!tags) return undefined;
+  return [...new Set(tags
+    .map((tag) => tag.trim())
+    .filter((tag) => tag.length > 0)
+    .filter((tag) => {
+      const normalized = tag.toLowerCase();
+      return !SERVER_OWNED_FRICTION_TAG_PREFIXES.some((prefix) =>
+        normalized.startsWith(prefix));
+    }))];
+}
+
+function frictionClassification(linkedTaskClassification: string | undefined): string {
+  const normalized = linkedTaskClassification?.trim().toLowerCase();
+  if (normalized === "client-restricted") return "client-restricted";
+  return muninClassificationToSensitivity(linkedTaskClassification) === "private"
+    ? "client-confidential"
+    : "internal";
 }
 
 export class FrictionIdempotencyConflictError extends Error {
@@ -144,6 +180,8 @@ export interface SubmitTaskParams {
 export class BrokerTaskStore {
   /** Per-task guard so a poll storm cannot pile up un-awaited observation writes. */
   private readonly awaitWritesInFlight = new Set<string>();
+  /** Serialize same-process writes for one friction event identity. */
+  private readonly frictionWritesInFlight = new Map<string, Promise<FrictionWriteResult>>();
 
   constructor(private readonly munin: MuninClient) {}
 
@@ -299,17 +337,12 @@ export class BrokerTaskStore {
     reporter: string,
     recordedAt: Date,
   ): Promise<FrictionWriteResult> {
-    // `reporter:*` and `source:*` are server-owned provenance. Drop caller
-    // attempts to add either so consumers never have to guess which one wins.
+    // Taxonomy, provenance, task, and classification tags are server-owned.
+    // Keep arbitrary routing tags (for example repo:* and issue:*) while
+    // preventing callers from adding a second authoritative value.
     const trustedInput: ReportFrictionInput = {
       ...input,
-      ...(input.tags
-        ? {
-            tags: input.tags.filter(
-              (tag) => !tag.startsWith("reporter:") && !tag.startsWith("source:"),
-            ),
-          }
-        : {}),
+      ...(input.tags ? { tags: keepCallerFrictionTags(input.tags) } : {}),
     };
     const resolvedTaskId = trustedInput.task_id?.trim()
       ? sanitiseTaskId(trustedInput.task_id)
@@ -326,36 +359,67 @@ export class BrokerTaskStore {
       resolvedTaskId,
       modelId,
     );
-    const existing = await this.munin.read(namespace, key);
-    if (existing) {
+    // Munin has update-CAS but no create-only CAS. Serialize one key inside the
+    // single Broker process so simultaneous retries cannot overwrite a payload
+    // conflict before either request observes the durable event.
+    while (this.frictionWritesInFlight.has(key)) {
       try {
-        const existingPayload = JSON.parse(existing.content) as Record<string, unknown>;
-        if (existingPayload.broker_event_payload_sha256 === payloadHash) {
-          return { ok: true, dropped: false, namespace, key, deduplicated: true };
-        }
+        await this.frictionWritesInFlight.get(key);
       } catch {
-        // A corrupt/conflicting durable record must never be mistaken for a
-        // successful retry.
+        // The waiting request must re-run the durable read after a failed write.
       }
-      throw new FrictionIdempotencyConflictError(trustedInput.event_id!);
     }
-    const tags = [...new Set([
-      ...buildFrictionTags({ input: trustedInput, modelId, resolvedTaskId }),
-      "source:broker-api",
-      `reporter:${reporterTag}`,
-    ])];
-    const contentPayload = JSON.parse(buildFrictionContent({
-      input: trustedInput,
-      modelId,
-      resolvedTaskId,
-      recordedAt,
-    })) as Record<string, unknown>;
-    const content = JSON.stringify({
-      ...contentPayload,
-      broker_event_payload_sha256: payloadHash,
-    }, null, 2);
-    await this.munin.write(namespace, key, content, tags, undefined, "internal");
-    return { ok: true, dropped: false, namespace, key, deduplicated: false };
+
+    const write = (async (): Promise<FrictionWriteResult> => {
+      const existing = await this.munin.read(namespace, key);
+      if (existing) {
+        try {
+          const existingPayload = JSON.parse(existing.content) as Record<string, unknown>;
+          if (existingPayload.broker_event_payload_sha256 === payloadHash) {
+            return { ok: true, dropped: false, namespace, key, deduplicated: true };
+          }
+        } catch {
+          // A corrupt/conflicting durable record must never be mistaken for a
+          // successful retry.
+        }
+        throw new FrictionIdempotencyConflictError(trustedInput.event_id!);
+      }
+      const tags = [...new Set([
+        ...buildFrictionTags({ input: trustedInput, modelId, resolvedTaskId }),
+        "source:broker-api",
+        `reporter:${reporterTag}`,
+      ])];
+      const contentPayload = JSON.parse(buildFrictionContent({
+        input: trustedInput,
+        modelId,
+        resolvedTaskId,
+        recordedAt,
+      })) as Record<string, unknown>;
+      const content = JSON.stringify({
+        ...contentPayload,
+        broker_event_payload_sha256: payloadHash,
+      }, null, 2);
+      const linkedTask = resolvedTaskId
+        ? await this.munin.read(namespaceForTaskId(resolvedTaskId), STATUS_KEY)
+        : null;
+      await this.munin.write(
+        namespace,
+        key,
+        content,
+        tags,
+        undefined,
+        frictionClassification(linkedTask?.classification),
+      );
+      return { ok: true, dropped: false, namespace, key, deduplicated: false };
+    })();
+    this.frictionWritesInFlight.set(key, write);
+    try {
+      return await write;
+    } finally {
+      if (this.frictionWritesInFlight.get(key) === write) {
+        this.frictionWritesInFlight.delete(key);
+      }
+    }
   }
 
   /**

--- a/src/broker/task-store.ts
+++ b/src/broker/task-store.ts
@@ -76,15 +76,25 @@ export interface FrictionWriteResult {
   deduplicated: boolean;
 }
 
-function buildBrokerFrictionKey(
+export class FrictionIdempotencyConflictError extends Error {
+  constructor(public readonly eventId: string) {
+    super(`friction event_id ${eventId} was already used with a different payload`);
+    this.name = "FrictionIdempotencyConflictError";
+  }
+}
+
+function buildBrokerFrictionIdentity(
   input: ReportFrictionInput,
   reporterTag: string,
   resolvedTaskId: string | undefined,
   modelId: string,
-): string {
-  // A friction report describes a semantic event, not an HTTP attempt. Hash
-  // the normalized event so an ambiguous client retry reuses one Munin key.
-  // Tags are set-like metadata, so their order must not change the identity.
+): { key: string; payloadHash: string } {
+  if (!input.event_id) {
+    throw new Error("authenticated Broker friction writes require event_id");
+  }
+  // event_id identifies one occurrence. The separate payload hash catches an
+  // accidental or malicious reuse of that identity for different evidence.
+  // Tags are set-like metadata, so ordering does not change payload identity.
   const normalized = {
     reporter: reporterTag,
     model_id: modelId,
@@ -98,11 +108,17 @@ function buildBrokerFrictionKey(
     tool_name: input.tool_name ?? null,
     tags: [...new Set(input.tags ?? [])].sort(),
   };
-  const digest = createHash("sha256")
+  const payloadHash = createHash("sha256")
     .update(JSON.stringify(normalized))
+    .digest("hex");
+  const eventHash = createHash("sha256")
+    .update(`${reporterTag}\0${input.event_id}`)
     .digest("hex")
     .slice(0, 32);
-  return `${sanitiseTaskId(resolvedTaskId)}-broker-${digest}`;
+  return {
+    key: `${sanitiseTaskId(resolvedTaskId)}-broker-${eventHash}`,
+    payloadHash,
+  };
 }
 
 /**
@@ -304,26 +320,40 @@ export class BrokerTaskStore {
       .trim()
       .replace(/[^A-Za-z0-9._-]/g, "_")
       .slice(0, 64) || "unknown";
-    const key = buildBrokerFrictionKey(
+    const { key, payloadHash } = buildBrokerFrictionIdentity(
       trustedInput,
       reporterTag,
       resolvedTaskId,
       modelId,
     );
-    if (await this.munin.read(namespace, key)) {
-      return { ok: true, dropped: false, namespace, key, deduplicated: true };
+    const existing = await this.munin.read(namespace, key);
+    if (existing) {
+      try {
+        const existingPayload = JSON.parse(existing.content) as Record<string, unknown>;
+        if (existingPayload.broker_event_payload_sha256 === payloadHash) {
+          return { ok: true, dropped: false, namespace, key, deduplicated: true };
+        }
+      } catch {
+        // A corrupt/conflicting durable record must never be mistaken for a
+        // successful retry.
+      }
+      throw new FrictionIdempotencyConflictError(trustedInput.event_id!);
     }
     const tags = [...new Set([
       ...buildFrictionTags({ input: trustedInput, modelId, resolvedTaskId }),
       "source:broker-api",
       `reporter:${reporterTag}`,
     ])];
-    const content = buildFrictionContent({
+    const contentPayload = JSON.parse(buildFrictionContent({
       input: trustedInput,
       modelId,
       resolvedTaskId,
       recordedAt,
-    });
+    })) as Record<string, unknown>;
+    const content = JSON.stringify({
+      ...contentPayload,
+      broker_event_payload_sha256: payloadHash,
+    }, null, 2);
     await this.munin.write(namespace, key, content, tags, undefined, "internal");
     return { ok: true, dropped: false, namespace, key, deduplicated: false };
   }

--- a/src/friction-cli.ts
+++ b/src/friction-cli.ts
@@ -22,6 +22,7 @@ Required:
 Optional:
   --task-id <id>          Related Hugin task id
   --model-id <id>         Model/runtime identifier (defaults to Broker principal)
+  --event-id <uuid>       Reuse only when retrying the same occurrence
   --tool-name <name>      Tool that failed or was missing
   --resource-assessment <value>
                           under-resourced | appropriate | over-resourced
@@ -46,6 +47,7 @@ export function parseFrictionCliArgs(argv: string[]): ReportFrictionInput | null
       detail: { type: "string" },
       "task-id": { type: "string" },
       "model-id": { type: "string" },
+      "event-id": { type: "string" },
       "tool-name": { type: "string" },
       "resource-assessment": { type: "string" },
       "alias-suggested": { type: "string" },
@@ -61,6 +63,7 @@ export function parseFrictionCliArgs(argv: string[]): ReportFrictionInput | null
     detail: values.detail,
     task_id: values["task-id"],
     model_id: values["model-id"],
+    event_id: values["event-id"],
     tool_name: values["tool-name"],
     resource_assessment: values["resource-assessment"],
     alias_suggested: values["alias-suggested"],

--- a/src/friction-cli.ts
+++ b/src/friction-cli.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+import { parseArgs as parseNodeArgs } from "node:util";
+import { pathToFileURL } from "node:url";
+import { resolve } from "node:path";
+import { BrokerClient } from "./mcp/broker-client.js";
+import {
+  reportFrictionInputSchema,
+  type ReportFrictionInput,
+} from "./friction/schema.js";
+
+const USAGE = `Usage: hugin-friction [options]
+
+Submit one friction event to Hugin's authenticated Broker API.
+
+Required:
+  --friction-type <type>  Friction taxonomy value (for example tool_failure)
+  --severity <level>      low | medium | high | blocking
+  --summary <text>        One-sentence headline
+  --detail <text>         What failed and what would have helped
+
+Optional:
+  --task-id <id>          Related Hugin task id
+  --model-id <id>         Model/runtime identifier (defaults to Broker principal)
+  --tool-name <name>      Tool that failed or was missing
+  --resource-assessment <value>
+                          under-resourced | appropriate | over-resourced
+  --alias-suggested <id>  Suggested Hugin alias
+  --tag <tag>             Extra tag; repeat up to 16 times
+  --help                  Show this help
+
+Environment:
+  HUGIN_BROKER_URL        Broker base URL, e.g. http://huginmunin:3033
+  HUGIN_BROKER_TOKEN      Bearer token registered in HUGIN_BROKER_KEYS
+`;
+
+export function parseFrictionCliArgs(argv: string[]): ReportFrictionInput | null {
+  const { values } = parseNodeArgs({
+    args: argv,
+    strict: true,
+    allowPositionals: false,
+    options: {
+      "friction-type": { type: "string" },
+      severity: { type: "string" },
+      summary: { type: "string" },
+      detail: { type: "string" },
+      "task-id": { type: "string" },
+      "model-id": { type: "string" },
+      "tool-name": { type: "string" },
+      "resource-assessment": { type: "string" },
+      "alias-suggested": { type: "string" },
+      tag: { type: "string", multiple: true },
+      help: { type: "boolean", default: false },
+    },
+  });
+  if (values.help) return null;
+  return reportFrictionInputSchema.parse({
+    friction_type: values["friction-type"],
+    severity: values.severity,
+    summary: values.summary,
+    detail: values.detail,
+    task_id: values["task-id"],
+    model_id: values["model-id"],
+    tool_name: values["tool-name"],
+    resource_assessment: values["resource-assessment"],
+    alias_suggested: values["alias-suggested"],
+    tags: values.tag,
+  });
+}
+
+function requiredEnv(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+export async function main(argv = process.argv.slice(2)): Promise<void> {
+  const input = parseFrictionCliArgs(argv);
+  if (!input) {
+    process.stdout.write(USAGE);
+    return;
+  }
+  const client = new BrokerClient({
+    baseUrl: requiredEnv("HUGIN_BROKER_URL"),
+    bearerToken: requiredEnv("HUGIN_BROKER_TOKEN"),
+  });
+  const result = await client.reportFriction(input);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}
+
+const invokedPath = process.argv[1]
+  ? pathToFileURL(resolve(process.argv[1])).href
+  : "";
+if (import.meta.url === invokedPath) {
+  main().catch((error) => {
+    process.stderr.write(
+      `hugin-friction: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/src/friction/munin-key.ts
+++ b/src/friction/munin-key.ts
@@ -106,6 +106,7 @@ export function buildFrictionContent(args: FrictionContentInputs): string {
     schema_version: FRICTION_SCHEMA_VERSION,
     recorded_at: recordedAt.toISOString(),
     model_id: modelId,
+    event_id: input.event_id ?? null,
     task_id_resolved: resolvedTaskId ?? null,
     friction_type: input.friction_type,
     friction_category: category,

--- a/src/friction/schema.ts
+++ b/src/friction/schema.ts
@@ -101,6 +101,13 @@ export const reportFrictionInputShape = {
     .describe(
       "Your own model identifier (e.g. claude-opus-4-8, claude-sonnet-4-6). Set this so the friction event is attributed to the right model — interactive sessions are not tagged via env. Falls back to the server's HUGIN_FRICTION_MODEL_ID env (default \"unknown\") when omitted.",
     ),
+  event_id: z
+    .string()
+    .uuid()
+    .optional()
+    .describe(
+      "Stable identity for one occurrence. Reuse only when retrying the same report. Broker clients generate this automatically.",
+    ),
   tags: z
     .array(z.string().max(80))
     .max(16)

--- a/src/friction/schema.ts
+++ b/src/friction/schema.ts
@@ -13,6 +13,14 @@
 import { z } from "zod";
 import { aliasSchema } from "../broker/types.js";
 
+const metadataString = (max: number) => z
+  .string()
+  .trim()
+  .max(max)
+  .regex(/^[^\r\n\0]*$/, "must not contain line breaks or NUL bytes");
+
+const nonEmptyMetadataString = (max: number) => metadataString(max).min(1);
+
 export const frictionTypeSchema = z.enum([
   // capability
   "reasoning_limit",
@@ -66,11 +74,13 @@ export const reportFrictionInputShape = {
   ),
   summary: z
     .string()
+    .trim()
     .min(1)
     .max(500)
     .describe("One-sentence headline of the friction."),
   detail: z
     .string()
+    .trim()
     .min(1)
     .max(8_000)
     .describe("What you tried, what failed, and what would have made this easier."),
@@ -84,19 +94,13 @@ export const reportFrictionInputShape = {
     .describe(
       "If under-resourced, which alias from {tiny, medium, large-reasoning, pi-large-coder} would have helped? Skip if unsure.",
     ),
-  tool_name: z
-    .string()
-    .max(120)
+  tool_name: metadataString(120)
     .optional()
     .describe("Tool that failed or was missing (only for tool_failure/tool_missing)."),
-  task_id: z
-    .string()
-    .max(200)
+  task_id: metadataString(200)
     .optional()
     .describe("Override for HUGIN_FRICTION_TASK_ID env."),
-  model_id: z
-    .string()
-    .max(200)
+  model_id: metadataString(200)
     .optional()
     .describe(
       "Your own model identifier (e.g. claude-opus-4-8, claude-sonnet-4-6). Set this so the friction event is attributed to the right model — interactive sessions are not tagged via env. Falls back to the server's HUGIN_FRICTION_MODEL_ID env (default \"unknown\") when omitted.",
@@ -109,7 +113,7 @@ export const reportFrictionInputShape = {
       "Stable identity for one occurrence. Reuse only when retrying the same report. Broker clients generate this automatically.",
     ),
   tags: z
-    .array(z.string().max(80))
+    .array(nonEmptyMetadataString(80))
     .max(16)
     .optional()
     .describe("Extra free-form tags appended to the Munin entry."),

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -131,6 +131,7 @@ export async function main(): Promise<void> {
     tools.rate as HuginTool<Record<string, unknown>>,
     tools.list as HuginTool<Record<string, unknown>>,
     tools.models as HuginTool<Record<string, unknown>>,
+    tools.friction as HuginTool<Record<string, unknown>>,
     tools.experimentCreate as HuginTool<Record<string, unknown>>,
     tools.experimentObserve as HuginTool<Record<string, unknown>>,
     tools.experimentRate as HuginTool<Record<string, unknown>>,

--- a/src/mcp/broker-client.ts
+++ b/src/mcp/broker-client.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 /**
  * HTTP client for the Pi-side orchestrator broker.
  *
@@ -97,7 +99,21 @@ export class BrokerClient {
   }
 
   async reportFriction(payload: Record<string, unknown>): Promise<unknown> {
-    return this.post("/v1/friction/report", payload);
+    const event = {
+      ...payload,
+      event_id: typeof payload.event_id === "string" && payload.event_id.trim()
+        ? payload.event_id
+        : randomUUID(),
+    };
+    try {
+      return await this.post("/v1/friction/report", event);
+    } catch (err) {
+      // A connection reset can happen after the Broker committed the write.
+      // Retry once with the same event_id; the server will return the existing
+      // key instead of recording a second occurrence.
+      if (!(err instanceof BrokerNetworkError)) throw err;
+      return this.post("/v1/friction/report", event);
+    }
   }
 
   async list(payload: Record<string, unknown>): Promise<unknown> {

--- a/src/mcp/broker-client.ts
+++ b/src/mcp/broker-client.ts
@@ -96,6 +96,10 @@ export class BrokerClient {
     return this.post("/v1/delegate/rate", payload);
   }
 
+  async reportFriction(payload: Record<string, unknown>): Promise<unknown> {
+    return this.post("/v1/friction/report", payload);
+  }
+
   async list(payload: Record<string, unknown>): Promise<unknown> {
     return this.post("/v1/delegate/list", payload);
   }

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -6,6 +6,8 @@
  * Five learning tools expose the durable champion/challenger loop:
  *   hugin_experiment_create, hugin_experiment_observe,
  *   hugin_experiment_rate, hugin_experiment_status, hugin_experiment_promote.
+ * One shared friction tool writes into the same corpus as friction-mcp:
+ *   hugin_report_friction.
  *
  * The MCP layer is the only place that fills in protocol envelope
  * fields (`envelope_version`, `alias_map_version`, `idempotency_key`,
@@ -43,6 +45,10 @@ import {
   learningObservationInputShape,
   learningObservationSchema,
 } from "../learning/experiment-schema.js";
+import {
+  reportFrictionInputSchema,
+  reportFrictionInputShape,
+} from "../friction/schema.js";
 
 export const ALIAS_MAP_VERSION = 2;
 export const ENVELOPE_VERSION = 2 as const;
@@ -156,6 +162,8 @@ const listInputSchema = z.object(listInputShape);
 export const modelsInputShape = {};
 const modelsInputSchema = z.object(modelsInputShape);
 
+export const frictionInputShape = reportFrictionInputShape;
+
 export const experimentCreateInputShape = learningExperimentCreateInputShape;
 export const experimentObserveInputShape = learningObservationInputShape;
 export const experimentStatusInputShape = learningExperimentStatusInputShape;
@@ -231,6 +239,7 @@ export function buildTools(deps: ToolDeps): {
   rate: HuginTool<z.infer<typeof rateInputSchema>>;
   list: HuginTool<z.infer<typeof listInputSchema>>;
   models: HuginTool<z.infer<typeof modelsInputSchema>>;
+  friction: HuginTool<z.infer<typeof reportFrictionInputSchema>>;
   experimentCreate: HuginTool<z.infer<typeof learningExperimentCreateSchema>>;
   experimentObserve: HuginTool<z.infer<typeof learningObservationSchema>>;
   experimentRate: HuginTool<z.infer<typeof learningExperimentRateSchema>>;
@@ -368,6 +377,22 @@ export function buildTools(deps: ToolDeps): {
     },
   };
 
+  const friction: HuginTool<z.infer<typeof reportFrictionInputSchema>> = {
+    name: "hugin_report_friction",
+    title: "Report friction encountered while solving a task",
+    description:
+      "Persist one concrete capability, environment, or specification friction event in Hugin's shared signals/friction corpus. Use task_id when the event came from a Hugin task. This is operational evidence, not a semantic task rating.",
+    inputShape: frictionInputShape,
+    handler: async (rawInput) => {
+      try {
+        const input = reportFrictionInputSchema.parse(rawInput);
+        return asResult(await deps.broker.reportFriction(input));
+      } catch (err) {
+        return asResult(errorPayload(err), true);
+      }
+    },
+  };
+
   const experimentCreate: HuginTool<z.infer<typeof learningExperimentCreateSchema>> = {
     name: "hugin_experiment_create",
     title: "Create a versioned learning experiment",
@@ -454,6 +479,7 @@ export function buildTools(deps: ToolDeps): {
     rate,
     list,
     models,
+    friction,
     experimentCreate,
     experimentObserve,
     experimentRate,

--- a/src/task-helpers.ts
+++ b/src/task-helpers.ts
@@ -681,7 +681,7 @@ export async function finalizeTaskBranch(
       await new Promise<void>((resolve) => {
         const child = spawn(
           "git",
-          ["commit", "-m", "hugin: auto-commit task output [skip ci]"],
+          ["commit", "-m", "hugin: auto-commit task output"],
           {
             cwd: workingDir,
             stdio: "ignore",

--- a/tests/broker/handlers.test.ts
+++ b/tests/broker/handlers.test.ts
@@ -12,6 +12,7 @@ import type { MuninClient } from "../../src/munin-client.js";
 
 const SECRET = "a".repeat(64);
 const OTHER_SECRET = "b".repeat(64);
+const FRICTION_EVENT_ID = "11111111-2222-4333-8444-555555555555";
 
 class FakeMunin {
   writes: Array<{ namespace: string; key: string; content: string; tags?: string[] }> = [];
@@ -850,7 +851,9 @@ describe("POST /v1/friction/report", () => {
         severity: "blocking",
         summary: "Codex sandbox could not start",
         detail: "The systemd address-family allowlist omitted AF_NETLINK.",
+        event_id: FRICTION_EVENT_ID,
         task_id: "cassette/task-1",
+        model_id: "gpt-5.4-codex",
         tool_name: "codex-exec",
         tags: ["reporter:spoofed", "source:standalone-mcp", "repo:cassette-ai"],
       }),
@@ -870,16 +873,18 @@ describe("POST /v1/friction/report", () => {
     expect(write.tags).toEqual(expect.arrayContaining([
       "friction:tool_failure",
       "severity:blocking",
-      "model:claude-code",
+      "model:gpt-5.4-codex",
       "source:broker-api",
       "reporter:claude-code",
       "task:cassette_task-1",
       "repo:cassette-ai",
     ]));
     expect(write.tags).not.toContain("reporter:spoofed");
+    expect(write.tags).not.toContain("reporter:gpt-5.4-codex");
     expect(write.tags).not.toContain("source:standalone-mcp");
     expect(JSON.parse(write.content)).toMatchObject({
-      model_id: "claude-code",
+      model_id: "gpt-5.4-codex",
+      event_id: FRICTION_EVENT_ID,
       task_id_resolved: "cassette_task-1",
       friction_type: "tool_failure",
       user_tags: ["repo:cassette-ai"],
@@ -892,6 +897,7 @@ describe("POST /v1/friction/report", () => {
       severity: "medium",
       summary: "M5 connection reset",
       detail: "The first response was ambiguous after the request was sent.",
+      event_id: "22222222-3333-4444-8555-666666666666",
       task_id: "task-1",
       tags: ["repo:hugin", "phase:dogfood"],
     });
@@ -922,6 +928,50 @@ describe("POST /v1/friction/report", () => {
     expect(harness.munin.writes.filter(
       (write) => write.namespace === "signals/friction" && write.key === firstResult.key,
     )).toHaveLength(1);
+  });
+
+  it("rejects reuse of an event identity with different evidence", async () => {
+    const eventId = "33333333-4444-4555-8666-777777777777";
+    const original = {
+      friction_type: "tool_failure",
+      severity: "high",
+      summary: "tool failed",
+      detail: "first evidence",
+      event_id: eventId,
+      task_id: "task-2",
+    };
+    const first = await fetch(`${harness.url}/v1/friction/report`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify(original),
+    });
+    const collision = await fetch(`${harness.url}/v1/friction/report`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify({ ...original, detail: "conflicting evidence" }),
+    });
+
+    expect(first.status).toBe(201);
+    expect(collision.status).toBe(409);
+    expect(await collision.json()).toMatchObject({ error: "idempotency_collision" });
+    expect(harness.munin.writes.filter(
+      (write) => write.namespace === "signals/friction",
+    )).toHaveLength(1);
+  });
+
+  it("requires an event identity on the authenticated API", async () => {
+    const res = await fetch(`${harness.url}/v1/friction/report`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify({
+        friction_type: "ambiguity",
+        severity: "low",
+        summary: "unclear wording",
+        detail: "needed an assumption",
+      }),
+    });
+
+    expect(res.status).toBe(400);
   });
 
   it("rejects malformed friction without writing", async () => {

--- a/tests/broker/handlers.test.ts
+++ b/tests/broker/handlers.test.ts
@@ -840,6 +840,66 @@ describe("POST /v1/delegate/rate", () => {
   });
 });
 
+describe("POST /v1/friction/report", () => {
+  it("writes a shared friction event with authenticated reporter provenance", async () => {
+    const res = await fetch(`${harness.url}/v1/friction/report`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify({
+        friction_type: "tool_failure",
+        severity: "blocking",
+        summary: "Codex sandbox could not start",
+        detail: "The systemd address-family allowlist omitted AF_NETLINK.",
+        task_id: "cassette/task-1",
+        tool_name: "codex-exec",
+        tags: ["reporter:spoofed", "repo:cassette-ai"],
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    const response = await res.json() as Record<string, unknown>;
+    expect(response).toMatchObject({
+      ok: true,
+      dropped: false,
+      namespace: "signals/friction",
+    });
+    const write = harness.munin.writes.at(-1)!;
+    expect(write.namespace).toBe("signals/friction");
+    expect(write.key).toContain("cassette_task-1-");
+    expect(write.tags).toEqual(expect.arrayContaining([
+      "friction:tool_failure",
+      "severity:blocking",
+      "model:claude-code",
+      "source:broker-api",
+      "reporter:claude-code",
+      "task:cassette_task-1",
+      "repo:cassette-ai",
+    ]));
+    expect(write.tags).not.toContain("reporter:spoofed");
+    expect(JSON.parse(write.content)).toMatchObject({
+      model_id: "claude-code",
+      task_id_resolved: "cassette_task-1",
+      friction_type: "tool_failure",
+    });
+  });
+
+  it("rejects malformed friction without writing", async () => {
+    const writesBefore = harness.munin.writes.length;
+    const res = await fetch(`${harness.url}/v1/friction/report`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify({
+        friction_type: "made_up",
+        severity: "blocking",
+        summary: "bad",
+        detail: "bad",
+      }),
+    });
+    expect(res.status).toBe(400);
+    expect(harness.munin.writes).toHaveLength(writesBefore);
+  });
+});
+
 describe("GET /v1/delegate/list", () => {
   it("rejects a malformed since_ts instead of applying inconsistent time filters", async () => {
     const res = await fetch(

--- a/tests/broker/handlers.test.ts
+++ b/tests/broker/handlers.test.ts
@@ -852,7 +852,7 @@ describe("POST /v1/friction/report", () => {
         detail: "The systemd address-family allowlist omitted AF_NETLINK.",
         task_id: "cassette/task-1",
         tool_name: "codex-exec",
-        tags: ["reporter:spoofed", "repo:cassette-ai"],
+        tags: ["reporter:spoofed", "source:standalone-mcp", "repo:cassette-ai"],
       }),
     });
 
@@ -861,6 +861,7 @@ describe("POST /v1/friction/report", () => {
     expect(response).toMatchObject({
       ok: true,
       dropped: false,
+      deduplicated: false,
       namespace: "signals/friction",
     });
     const write = harness.munin.writes.at(-1)!;
@@ -876,11 +877,51 @@ describe("POST /v1/friction/report", () => {
       "repo:cassette-ai",
     ]));
     expect(write.tags).not.toContain("reporter:spoofed");
+    expect(write.tags).not.toContain("source:standalone-mcp");
     expect(JSON.parse(write.content)).toMatchObject({
       model_id: "claude-code",
       task_id_resolved: "cassette_task-1",
       friction_type: "tool_failure",
+      user_tags: ["repo:cassette-ai"],
     });
+  });
+
+  it("deduplicates an identical authenticated retry onto one Munin event", async () => {
+    const body = JSON.stringify({
+      friction_type: "connectivity",
+      severity: "medium",
+      summary: "M5 connection reset",
+      detail: "The first response was ambiguous after the request was sent.",
+      task_id: "task-1",
+      tags: ["repo:hugin", "phase:dogfood"],
+    });
+
+    const first = await fetch(`${harness.url}/v1/friction/report`, {
+      method: "POST",
+      headers: authHeader(),
+      body,
+    });
+    const second = await fetch(`${harness.url}/v1/friction/report`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify({
+        ...JSON.parse(body) as Record<string, unknown>,
+        tags: ["phase:dogfood", "repo:hugin"],
+      }),
+    });
+
+    expect(first.status).toBe(201);
+    expect(second.status).toBe(201);
+    const firstResult = await first.json() as Record<string, unknown>;
+    const secondResult = await second.json() as Record<string, unknown>;
+    expect(firstResult).toMatchObject({ deduplicated: false });
+    expect(secondResult).toMatchObject({
+      deduplicated: true,
+      key: firstResult.key,
+    });
+    expect(harness.munin.writes.filter(
+      (write) => write.namespace === "signals/friction" && write.key === firstResult.key,
+    )).toHaveLength(1);
   });
 
   it("rejects malformed friction without writing", async () => {

--- a/tests/broker/handlers.test.ts
+++ b/tests/broker/handlers.test.ts
@@ -15,7 +15,13 @@ const OTHER_SECRET = "b".repeat(64);
 const FRICTION_EVENT_ID = "11111111-2222-4333-8444-555555555555";
 
 class FakeMunin {
-  writes: Array<{ namespace: string; key: string; content: string; tags?: string[] }> = [];
+  writes: Array<{
+    namespace: string;
+    key: string;
+    content: string;
+    tags?: string[];
+    classification?: string;
+  }> = [];
   reads: Record<string, unknown> = {};
   queryCalls = 0;
   queryReturn: { results: unknown[]; total: number } = { results: [], total: 0 };
@@ -25,11 +31,12 @@ class FakeMunin {
     content: string,
     tags?: string[],
     _expectedUpdatedAt?: string,
-    _classification?: string,
+    classification?: string,
   ): Promise<Record<string, unknown>> {
-    this.writes.push({ namespace, key, content, tags });
+    this.writes.push({ namespace, key, content, tags, classification });
     this.reads[`${namespace}/${key}`] = {
       namespace, key, content, tags: tags ?? [],
+      classification,
       created_at: "2026-07-11T12:00:00.000Z",
       updated_at: "2026-07-11T12:00:00.000Z",
     };
@@ -855,7 +862,17 @@ describe("POST /v1/friction/report", () => {
         task_id: "cassette/task-1",
         model_id: "gpt-5.4-codex",
         tool_name: "codex-exec",
-        tags: ["reporter:spoofed", "source:standalone-mcp", "repo:cassette-ai"],
+        tags: [
+          "reporter:spoofed",
+          "source:standalone-mcp",
+          "Severity:low",
+          "model:spoofed",
+          "friction:ambiguity",
+          "task:spoofed",
+          "tool:spoofed",
+          "classification:public",
+          "repo:cassette-ai",
+        ],
       }),
     });
 
@@ -882,6 +899,12 @@ describe("POST /v1/friction/report", () => {
     expect(write.tags).not.toContain("reporter:spoofed");
     expect(write.tags).not.toContain("reporter:gpt-5.4-codex");
     expect(write.tags).not.toContain("source:standalone-mcp");
+    expect(write.tags).not.toContain("Severity:low");
+    expect(write.tags).not.toContain("model:spoofed");
+    expect(write.tags).not.toContain("friction:ambiguity");
+    expect(write.tags).not.toContain("task:spoofed");
+    expect(write.tags).not.toContain("tool:spoofed");
+    expect(write.tags).not.toContain("classification:public");
     expect(JSON.parse(write.content)).toMatchObject({
       model_id: "gpt-5.4-codex",
       event_id: FRICTION_EVENT_ID,
@@ -889,6 +912,34 @@ describe("POST /v1/friction/report", () => {
       friction_type: "tool_failure",
       user_tags: ["repo:cassette-ai"],
     });
+  });
+
+  it("inherits the restricted classification of a linked private task", async () => {
+    harness.munin.reads["tasks/private-task/status"] = {
+      namespace: "tasks/private-task",
+      key: "status",
+      content: "private task",
+      tags: ["running"],
+      classification: "client-restricted",
+      created_at: "2026-07-11T12:00:00.000Z",
+      updated_at: "2026-07-11T12:00:00.000Z",
+    };
+
+    const res = await fetch(`${harness.url}/v1/friction/report`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify({
+        friction_type: "tool_failure",
+        severity: "high",
+        summary: "private task tool failed",
+        detail: "Only operational metadata is included.",
+        event_id: "44444444-5555-4666-8777-888888888888",
+        task_id: "private-task",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(harness.munin.writes.at(-1)?.classification).toBe("client-restricted");
   });
 
   it("deduplicates an identical authenticated retry onto one Munin event", async () => {
@@ -968,6 +1019,23 @@ describe("POST /v1/friction/report", () => {
         severity: "low",
         summary: "unclear wording",
         detail: "needed an assumption",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects unknown authenticated API fields instead of silently dropping them", async () => {
+    const res = await fetch(`${harness.url}/v1/friction/report`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify({
+        friction_type: "ambiguity",
+        severity: "low",
+        summary: "unclear wording",
+        detail: "needed an assumption",
+        event_id: "55555555-6666-4777-8888-999999999999",
+        severty: "high",
       }),
     });
 

--- a/tests/friction/cli.test.ts
+++ b/tests/friction/cli.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { parseFrictionCliArgs } from "../../src/friction-cli.js";
+
+describe("hugin-friction CLI", () => {
+  it("maps flags into the shared friction schema", () => {
+    expect(parseFrictionCliArgs([
+      "--friction-type", "tool_failure",
+      "--severity", "blocking",
+      "--summary", "bubblewrap failed",
+      "--detail", "AF_NETLINK was unavailable",
+      "--task-id", "task-1",
+      "--tool-name", "codex-exec",
+      "--tag", "repo:cassette-ai",
+      "--tag", "issue:hugin-218",
+    ])).toEqual({
+      friction_type: "tool_failure",
+      severity: "blocking",
+      summary: "bubblewrap failed",
+      detail: "AF_NETLINK was unavailable",
+      task_id: "task-1",
+      tool_name: "codex-exec",
+      tags: ["repo:cassette-ai", "issue:hugin-218"],
+    });
+  });
+
+  it("returns null for help before enforcing required fields", () => {
+    expect(parseFrictionCliArgs(["--help"])).toBeNull();
+  });
+
+  it("rejects unknown taxonomy values", () => {
+    expect(() => parseFrictionCliArgs([
+      "--friction-type", "made_up",
+      "--severity", "high",
+      "--summary", "bad",
+      "--detail", "bad",
+    ])).toThrow();
+  });
+});

--- a/tests/friction/cli.test.ts
+++ b/tests/friction/cli.test.ts
@@ -9,6 +9,7 @@ describe("hugin-friction CLI", () => {
       "--summary", "bubblewrap failed",
       "--detail", "AF_NETLINK was unavailable",
       "--task-id", "task-1",
+      "--event-id", "11111111-2222-4333-8444-555555555555",
       "--tool-name", "codex-exec",
       "--tag", "repo:cassette-ai",
       "--tag", "issue:hugin-218",
@@ -18,6 +19,7 @@ describe("hugin-friction CLI", () => {
       summary: "bubblewrap failed",
       detail: "AF_NETLINK was unavailable",
       task_id: "task-1",
+      event_id: "11111111-2222-4333-8444-555555555555",
       tool_name: "codex-exec",
       tags: ["repo:cassette-ai", "issue:hugin-218"],
     });

--- a/tests/friction/munin-key.test.ts
+++ b/tests/friction/munin-key.test.ts
@@ -150,6 +150,7 @@ describe("buildFrictionContent", () => {
       schema_version: 1,
       recorded_at: "2026-05-05T10:30:00.123Z",
       model_id: "claude-haiku-4-5",
+      event_id: null,
       task_id_resolved: "t-abc",
       friction_type: "knowledge_gap",
       friction_category: "capability",
@@ -177,6 +178,7 @@ describe("buildFrictionContent", () => {
     });
     const parsed = JSON.parse(content);
     expect(parsed.task_id_resolved).toBeNull();
+    expect(parsed.event_id).toBeNull();
     expect(parsed.resource_assessment).toBeNull();
     expect(parsed.alias_suggested).toBeNull();
     expect(parsed.tool_name).toBeNull();

--- a/tests/friction/schema.test.ts
+++ b/tests/friction/schema.test.ts
@@ -27,10 +27,22 @@ describe("friction schema", () => {
       alias_suggested: "medium",
       tool_name: "ssh",
       task_id: "t-123",
+      event_id: "11111111-2222-4333-8444-555555555555",
       tags: ["network", "infra"],
     });
     expect(parsed.alias_suggested).toBe("medium");
     expect(parsed.tags).toEqual(["network", "infra"]);
+    expect(parsed.event_id).toBe("11111111-2222-4333-8444-555555555555");
+  });
+
+  it("rejects malformed event identities", () => {
+    expect(() => reportFrictionInputSchema.parse({
+      friction_type: "ambiguity",
+      severity: "low",
+      summary: "x",
+      detail: "y",
+      event_id: "not-a-uuid",
+    })).toThrow();
   });
 
   it("rejects unknown friction_type", () => {

--- a/tests/friction/schema.test.ts
+++ b/tests/friction/schema.test.ts
@@ -85,6 +85,31 @@ describe("friction schema", () => {
         detail: "",
       }),
     ).toThrow();
+    expect(() =>
+      reportFrictionInputSchema.parse({
+        friction_type: "ambiguity",
+        severity: "low",
+        summary: "   ",
+        detail: "y",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects line breaks and empty values in tag metadata", () => {
+    expect(() => reportFrictionInputSchema.parse({
+      friction_type: "tool_failure",
+      severity: "high",
+      summary: "x",
+      detail: "y",
+      model_id: "model\nspoof",
+    })).toThrow();
+    expect(() => reportFrictionInputSchema.parse({
+      friction_type: "tool_failure",
+      severity: "high",
+      summary: "x",
+      detail: "y",
+      tags: ["   "],
+    })).toThrow();
   });
 
   it("rejects too-long summary or detail", () => {

--- a/tests/mcp/broker-client.test.ts
+++ b/tests/mcp/broker-client.test.ts
@@ -57,6 +57,28 @@ describe("BrokerClient", () => {
     expect(init?.body).toBeUndefined();
   });
 
+  it("posts friction reports to the authenticated shared endpoint", async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({ ok: true, namespace: "signals/friction", key: "event-1" }, { status: 201 }),
+    );
+    const client = new BrokerClient({
+      baseUrl: "http://broker.test:3033",
+      bearerToken: "tk",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await client.reportFriction({
+      friction_type: "tool_failure",
+      severity: "high",
+      summary: "failed",
+      detail: "details",
+    });
+
+    const [url, init] = fetchImpl.mock.calls[0]!;
+    expect(url).toBe("http://broker.test:3033/v1/friction/report");
+    expect(init?.method).toBe("POST");
+  });
+
   it("posts learning-loop operations to their authenticated endpoints", async () => {
     const fetchImpl = vi.fn(async () => jsonResponse({ ok: true }));
     const client = new BrokerClient({

--- a/tests/mcp/broker-client.test.ts
+++ b/tests/mcp/broker-client.test.ts
@@ -77,6 +77,39 @@ describe("BrokerClient", () => {
     const [url, init] = fetchImpl.mock.calls[0]!;
     expect(url).toBe("http://broker.test:3033/v1/friction/report");
     expect(init?.method).toBe("POST");
+    expect(JSON.parse(init?.body as string)).toMatchObject({
+      friction_type: "tool_failure",
+      event_id: expect.stringMatching(/^[0-9a-f-]{36}$/),
+    });
+  });
+
+  it("retries an ambiguous friction transport failure with the same event id", async () => {
+    const fetchImpl = vi.fn()
+      .mockRejectedValueOnce(new Error("ECONNRESET"))
+      .mockResolvedValueOnce(jsonResponse({
+        ok: true,
+        namespace: "signals/friction",
+        key: "event-1",
+        deduplicated: true,
+      }, { status: 201 }));
+    const client = new BrokerClient({
+      baseUrl: "http://broker.test:3033",
+      bearerToken: "tk",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await client.reportFriction({
+      friction_type: "connectivity",
+      severity: "medium",
+      summary: "connection reset",
+      detail: "response was ambiguous",
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+    const firstBody = JSON.parse(fetchImpl.mock.calls[0]![1]?.body as string);
+    const secondBody = JSON.parse(fetchImpl.mock.calls[1]![1]?.body as string);
+    expect(firstBody.event_id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(secondBody.event_id).toBe(firstBody.event_id);
   });
 
   it("posts learning-loop operations to their authenticated endpoints", async () => {

--- a/tests/mcp/tools.test.ts
+++ b/tests/mcp/tools.test.ts
@@ -17,6 +17,7 @@ function fakeBroker(overrides: Partial<BrokerClient> = {}): BrokerClient {
     submit: noop,
     await_: noop,
     rate: noop,
+    reportFriction: noop,
     list: noop,
     models: noop,
     experimentCreate: noop,
@@ -380,6 +381,44 @@ describe("buildTools — hugin_rate", () => {
       rating: "pass",
       rating_reason: "looked correct",
       verification_outcome: "accepted_unchanged",
+    });
+  });
+});
+
+describe("buildTools — hugin_report_friction", () => {
+  it("validates and forwards the shared friction payload", async () => {
+    const reportFriction = vi.fn(async () => ({
+      ok: true,
+      dropped: false,
+      namespace: "signals/friction",
+      key: "t-1-stamp",
+    }));
+    const broker = fakeBroker({ reportFriction });
+    const tools = buildTools({ broker, sessionId: "sess", submitter: "codex" });
+
+    const result = await tools.friction.handler({
+      friction_type: "tool_failure",
+      severity: "blocking",
+      summary: "bubblewrap could not start",
+      detail: "AF_NETLINK was blocked by the outer service sandbox",
+      task_id: "t-1",
+      tool_name: "codex-exec",
+      tags: ["repo:cassette-ai"],
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(reportFriction).toHaveBeenCalledWith({
+      friction_type: "tool_failure",
+      severity: "blocking",
+      summary: "bubblewrap could not start",
+      detail: "AF_NETLINK was blocked by the outer service sandbox",
+      task_id: "t-1",
+      tool_name: "codex-exec",
+      tags: ["repo:cassette-ai"],
+    });
+    expect(parseResult(result)).toMatchObject({
+      ok: true,
+      namespace: "signals/friction",
     });
   });
 });

--- a/tests/repo-sync.test.ts
+++ b/tests/repo-sync.test.ts
@@ -318,6 +318,12 @@ describe("finalizeTaskBranch", () => {
     const commitCall = spawnCalls[2];
     expect(commitCall.args).toContain("commit");
     expect(commitCall.args).toContain("-m");
+    expect(commitCall.args).toEqual([
+      "commit",
+      "-m",
+      "hugin: auto-commit task output",
+    ]);
+    expect(commitCall.args.join(" ")).not.toContain("skip ci");
   });
 
   it("creates PR when commits exist without dirty tree", async () => {


### PR DESCRIPTION
## Summary

- let Hugin auto-commits trigger repository CI by removing `[skip ci]`
- expose the existing friction schema/corpus through authenticated `POST /v1/friction/report`, the main `hugin-mcp` as `hugin_report_friction`, and the new `hugin-friction` CLI
- preserve authenticated reporter provenance and reject spoofed `reporter:*` tags
- document the July M5 dogfood routing hypothesis, its low confidence, and the separation between execution completion, semantic acceptance, and friction
- explicitly document that the current daily exam factory does not yet ingest general reviewer feedback

Related: #216, #217, #218

## Verification

- `npm ci`
- `npm run build`
- `npm test` — 110 files / 1,803 tests
- `bash scripts/deploy-pi.test.sh`
- `bash scripts/lib/claude-config-bootstrap.test.sh`
- `node dist/friction-cli.js --help`
- `git diff --check`

## Deployment note

After deployment, future Hugin-generated commits will run target-repository CI. Existing PR heads whose final commit already contains `[skip ci]` still need a new non-skipping commit or an explicit workflow rerun.
