### PR TITLE
Test deploy health parser across SSH quoting

### DIFF
--- a/scripts/deploy-pi.sh
+++ b/scripts/deploy-pi.sh
@@ -228,8 +228,8 @@ echo "==> Health check..."
 ssh "$REMOTE" "
   for attempt in \$(seq 1 15); do
     if curl -fsS http://127.0.0.1:3032/health | /usr/bin/node -e '
-      let raw = "";
-      process.stdin.on("data", (chunk) => raw += chunk).on("end", () => {
+      let raw = \"\";
+      process.stdin.on(\"data\", (chunk) => raw += chunk).on(\"end\", () => {
         const health = JSON.parse(raw);
         if (health.codex_sandbox?.available !== true) process.exit(1);
         process.stdout.write(raw);

--- a/scripts/deploy-pi.test.sh
+++ b/scripts/deploy-pi.test.sh
@@ -44,12 +44,22 @@ if [[ "$call" == *"test -d ~/repos/claude-config"* ]]; then
   exit 1
 fi
 if [[ "$call" == *"curl -fsS http://127.0.0.1:3032/health"* ]]; then
-  printf '{"status":"ok","polling":true,"codex_sandbox":{"available":true}}\n'
+  # Execute the exact remote command string so local-to-remote quote loss is a
+  # tested failure, not merely invisible text in the call log (#220 follow-up).
+  local_node="$(command -v node)"
+  health_command="${2//\/usr\/bin\/node/$local_node}"
+  bash -c "$health_command"
+  exit $?
 fi
 exit 0
 EOF
 
-chmod +x "$FAKE_BIN/npm" "$FAKE_BIN/rsync" "$FAKE_BIN/ssh"
+cat >"$FAKE_BIN/curl" <<'EOF'
+#!/usr/bin/env bash
+printf '{"status":"ok","polling":true,"codex_sandbox":{"available":true}}\n'
+EOF
+
+chmod +x "$FAKE_BIN/npm" "$FAKE_BIN/rsync" "$FAKE_BIN/ssh" "$FAKE_BIN/curl"
 export PATH="$FAKE_BIN:$PATH"
 export CALL_LOG
 export FAKE_NPM_DIRTY_ON_BUILD=0


### PR DESCRIPTION
Follow-up to #220.

The first live deployment proved the service-side Codex sandbox probe succeeds, but also exposed that the local shell removed JavaScript string quotes before sending the health parser over SSH. The deployment correctly remained markerless.

This hotfix:

- preserves the JavaScript quotes across the local-to-remote shell boundary
- upgrades `deploy-pi.test.sh` to execute the exact captured remote health command with a fake health response, so this class of quoting regression fails in CI

Validation: `bash -n scripts/deploy-pi.sh`, `bash scripts/deploy-pi.test.sh`, and `git diff --check` all pass. Native Codex review found no remaining issue. Fable remains spend-limited and Opus previously produced no result, so the requested self-review fallback is authoritative.