### PR TITLE
Resolve managed repository default branches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,14 @@ Content format:
 - `files` → `/home/magnus/mimir`
 - Raw absolute paths under `/home/magnus/` are passed through; paths outside this prefix are rejected and fall back to the default workspace
 
+**Managed-repository base branch:** Hugin prefers the fetched
+`refs/remotes/origin/HEAD`, then queries the remote `HEAD` symref. Use the
+optional `Base branch:` field only for disconnected or unusual repositories;
+its value is a validated branch name such as `main`, `master`, or
+`release/stable` (not an `origin/*` or `refs/*` ref). The resolved branch is
+bound once and reused for checkout, no-change detection, cleanup, PR base, and
+repository evidence.
+
 **Reply routing:** `Reply-to:` and `Reply-format:` are forwarded in the result for downstream consumers (e.g., Ratatoskr).
 
 **Task groups:** `Group:` and `Sequence:` enable multi-step task orchestration. Both are forwarded in results and heartbeats.
@@ -134,10 +142,12 @@ maps to the `build` agent with `edit`/`bash` allowed.
 - `result` — human-readable markdown with exit code, timestamps, duration, and response body
 - `result-structured` — machine-readable JSON (Zod-validated) with schema version, lifecycle metadata, runtime metadata (requested vs effective model/host), sensitivity audit, honest submission provenance (`claimedSubmitter`, nullable `verifiedSubmitter`, signing policy/status/keyId), and structured body. Prefer this for programmatic consumption.
 
-Successful managed-repository tasks may include `repositoryChange` in `result-structured`:
-the pre-agent `origin/main`, final task-branch commit, changed paths, and binary Git diff
-SHA-256. The daily exam factory uses this content-blind evidence only to classify history as
-provisional holdout, regression, or quarantine; it never runs or promotes candidates. See
+Successful managed-repository tasks may include `repositoryChange` in
+`result-structured`. Current writers bind the resolved base branch, its exact
+pre-agent commit, final task-branch commit, changed paths, and binary Git diff
+SHA-256. The daily exam factory uses this content-blind evidence only to
+classify history as provisional holdout, regression, or quarantine; it never
+runs or promotes candidates. See
 `docs/daily-exam-factory.md`.
 
 **M5 execution provenance (issue #163):** every M5 `/delegate` call — whether it arrives via the canonical #167 Broker leaf (`runtime:homeserver`) or as an orchestrator fan-out worker leaf — records the same canonical trace: `ledgerId` (the join key to M5's authoritative evidence row), effective `nodeId`/`modelId`, `taskType`, verification `outcome`/`score`, `verifier` identity + `verifierNotes`, `delegated`/`escalated` + `decisionReason`, route-policy `policyMode`/`policyAction`/`policyReason`, `priceCatalogVersion`, and `costTraceId`. It surfaces at `runtimeMetadata.delegation` for the direct path and per-leaf at `orchestratorOutcomes[].delegation` for fan-out. `src/m5-provenance.ts` is the **only** sanctioned producer: the gateway body is untrusted input, so it validates enums/bounds and DROPS anything out of contract rather than throwing — a malformed gateway value must never sink the `result-structured` write of an already-paid run (`buildStructuredTaskResult` calls `.parse()`). This is a **trace, not a verdict**: M5 remains the sole capability-evidence authority and Hugin never duplicates its judgements into a Hugin-owned capability store. Retrieving the row *by* `ledgerId` currently needs an id-addressable read on the gateway — filed as gille-inference#227.

--- a/docs/daily-exam-factory.md
+++ b/docs/daily-exam-factory.md
@@ -14,7 +14,7 @@ non-runnable artifacts and must never be treated as fresh evidence.
 For a successful task branch, Hugin records a content-blind repository binding
 in `result-structured`:
 
-- exact `origin/main` commit used as the before tree;
+- resolved repository base branch and its exact commit used as the before tree;
 - exact task-branch head commit;
 - repository-relative changed-file names; and
 - SHA-256 of the binary Git diff.

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import {
   type MuninClientConfig,
   type MuninReadResult,
 } from "./munin-client.js";
-import { getFoundBatchEntry, extractTaskId, pickEarliestTask, selectNextTask, checkoutTaskBranch, finalizeTaskBranch, shouldReapExpiredLease, decideStartupRecovery, decideDeliveryRetry, finalizeTaskCompletion, resolveTaskWorkingDirectory, normalizeRoot, DEFAULT_REPOS_ROOT, MAX_TASK_OUTPUT_TOKENS, MAX_TASK_TIMEOUT_MS, parseBoundedPositiveInt } from "./task-helpers.js";
+import { getFoundBatchEntry, extractTaskId, pickEarliestTask, selectNextTask, checkoutTaskBranch, finalizeTaskBranch, shouldReapExpiredLease, decideStartupRecovery, decideDeliveryRetry, finalizeTaskCompletion, resolveTaskWorkingDirectory, normalizeRoot, parseBaseBranchOverride, DEFAULT_REPOS_ROOT, MAX_TASK_OUTPUT_TOKENS, MAX_TASK_TIMEOUT_MS, parseBoundedPositiveInt } from "./task-helpers.js";
 import { queryAllMuninEntries } from "./munin-pagination.js";
 import { executeSdkTask, type SdkExecutorResult, type SdkExecutorOptions, type SdkTaskConfig, type TaskPermissionProfile } from "./sdk-executor.js";
 import {
@@ -651,6 +651,8 @@ interface TaskConfig {
   runtime: "claude" | "codex" | "ollama" | "opencode" | "homeserver" | "orchestrator";
   workingDir: string;
   context?: string;
+  baseBranch?: string;
+  baseBranchError?: string;
   timeoutMs: number;
   submittedBy: string;
   submittedAt: string;
@@ -755,6 +757,7 @@ function parseTask(content: string): TaskConfig | null {
   const contextRaw = content.match(
     /\*\*Context:\*\*\s*(.+)/i
   )?.[1]?.trim();
+  const baseBranchOverride = parseBaseBranchOverride(content);
   const timeoutStr = content.match(/\*\*Timeout:\*\*\s*(\d+)/i)?.[1];
   const submittedBy = content.match(
     /\*\*Submitted by:\*\*\s*(.+)/i
@@ -885,6 +888,8 @@ function parseTask(content: string): TaskConfig | null {
     runtime: runtime || "claude",  // temporary for auto — overwritten by router
     workingDir: resolvedDir,
     context: contextRaw || undefined,
+    baseBranch: baseBranchOverride.baseBranch,
+    baseBranchError: baseBranchOverride.error,
     timeoutMs: parseBoundedPositiveInt(
       canonicalBrokerEnvelope?.timeout_ms ?? timeoutStr,
       config.defaultTimeoutMs,
@@ -4156,6 +4161,16 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     return { hadTask: true, queueDepth };
   }
 
+  if (parsedTask?.baseBranchError) {
+    const rejection = `Repository base branch invalid: ${parsedTask.baseBranchError}`;
+    console.warn(`Rejecting task ${taskNs}: ${rejection}`);
+    await failTaskWithMessage(taskNs, entry, rejection);
+    await munin.log(taskNs, `Task rejected before execution: ${rejection}`);
+    await promoteDependents(extractTaskId(taskNs));
+    await refreshPipelineSummaryFromContent(entry.content);
+    return { hadTask: true, queueDepth };
+  }
+
   if (declaredRuntime !== "pipeline" && parsedTask) {
     const sensitivityAssessment = await assessTaskSecurity(parsedTask);
 
@@ -4468,11 +4483,13 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
       throw new Error(`Internal dispatcher error: parsed task missing for ${taskNs}`);
     }
 
-    // Pre-task: checkout a fresh hugin/<taskId> branch from origin/main (#47)
+    // Pre-task: checkout a fresh hugin/<taskId> branch from the repository's
+    // resolved default branch (or validated explicit override, #217).
     let branchResult: Awaited<ReturnType<typeof checkoutTaskBranch>> = { action: "skipped" };
     if (task.runtime !== "homeserver") {
       branchResult = await checkoutTaskBranch(task.workingDir, taskId, {
         reposRoot: config.reposRoot,
+        baseBranchOverride: task.baseBranch,
         captureBaseCommit: true,
       });
       if (branchResult.action === "fetch-failed") {
@@ -5102,6 +5119,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         egressPolicy.allowedHosts,
         {
           captureRepositoryChange: true,
+          baseBranch: branchResult.baseBranch,
           baseCommit: branchResult.baseCommit,
         },
       );

--- a/src/learning/daily-task-exam-factory.ts
+++ b/src/learning/daily-task-exam-factory.ts
@@ -37,6 +37,9 @@ export const dailyExamCandidateSchema = z.object({
     githubRepository: z.string().regex(/^[^/\s]+\/[^/\s]+$/),
     contextAlias: z.string().regex(/^repo:[A-Za-z0-9._-]+$/).optional(),
     pullRequestUrl: z.string().url(),
+    // Optional for historical task-result schema v1 rows; current Hugin
+    // results always bind the resolved repository base branch (#217).
+    baseBranch: z.string().min(1).max(255).optional(),
     baseCommit: gitCommitSchema,
     headCommit: gitCommitSchema,
     changedFiles: z.array(z.string().min(1)).min(1).max(10_000),
@@ -284,6 +287,7 @@ export function buildDailyExamCandidate(source: DailyTaskHarvestSource): DailyEx
     taskNamespace: source.status.namespace,
     taskDocumentSha256: sha256(taskDocument),
     promptSha256: promptFingerprint ?? null,
+    baseBranch: change?.baseBranch ?? null,
     baseCommit: change?.baseCommit ?? null,
     headCommit: change?.headCommit ?? null,
     diffSha256: change?.diffSha256 ?? null,

--- a/src/task-helpers.ts
+++ b/src/task-helpers.ts
@@ -437,7 +437,9 @@ export interface TaskBranchOptions {
    * can never branch a production checkout.
    */
   reposRoot?: string;
-  /** Pin origin/main before the agent runs so later exam evidence cannot trust an agent-mutated ref. */
+  /** Explicit remote branch name for disconnected or unusual repositories. */
+  baseBranchOverride?: string;
+  /** Pin the resolved base before the agent runs so later evidence cannot trust an agent-mutated ref. */
   captureBaseCommit?: boolean;
 }
 
@@ -445,6 +447,7 @@ export interface TaskBranchResult {
   /** skipped: not a managed git repo; created: branch ready; fetch-failed: network error, no branch */
   action: "skipped" | "created" | "fetch-failed";
   branchName?: string;
+  baseBranch?: string;
   baseCommit?: string;
   error?: string;
 }
@@ -464,6 +467,7 @@ export interface BranchFinalizeResult {
  * this record only pins the exact before/after trees and their changed paths.
  */
 export interface RepositoryChangeEvidence {
+  baseBranch: string;
   baseCommit: string;
   headCommit: string;
   changedFiles: string[];
@@ -473,11 +477,167 @@ export interface RepositoryChangeEvidence {
 export interface BranchFinalizeOptions {
   /** Capture exact before/after repository evidence for the daily exam factory. */
   captureRepositoryChange?: boolean;
-  /** Pre-agent origin/main commit returned by checkoutTaskBranch. */
+  /** Resolved remote branch returned by checkoutTaskBranch. */
+  baseBranch?: string;
+  /** Pre-agent base commit returned by checkoutTaskBranch. */
   baseCommit?: string;
 }
 
 const DEFAULT_FETCH_RETRY_DELAYS_MS = [500, 2000];
+const GIT_COMMIT_ID = /^[0-9a-f]{40,64}$/;
+
+export interface ParsedBaseBranchOverride {
+  baseBranch?: string;
+  error?: string;
+}
+
+/**
+ * Validate a branch name without invoking a shell. This mirrors Git's
+ * check-ref-format restrictions and additionally requires a branch name (not
+ * an `origin/*` or `refs/*` ref) so Hugin can construct one canonical remote
+ * tracking ref for every subsequent operation.
+ */
+export function isValidBaseBranchName(value: string): boolean {
+  if (!value || value !== value.trim() || value.length > 255) return false;
+  if (
+    !/^[A-Za-z0-9][A-Za-z0-9._/-]*$/.test(value) ||
+    value === "@" ||
+    value.toUpperCase() === "HEAD" ||
+    value.startsWith("-") ||
+    value.startsWith("/") ||
+    value.endsWith("/") ||
+    value.endsWith(".") ||
+    value.startsWith("origin/") ||
+    value.startsWith("refs/") ||
+    value.includes("..") ||
+    value.includes("//") ||
+    value.includes("@{") ||
+    /[\x00-\x20\x7f~^:?*[\]\\]/.test(value)
+  ) {
+    return false;
+  }
+  return value.split("/").every(
+    (component) =>
+      component.length > 0 &&
+      !component.startsWith(".") &&
+      !component.endsWith(".lock"),
+  );
+}
+
+/** Parse and validate the optional `Base branch:` task field. */
+export function parseBaseBranchOverride(content: string): ParsedBaseBranchOverride {
+  // Task metadata ends at `### Prompt`; prompt prose must never be able to
+  // select Git control-plane state by merely mentioning this field.
+  const metadata = content.split(/^###\s*Prompt\s*$/im, 1)[0] ?? "";
+  const raw = metadata.match(/\*\*Base branch:\*\*\s*(.+)/i)?.[1]?.trim();
+  if (!raw) return {};
+  if (!isValidBaseBranchName(raw)) {
+    return {
+      error:
+        `invalid Base branch override ${JSON.stringify(raw)}; provide a branch name ` +
+        "such as main, master, or release/stable (not an origin/* or refs/* ref)",
+    };
+  }
+  return { baseBranch: raw };
+}
+
+interface ResolvedBaseBranch {
+  baseBranch: string;
+  baseCommit: string;
+  source: "override" | "origin-head" | "remote-head";
+}
+
+async function verifyRemoteBaseBranch(
+  workingDir: string,
+  baseBranch: string,
+): Promise<{ baseCommit?: string; error?: string }> {
+  const remoteRef = `refs/remotes/origin/${baseBranch}`;
+  const base = await runGitCapture(workingDir, [
+    "rev-parse", "--verify", `${remoteRef}^{commit}`,
+  ]);
+  const baseCommit = base.stdout.toString("utf8").trim().toLowerCase();
+  if (!base.ok || !GIT_COMMIT_ID.test(baseCommit)) {
+    return {
+      error: `${remoteRef} has no valid commit: ${base.stderr || "invalid commit id"}`,
+    };
+  }
+  return { baseCommit };
+}
+
+async function resolveRepositoryBaseBranch(
+  workingDir: string,
+  override: string | undefined,
+): Promise<{ resolved?: ResolvedBaseBranch; error?: string }> {
+  if (override) {
+    if (!isValidBaseBranchName(override)) {
+      return { error: `invalid base-branch override ${JSON.stringify(override)}` };
+    }
+    const verified = await verifyRemoteBaseBranch(workingDir, override);
+    if (!verified.baseCommit) {
+      return {
+        error:
+          `explicit base branch ${JSON.stringify(override)} is unavailable: ` +
+          (verified.error || "unknown error"),
+      };
+    }
+    return {
+      resolved: {
+        baseBranch: override,
+        baseCommit: verified.baseCommit,
+        source: "override",
+      },
+    };
+  }
+
+  const symbolic = await runGitCapture(workingDir, [
+    "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD",
+  ]);
+  if (symbolic.ok) {
+    const candidate = symbolic.stdout.toString("utf8").trim();
+    if (candidate.startsWith("origin/")) {
+      const branch = candidate.slice("origin/".length);
+      if (isValidBaseBranchName(branch)) {
+        const verified = await verifyRemoteBaseBranch(workingDir, branch);
+        if (verified.baseCommit) {
+          return {
+            resolved: {
+              baseBranch: branch,
+              baseCommit: verified.baseCommit,
+              source: "origin-head",
+            },
+          };
+        }
+      }
+    }
+  }
+
+  const remoteHead = await runGitCapture(workingDir, [
+    "ls-remote", "--symref", "origin", "HEAD",
+  ]);
+  if (remoteHead.ok) {
+    for (const line of remoteHead.stdout.toString("utf8").split("\n")) {
+      const match = line.match(/^ref:\s+refs\/heads\/(.+)\tHEAD$/);
+      const branch = match?.[1];
+      if (!branch || !isValidBaseBranchName(branch)) continue;
+      const verified = await verifyRemoteBaseBranch(workingDir, branch);
+      if (verified.baseCommit) {
+        return {
+          resolved: {
+            baseBranch: branch,
+            baseCommit: verified.baseCommit,
+            source: "remote-head",
+          },
+        };
+      }
+    }
+  }
+
+  return {
+    error:
+      "could not resolve a valid origin default branch from origin/HEAD or remote HEAD; " +
+      "set an explicit Base branch task field",
+  };
+}
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
@@ -507,8 +667,9 @@ async function runGitFetch(
 }
 
 /**
- * Pre-task: fetch origin and checkout a fresh branch `hugin/<taskId>` from
- * `origin/main`. Replaces the old `syncRepoBeforeTask` fast-forward approach.
+ * Pre-task: fetch origin, resolve its default branch, and checkout a fresh
+ * `hugin/<taskId>` branch from that exact remote-tracking ref. Replaces the old
+ * `syncRepoBeforeTask` fast-forward approach.
  *
  * - Returns `skipped` for non-managed directories (outside `reposRoot`
  *   (default /home/magnus/repos/), not a git repo, no remote). Task proceeds
@@ -522,6 +683,15 @@ export async function checkoutTaskBranch(
   taskId: string,
   options: TaskBranchOptions = {},
 ): Promise<TaskBranchResult> {
+  if (
+    options.baseBranchOverride !== undefined &&
+    !isValidBaseBranchName(options.baseBranchOverride)
+  ) {
+    return {
+      action: "fetch-failed",
+      error: `Invalid base-branch override ${JSON.stringify(options.baseBranchOverride)}`,
+    };
+  }
   // Canonicalize both sides before the prefix check: a raw `startsWith` guard
   // can be bypassed with `..` segments that string-match the isolated root but
   // resolve (via the OS `cwd`) onto a production checkout — the exact
@@ -583,30 +753,36 @@ export async function checkoutTaskBranch(
     );
   }
 
-  if (!fetchOk) {
+  if (!fetchOk && !options.baseBranchOverride) {
     return {
       action: "fetch-failed",
       error: `git fetch origin failed in ${workingDir} after ${totalAttempts} attempts — proceeding without branch`,
     };
   }
-
-  let baseCommit: string | undefined;
-  if (options.captureBaseCommit) {
-    const base = await runGitCapture(workingDir, ["rev-parse", "origin/main"]);
-    const candidate = base.stdout.toString("utf8").trim().toLowerCase();
-    if (!base.ok || !/^[0-9a-f]{40,64}$/.test(candidate)) {
-      return {
-        action: "fetch-failed",
-        error: `Failed to pin origin/main before task execution: ${base.stderr || "invalid commit id"}`,
-      };
-    }
-    baseCommit = candidate;
+  if (!fetchOk) {
+    console.warn(
+      `Pre-task git fetch failed in ${workingDir}; attempting explicit base branch ` +
+        `${JSON.stringify(options.baseBranchOverride)} from the existing remote-tracking ref`,
+    );
   }
+
+  const baseResolution = await resolveRepositoryBaseBranch(
+    workingDir,
+    options.baseBranchOverride,
+  );
+  if (!baseResolution.resolved) {
+    return {
+      action: "fetch-failed",
+      error: `Failed to resolve repository base branch: ${baseResolution.error || "unknown error"}`,
+    };
+  }
+  const { baseBranch, baseCommit, source } = baseResolution.resolved;
+  const baseRef = `origin/${baseBranch}`;
 
   const branchName = `hugin/${taskId}`;
 
   const checkoutOk = await new Promise<boolean>((resolve) => {
-    const child = spawn("git", ["checkout", "-b", branchName, "origin/main"], {
+    const child = spawn("git", ["checkout", "-b", branchName, baseRef], {
       cwd: workingDir,
       stdio: ["ignore", "pipe", "pipe"],
       env: { ...process.env, HOME: "/home/magnus" },
@@ -630,17 +806,25 @@ export async function checkoutTaskBranch(
     };
   }
 
-  console.log(`Pre-task: checked out branch ${branchName} from origin/main in ${workingDir}`);
-  return { action: "created", branchName, baseCommit };
+  console.log(
+    `Pre-task: checked out branch ${branchName} from ${baseRef} ` +
+      `(resolved via ${source}) in ${workingDir}`,
+  );
+  return {
+    action: "created",
+    branchName,
+    baseBranch,
+    baseCommit: options.captureBaseCommit ? baseCommit : undefined,
+  };
 }
 
 /**
  * Post-task: finalize a task branch.
  *
  * 1. Auto-commits any uncommitted changes the task left behind.
- * 2. If no commits exist on the branch vs origin/main: cleans up the branch
+ * 2. If no commits exist on the branch vs the resolved base: cleans up the branch
  *    (read-only tasks like research spikes).
- * 3. If commits exist: pushes branch and opens a PR against main.
+ * 3. If commits exist: pushes branch and opens a PR against that same base.
  *
  * Returns `pr-created` with `prUrl` on success, `no-changes` if nothing to
  * deliver, or `push-failed` on git/gh errors (non-fatal: task result is still
@@ -653,6 +837,20 @@ export async function finalizeTaskBranch(
   allowedEgressHosts: string[],
   options: BranchFinalizeOptions = {},
 ): Promise<BranchFinalizeResult> {
+  const baseBranch = options.baseBranch ?? "main";
+  if (!isValidBaseBranchName(baseBranch)) {
+    return {
+      action: "push-failed",
+      branchName,
+      error: `Invalid resolved base branch ${JSON.stringify(baseBranch)}`,
+    };
+  }
+  const baseRef = `origin/${baseBranch}`;
+  const pinnedBaseCommit = options.baseCommit?.trim().toLowerCase();
+  const comparisonBase = pinnedBaseCommit && GIT_COMMIT_ID.test(pinnedBaseCommit)
+    ? pinnedBaseCommit
+    : baseRef;
+
   // Auto-commit uncommitted changes (task may have written files without committing)
   const isDirty = await new Promise<boolean>((resolve) => {
     const child = spawn("git", ["status", "--porcelain"], {
@@ -694,29 +892,47 @@ export async function finalizeTaskBranch(
     }
   }
 
-  // Count commits on the branch that aren't on origin/main
-  const commitsAhead = await new Promise<number>((resolve) => {
-    const child = spawn("git", ["rev-list", "--count", "origin/main..HEAD"], {
+  // Count commits on the branch that aren't on the resolved remote base.
+  const commitsAhead = await new Promise<number | null>((resolve) => {
+    const child = spawn("git", ["rev-list", "--count", `${comparisonBase}..HEAD`], {
       cwd: workingDir,
       stdio: ["ignore", "pipe", "pipe"],
       env: { ...process.env, HOME: "/home/magnus" },
     });
     let out = "";
     child.stdout?.on("data", (d: Buffer) => (out += d.toString()));
-    child.on("close", (code) => resolve(code === 0 ? parseInt(out.trim(), 10) || 0 : 0));
-    child.on("error", () => resolve(0));
+    child.on("close", (code) => {
+      if (code !== 0 || !/^\d+$/.test(out.trim())) {
+        resolve(null);
+        return;
+      }
+      resolve(parseInt(out.trim(), 10));
+    });
+    child.on("error", () => resolve(null));
   });
+
+  if (commitsAhead === null) {
+    return {
+      action: "push-failed",
+      branchName,
+      error: `Failed to compare task branch against pinned base ${comparisonBase}`,
+    };
+  }
 
   if (commitsAhead === 0) {
     console.log(`Post-task: no changes on ${branchName} — cleaning up`);
-    await cleanupLocalBranch(workingDir, branchName);
+    await cleanupLocalBranch(workingDir, branchName, comparisonBase);
     return { action: "no-changes" };
   }
 
   let repositoryChange: RepositoryChangeEvidence | undefined;
   let repositoryChangeError: string | undefined;
   if (options.captureRepositoryChange) {
-    const captured = await captureRepositoryChange(workingDir, options.baseCommit);
+    const captured = await captureRepositoryChange(
+      workingDir,
+      baseBranch,
+      options.baseCommit,
+    );
     repositoryChange = captured.evidence;
     repositoryChangeError = captured.error;
     if (repositoryChangeError) {
@@ -784,7 +1000,13 @@ export async function finalizeTaskBranch(
 
   // Open PR
   const taskId = branchName.replace(/^hugin\//, "");
-  const prUrl = await createPullRequest(workingDir, branchName, taskId, prBody);
+  const prUrl = await createPullRequest(
+    workingDir,
+    branchName,
+    baseBranch,
+    taskId,
+    prBody,
+  );
   if (!prUrl) {
     return {
       action: "push-failed",
@@ -834,6 +1056,7 @@ async function runGitCapture(
 
 async function captureRepositoryChange(
   workingDir: string,
+  baseBranch: string,
   preTaskBaseCommit: string | undefined,
 ): Promise<{ evidence?: RepositoryChangeEvidence; error?: string }> {
   const baseCommit = preTaskBaseCommit?.trim().toLowerCase();
@@ -870,6 +1093,7 @@ async function captureRepositoryChange(
 
   return {
     evidence: {
+      baseBranch,
       baseCommit,
       headCommit,
       changedFiles,
@@ -878,10 +1102,14 @@ async function captureRepositoryChange(
   };
 }
 
-async function cleanupLocalBranch(workingDir: string, branchName: string): Promise<void> {
+async function cleanupLocalBranch(
+  workingDir: string,
+  branchName: string,
+  detachTarget: string,
+): Promise<void> {
   // Detach HEAD so we can delete the branch we're on
   await new Promise<void>((resolve) => {
-    const child = spawn("git", ["checkout", "--detach", "origin/main"], {
+    const child = spawn("git", ["checkout", "--detach", detachTarget], {
       cwd: workingDir,
       stdio: "ignore",
       env: { ...process.env, HOME: "/home/magnus" },
@@ -904,6 +1132,7 @@ async function cleanupLocalBranch(workingDir: string, branchName: string): Promi
 async function createPullRequest(
   workingDir: string,
   branchName: string,
+  baseBranch: string,
   taskId: string,
   body: string,
 ): Promise<string | null> {
@@ -912,7 +1141,7 @@ async function createPullRequest(
       "gh",
       [
         "pr", "create",
-        "--base", "main",
+        "--base", baseBranch,
         "--head", branchName,
         "--title", `hugin: ${taskId}`,
         "--body", body,

--- a/src/task-result-schema.ts
+++ b/src/task-result-schema.ts
@@ -295,6 +295,25 @@ export type TaskSubmissionProvenance = z.infer<
 // factory reconstruct the exact before/after trees from Git without trusting
 // an agent's prose claim that it edited or tested something.
 export const repositoryChangeEvidenceSchema = z.object({
+  // Optional only for historical schema-v1 results. Every current managed
+  // repository writer supplies the resolved/validated branch (#217).
+  baseBranch: z.string()
+    .min(1)
+    .max(255)
+    .regex(/^[A-Za-z0-9][A-Za-z0-9._/-]*$/)
+    .refine(
+      (value) =>
+        value.toUpperCase() !== "HEAD" &&
+        !value.startsWith("origin/") &&
+        !value.startsWith("refs/") &&
+        !value.includes("..") &&
+        !value.includes("//") &&
+        !value.split("/").some(
+          (component) => component.startsWith(".") || component.endsWith(".lock"),
+        ),
+      "invalid repository base branch",
+    )
+    .optional(),
   baseCommit: z.string().regex(/^[0-9a-f]{40,64}$/),
   headCommit: z.string().regex(/^[0-9a-f]{40,64}$/),
   changedFiles: z.array(z.string().min(1)).min(1).max(10_000),

--- a/tests/daily-task-exam-factory.test.ts
+++ b/tests/daily-task-exam-factory.test.ts
@@ -54,6 +54,7 @@ function resultContent(runtime: "claude" | "homeserver" = "claude"): string {
     bodyText: "Sensitive answer text that must not enter the candidate manifest",
     prUrl: "https://github.com/Magnus-Gille/demo/pull/42",
     repositoryChange: {
+      baseBranch: "master",
       baseCommit: BASE,
       headCommit: HEAD,
       changedFiles: ["src/parser.ts", "tests/parser.test.ts"],
@@ -138,6 +139,7 @@ describe("daily task exam factory", () => {
     expect(candidate.repository).toEqual(expect.objectContaining({
       githubRepository: "Magnus-Gille/demo",
       contextAlias: "repo:demo",
+      baseBranch: "master",
       baseCommit: BASE,
       headCommit: HEAD,
       diffSha256: DIFF,

--- a/tests/repo-sync.test.ts
+++ b/tests/repo-sync.test.ts
@@ -10,6 +10,7 @@ let spawnBehaviors: Array<{
   stderr?: string;
 }> = [];
 let spawnCallIndex = 0;
+let autoResolveMain = true;
 
 class MockChildProcess extends EventEmitter {
   stdout = new EventEmitter();
@@ -18,10 +19,19 @@ class MockChildProcess extends EventEmitter {
 
 vi.mock("node:child_process", () => ({
   spawn: (cmd: string, args: string[], opts: Record<string, unknown>) => {
-    spawnCalls.push({ cmd, args, opts });
     const child = new MockChildProcess();
-    const behavior = spawnBehaviors[spawnCallIndex] ?? { exitCode: 0 };
-    spawnCallIndex++;
+    const autoBehavior = autoResolveMain && cmd === "git"
+      ? args[0] === "symbolic-ref"
+        ? { exitCode: 0, stdout: "origin/main\n" }
+        : args[0] === "rev-parse" && args.includes("refs/remotes/origin/main^{commit}")
+          ? { exitCode: 0, stdout: `${"a".repeat(40)}\n` }
+          : null
+      : null;
+    const behavior = autoBehavior ?? spawnBehaviors[spawnCallIndex] ?? { exitCode: 0 };
+    if (!autoBehavior) {
+      spawnCalls.push({ cmd, args, opts });
+      spawnCallIndex++;
+    }
 
     // Emit stdout/stderr and close asynchronously
     setImmediate(() => {
@@ -39,19 +49,25 @@ vi.mock("node:child_process", () => ({
 }));
 
 // Import after mocking
-const { checkoutTaskBranch, finalizeTaskBranch } = await import("../src/task-helpers.js");
+const {
+  checkoutTaskBranch,
+  finalizeTaskBranch,
+  isValidBaseBranchName,
+  parseBaseBranchOverride,
+} = await import("../src/task-helpers.js");
 
 beforeEach(() => {
   spawnCalls.length = 0;
   spawnBehaviors = [];
   spawnCallIndex = 0;
+  autoResolveMain = true;
 });
 
 // Sequences for checkoutTaskBranch:
 //   1. git rev-parse --git-dir
 //   2. git remote get-url origin
 //   3. git fetch origin  (+ retries)
-//   4. git checkout -b hugin/<taskId> origin/main
+//   4+. resolve + verify the base, then git checkout -b hugin/<taskId> origin/<base>
 
 describe("checkoutTaskBranch", () => {
   it("skips directories outside /home/magnus/repos/", async () => {
@@ -120,10 +136,10 @@ describe("checkoutTaskBranch", () => {
     expect(result).toEqual({
       action: "created",
       branchName: "hugin/task-pinned",
+      baseBranch: "main",
       baseCommit: base,
     });
-    expect(spawnCalls[3].args).toEqual(["rev-parse", "origin/main"]);
-    expect(spawnCalls[4].args).toEqual([
+    expect(spawnCalls[3].args).toEqual([
       "checkout", "-b", "hugin/task-pinned", "origin/main",
     ]);
   });
@@ -266,11 +282,128 @@ describe("checkoutTaskBranch", () => {
       expect(call.opts.cwd).toBe(dir);
     }
   });
+
+  it("resolves origin/HEAD and works when the repository has master but no main", async () => {
+    autoResolveMain = false;
+    const base = "b".repeat(40);
+    spawnBehaviors = [
+      { exitCode: 0 },
+      { exitCode: 0 },
+      { exitCode: 0 },
+      { exitCode: 0, stdout: "origin/master\n" },
+      { exitCode: 0, stdout: `${base}\n` },
+      { exitCode: 0 },
+    ];
+
+    const result = await checkoutTaskBranch(
+      "/home/magnus/repos/cassette-ai",
+      "task-master",
+      { fetchRetryDelaysMs: [0, 0], captureBaseCommit: true },
+    );
+
+    expect(result).toEqual({
+      action: "created",
+      branchName: "hugin/task-master",
+      baseBranch: "master",
+      baseCommit: base,
+    });
+    expect(spawnCalls[3].args).toEqual([
+      "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD",
+    ]);
+    expect(spawnCalls[4].args).toEqual([
+      "rev-parse", "--verify", "refs/remotes/origin/master^{commit}",
+    ]);
+    expect(spawnCalls[5].args).toEqual([
+      "checkout", "-b", "hugin/task-master", "origin/master",
+    ]);
+    expect(spawnCalls.flatMap((call) => call.args)).not.toContain("origin/main");
+  });
+
+  it("falls back to the remote HEAD symref when origin/HEAD is stale", async () => {
+    autoResolveMain = false;
+    const base = "c".repeat(40);
+    spawnBehaviors = [
+      { exitCode: 0 },
+      { exitCode: 0 },
+      { exitCode: 0 },
+      { exitCode: 0, stdout: "origin/main\n" },
+      { exitCode: 128, stderr: "unknown revision" },
+      { exitCode: 0, stdout: "ref: refs/heads/master\tHEAD\n" },
+      { exitCode: 0, stdout: `${base}\n` },
+      { exitCode: 0 },
+    ];
+
+    const result = await checkoutTaskBranch(
+      "/home/magnus/repos/cassette-ai",
+      "task-remote-head",
+      { fetchRetryDelaysMs: [0, 0], captureBaseCommit: true },
+    );
+
+    expect(result.baseBranch).toBe("master");
+    expect(result.baseCommit).toBe(base);
+    expect(spawnCalls[5].args).toEqual([
+      "ls-remote", "--symref", "origin", "HEAD",
+    ]);
+    expect(spawnCalls[7].args.at(-1)).toBe("origin/master");
+  });
+
+  it("uses a validated override with an existing ref when fetch is unavailable", async () => {
+    autoResolveMain = false;
+    const base = "d".repeat(40);
+    spawnBehaviors = [
+      { exitCode: 0 },
+      { exitCode: 0 },
+      { exitCode: 128, stderr: "offline" },
+      { exitCode: 128, stderr: "offline" },
+      { exitCode: 128, stderr: "offline" },
+      { exitCode: 0, stdout: `${base}\n` },
+      { exitCode: 0 },
+    ];
+
+    const result = await checkoutTaskBranch(
+      "/home/magnus/repos/cassette-ai",
+      "task-explicit",
+      {
+        fetchRetryDelaysMs: [0, 0],
+        captureBaseCommit: true,
+        baseBranchOverride: "release/stable",
+      },
+    );
+
+    expect(result).toMatchObject({
+      action: "created",
+      baseBranch: "release/stable",
+      baseCommit: base,
+    });
+    expect(spawnCalls[5].args).toEqual([
+      "rev-parse", "--verify", "refs/remotes/origin/release/stable^{commit}",
+    ]);
+    expect(spawnCalls[6].args.at(-1)).toBe("origin/release/stable");
+  });
+
+  it("validates Base branch task overrides before Git execution", async () => {
+    expect(parseBaseBranchOverride("- **Base branch:** release/stable")).toEqual({
+      baseBranch: "release/stable",
+    });
+    expect(parseBaseBranchOverride("- **Base branch:** origin/main").error).toContain(
+      "invalid Base branch",
+    );
+    expect(parseBaseBranchOverride(`## Task\n### Prompt\nDiscuss **Base branch:** evil`)).toEqual({});
+    expect(isValidBaseBranchName("main; touch owned")).toBe(false);
+
+    const result = await checkoutTaskBranch(
+      "/home/magnus/repos/demo",
+      "task-invalid",
+      { baseBranchOverride: "../main" },
+    );
+    expect(result.action).toBe("fetch-failed");
+    expect(spawnCalls).toHaveLength(0);
+  });
 });
 
 // Sequences for finalizeTaskBranch (happy path — commits exist):
 //   1. git status --porcelain  (dirty check)
-//   2. git rev-list --count origin/main..HEAD
+//   2. git rev-list --count <pinned-base>..HEAD
 //   3. git remote get-url --push origin
 //   4. git push -u origin <branch>
 //   5. gh pr create ...
@@ -279,6 +412,7 @@ describe("finalizeTaskBranch", () => {
   const allowedHosts = ["github.com"];
 
   it("returns no-changes and cleans up when no commits and clean tree", async () => {
+    const base = "e".repeat(40);
     spawnBehaviors = [
       { exitCode: 0, stdout: "" },  // git status --porcelain: clean
       { exitCode: 0, stdout: "0\n" }, // git rev-list: 0 ahead
@@ -290,9 +424,32 @@ describe("finalizeTaskBranch", () => {
       "hugin/task-123",
       "pr body",
       allowedHosts,
+      { baseBranch: "master", baseCommit: base },
     );
     expect(result.action).toBe("no-changes");
-    expect(spawnCalls[1].args).toContain("origin/main..HEAD");
+    expect(spawnCalls[1].args).toContain(`${base}..HEAD`);
+    expect(spawnCalls[2].args).toEqual(["checkout", "--detach", base]);
+  });
+
+  it("preserves the task branch when comparison with the pinned base fails", async () => {
+    const base = "f".repeat(40);
+    spawnBehaviors = [
+      { exitCode: 0, stdout: "" },
+      { exitCode: 128, stderr: "bad revision" },
+    ];
+
+    const result = await finalizeTaskBranch(
+      "/home/magnus/repos/grimnir",
+      "hugin/task-compare-failed",
+      "body",
+      allowedHosts,
+      { baseBranch: "master", baseCommit: base },
+    );
+
+    expect(result.action).toBe("push-failed");
+    expect(result.error).toContain("pinned base");
+    expect(spawnCalls).toHaveLength(2);
+    expect(spawnCalls.some((call) => call.args.includes("branch"))).toBe(false);
   });
 
   it("auto-commits dirty tree and creates PR when commits exist after commit", async () => {
@@ -366,10 +523,11 @@ describe("finalizeTaskBranch", () => {
       "hugin/task-evidence",
       "body",
       allowedHosts,
-      { captureRepositoryChange: true, baseCommit: base },
+      { captureRepositoryChange: true, baseBranch: "master", baseCommit: base },
     );
     expect(result.action).toBe("pr-created");
     expect(result.repositoryChange).toEqual(expect.objectContaining({
+      baseBranch: "master",
       baseCommit: base,
       headCommit: head,
       changedFiles: ["src/parser.ts", "tests/parser.test.ts"],
@@ -381,6 +539,9 @@ describe("finalizeTaskBranch", () => {
     expect(spawnCalls[4].args).toEqual([
       "diff", "--binary", "--no-ext-diff", "--no-textconv", `${base}..${head}`,
     ]);
+    expect(spawnCalls[1].args).toContain(`${base}..HEAD`);
+    const ghCall = spawnCalls.find((call) => call.cmd === "gh");
+    expect(ghCall?.args).toEqual(expect.arrayContaining(["--base", "master"]));
   });
 
   it("returns push-failed when remote is not in egress allowlist", async () => {

--- a/tests/task-result-schema.test.ts
+++ b/tests/task-result-schema.test.ts
@@ -9,6 +9,7 @@ describe("structured task result schema", () => {
       executor: "claude-sdk", resultSource: "sdk-result", exitCode: 0,
       completedAt: "2026-07-14T12:00:00Z", bodyKind: "response", bodyText: "ok",
       repositoryChange: {
+        baseBranch: "master",
         baseCommit: "a".repeat(40),
         headCommit: "b".repeat(40),
         changedFiles: ["src/parser.ts", "tests/parser.test.ts"],
@@ -19,6 +20,7 @@ describe("structured task result schema", () => {
       "src/parser.ts",
       "tests/parser.test.ts",
     ]);
+    expect(result.repositoryChange?.baseBranch).toBe("master");
   });
 
   it("preserves M5 delegation provenance on canonical homeserver results", () => {


### PR DESCRIPTION
## Summary
- resolve and pin the managed repository base from origin/HEAD, with remote-HEAD fallback
- support a validated Base branch task override, including disconnected repositories with a verified tracking ref
- reuse the resolved branch for checkout, comparison, cleanup, PR base, and repositoryChange evidence
- preserve schema-v1 compatibility for historical results and daily-exam candidates

## Validation
- npm run build
- npm test — 111 files, 1826 tests passed
- bash scripts/deploy-pi.test.sh
- bash scripts/lib/claude-config-bootstrap.test.sh
- git diff --check origin/main...HEAD
- read-only Cassette evidence: origin/HEAD resolves to origin/master at 4e26895d04ccf48c8e196a05f863ca9b0edaac7c and no origin/main exists

## Review
- Fable review unavailable due the account monthly spend limit
- Opus high was attempted earlier in this session but hung without output
- native Codex review completed; no blocking findings

Closes #217