### PR TITLE
Fail fast when Codex sandbox is unavailable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,6 +197,13 @@ that local payload by rsync (the remote Hugin tree intentionally needs no
 atomically stamps the exact local full SHA only after service restart/status and
 the loopback health check succeed. Any failed acceptance remains markerless.
 
+The health acceptance includes a zero-token `codex sandbox -- /bin/true` probe
+run from inside the live `hugin.service` confinement. Codex's bubblewrap sandbox
+needs `AF_NETLINK` to create its isolated loopback interface; the systemd unit
+therefore includes that family in `RestrictAddressFamilies`. Hugin repeats the
+probe before every Codex task and records a `failure:infra` friction event if it
+fails, without invoking a model.
+
 The Pi needs a `.env` file at `/home/magnus/hugin/.env`:
 ```
 MUNIN_API_KEY=<same key Munin uses>

--- a/hugin.service
+++ b/hugin.service
@@ -23,7 +23,10 @@ Environment=PATH=/home/magnus/.npm-global/bin:/usr/local/bin:/usr/bin:/bin
 # families). ReadWritePaths is dropped with it (a no-op without ProtectSystem).
 NoNewPrivileges=true
 PrivateTmp=false
-RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+# AF_NETLINK is required by Codex's bubblewrap sandbox to create/configure the
+# isolated loopback interface. Omitting it makes every Codex shell/edit command
+# fail before execution while the outer agent can still consume tokens (#218).
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
 
 [Install]
 WantedBy=default.target

--- a/scripts/deploy-pi.sh
+++ b/scripts/deploy-pi.sh
@@ -176,28 +176,20 @@ else
   echo "  NAS reachability are fixed (else delivery-capable tasks will fail)."
 fi
 
-echo "==> Codex sandbox preflight (issue #59)..."
-# Codex's `codex exec` sandboxes shell commands and apply_patch through
-# bubblewrap. When the system `bwrap` is missing, Codex silently falls back to a
-# VENDORED bwrap that is incompatible with the Pi kernel: every shell command and
-# file write fails with `bwrap: loopback: Failed to create NETLINK_ROUTE socket`,
-# yet the task still exits 0 — so codex tasks "succeed" while delivering nothing
-# (issue #59). Ensure the system bwrap exists AND can actually create the
-# network namespace + loopback that Codex relies on. Non-fatal WARNING: this only
-# affects the codex runtime, so it must not block a deploy that runs claude/ollama
-# tasks. The runtime fix is `sudo apt install bubblewrap`.
+echo "==> Host-side Codex sandbox preflight (issues #59/#218)..."
+# Exercise Codex's own zero-token sandbox entry point, not merely whichever
+# bwrap happens to be first on PATH. This catches a missing/incompatible system
+# bwrap before restart. It is still outside hugin.service confinement; the
+# post-restart /health gate below is authoritative because Hugin repeats this
+# exact command from inside the live unit before polling or any Codex task.
 if ssh "$REMOTE" "
-  command -v bwrap >/dev/null 2>&1 || { echo 'NO_BWRAP'; exit 1; }
-  # Mirror codex's usage: unshare the network namespace and bring up loopback.
-  # This is the exact path that fails with the vendored bwrap on the Pi kernel.
-  bwrap --unshare-net --ro-bind / / --dev /dev /bin/true 2>/dev/null || { echo 'BWRAP_NETNS_FAIL'; exit 1; }
+  command -v codex >/dev/null 2>&1 || { echo 'NO_CODEX'; exit 1; }
+  codex sandbox -- /bin/true >/dev/null 2>&1 || { echo 'CODEX_SANDBOX_FAIL'; exit 1; }
 "; then
-  echo "  OK: system bwrap present and network-namespace probe passed (codex sandbox healthy)"
+  echo "  OK: Codex zero-token sandbox command passed on the host"
 else
-  echo "  WARNING: codex sandbox preflight FAILED."
-  echo "  Codex tasks will exit 0 but deliver nothing (vendored-bwrap fallback is"
-  echo "  incompatible with the Pi kernel). Fix on the Pi: sudo apt install bubblewrap"
-  echo "  then re-run this probe. Until then, do not route code-capable tasks to codex."
+  echo "  WARNING: host-side Codex sandbox preflight FAILED."
+  echo "  The post-restart in-service health acceptance will remain authoritative."
 fi
 
 echo "==> Refreshing Claude config on the Pi (claude-config bootstrap)..."
@@ -233,7 +225,23 @@ echo "==> Restarting service..."
 ssh "$REMOTE" "XDG_RUNTIME_DIR=/run/user/1000 systemctl --user restart hugin.service && sleep 2 && XDG_RUNTIME_DIR=/run/user/1000 systemctl --user status hugin.service --no-pager"
 
 echo "==> Health check..."
-ssh "$REMOTE" "curl -fsS http://127.0.0.1:3032/health"
+ssh "$REMOTE" "
+  for attempt in \$(seq 1 15); do
+    if curl -fsS http://127.0.0.1:3032/health | /usr/bin/node -e '
+      let raw = "";
+      process.stdin.on("data", (chunk) => raw += chunk).on("end", () => {
+        const health = JSON.parse(raw);
+        if (health.codex_sandbox?.available !== true) process.exit(1);
+        process.stdout.write(raw);
+      });
+    '; then
+      exit 0
+    fi
+    sleep 1
+  done
+  echo 'in-service Codex sandbox self-test unavailable after 15 attempts' >&2
+  exit 1
+"
 
 echo "==> Daily exam factory acceptance..."
 ssh "$REMOTE" "

--- a/scripts/deploy-pi.test.sh
+++ b/scripts/deploy-pi.test.sh
@@ -44,7 +44,7 @@ if [[ "$call" == *"test -d ~/repos/claude-config"* ]]; then
   exit 1
 fi
 if [[ "$call" == *"curl -fsS http://127.0.0.1:3032/health"* ]]; then
-  printf '{"status":"ok","polling":true}\n'
+  printf '{"status":"ok","polling":true,"codex_sandbox":{"available":true}}\n'
 fi
 exit 0
 EOF
@@ -246,6 +246,9 @@ assert_not_contains "$full_calls" "git reset" "deployment never depends on a rem
 assert_contains "$full_calls" "npm ci --omit=dev" "deployment installs the shipped lockfile deterministically"
 assert_not_contains "$full_calls" "npm install --omit=dev" "deployment never rewrites the shipped lockfile with npm install"
 assert_contains "$full_calls" "curl -fsS http://127.0.0.1:3032/health" "deployment retains the health acceptance gate"
+assert_contains "$full_calls" "health.codex_sandbox?.available !== true" "deployment health gate requires the live service-context Codex probe"
+assert_contains "$full_calls" "in-service Codex sandbox self-test unavailable after 15 attempts" "deployment waits for a definitive in-service probe result"
+assert_contains "$full_calls" "codex sandbox -- /bin/true" "deployment host preflight exercises Codex's zero-token sandbox entry point"
 assert_contains "$full_calls" "enable --now hugin-daily-exam-factory.timer" "deployment enables the automatic daily factory"
 assert_contains "$full_calls" "start hugin-daily-exam-factory.service" "deployment runs a factory acceptance sweep"
 assert_contains "$full_calls" "daily exam manifest must be schema v2" "deployment requires the cross-client exposure manifest contract"

--- a/src/codex-sandbox.ts
+++ b/src/codex-sandbox.ts
@@ -1,0 +1,148 @@
+/**
+ * Zero-token Codex sandbox readiness probe (issue #218).
+ *
+ * `codex sandbox -- /bin/true` exercises the same Codex-owned sandbox launcher
+ * used for shell/tool execution, but does not contact a model. When Hugin runs
+ * this probe, it inherits the live systemd unit's address-family restrictions;
+ * an omitted AF_NETLINK therefore fails here before a paid agent loop starts.
+ */
+
+import { execFile, type ExecFileException } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import type { FailureClassification } from "./failure-classification.js";
+import {
+  buildFrictionContent,
+  buildFrictionKey,
+  buildFrictionNamespace,
+  buildFrictionTags,
+} from "./friction/munin-key.js";
+import type { ReportFrictionInput } from "./friction/schema.js";
+
+export const CODEX_SANDBOX_FAILURE_KIND = "CODEX_SANDBOX_UNAVAILABLE";
+export const CODEX_SANDBOX_FAILURE_TAG = "failure:infra";
+export const CODEX_SANDBOX_PROBE_COMMAND = "codex sandbox -- /bin/true";
+
+export interface CodexSandboxProbeResult {
+  available: boolean;
+  checkedAt: string;
+  command: typeof CODEX_SANDBOX_PROBE_COMMAND;
+  failureKind?: typeof CODEX_SANDBOX_FAILURE_KIND;
+  reason?: string;
+}
+
+export interface CodexSandboxProbeOptions {
+  timeoutMs?: number;
+  now?: () => Date;
+  execFileImpl?: typeof execFile;
+}
+
+function boundedDiagnostic(stdout: string, stderr: string): string {
+  const combined = `${stdout}\n${stderr}`.trim();
+  return combined ? combined.slice(-2_000) : "no diagnostic output";
+}
+
+/** Run the real Codex sandbox launcher without invoking a model. */
+export function probeCodexSandbox(
+  options: CodexSandboxProbeOptions = {},
+): Promise<CodexSandboxProbeResult> {
+  const timeoutMs = options.timeoutMs ?? 10_000;
+  const now = options.now ?? (() => new Date());
+  const exec = options.execFileImpl ?? execFile;
+
+  return new Promise((resolve) => {
+    exec(
+      "codex",
+      ["sandbox", "--", "/bin/true"],
+      {
+        encoding: "utf8",
+        timeout: timeoutMs,
+        maxBuffer: 16 * 1024,
+        env: process.env,
+      },
+      (error: ExecFileException | null, stdout: string, stderr: string) => {
+        const checkedAt = now().toISOString();
+        if (!error) {
+          resolve({
+            available: true,
+            checkedAt,
+            command: CODEX_SANDBOX_PROBE_COMMAND,
+          });
+          return;
+        }
+
+        const diagnostic = boundedDiagnostic(stdout, stderr);
+        const timedOut = error.killed || error.signal === "SIGTERM";
+        const prefix = timedOut
+          ? `Codex sandbox self-test timed out after ${timeoutMs}ms`
+          : `Codex sandbox self-test failed${error.code !== undefined ? ` (exit ${error.code})` : ""}`;
+        resolve({
+          available: false,
+          checkedAt,
+          command: CODEX_SANDBOX_PROBE_COMMAND,
+          failureKind: CODEX_SANDBOX_FAILURE_KIND,
+          reason: `${prefix}: ${diagnostic}`,
+        });
+      },
+    );
+  });
+}
+
+/** Trusted classification for a probe-generated, pre-model refusal. */
+export function codexSandboxFailureClassification(reason: string): FailureClassification {
+  return {
+    kind: CODEX_SANDBOX_FAILURE_KIND,
+    tag: CODEX_SANDBOX_FAILURE_TAG,
+    reason,
+  };
+}
+
+export interface CodexSandboxFrictionEvent {
+  namespace: string;
+  key: string;
+  content: string;
+  tags: string[];
+}
+
+/** Build the shared schema-v1 infrastructure-friction event for a failed probe. */
+export function buildCodexSandboxFrictionEvent(args: {
+  taskId: string;
+  modelId?: string;
+  reason: string;
+  recordedAt: Date;
+}): CodexSandboxFrictionEvent {
+  const input: ReportFrictionInput = {
+    event_id: randomUUID(),
+    friction_type: "tool_failure",
+    severity: "blocking",
+    summary: "Codex sandbox self-test failed before task execution",
+    detail: args.reason.slice(0, 8_000),
+    task_id: args.taskId,
+    model_id: args.modelId?.trim() || "codex",
+    tool_name: "codex-sandbox",
+    tags: ["runtime:codex", `failure-kind:${CODEX_SANDBOX_FAILURE_KIND}`],
+  };
+  const modelId = input.model_id || "codex";
+  const tags = buildFrictionTags({
+    input,
+    modelId,
+    resolvedTaskId: args.taskId,
+  }).filter((tag) => tag !== "source:model-self-report");
+  tags.push("source:hugin-preflight");
+  const baseContent = JSON.parse(buildFrictionContent({
+    input,
+    modelId,
+    resolvedTaskId: args.taskId,
+    recordedAt: args.recordedAt,
+  })) as Record<string, unknown>;
+
+  return {
+    namespace: buildFrictionNamespace(),
+    key: buildFrictionKey(args.taskId, args.recordedAt),
+    content: JSON.stringify({
+      ...baseContent,
+      reporter: "hugin-preflight",
+      failure_kind: CODEX_SANDBOX_FAILURE_KIND,
+    }, null, 2),
+    tags,
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,13 @@ import {
   DEPS_DRIFT_FAILURE_KIND,
 } from "./failure-classification.js";
 import {
+  buildCodexSandboxFrictionEvent,
+  CODEX_SANDBOX_FAILURE_KIND,
+  codexSandboxFailureClassification,
+  probeCodexSandbox,
+  type CodexSandboxProbeResult,
+} from "./codex-sandbox.js";
+import {
   decideAuthAlarm,
   alertDeliveryCommitsTransition,
   hydratePersistedAuthAlarmState,
@@ -2026,10 +2033,31 @@ interface SpawnContext {
   muninClient: MuninClient;
 }
 
+interface SpawnRuntimeResult {
+  exitCode: number | "TIMEOUT";
+  output: string;
+  logFile: string;
+  preflightFailureKind?: typeof CODEX_SANDBOX_FAILURE_KIND;
+  preflightFailureReason?: string;
+}
+
+let codexSandboxStatus: CodexSandboxProbeResult | null = null;
+
+async function refreshCodexSandboxStatus(): Promise<CodexSandboxProbeResult> {
+  const result = await probeCodexSandbox();
+  codexSandboxStatus = result;
+  if (result.available) {
+    console.log(`[codex-sandbox] ready (${result.command})`);
+  } else {
+    console.error(`[codex-sandbox] unavailable: ${result.reason}`);
+  }
+  return result;
+}
+
 function spawnRuntime(
   task: TaskConfig,
   ctx: SpawnContext
-): Promise<{ exitCode: number | "TIMEOUT"; output: string; logFile: string }> {
+): Promise<SpawnRuntimeResult> {
   if (task.runtime !== "codex") {
     throw new Error(`Spawn executor no longer supports runtime "${task.runtime}"`);
   }
@@ -2169,6 +2197,47 @@ function spawnRuntime(
       });
     });
   });
+}
+
+async function executeCodexWithPreflightChecks(
+  task: TaskConfig,
+  ctx: SpawnContext,
+): Promise<SpawnRuntimeResult> {
+  const probe = await refreshCodexSandboxStatus();
+  if (probe.available) return spawnRuntime(task, ctx);
+
+  const taskId = extractTaskId(ctx.taskNs);
+  const logFile = path.join(LOG_DIR, `${taskId}.log`);
+  const reason = probe.reason || "Codex sandbox self-test failed without a diagnostic";
+  try {
+    fs.writeFileSync(
+      logFile,
+      [
+        "=== Hugin Task Log (Codex preflight) ===",
+        `Task: ${ctx.taskNs}`,
+        `Started: ${new Date().toISOString()}`,
+        "===",
+        reason,
+        "",
+        "===",
+        "Exit code: 1",
+        `Failure kind: ${CODEX_SANDBOX_FAILURE_KIND}`,
+        "No model was invoked.",
+        "===",
+        "",
+      ].join("\n"),
+      { encoding: "utf8" },
+    );
+  } catch {
+    /* log is best-effort — never turn a known infra refusal into a crash */
+  }
+  return {
+    exitCode: 1,
+    output: reason,
+    logFile,
+    preflightFailureKind: CODEX_SANDBOX_FAILURE_KIND,
+    preflightFailureReason: reason,
+  };
 }
 
 // --- Lease helpers ---
@@ -4447,6 +4516,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
 
     const isOllama = task.runtime === "ollama";
     const isClaude = task.runtime === "claude";
+    const isCodex = task.runtime === "codex";
     const isOpencode = task.runtime === "opencode";
     const isHomeserver = task.runtime === "homeserver";
     const isOrchestrator = task.runtime === "orchestrator";
@@ -4454,13 +4524,15 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
       ? "ollama"
       : isClaude
         ? "agent-sdk"
-        : isHomeserver
-          ? "homeserver-delegate"
-        : isOpencode
-          ? "opencode"
-          : isOrchestrator
-            ? "orchestrator"
-            : "spawn";
+        : isCodex
+          ? "codex-spawn"
+          : isHomeserver
+            ? "homeserver-delegate"
+            : isOpencode
+              ? "opencode"
+              : isOrchestrator
+                ? "orchestrator"
+                : "spawn";
 
     // Capture quota before task execution (skip for ollama — it's Claude-specific)
     const quotaBefore = isOllama || isHomeserver ? { q5: null, q7: null } : await fetchQuota();
@@ -4495,6 +4567,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     // refused the task itself, so the classification below never has to
     // regex-sniff synthetic output.
     let sdkPreflightFailureKind: typeof AUTH_FAILURE_KIND | typeof DEPS_DRIFT_FAILURE_KIND | undefined;
+    let codexPreflightFailureReason: string | undefined;
     let fallbackTriggered = false;
     let fallbackReason: string | null = null;
 
@@ -4879,10 +4952,16 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     orchOutcomes = orchResult.outcomes;
     orchSavings = orchResult.savings;
     } else {
-      const spawnResult = await spawnRuntime(task, { taskNs, muninClient: munin });
+      const spawnResult = await executeCodexWithPreflightChecks(task, {
+        taskNs,
+        muninClient: munin,
+      });
       exitCode = spawnResult.exitCode;
       output = spawnResult.output;
       logFile = spawnResult.logFile;
+      if (spawnResult.preflightFailureKind === CODEX_SANDBOX_FAILURE_KIND) {
+        codexPreflightFailureReason = spawnResult.preflightFailureReason;
+      }
     }
 
     // The agent run is done. Lease renewal is stopped HERE, before the
@@ -4944,17 +5023,43 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     // discriminator (sdkPreflightFailureKind) — only a REAL SDK run (no
     // discriminator) falls back to regex-classifying its output (Codex
     // review, #123: DEPS_DRIFT is never inferred from output text).
-    const failureClassification =
-      !ok && !isTimeout && !isCancelled && (isClaude || fallbackTriggered)
-        ? sdkPreflightFailureKind === DEPS_DRIFT_FAILURE_KIND
-          ? driftFailureClassification()
-          : classifyClaudeFailure(output)
-        : null;
+    const failureClassification = !ok && !isTimeout && !isCancelled
+      ? isCodex && codexPreflightFailureReason
+        ? codexSandboxFailureClassification(codexPreflightFailureReason)
+        : isClaude || fallbackTriggered
+          ? sdkPreflightFailureKind === DEPS_DRIFT_FAILURE_KIND
+            ? driftFailureClassification()
+            : classifyClaudeFailure(output)
+          : null
+      : null;
     if (failureClassification) {
       await munin.log(
         taskNs,
         `Task failed (${failureClassification.kind}): ${failureClassification.reason}`,
       );
+    }
+    if (failureClassification?.kind === CODEX_SANDBOX_FAILURE_KIND) {
+      const friction = buildCodexSandboxFrictionEvent({
+        taskId,
+        modelId: task.model,
+        reason: failureClassification.reason,
+        recordedAt: new Date(),
+      });
+      try {
+        await munin.write(
+          friction.namespace,
+          friction.key,
+          friction.content,
+          friction.tags,
+          undefined,
+          taskClassification,
+        );
+      } catch (err) {
+        console.error(
+          `[codex-sandbox] failed to persist infrastructure friction for ${taskNs}:`,
+          err,
+        );
+      }
     }
 
     // #131: feed the CONFIRMED Claude auth outcome into the proactive alarm. A
@@ -5809,6 +5914,18 @@ app.get("/health", (_req, res) => {
       enabled: egressPolicy.enabled,
       allowed_hosts: egressPolicy.allowedHosts,
     },
+    codex_sandbox: codexSandboxStatus
+      ? {
+          available: codexSandboxStatus.available,
+          checked_at: codexSandboxStatus.checkedAt,
+          command: codexSandboxStatus.command,
+          failure_kind: codexSandboxStatus.failureKind,
+          reason: codexSandboxStatus.reason,
+        }
+      : {
+          available: false,
+          state: "checking",
+        },
   });
 });
 
@@ -6047,8 +6164,10 @@ if (brokerEnv.enabled) {
   console.log("Broker: disabled (set HUGIN_BROKER_KEYS to enable)");
 }
 
-// Check Munin is reachable before starting poll loop
-munin.health().then((ok) => {
+// Check Munin and the zero-token Codex sandbox concurrently before polling.
+// The HTTP server is already listening so deploy acceptance can observe the
+// probe's transient `checking` state, then its definitive result.
+Promise.all([munin.health(), refreshCodexSandboxStatus()]).then(([ok]) => {
   if (!ok) {
     console.warn("WARNING: Munin health check failed — will retry on first poll");
   } else {

--- a/tests/codex-sandbox.test.ts
+++ b/tests/codex-sandbox.test.ts
@@ -1,0 +1,141 @@
+import { readFileSync } from "node:fs";
+import type { execFile, ExecFileException } from "node:child_process";
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildCodexSandboxFrictionEvent,
+  CODEX_SANDBOX_FAILURE_KIND,
+  CODEX_SANDBOX_FAILURE_TAG,
+  codexSandboxFailureClassification,
+  probeCodexSandbox,
+} from "../src/codex-sandbox.js";
+
+type ExecCallback = (
+  error: ExecFileException | null,
+  stdout: string,
+  stderr: string,
+) => void;
+
+function fakeExec(
+  implementation: (callback: ExecCallback) => void,
+): typeof execFile {
+  return vi.fn((
+    _command: string,
+    _args: string[],
+    _options: unknown,
+    callback: ExecCallback,
+  ) => {
+    implementation(callback);
+    return {};
+  }) as unknown as typeof execFile;
+}
+
+describe("probeCodexSandbox", () => {
+  it("runs Codex's zero-token sandbox command", async () => {
+    const execFileImpl = fakeExec((callback) => callback(null, "", ""));
+    const result = await probeCodexSandbox({
+      execFileImpl,
+      now: () => new Date("2026-07-15T09:00:00.000Z"),
+    });
+
+    expect(execFileImpl).toHaveBeenCalledWith(
+      "codex",
+      ["sandbox", "--", "/bin/true"],
+      expect.objectContaining({ timeout: 10_000, encoding: "utf8" }),
+      expect.any(Function),
+    );
+    expect(result).toEqual({
+      available: true,
+      checkedAt: "2026-07-15T09:00:00.000Z",
+      command: "codex sandbox -- /bin/true",
+    });
+  });
+
+  it("fails closed on the real AF_NETLINK sandbox signature", async () => {
+    const error = Object.assign(new Error("command failed"), {
+      code: 1,
+      killed: false,
+      signal: null,
+      cmd: "codex sandbox -- /bin/true",
+    }) as ExecFileException;
+    const execFileImpl = fakeExec((callback) => callback(
+      error,
+      "",
+      "bwrap: loopback: Failed to create NETLINK_ROUTE socket: Address family not supported by protocol",
+    ));
+
+    const result = await probeCodexSandbox({ execFileImpl });
+
+    expect(result.available).toBe(false);
+    expect(result.failureKind).toBe(CODEX_SANDBOX_FAILURE_KIND);
+    expect(result.reason).toContain("NETLINK_ROUTE");
+  });
+
+  it("treats an inconclusive timeout as unavailable", async () => {
+    const error = Object.assign(new Error("timed out"), {
+      code: null,
+      killed: true,
+      signal: "SIGTERM",
+      cmd: "codex sandbox -- /bin/true",
+    }) as ExecFileException;
+    const result = await probeCodexSandbox({
+      timeoutMs: 123,
+      execFileImpl: fakeExec((callback) => callback(error, "", "")),
+    });
+
+    expect(result).toMatchObject({
+      available: false,
+      failureKind: CODEX_SANDBOX_FAILURE_KIND,
+    });
+    expect(result.reason).toContain("timed out after 123ms");
+  });
+});
+
+describe("Codex sandbox failure evidence", () => {
+  it("classifies a trusted preflight refusal as infrastructure", () => {
+    const classification = codexSandboxFailureClassification("AF_NETLINK blocked");
+    expect(classification).toEqual({
+      kind: CODEX_SANDBOX_FAILURE_KIND,
+      tag: CODEX_SANDBOX_FAILURE_TAG,
+      reason: "AF_NETLINK blocked",
+    });
+  });
+
+  it("builds a blocking shared friction event with Hugin provenance", () => {
+    const event = buildCodexSandboxFrictionEvent({
+      taskId: "task-218",
+      modelId: "gpt-5.4-codex",
+      reason: "bwrap could not create NETLINK_ROUTE socket",
+      recordedAt: new Date("2026-07-15T09:00:00.000Z"),
+    });
+
+    expect(event.namespace).toBe("signals/friction");
+    expect(event.tags).toEqual(expect.arrayContaining([
+      "friction:tool_failure",
+      "friction-category:env",
+      "severity:blocking",
+      "model:gpt-5.4-codex",
+      "task:task-218",
+      "tool:codex-sandbox",
+      "source:hugin-preflight",
+      `failure-kind:${CODEX_SANDBOX_FAILURE_KIND}`,
+    ]));
+    expect(event.tags).not.toContain("source:model-self-report");
+    expect(JSON.parse(event.content)).toMatchObject({
+      event_id: expect.stringMatching(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+      ),
+      friction_category: "environment",
+      severity: "blocking",
+      reporter: "hugin-preflight",
+      failure_kind: CODEX_SANDBOX_FAILURE_KIND,
+    });
+  });
+});
+
+describe("hugin.service Codex sandbox allowance", () => {
+  it("allows AF_NETLINK with a load-bearing rationale", () => {
+    const unit = readFileSync(new URL("../hugin.service", import.meta.url), "utf8");
+    expect(unit).toMatch(/RestrictAddressFamilies=.*\bAF_NETLINK\b/);
+    expect(unit).toMatch(/bubblewrap sandbox[\s\S]*loopback/i);
+  });
+});


### PR DESCRIPTION
Closes #218.

## What changed

- allow `AF_NETLINK` in the deployed systemd unit, with the bubblewrap rationale documented
- run `codex sandbox -- /bin/true` at startup and before every Codex task, without invoking a model
- fail affected tasks as `CODEX_SANDBOX_UNAVAILABLE` / `failure:infra` and emit shared friction evidence
- expose probe state in `/health` and require the live in-service probe during deployment acceptance
- retain a host-side Codex preflight and wait for the startup probe to settle

## Validation

- `npm run build`
- `npm test` (111 files, 1,817 tests)
- `bash scripts/deploy-pi.test.sh`
- `bash -n scripts/deploy-pi.sh`
- `git diff --check`

## Review

- Claude Fable: unavailable (monthly spend limit)
- Claude Opus high: attempted, but the headless CLI produced no result and was stopped after repeated silent waits
- Native Codex review: no correctness, security, API-contract, or deployment blockers found; live systemd acceptance remains the intentional final proof.