### PR TITLE
Harden friction provenance and retry integrity

### DIFF
--- a/docs/friction-reporting.md
+++ b/docs/friction-reporting.md
@@ -27,12 +27,17 @@ The standalone MCP remains deliberately lossy: a Munin timeout is reported as
 Broker API and its MCP/CLI clients are explicit post-run operations; a failed
 write returns an error so the caller knows the evidence was not recorded.
 
+All writers enforce the same authoritative tag families. The injected writer
+stamps `source:standalone-mcp`; authenticated API/MCP/CLI writes stamp
+`source:broker-api` and `reporter:<principal>`. Caller-supplied values in those
+families are discarded on every surface.
+
 The Broker endpoint is available only when the authenticated Broker is enabled.
 It defaults `model_id` to the authenticated principal and adds
 `source:broker-api` plus `reporter:<principal>` tags. A caller may provide a
 more precise `model_id`, but the authenticated reporter tag remains. Taxonomy,
-model, task, tool, classification, and provenance tag prefixes are server-owned;
-caller-supplied tags with those prefixes are discarded. Routing tags such as
+model, task, tool, classification, and provenance tag prefixes are server-owned.
+Routing tags such as
 `repo:*`, `issue:*`, and `phase:*` remain available to callers.
 
 When `task_id` resolves to a private Munin task, the friction event inherits its

--- a/docs/friction-reporting.md
+++ b/docs/friction-reporting.md
@@ -28,9 +28,9 @@ Broker API and its MCP/CLI clients are explicit post-run operations; a failed
 write returns an error so the caller knows the evidence was not recorded.
 
 All writers enforce the same authoritative tag families. The injected writer
-stamps `source:standalone-mcp`; authenticated API/MCP/CLI writes stamp
-`source:broker-api` and `reporter:<principal>`. Caller-supplied values in those
-families are discarded on every surface.
+keeps the corpus's established `source:model-self-report` value; authenticated
+API/MCP/CLI writes stamp `source:broker-api` and `reporter:<principal>`.
+Caller-supplied values in those families are discarded on every surface.
 
 The Broker endpoint is available only when the authenticated Broker is enabled.
 It defaults `model_id` to the authenticated principal and adds

--- a/docs/friction-reporting.md
+++ b/docs/friction-reporting.md
@@ -40,6 +40,11 @@ model, task, tool, classification, and provenance tag prefixes are server-owned.
 Routing tags such as
 `repo:*`, `issue:*`, and `phase:*` remain available to callers.
 
+`model_id` is self-declared metadata, not authenticated identity. Consumers may
+use it as a routing hypothesis or diagnostic dimension, but any attribution or
+anti-poisoning decision must key on the authenticated `reporter:<principal>`
+tag (or another independently bound model receipt), never `model:*` alone.
+
 When `task_id` resolves to a private Munin task, the friction event inherits its
 restricted classification. Reports without a linked task remain `internal`.
 

--- a/docs/research/m5-task-solver-dogfood-2026-07.md
+++ b/docs/research/m5-task-solver-dogfood-2026-07.md
@@ -68,6 +68,17 @@ Do not train routing from exit code, PR existence, or green repository tests
 alone. Hugin [#216](https://github.com/Magnus-Gille/hugin/issues/216) tracks the
 missing general semantic-acceptance contract.
 
+### CI on task-output branches
+
+Hugin's automatic task-output commits intentionally do not contain `[skip ci]`.
+The resulting pull request must run the repository's normal CI because those
+checks are independent mechanical evidence for the quality gate and future
+exam record. Hugin does not auto-merge the PR or enqueue a follow-up Hugin task
+from CI, so the dispatcher itself does not create a commit → CI → task loop.
+Repositories that add such automation must provide their own actor, branch, or
+event guard to prevent recursion. CI success still does not replace independent
+semantic acceptance.
+
 ## M5 meta-check of this finding
 
 A bounded M5 `mellum` classification call was run against the evidence summary

--- a/src/broker/task-store.ts
+++ b/src/broker/task-store.ts
@@ -33,6 +33,7 @@ import {
   buildFrictionContent,
   buildFrictionNamespace,
   buildFrictionTags,
+  keepCallerFrictionTags,
   sanitiseTaskId,
 } from "../friction/munin-key.js";
 
@@ -75,33 +76,6 @@ export interface FrictionWriteResult {
   namespace: string;
   key: string;
   deduplicated: boolean;
-}
-
-const SERVER_OWNED_FRICTION_TAG_PREFIXES = [
-  "friction:",
-  "friction-category:",
-  "severity:",
-  "model:",
-  "source:",
-  "schema:",
-  "task:",
-  "resource:",
-  "alias-suggested:",
-  "tool:",
-  "reporter:",
-  "classification:",
-] as const;
-
-function keepCallerFrictionTags(tags: string[] | undefined): string[] | undefined {
-  if (!tags) return undefined;
-  return [...new Set(tags
-    .map((tag) => tag.trim())
-    .filter((tag) => tag.length > 0)
-    .filter((tag) => {
-      const normalized = tag.toLowerCase();
-      return !SERVER_OWNED_FRICTION_TAG_PREFIXES.some((prefix) =>
-        normalized.startsWith(prefix));
-    }))];
 }
 
 function frictionClassification(linkedTaskClassification: string | undefined): string {
@@ -152,7 +126,7 @@ function buildBrokerFrictionIdentity(
     .digest("hex")
     .slice(0, 32);
   return {
-    key: `${sanitiseTaskId(resolvedTaskId)}-broker-${eventHash}`,
+    key: `friction-broker-${eventHash}`,
     payloadHash,
   };
 }

--- a/src/broker/task-store.ts
+++ b/src/broker/task-store.ts
@@ -95,7 +95,7 @@ export class FrictionIdempotencyConflictError extends Error {
 
 function buildBrokerFrictionIdentity(
   input: ReportFrictionInput,
-  reporterTag: string,
+  authenticatedReporter: string,
   resolvedTaskId: string | undefined,
   modelId: string,
 ): { key: string; payloadHash: string } {
@@ -106,7 +106,7 @@ function buildBrokerFrictionIdentity(
   // accidental or malicious reuse of that identity for different evidence.
   // Tags are set-like metadata, so ordering does not change payload identity.
   const normalized = {
-    reporter: reporterTag,
+    reporter: authenticatedReporter,
     model_id: modelId,
     task_id: resolvedTaskId ?? null,
     friction_type: input.friction_type,
@@ -122,13 +122,28 @@ function buildBrokerFrictionIdentity(
     .update(JSON.stringify(normalized))
     .digest("hex");
   const eventHash = createHash("sha256")
-    .update(`${reporterTag}\0${input.event_id}`)
+    .update(`${authenticatedReporter}\0${input.event_id}`)
     .digest("hex")
     .slice(0, 32);
   return {
     key: `friction-broker-${eventHash}`,
     payloadHash,
   };
+}
+
+function brokerReporterTag(authenticatedReporter: string): string {
+  if (/^[A-Za-z0-9._-]{1,64}$/.test(authenticatedReporter)) {
+    return authenticatedReporter;
+  }
+  const digest = createHash("sha256")
+    .update(authenticatedReporter)
+    .digest("hex")
+    .slice(0, 16);
+  const readable = authenticatedReporter
+    .replace(/[^A-Za-z0-9._-]/g, "_")
+    .replace(/^[^A-Za-z0-9]+/, "")
+    .slice(0, 47) || "principal";
+  return `${readable}-${digest}`;
 }
 
 /**
@@ -323,13 +338,11 @@ export class BrokerTaskStore {
       : undefined;
     const modelId = trustedInput.model_id?.trim() || reporter.trim() || "unknown";
     const namespace = buildFrictionNamespace();
-    const reporterTag = reporter
-      .trim()
-      .replace(/[^A-Za-z0-9._-]/g, "_")
-      .slice(0, 64) || "unknown";
+    const authenticatedReporter = reporter || "unknown";
+    const reporterTag = brokerReporterTag(authenticatedReporter);
     const { key, payloadHash } = buildBrokerFrictionIdentity(
       trustedInput,
-      reporterTag,
+      authenticatedReporter,
       resolvedTaskId,
       modelId,
     );
@@ -359,8 +372,12 @@ export class BrokerTaskStore {
         throw new FrictionIdempotencyConflictError(trustedInput.event_id!);
       }
       const tags = [...new Set([
-        ...buildFrictionTags({ input: trustedInput, modelId, resolvedTaskId }),
-        "source:broker-api",
+        ...buildFrictionTags({
+          input: trustedInput,
+          modelId,
+          resolvedTaskId,
+          source: "broker-api",
+        }),
         `reporter:${reporterTag}`,
       ])];
       const contentPayload = JSON.parse(buildFrictionContent({

--- a/src/friction/munin-key.ts
+++ b/src/friction/munin-key.ts
@@ -83,6 +83,7 @@ export interface FrictionTagInputs {
   input: ReportFrictionInput;
   modelId: string;
   resolvedTaskId: string | undefined;
+  source?: "model-self-report" | "standalone-mcp" | "broker-api";
 }
 
 export function buildFrictionTags(args: FrictionTagInputs): string[] {
@@ -94,7 +95,7 @@ export function buildFrictionTags(args: FrictionTagInputs): string[] {
     `friction-category:${shortCategory(category)}`,
     `severity:${input.severity}`,
     `model:${modelId}`,
-    "source:model-self-report",
+    `source:${args.source ?? "model-self-report"}`,
     `schema:v${FRICTION_SCHEMA_VERSION}`,
   ];
 

--- a/src/friction/munin-key.ts
+++ b/src/friction/munin-key.ts
@@ -21,6 +21,36 @@ import {
 export const FRICTION_NAMESPACE = "signals/friction";
 export const FRICTION_NO_TASK = "no-task";
 
+const SERVER_OWNED_FRICTION_TAG_PREFIXES = [
+  "friction:",
+  "friction-category:",
+  "severity:",
+  "model:",
+  "source:",
+  "schema:",
+  "task:",
+  "resource:",
+  "alias-suggested:",
+  "tool:",
+  "reporter:",
+  "classification:",
+] as const;
+
+/** Keep free-form routing tags while rejecting all authoritative tag families. */
+export function keepCallerFrictionTags(
+  tags: string[] | undefined,
+): string[] | undefined {
+  if (!tags) return undefined;
+  return [...new Set(tags
+    .map((tag) => tag.trim())
+    .filter((tag) => tag.length > 0)
+    .filter((tag) => {
+      const normalized = tag.toLowerCase();
+      return !SERVER_OWNED_FRICTION_TAG_PREFIXES.some((prefix) =>
+        normalized.startsWith(prefix));
+    }))];
+}
+
 /**
  * Munin keys must be `[A-Za-z0-9_-]+` and start with an alphanumeric.
  * Dots (`.`) are not allowed — that's why the millisecond `.` and the

--- a/src/friction/schema.ts
+++ b/src/friction/schema.ts
@@ -103,7 +103,7 @@ export const reportFrictionInputShape = {
   model_id: metadataString(200)
     .optional()
     .describe(
-      "Your own model identifier (e.g. claude-opus-4-8, claude-sonnet-4-6). Set this so the friction event is attributed to the right model — interactive sessions are not tagged via env. Falls back to the server's HUGIN_FRICTION_MODEL_ID env (default \"unknown\") when omitted.",
+      "Self-declared, unauthenticated model metadata (e.g. claude-opus-4-8). Set this for diagnostics, but consumers requiring trusted attribution must use reporter provenance instead. Interactive sessions are not tagged via env. Falls back to HUGIN_FRICTION_MODEL_ID (default \"unknown\") when omitted.",
     ),
   event_id: z
     .string()

--- a/src/friction/tool.ts
+++ b/src/friction/tool.ts
@@ -131,7 +131,7 @@ export function buildFrictionTool(deps: FrictionToolDeps): FrictionTool {
         input,
         modelId: resolvedModelId,
         resolvedTaskId,
-        source: "standalone-mcp",
+        source: "model-self-report",
       });
       const content = buildFrictionContent({
         input,

--- a/src/friction/tool.ts
+++ b/src/friction/tool.ts
@@ -17,6 +17,7 @@ import {
   buildFrictionKey,
   buildFrictionNamespace,
   buildFrictionTags,
+  keepCallerFrictionTags,
   sanitiseTaskId,
 } from "./munin-key.js";
 import {
@@ -113,6 +114,10 @@ export function buildFrictionTool(deps: FrictionToolDeps): FrictionTool {
       let input: ReportFrictionInput;
       try {
         input = reportFrictionInputSchema.parse(rawInput);
+        input = {
+          ...input,
+          ...(input.tags ? { tags: keepCallerFrictionTags(input.tags) } : {}),
+        };
       } catch (err) {
         return asResult(errorPayload(err), true);
       }
@@ -122,11 +127,14 @@ export function buildFrictionTool(deps: FrictionToolDeps): FrictionTool {
       const resolvedModelId = pickModelId(input.model_id, deps.modelId);
       const namespace = buildFrictionNamespace();
       const key = buildFrictionKey(resolvedTaskId, recordedAt);
-      const tags = buildFrictionTags({
-        input,
-        modelId: resolvedModelId,
-        resolvedTaskId,
-      });
+      const tags = [...new Set([
+        ...buildFrictionTags({
+          input,
+          modelId: resolvedModelId,
+          resolvedTaskId,
+        }),
+        "source:standalone-mcp",
+      ])];
       const content = buildFrictionContent({
         input,
         modelId: resolvedModelId,

--- a/src/friction/tool.ts
+++ b/src/friction/tool.ts
@@ -127,14 +127,12 @@ export function buildFrictionTool(deps: FrictionToolDeps): FrictionTool {
       const resolvedModelId = pickModelId(input.model_id, deps.modelId);
       const namespace = buildFrictionNamespace();
       const key = buildFrictionKey(resolvedTaskId, recordedAt);
-      const tags = [...new Set([
-        ...buildFrictionTags({
-          input,
-          modelId: resolvedModelId,
-          resolvedTaskId,
-        }),
-        "source:standalone-mcp",
-      ])];
+      const tags = buildFrictionTags({
+        input,
+        modelId: resolvedModelId,
+        resolvedTaskId,
+        source: "standalone-mcp",
+      });
       const content = buildFrictionContent({
         input,
         modelId: resolvedModelId,

--- a/tests/broker/handlers.test.ts
+++ b/tests/broker/handlers.test.ts
@@ -12,6 +12,8 @@ import type { MuninClient } from "../../src/munin-client.js";
 
 const SECRET = "a".repeat(64);
 const OTHER_SECRET = "b".repeat(64);
+const UNSAFE_PRINCIPAL_SECRET = "c".repeat(64);
+const SAFE_PRINCIPAL_SECRET = "d".repeat(64);
 const FRICTION_EVENT_ID = "11111111-2222-4333-8444-555555555555";
 
 class FakeMunin {
@@ -71,7 +73,12 @@ beforeEach(async () => {
   const broker = await startBroker({
     host: "127.0.0.1",
     port: 0,
-    keys: { "claude-code": SECRET, codex: OTHER_SECRET },
+    keys: {
+      "claude-code": SECRET,
+      codex: OTHER_SECRET,
+      "alice/bob": UNSAFE_PRINCIPAL_SECRET,
+      alice_bob: SAFE_PRINCIPAL_SECRET,
+    },
     deps: {
       taskStore,
       journal,
@@ -899,6 +906,7 @@ describe("POST /v1/friction/report", () => {
     expect(write.tags).not.toContain("reporter:spoofed");
     expect(write.tags).not.toContain("reporter:gpt-5.4-codex");
     expect(write.tags).not.toContain("source:standalone-mcp");
+    expect(write.tags).not.toContain("source:model-self-report");
     expect(write.tags).not.toContain("Severity:low");
     expect(write.tags).not.toContain("model:spoofed");
     expect(write.tags).not.toContain("friction:ambiguity");
@@ -1027,6 +1035,37 @@ describe("POST /v1/friction/report", () => {
     });
 
     expect(res.status).toBe(400);
+  });
+
+  it("keeps colliding readable principal names in distinct provenance keyspaces", async () => {
+    const body = JSON.stringify({
+      friction_type: "ambiguity",
+      severity: "low",
+      summary: "same event id",
+      detail: "reported by two authenticated principals",
+      event_id: "66666666-7777-4888-8999-aaaaaaaaaaaa",
+    });
+    const postAs = (token: string) => fetch(`${harness.url}/v1/friction/report`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token}`,
+      },
+      body,
+    });
+
+    const unsafe = await postAs(UNSAFE_PRINCIPAL_SECRET);
+    const safe = await postAs(SAFE_PRINCIPAL_SECRET);
+    expect(unsafe.status).toBe(201);
+    expect(safe.status).toBe(201);
+    const [unsafeWrite, safeWrite] = harness.munin.writes.filter(
+      (write) => write.namespace === "signals/friction",
+    );
+    expect(unsafeWrite?.key).not.toBe(safeWrite?.key);
+    expect(unsafeWrite?.tags).toContainEqual(expect.stringMatching(
+      /^reporter:alice_bob-[0-9a-f]{16}$/,
+    ));
+    expect(safeWrite?.tags).toContain("reporter:alice_bob");
   });
 
   it("rejects unknown authenticated API fields instead of silently dropping them", async () => {

--- a/tests/broker/handlers.test.ts
+++ b/tests/broker/handlers.test.ts
@@ -893,6 +893,7 @@ describe("POST /v1/friction/report", () => {
     });
     const write = harness.munin.writes.at(-1)!;
     expect(write.namespace).toBe("signals/friction");
+    expect(write.classification).toBe("internal");
     expect(write.key).toMatch(/^friction-broker-[0-9a-f]{32}$/);
     expect(write.tags).toEqual(expect.arrayContaining([
       "friction:tool_failure",
@@ -950,6 +951,34 @@ describe("POST /v1/friction/report", () => {
     expect(harness.munin.writes.at(-1)?.classification).toBe("client-restricted");
   });
 
+  it("maps a linked private task to client-confidential friction", async () => {
+    harness.munin.reads["tasks/confidential-task/status"] = {
+      namespace: "tasks/confidential-task",
+      key: "status",
+      content: "private task",
+      tags: ["completed"],
+      classification: "private",
+      created_at: "2026-07-11T12:00:00.000Z",
+      updated_at: "2026-07-11T12:00:00.000Z",
+    };
+
+    const res = await fetch(`${harness.url}/v1/friction/report`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify({
+        friction_type: "tool_failure",
+        severity: "high",
+        summary: "confidential task tool failed",
+        detail: "Only operational metadata is included.",
+        event_id: "77777777-8888-4999-8aaa-bbbbbbbbbbbb",
+        task_id: "confidential-task",
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(harness.munin.writes.at(-1)?.classification).toBe("client-confidential");
+  });
+
   it("deduplicates an identical authenticated retry onto one Munin event", async () => {
     const body = JSON.stringify({
       friction_type: "connectivity",
@@ -987,6 +1016,83 @@ describe("POST /v1/friction/report", () => {
     expect(harness.munin.writes.filter(
       (write) => write.namespace === "signals/friction" && write.key === firstResult.key,
     )).toHaveLength(1);
+  });
+
+  it("serializes overlapping identical and conflicting event retries", async () => {
+    const eventId = "88888888-9999-4aaa-8bbb-cccccccccccc";
+    const event = {
+      friction_type: "connectivity",
+      severity: "high",
+      summary: "overlapping retry",
+      detail: "original evidence",
+      event_id: eventId,
+      task_id: "task-overlap",
+    };
+    const originalWrite = harness.munin.write.bind(harness.munin);
+    let releaseWrite = (): void => {};
+    let markStarted = (): void => {};
+    const writeGate = new Promise<void>((resolve) => { releaseWrite = resolve; });
+    const writeStarted = new Promise<void>((resolve) => { markStarted = resolve; });
+    let blocked = false;
+    const spy = vi.spyOn(harness.munin, "write").mockImplementation(async (
+      namespace,
+      key,
+      content,
+      tags,
+      expectedUpdatedAt,
+      classification,
+    ) => {
+      if (namespace === "signals/friction" && !blocked) {
+        blocked = true;
+        markStarted();
+        await writeGate;
+      }
+      return originalWrite(
+        namespace,
+        key,
+        content,
+        tags,
+        expectedUpdatedAt,
+        classification,
+      );
+    });
+
+    try {
+      const firstPromise = fetch(`${harness.url}/v1/friction/report`, {
+        method: "POST",
+        headers: authHeader(),
+        body: JSON.stringify(event),
+      });
+      await writeStarted;
+      const retryPromise = fetch(`${harness.url}/v1/friction/report`, {
+        method: "POST",
+        headers: authHeader(),
+        body: JSON.stringify(event),
+      });
+      const conflictPromise = fetch(`${harness.url}/v1/friction/report`, {
+        method: "POST",
+        headers: authHeader(),
+        body: JSON.stringify({ ...event, detail: "conflicting evidence" }),
+      });
+      releaseWrite();
+
+      const [first, retry, conflict] = await Promise.all([
+        firstPromise,
+        retryPromise,
+        conflictPromise,
+      ]);
+      expect(first.status).toBe(201);
+      expect(retry.status).toBe(201);
+      expect(await retry.json()).toMatchObject({ deduplicated: true });
+      expect(conflict.status).toBe(409);
+      expect(await conflict.json()).toMatchObject({ error: "idempotency_collision" });
+      expect(harness.munin.writes.filter(
+        (write) => write.namespace === "signals/friction",
+      )).toHaveLength(1);
+    } finally {
+      releaseWrite();
+      spy.mockRestore();
+    }
   });
 
   it("rejects reuse of an event identity with different evidence", async () => {

--- a/tests/broker/handlers.test.ts
+++ b/tests/broker/handlers.test.ts
@@ -886,7 +886,7 @@ describe("POST /v1/friction/report", () => {
     });
     const write = harness.munin.writes.at(-1)!;
     expect(write.namespace).toBe("signals/friction");
-    expect(write.key).toContain("cassette_task-1-");
+    expect(write.key).toMatch(/^friction-broker-[0-9a-f]{32}$/);
     expect(write.tags).toEqual(expect.arrayContaining([
       "friction:tool_failure",
       "severity:blocking",
@@ -999,7 +999,11 @@ describe("POST /v1/friction/report", () => {
     const collision = await fetch(`${harness.url}/v1/friction/report`, {
       method: "POST",
       headers: authHeader(),
-      body: JSON.stringify({ ...original, detail: "conflicting evidence" }),
+      body: JSON.stringify({
+        ...original,
+        detail: "conflicting evidence",
+        task_id: "changed-task-id",
+      }),
     });
 
     expect(first.status).toBe(201);

--- a/tests/friction/tool.test.ts
+++ b/tests/friction/tool.test.ts
@@ -46,8 +46,8 @@ describe("report_friction tool — happy path", () => {
     expect(tags).toContain("friction:reasoning_limit");
     expect(tags).toContain("severity:high");
     expect(tags).toContain("model:claude-sonnet-4-6");
-    expect(tags).toContain("source:model-self-report");
     expect(tags).toContain("source:standalone-mcp");
+    expect(tags).not.toContain("source:model-self-report");
     expect(tags).toContain("repo:hugin");
     expect(tags).not.toContain("source:broker-api");
     expect(tags).not.toContain("reporter:spoofed");

--- a/tests/friction/tool.test.ts
+++ b/tests/friction/tool.test.ts
@@ -32,6 +32,7 @@ describe("report_friction tool — happy path", () => {
       detail: "Tried two simplifications, both wrong.",
       resource_assessment: "under-resourced",
       alias_suggested: "large-reasoning",
+      tags: ["source:broker-api", "reporter:spoofed", "repo:hugin"],
     });
 
     expect(result.isError).toBeUndefined();
@@ -46,6 +47,10 @@ describe("report_friction tool — happy path", () => {
     expect(tags).toContain("severity:high");
     expect(tags).toContain("model:claude-sonnet-4-6");
     expect(tags).toContain("source:model-self-report");
+    expect(tags).toContain("source:standalone-mcp");
+    expect(tags).toContain("repo:hugin");
+    expect(tags).not.toContain("source:broker-api");
+    expect(tags).not.toContain("reporter:spoofed");
     expect(tags).toContain("alias-suggested:large-reasoning");
     expect(tags).toContain("task:t-abc");
 
@@ -53,6 +58,7 @@ describe("report_friction tool — happy path", () => {
     expect(parsed.schema_version).toBe(1);
     expect(parsed.task_id_resolved).toBe("t-abc");
     expect(parsed.summary).toBe("Hit ceiling on algebra step.");
+    expect(parsed.user_tags).toEqual(["repo:hugin"]);
 
     const body = parseResult(result) as {
       ok: boolean;

--- a/tests/friction/tool.test.ts
+++ b/tests/friction/tool.test.ts
@@ -46,8 +46,8 @@ describe("report_friction tool — happy path", () => {
     expect(tags).toContain("friction:reasoning_limit");
     expect(tags).toContain("severity:high");
     expect(tags).toContain("model:claude-sonnet-4-6");
-    expect(tags).toContain("source:standalone-mcp");
-    expect(tags).not.toContain("source:model-self-report");
+    expect(tags).toContain("source:model-self-report");
+    expect(tags).not.toContain("source:standalone-mcp");
     expect(tags).toContain("repo:hugin");
     expect(tags).not.toContain("source:broker-api");
     expect(tags).not.toContain("reporter:spoofed");

--- a/tests/mcp/broker-client.test.ts
+++ b/tests/mcp/broker-client.test.ts
@@ -112,6 +112,26 @@ describe("BrokerClient", () => {
     expect(secondBody.event_id).toBe(firstBody.event_id);
   });
 
+  it("does not retry a friction HTTP error", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(
+      { error: "policy_rejected" },
+      { status: 400 },
+    ));
+    const client = new BrokerClient({
+      baseUrl: "http://broker.test:3033",
+      bearerToken: "tk",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+
+    await expect(client.reportFriction({
+      friction_type: "ambiguity",
+      severity: "low",
+      summary: "bad request",
+      detail: "the server rejected it",
+    })).rejects.toBeInstanceOf(BrokerHttpError);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
   it("posts learning-loop operations to their authenticated endpoints", async () => {
     const fetchImpl = vi.fn(async () => jsonResponse({ ok: true }));
     const client = new BrokerClient({


### PR DESCRIPTION
Follow-up to #219. PR #219 merged while its independent Claude review was still converging, so this PR carries only the post-merge review fixes onto current main. It centralizes reserved-tag sanitization across Broker and standalone writers, makes authenticated event identity retry-safe and principal-collision-safe, preserves recurring events and historical source compatibility, inherits linked-task classification, documents CI/model trust boundaries, and pins concurrent dedup/conflict behavior. Verified on current main: TypeScript build and all 1,821 tests pass.