### PR TITLE
Separate task completion from quality acceptance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -176,9 +176,13 @@ and logs any failure. Consumers must treat a missing structured result on a term
 task as an infrastructure/recovery fault; they must not invent one.
 
 `completed` means the executor completed successfully. It does **not** prove that the
-answer was correct, useful, reviewed, merged, or accepted. `hugin_rate` is product
-usefulness feedback. Friction reports are orthogonal execution evidence. See
-`docs/friction-reporting.md`.
+answer was correct, useful, reviewed, merged, or accepted. `hugin_rate` appends an
+authenticated schema-v1 quality receipt for any terminal Hugin task; Broker tasks
+remain owner-only. The receipt binds the exact task/result hashes and repository
+state/diff, records reviewer independence, rejects stale caller-supplied bindings,
+and cannot overwrite a prior verdict from the same reviewer. Legacy flat feedback
+is readable but never counts as bound acceptance. Friction reports are orthogonal
+execution evidence. See `docs/friction-reporting.md`.
 
 ### Submission provenance
 
@@ -194,9 +198,12 @@ in credential stores or the Pi environment, never Git or Munin.
 
 ### Managed-repository evidence
 
-Successful managed-repository tasks may include `repositoryChange`. Current writers
-bind the resolved base branch, its exact pre-agent commit, the final task-branch commit,
-safe repository-relative changed paths, and SHA-256 of the binary Git diff.
+Current normal task results include `repositoryOutcome`: `not-managed`,
+`checkout-failed`, `not-finalized`, `no-changes`, `changes-present`, or
+`publication-failed`. A managed no-op is therefore machine-readable rather than an
+implicit success. Managed tasks with changes may also include `repositoryChange`,
+binding the resolved base branch, its exact pre-agent commit, the final task-branch
+commit, safe repository-relative changed paths, and SHA-256 of the binary Git diff.
 
 This object is content-blind: it contains no prompt, response, diff, file content, or
 credential. Base and head must differ; changed paths must not be absolute, contain

--- a/docs/continuous-learning-loop.md
+++ b/docs/continuous-learning-loop.md
@@ -70,6 +70,14 @@ The challenger is rejected if it exceeds any configured regression limit for cor
 completion, human rescue, infrastructure failures, latency, or cost. If every guard passes, it
 must still clear the predeclared primary improvement threshold. Otherwise the champion remains.
 
+`promotion-ready` is a mechanical evaluator result, not authorization to apply
+the challenger. The promotion mutation additionally requires at least one
+challenger run with an independent `pass` and an explicit product outcome of
+accepted unchanged or minor edit. This guard remains active even when an
+experiment deliberately sets `minRatedCoverage` to zero, so unrated mechanical
+evidence can never advance the champion pointer. Hugin has no automatic PR
+merge path; a repository merge remains a separately reviewed action.
+
 Every evaluation returns dominant challenger failure signals and a concrete next action. Common
 signals are `no-edit`, `tests-not-run`, `tests-failed`, `unverified-output`, `infra-error`, and the
 explicit failure kind supplied by the harness.

--- a/docs/daily-exam-factory.md
+++ b/docs/daily-exam-factory.md
@@ -24,6 +24,11 @@ factory manifest. They remain in their existing owner-controlled systems. The
 manifest keeps hashes and Munin/Git references so a later, reviewed packager can
 reconstruct and verify the candidate.
 
+Current Hugin results also record `repositoryOutcome` independently of change
+evidence. A managed no-op is therefore explicit (`no-changes`) rather than
+being indistinguishable from a skipped checkout, a checkout failure, an
+unfinished finalization, or a publication failure.
+
 `source.taskCreatedAt` is the Munin status entry's original `created_at`, not its
 terminal update or result completion time. That distinction is load-bearing: a
 task created before M5's complete capture window cannot become fresh merely
@@ -40,16 +45,21 @@ classifies them without running a model or writing any learning state:
 | `regression` | Hugin has evidence that the task reached an M5 runtime or leaf. It may test non-regression, but it is not fresh. |
 | `quarantine` | Reproducibility, privacy, completion, repository, PR, or exposure evidence is incomplete. |
 
-Every non-quarantined candidate still has readiness
-`needs-independent-verifier`. Agent prose and a changed test file are not an
-independent grading oracle.
-
 `completed` means that the executor lifecycle finished successfully; it is not
-proof that the solution was accepted. The schema-v2 factory does not yet join
-general post-run reviewer feedback. Hugin
-[#216](https://github.com/Magnus-Gille/hugin/issues/216) tracks binding semantic
-acceptance to the exact result/diff and carrying it into harvesting. Until then,
-neither a candidate record nor a green task lifecycle is a golden answer.
+proof that the solution was accepted. The factory reads each task's optional
+`feedback` document and joins only schema-v1 quality receipts whose hashes bind
+the exact task document, structured result, and repository state/diff. It
+preserves the receipt IDs, authenticated reviewer principals, and whether an
+independent reviewer explicitly accepted the unchanged result. Legacy flat
+feedback is labeled `legacy-unbound` and never upgraded into acceptance.
+
+Every non-quarantined candidate remains `needs-independent-verifier`, including
+one whose product output has an exact independent acceptance: accepting the
+delivered change is not the same as proving it is a suitable exam oracle. The
+acceptance is preserved separately as `quality.state: accepted` plus
+`independentAccepted: true`. A partial, rejected, conflicting, malformed, or
+stale receipt quarantines the candidate. The factory never promotes
+configuration or merges a pull request.
 
 ## Cross-client exposure snapshot
 

--- a/docs/friction-reporting.md
+++ b/docs/friction-reporting.md
@@ -5,10 +5,11 @@ Munin namespace `signals/friction`. A friction event says that the model,
 environment, or task specification made execution harder than it should have
 been. It is operational evidence; it is not a verdict on the final answer.
 
-Use `hugin_rate` for product usefulness of a terminal Broker task. Use friction
-reporting for events such as a missing tool, a sandbox failure, an unclear
-prerequisite, or a model hitting a reasoning limit. One task can legitimately
-have both kinds of evidence.
+Use `hugin_rate` for exact-bound product quality of a terminal Hugin task
+(owner-only when it is a Broker task). Use friction reporting for events such
+as a missing tool, a sandbox failure, an unclear prerequisite, or a model
+hitting a reasoning limit. One task can legitimately have both kinds of
+evidence.
 
 ## Submission surfaces
 

--- a/docs/mcp-durable-m5-lifecycle.md
+++ b/docs/mcp-durable-m5-lifecycle.md
@@ -27,9 +27,10 @@ with a different behavior payload is rejected. An in-process reservation closes
 the concurrent-submit race before the first Munin write completes. Both the
 durable identity and that reservation are scoped by authenticated principal.
 
-Await, list, and rate are principal-isolated. A Broker key cannot discover or
-read another principal's canonical results, and product feedback is accepted
-only for an owned terminal task.
+Await and list are principal-isolated. A Broker key cannot discover or read
+another principal's canonical results. Rate remains owner-only for Broker
+tasks; the same authenticated endpoint can also review an ordinary terminal
+Hugin task, which has no Broker owner.
 
 This guarantees one durable task for idempotent submission retries. It does not
 claim exactly-once network execution if the process crashes after M5 performs a
@@ -40,7 +41,9 @@ gateway-side idempotency or a prepare/commit protocol before being admitted.
 M5 remains the authority for model selection, verification and capability
 evidence. Hugin preserves the returned task type, node, model, outcome, score,
 decision reason, verifier notes and `ledgerId` in `result-structured`; Hugin's
-`feedback` entry is separate product-usefulness evidence.
+`feedback` entry is a separate append-only quality-receipt ledger. Each current
+receipt binds the exact status/result bytes and repository state, records the
+authenticated reviewer, and never changes M5's capability ledger.
 
 The old orch-v1 worker, reconciler and new journal writes are retired. The v1
 alias catalogue and existing JSONL journal remain available for historical

--- a/docs/orchestrator-v1-data-model.md
+++ b/docs/orchestrator-v1-data-model.md
@@ -354,6 +354,11 @@ interface DelegationRatedEvent {
 }
 ```
 
+> Historical note: this section specifies the retired orch-v1 JSONL event.
+> Current canonical tasks persist schema-v1 append-only quality receipts in
+> Munin `feedback`, bound to the exact task/result/repository evidence. Legacy
+> flat feedback remains readable but is never treated as bound acceptance.
+
 **Forward-compat rule:** projection code MUST tolerate unknown `event_schema_version` values by skipping the event (with a logged warning) rather than crashing. Producers MUST bump the version on any breaking shape change; additive field changes do not require a bump.
 
 ### Projection (read-time)

--- a/src/broker/handlers.ts
+++ b/src/broker/handlers.ts
@@ -48,6 +48,12 @@ import type { AwaitLifecycle } from "./await-observation.js";
 import type { AuthenticatedRequest } from "./auth.js";
 import { computeSubmitWarnings } from "./submit-warnings.js";
 import { reportFrictionInputSchema } from "../friction/schema.js";
+import {
+  QualityReceiptConflictError,
+  buildQualityBinding,
+  buildQualityReceipt,
+} from "../quality-receipt.js";
+import { structuredTaskResultSchema } from "../task-result-schema.js";
 
 const brokerFrictionInputSchema = reportFrictionInputSchema.extend({
   event_id: z.string().uuid(),
@@ -440,6 +446,11 @@ export function createAwaitHandler(deps: BrokerHandlerDependencies) {
 
 export function createRateHandler(deps: BrokerHandlerDependencies) {
   return async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+    const authenticatedPrincipal = req.brokerPrincipal;
+    if (!authenticatedPrincipal) {
+      res.status(500).json({ error: "internal", message: "principal missing" });
+      return;
+    }
     let parsed;
     try {
       parsed = rateRequestSchema.parse(req.body);
@@ -456,7 +467,9 @@ export function createRateHandler(deps: BrokerHandlerDependencies) {
       });
       return;
     }
-    if (!requireOwnedBrokerTask(req, res, status)) return;
+    const canonical = parseCanonicalEnvelope(status.content);
+    const historicalBrokerTask = status.tags.includes("orch-v1");
+    if ((canonical.ok || historicalBrokerTask) && !requireOwnedBrokerTask(req, res, status)) return;
     if (!status.tags.some((tag) => ["completed", "failed", "cancelled"].includes(tag))) {
       res.status(409).json({
         error: "policy_rejected",
@@ -465,15 +478,92 @@ export function createRateHandler(deps: BrokerHandlerDependencies) {
       return;
     }
 
+    const structuredEntry = await deps.taskStore.readStructuredResult(parsed.task_id);
+    if (!structuredEntry) {
+      res.status(409).json({
+        error: "policy_rejected",
+        message: "task has no structured result to bind the quality receipt to",
+      });
+      return;
+    }
+    let structuredTaskId: string;
+    let verifiedSubmitter: string | null;
+    let binding;
     try {
-      await deps.taskStore.writeFeedback(parsed.task_id, {
-        ...parsed,
-        rated_at: nowFn(deps)().toISOString(),
-        rated_by: req.brokerPrincipal ?? "unknown",
+      const raw = JSON.parse(structuredEntry.content) as unknown;
+      const current = structuredTaskResultSchema.safeParse(raw);
+      if (current.success) {
+        structuredTaskId = current.data.taskId;
+        verifiedSubmitter = current.data.provenance?.verifiedSubmitter ?? null;
+      } else {
+        const legacy = z.object({
+          task_id: z.string().min(1),
+          result_schema_version: z.literal(1),
+        }).passthrough().parse(raw);
+        structuredTaskId = legacy.task_id;
+        verifiedSubmitter = null;
+      }
+      binding = buildQualityBinding({
+        statusContent: status.content,
+        structuredResultContent: structuredEntry.content,
       });
     } catch (err) {
-      res.status(500).json({
-        error: "internal",
+      res.status(409).json({
+        error: "policy_rejected",
+        message: `task structured result cannot be bound: ${err instanceof Error ? err.message : String(err)}`,
+      });
+      return;
+    }
+    if (structuredTaskId !== parsed.task_id) {
+      res.status(409).json({ error: "policy_rejected", message: "structured result task id mismatch" });
+      return;
+    }
+    const expected = parsed.expected_binding;
+    if (expected && (
+      expected.task_document_sha256 !== binding.taskDocumentSha256 ||
+      expected.structured_result_sha256 !== binding.structuredResultSha256 ||
+      (expected.repository_diff_sha256 !== undefined &&
+        expected.repository_diff_sha256 !== binding.repository.diffSha256)
+    )) {
+      res.status(409).json({ error: "policy_rejected", message: "reviewed binding is stale or mismatched" });
+      return;
+    }
+    const principal = authenticatedPrincipal;
+    const brokerOwner = canonical.ok
+      ? canonical.envelope.broker_principal
+      : historicalBrokerTask
+        ? storedBrokerPrincipal(status.content)
+        : null;
+    const reviewerIsOwner = brokerOwner === principal || verifiedSubmitter === principal;
+    if (parsed.reviewer_role === "independent" && reviewerIsOwner) {
+      res.status(409).json({
+        error: "policy_rejected",
+        message: "task owner cannot attest that this review is independent",
+      });
+      return;
+    }
+    const independence = parsed.reviewer_role === "independent"
+      ? "independent"
+      : parsed.reviewer_role === "self" || reviewerIsOwner
+        ? "self"
+        : "unknown";
+    const receipt = buildQualityReceipt({
+      taskId: parsed.task_id,
+      reviewerPrincipal: principal,
+      reviewerIndependence: independence,
+      rating: parsed.rating,
+      ratingReason: parsed.rating_reason,
+      verificationOutcome: parsed.verification_outcome,
+      retriesCount: parsed.retries_count,
+      ratedAt: nowFn(deps)().toISOString(),
+      bindingAttestation: expected ? "reviewer-confirmed" : "server-bound",
+      binding,
+    });
+    try {
+      await deps.taskStore.writeQualityReceipt(parsed.task_id, receipt);
+    } catch (err) {
+      res.status(err instanceof QualityReceiptConflictError ? 409 : 500).json({
+        error: err instanceof QualityReceiptConflictError ? "policy_rejected" : "internal",
         message: `feedback write failed: ${err instanceof Error ? err.message : String(err)}`,
       });
       return;

--- a/src/broker/task-store.ts
+++ b/src/broker/task-store.ts
@@ -8,7 +8,7 @@
  *   namespace: tasks/<task_id>
  *   key:       status              — task envelope + lifecycle tags
  *   key:       result-structured   — DelegationResult JSON (success path)
- *   key:       feedback            — product usefulness rating
+ *   key:       feedback            — append-only exact-bound quality receipts
  *
  * New v2 status entries are ordinary `runtime:homeserver` tasks consumed by
  * the canonical dispatcher. The orch-v1 constants/methods below remain only
@@ -36,6 +36,10 @@ import {
   keepCallerFrictionTags,
   sanitiseTaskId,
 } from "../friction/munin-key.js";
+import {
+  foldQualityReceipt,
+  type QualityReceipt,
+} from "../quality-receipt.js";
 
 export { MUNIN_QUERY_MAX } from "../munin-pagination.js";
 
@@ -301,17 +305,44 @@ export class BrokerTaskStore {
     }
   }
 
-  async writeFeedback(taskId: string, feedback: Record<string, unknown>): Promise<void> {
+  async writeQualityReceipt(
+    taskId: string,
+    receipt: QualityReceipt,
+  ): Promise<{ changed: boolean }> {
     const status = await this.readStatus(taskId);
     const envelope = status ? parseStoredEnvelope(status.content) : null;
-    await this.munin.write(
-      namespaceForTaskId(taskId),
-      "feedback",
-      JSON.stringify(feedback),
-      ["broker:mcp-v2", "feedback"],
-      undefined,
-      envelope?.sensitivity === "private" ? "client-restricted" : "internal",
-    );
+    const namespace = namespaceForTaskId(taskId);
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const current = await this.munin.read(namespace, "feedback");
+      let existing: Record<string, unknown> | null = null;
+      if (current) {
+        const parsed = JSON.parse(current.content) as unknown;
+        if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+          throw new Error("stored feedback is not a JSON object");
+        }
+        existing = parsed as Record<string, unknown>;
+      }
+      const folded = foldQualityReceipt(existing, receipt);
+      if (!folded.changed) return { changed: false };
+      try {
+        await this.munin.write(
+          namespace,
+          "feedback",
+          JSON.stringify(folded.ledger),
+          envelope
+            ? ["broker:mcp-v2", "feedback", "quality:receipt-v1"]
+            : ["feedback", "quality:receipt-v1"],
+          current?.updated_at,
+          envelope?.sensitivity === "private"
+            ? "client-restricted"
+            : current?.classification ?? status?.classification ?? "internal",
+        );
+        return { changed: true };
+      } catch (err) {
+        if (attempt === 2) throw err;
+      }
+    }
+    throw new Error("quality receipt update lost repeated CAS races");
   }
 
   /**

--- a/src/broker/types.ts
+++ b/src/broker/types.ts
@@ -179,7 +179,13 @@ export const rateRequestSchema = z.object({
   rating_reason: z.string().min(1),
   verification_outcome: verificationOutcomeSchema,
   retries_count: z.number().int().nonnegative().optional(),
-});
+  reviewer_role: z.enum(["independent", "self"]).optional(),
+  expected_binding: z.object({
+    task_document_sha256: z.string().regex(/^[0-9a-f]{64}$/),
+    structured_result_sha256: z.string().regex(/^[0-9a-f]{64}$/),
+    repository_diff_sha256: z.string().regex(/^[0-9a-f]{64}$/).optional(),
+  }).strict().optional(),
+}).strict();
 export type RateRequest = z.infer<typeof rateRequestSchema>;
 
 export const awaitRequestSchema = z.object({

--- a/src/daily-exam-harvest-cli.ts
+++ b/src/daily-exam-harvest-cli.ts
@@ -158,9 +158,10 @@ async function loadSources(
       .filter((entry) => entry.key === "status" && entry.namespace.startsWith("tasks/"))
       .map((entry) => entry.namespace),
   )].sort();
-  const [statuses, results] = await Promise.all([
+  const [statuses, results, feedback] = await Promise.all([
     munin.readBatch(namespaces.map((namespace) => ({ namespace, key: "status" }))),
     munin.readBatch(namespaces.map((namespace) => ({ namespace, key: "result-structured" }))),
+    munin.readBatch(namespaces.map((namespace) => ({ namespace, key: "feedback" }))),
   ]);
   const sources: DailyTaskHarvestSource[] = [];
   for (let index = 0; index < namespaces.length; index += 1) {
@@ -170,6 +171,7 @@ async function loadSources(
     sources.push({
       status: status as MuninEntry,
       resultStructured: result?.found ? result as MuninEntry : null,
+      feedback: feedback[index]?.found ? feedback[index] as MuninEntry : null,
     });
   }
   return { sources, historyComplete: !queried.truncated };

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import {
   type MuninClientConfig,
   type MuninReadResult,
 } from "./munin-client.js";
-import { getFoundBatchEntry, extractTaskId, pickEarliestTask, selectNextTask, checkoutTaskBranch, finalizeTaskBranch, shouldReapExpiredLease, decideStartupRecovery, decideDeliveryRetry, finalizeTaskCompletion, resolveTaskWorkingDirectory, normalizeRoot, parseBaseBranchOverride, DEFAULT_REPOS_ROOT, MAX_TASK_OUTPUT_TOKENS, MAX_TASK_TIMEOUT_MS, parseBoundedPositiveInt } from "./task-helpers.js";
+import { getFoundBatchEntry, extractTaskId, pickEarliestTask, selectNextTask, checkoutTaskBranch, finalizeTaskBranch, deriveRepositoryOutcome, shouldReapExpiredLease, decideStartupRecovery, decideDeliveryRetry, finalizeTaskCompletion, resolveTaskWorkingDirectory, normalizeRoot, parseBaseBranchOverride, DEFAULT_REPOS_ROOT, MAX_TASK_OUTPUT_TOKENS, MAX_TASK_TIMEOUT_MS, parseBoundedPositiveInt } from "./task-helpers.js";
 import { queryAllMuninEntries } from "./munin-pagination.js";
 import { executeSdkTask, type SdkExecutorResult, type SdkExecutorOptions, type SdkTaskConfig, type TaskPermissionProfile } from "./sdk-executor.js";
 import {
@@ -4498,6 +4498,8 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         console.log(`Pre-task: branch ${branchResult.branchName} ready in ${task.workingDir}`);
       }
     }
+    let repositoryOutcome: StructuredTaskResult["repositoryOutcome"] =
+      deriveRepositoryOutcome(branchResult);
 
     currentTaskConfig = task;
     const taskClassification = getTaskArtifactClassification(task);
@@ -5124,6 +5126,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         },
       );
       repositoryChange = finalizeResult.repositoryChange;
+      repositoryOutcome = deriveRepositoryOutcome(branchResult, finalizeResult.action);
       if (finalizeResult.action === "pr-created" && finalizeResult.prUrl) {
         prUrl = finalizeResult.prUrl;
         await munin.log(taskNs, `PR created: ${prUrl}`);
@@ -5695,6 +5698,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
             sequence: task.sequence,
             costUsd: costUsd ?? undefined,
             prUrl,
+            repositoryOutcome,
             repositoryChange,
             bodyKind: structuredBodyKind,
             bodyText: structuredBodyText,

--- a/src/learning-loop-collector.ts
+++ b/src/learning-loop-collector.ts
@@ -28,6 +28,12 @@ import {
   type LearningExperimentState,
 } from "./learning/experiment-schema.js";
 import { MUNIN_QUERY_MAX, queryAllMuninEntries } from "./munin-pagination.js";
+import {
+  buildQualityBinding,
+  qualityBindingsEqual,
+  qualityReceiptLedgerSchema,
+  summarizeQualityReceipts,
+} from "./quality-receipt.js";
 
 /** Dashboard-facing data: refresh a few times an hour, not every 60s poll. */
 export const DEFAULT_COLLECT_TTL_MS = 300_000;
@@ -310,19 +316,36 @@ export class LearningLoopCollector {
     let verificationOutcome: string | null = null;
     if (feedback) {
       try {
-        const parsed = JSON.parse(feedback.content) as {
-          rating?: string;
-          verification_outcome?: string;
-        };
-        if (
-          parsed.rating === "pass" ||
-          parsed.rating === "partial" ||
-          parsed.rating === "redo" ||
-          parsed.rating === "wrong"
-        ) {
-          rating = parsed.rating;
+        const raw = JSON.parse(feedback.content) as unknown;
+        const ledger = qualityReceiptLedgerSchema.safeParse(raw);
+        if (ledger.success && structured) {
+          const binding = buildQualityBinding({
+            statusContent: status.content,
+            structuredResultContent: structured.content,
+          });
+          const summary = summarizeQualityReceipts(feedback.content, binding);
+          const current = ledger.data.receipts
+            .filter((receipt) => qualityBindingsEqual(receipt.binding, binding))
+            .sort((left, right) => right.ratedAt.localeCompare(left.ratedAt))[0];
+          if (current && ["accepted", "partial", "rejected"].includes(summary.state)) {
+            rating = current.rating;
+            verificationOutcome = current.verificationOutcome;
+          }
+        } else {
+          const parsed = raw as {
+            rating?: string;
+            verification_outcome?: string;
+          };
+          if (
+            parsed.rating === "pass" ||
+            parsed.rating === "partial" ||
+            parsed.rating === "redo" ||
+            parsed.rating === "wrong"
+          ) {
+            rating = parsed.rating;
+          }
+          verificationOutcome = parsed.verification_outcome ?? null;
         }
-        verificationOutcome = parsed.verification_outcome ?? null;
       } catch {
         // A corrupt feedback doc is one lost data point, not a broken panel.
       }

--- a/src/learning/daily-task-exam-factory.ts
+++ b/src/learning/daily-task-exam-factory.ts
@@ -13,6 +13,11 @@ import {
   type TaskExposureLookupResult,
   type TaskExposureSnapshot,
 } from "./m5-task-exposure.js";
+import {
+  buildQualityBinding,
+  qualitySummarySchema,
+  summarizeQualityReceipts,
+} from "../quality-receipt.js";
 
 const sha256Schema = z.string().regex(/^[0-9a-f]{64}$/);
 const gitCommitSchema = z.string().regex(/^[0-9a-f]{40,64}$/);
@@ -29,9 +34,18 @@ export const dailyExamCandidateSchema = z.object({
     taskDocumentSha256: sha256Schema,
     promptSha256: sha256Schema.optional(),
     structuredResultSha256: sha256Schema.optional(),
+    qualityReceiptLedgerSha256: sha256Schema.optional(),
     runtime: z.string().min(1).optional(),
     taskType: z.string().min(1).optional(),
     sensitivity: z.enum(["public", "internal", "private"]).optional(),
+    repositoryOutcome: z.enum([
+      "not-managed",
+      "checkout-failed",
+      "not-finalized",
+      "no-changes",
+      "changes-present",
+      "publication-failed",
+    ]).optional(),
   }).strict(),
   repository: z.object({
     githubRepository: z.string().regex(/^[^/\s]+\/[^/\s]+$/),
@@ -50,6 +64,7 @@ export const dailyExamCandidateSchema = z.object({
     models: z.array(z.string().min(1)),
     evidence: z.array(z.string().min(1)),
   }).strict(),
+  quality: qualitySummarySchema.optional(),
   crossClientExposure: z.object({
     fingerprintVersion: z.literal(TASK_EXPOSURE_FINGERPRINT_VERSION),
     fingerprintSha256: sha256Schema.optional(),
@@ -130,6 +145,7 @@ export type DailyExamManifest = z.infer<typeof dailyExamManifestSchema>;
 export interface DailyTaskHarvestSource {
   status: MuninEntry;
   resultStructured?: MuninEntry | null;
+  feedback?: MuninEntry | null;
 }
 
 function sha256(value: string | Buffer): string {
@@ -232,6 +248,25 @@ export function buildDailyExamCandidate(source: DailyTaskHarvestSource): DailyEx
   const promptFingerprint = prompt ? taskTextFingerprint(prompt) : undefined;
   const resultContent = source.resultStructured?.content;
   const result = parseStructuredResult(resultContent);
+  const feedbackContent = source.feedback?.content;
+  let quality = qualitySummarySchema.parse({ state: "unrated" });
+  if (feedbackContent) {
+    if (resultContent && result) {
+      try {
+        quality = summarizeQualityReceipts(
+          feedbackContent,
+          buildQualityBinding({
+            statusContent: taskDocument,
+            structuredResultContent: resultContent,
+          }),
+        );
+      } catch {
+        quality = qualitySummarySchema.parse({ state: "invalid" });
+      }
+    } else {
+      quality = qualitySummarySchema.parse({ state: "invalid" });
+    }
+  }
   const exposure = exposureFor(result);
   const contextAlias = contextAliasFromTask(taskDocument);
   const githubRepository = githubRepositoryFromPr(result?.prUrl);
@@ -260,6 +295,9 @@ export function buildDailyExamCandidate(source: DailyTaskHarvestSource): DailyEx
   if (sensitivity === "private") reasons.push("private-task-not-eligible-for-automatic-packaging");
   if (sourceClassificationIsPrivate) reasons.push("source-classification-not-eligible-for-automatic-packaging");
   if (exposure.state === "unknown") reasons.push("m5-exposure-unknown");
+  if (["partial", "rejected", "conflicted", "invalid"].includes(quality.state)) {
+    reasons.push(`quality-receipt-${quality.state}`);
+  }
 
   const repository = sensitivity !== "private" && !sourceClassificationIsPrivate && change && result?.prUrl && githubRepository
     ? {
@@ -280,8 +318,13 @@ export function buildDailyExamCandidate(source: DailyTaskHarvestSource): DailyEx
     lane === "regression"
       ? "already-exposed-to-m5-use-only-as-regression"
       : "requires-cross-client-exposure-check-before-holdout-seal",
-    "independent-verifier-required",
   );
+  if (!quarantine) {
+    reasons.push("independent-verifier-required");
+    if (quality.state === "accepted" && quality.independentAccepted) {
+      reasons.push("independent-quality-receipt-present");
+    }
+  }
 
   const identity = JSON.stringify({
     taskNamespace: source.status.namespace,
@@ -291,6 +334,8 @@ export function buildDailyExamCandidate(source: DailyTaskHarvestSource): DailyEx
     baseCommit: change?.baseCommit ?? null,
     headCommit: change?.headCommit ?? null,
     diffSha256: change?.diffSha256 ?? null,
+    repositoryOutcome: result?.repositoryOutcome?.state ?? null,
+    qualityReceiptLedgerSha256: feedbackContent ? sha256(feedbackContent) : null,
   });
   const candidate: DailyExamCandidate = {
     schemaVersion: 2,
@@ -303,14 +348,17 @@ export function buildDailyExamCandidate(source: DailyTaskHarvestSource): DailyEx
       taskDocumentSha256: sha256(taskDocument),
       ...(promptFingerprint ? { promptSha256: promptFingerprint } : {}),
       ...(resultContent ? { structuredResultSha256: sha256(resultContent) } : {}),
+      ...(feedbackContent ? { qualityReceiptLedgerSha256: sha256(feedbackContent) } : {}),
       ...(result?.runtime ? { runtime: result.runtime } : {}),
       ...(taskTypeFromTags(source.status.tags)
         ? { taskType: taskTypeFromTags(source.status.tags) }
         : {}),
       ...(sensitivity ? { sensitivity } : {}),
+      ...(result?.repositoryOutcome ? { repositoryOutcome: result.repositoryOutcome.state } : {}),
     },
     repository,
     exposure,
+    quality,
     crossClientExposure: {
       fingerprintVersion: TASK_EXPOSURE_FINGERPRINT_VERSION,
       ...(promptFingerprint ? { fingerprintSha256: promptFingerprint } : {}),

--- a/src/learning/experiment-store.ts
+++ b/src/learning/experiment-store.ts
@@ -451,6 +451,20 @@ export class LearningExperimentStore {
           `experiment is ${current.status}; only promotion-ready evidence can be promoted`,
         );
       }
+      const hasAcceptedChallengerProduct = current.observations.some(
+        (observation) =>
+          observation.arm === "challenger" &&
+          observation.quality_outcome === "pass" &&
+          observation.verifier.independent &&
+          (observation.product_outcome === "accepted-unchanged" ||
+            observation.product_outcome === "minor-edit"),
+      );
+      if (!hasAcceptedChallengerProduct) {
+        throw new LearningStoreError(
+          "invalid-state",
+          "promotion requires an independently verified challenger with explicit accepted product evidence",
+        );
+      }
 
       const championNamespace = championNamespaceFor(principal, current.scope);
       const championEntry = await this.munin.read(championNamespace, STATE_KEY);

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -148,6 +148,13 @@ export const rateInputShape = {
   rating_reason: z.string().min(1),
   verification_outcome: verificationOutcomeSchema,
   retries_count: z.number().int().nonnegative().optional(),
+  reviewer_role: z.enum(["independent", "self"]).optional()
+    .describe("Authenticated reviewer attestation. Same-task owners cannot claim independent."),
+  expected_binding: z.object({
+    task_document_sha256: z.string().regex(/^[0-9a-f]{64}$/),
+    structured_result_sha256: z.string().regex(/^[0-9a-f]{64}$/),
+    repository_diff_sha256: z.string().regex(/^[0-9a-f]{64}$/).optional(),
+  }).strict().optional().describe("Optional exact hashes reviewed by the caller; stale hashes are rejected."),
 };
 const rateInputSchema = z.object(rateInputShape);
 
@@ -329,9 +336,9 @@ export function buildTools(deps: ToolDeps): {
 
   const rate: HuginTool<z.infer<typeof rateInputSchema>> = {
     name: "hugin_rate",
-    title: "Rate the outcome of a delegated task",
+    title: "Record an exact-bound task quality review",
     description:
-      "Store a product-usefulness rating for a terminal task. This is Hugin product evidence; it does not directly modify M5's capability ledger.",
+      "Append an authenticated quality receipt for a terminal Hugin task, bound to its current task/result/repository evidence. This does not directly modify M5's capability ledger.",
     inputShape: rateInputShape,
     handler: async (rawInput) => {
       try {

--- a/src/quality-receipt.ts
+++ b/src/quality-receipt.ts
@@ -1,0 +1,356 @@
+/** Content-blind, append-only post-run quality receipts (issue #216). */
+
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import { structuredTaskResultSchema } from "./task-result-schema.js";
+
+const sha256Schema = z.string().regex(/^[0-9a-f]{64}$/);
+const commitSchema = z.string().regex(/^[0-9a-f]{40,64}$/);
+
+export const qualityRepositoryBindingSchema = z.object({
+  state: z.enum([
+    "unknown",
+    "not-managed",
+    "checkout-failed",
+    "not-finalized",
+    "no-changes",
+    "changes-present",
+    "publication-failed",
+  ]),
+  baseBranch: z.string().min(1).max(255).optional(),
+  baseCommit: commitSchema.optional(),
+  headCommit: commitSchema.optional(),
+  diffSha256: sha256Schema.optional(),
+}).strict().superRefine((value, ctx) => {
+  if (value.state === "changes-present") {
+    for (const field of ["baseBranch", "baseCommit", "headCommit", "diffSha256"] as const) {
+      if (value[field] === undefined) {
+        ctx.addIssue({ code: "custom", path: [field], message: `${field} is required for changes-present` });
+      }
+    }
+  }
+  if (value.state === "no-changes") {
+    for (const field of ["baseBranch", "baseCommit"] as const) {
+      if (value[field] === undefined) {
+        ctx.addIssue({ code: "custom", path: [field], message: `${field} is required for no-changes` });
+      }
+    }
+    if (value.headCommit !== undefined || value.diffSha256 !== undefined) {
+      ctx.addIssue({ code: "custom", message: "no-changes cannot carry head or diff evidence" });
+    }
+  }
+});
+export type QualityRepositoryBinding = z.infer<typeof qualityRepositoryBindingSchema>;
+
+export const qualityBindingSchema = z.object({
+  taskDocumentSha256: sha256Schema,
+  structuredResultSha256: sha256Schema,
+  repository: qualityRepositoryBindingSchema,
+}).strict();
+export type QualityBinding = z.infer<typeof qualityBindingSchema>;
+
+const qualityReceiptBaseSchema = z.object({
+  schemaVersion: z.literal(1),
+  receiptId: z.string().regex(/^qr-[0-9a-f]{24}$/),
+  taskId: z.string().min(1).max(200),
+  rating: z.enum(["pass", "partial", "redo", "wrong"]),
+  ratingReason: z.string().min(1).max(10_000),
+  verificationOutcome: z.enum([
+    "accepted_unchanged",
+    "minor_edit",
+    "major_rewrite",
+    "discarded",
+    "escalated_to_claude",
+  ]),
+  retriesCount: z.number().int().nonnegative().optional(),
+  ratedAt: z.string().datetime(),
+  reviewer: z.object({
+    principal: z.string().min(1).max(200),
+    independence: z.enum(["independent", "self", "unknown"]),
+  }).strict(),
+  bindingAttestation: z.enum(["server-bound", "reviewer-confirmed"]),
+  binding: qualityBindingSchema,
+}).strict();
+export const qualityReceiptSchema = qualityReceiptBaseSchema.superRefine((value, ctx) => {
+  const expected = qualityReceiptId({
+    taskId: value.taskId,
+    reviewerPrincipal: value.reviewer.principal,
+    reviewerIndependence: value.reviewer.independence,
+    rating: value.rating,
+    ratingReason: value.ratingReason,
+    verificationOutcome: value.verificationOutcome,
+    retriesCount: value.retriesCount,
+    bindingAttestation: value.bindingAttestation,
+    binding: value.binding,
+  });
+  if (value.receiptId !== expected) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["receiptId"],
+      message: `receipt identity mismatch; expected ${expected}`,
+    });
+  }
+});
+export type QualityReceipt = z.infer<typeof qualityReceiptSchema>;
+
+export const qualityReceiptLedgerSchema = z.object({
+  schemaVersion: z.literal(1),
+  taskId: z.string().min(1).max(200),
+  receipts: z.array(qualityReceiptSchema).max(1_000),
+  legacyFeedback: z.record(z.string(), z.unknown()).optional(),
+}).strict().superRefine((value, ctx) => {
+  const ids = new Set<string>();
+  value.receipts.forEach((receipt, index) => {
+    if (receipt.taskId !== value.taskId) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["receipts", index, "taskId"],
+        message: "receipt task does not match ledger task",
+      });
+    }
+    if (ids.has(receipt.receiptId)) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["receipts", index, "receiptId"],
+        message: "duplicate receipt identity",
+      });
+    }
+    ids.add(receipt.receiptId);
+  });
+});
+export type QualityReceiptLedger = z.infer<typeof qualityReceiptLedgerSchema>;
+
+export const qualitySummarySchema = z.object({
+  state: z.enum([
+    "unrated",
+    "legacy-unbound",
+    "accepted",
+    "partial",
+    "rejected",
+    "conflicted",
+    "invalid",
+  ]),
+  receiptIds: z.array(z.string()).default([]),
+  reviewers: z.array(z.string()).default([]),
+  independentAccepted: z.boolean().default(false),
+}).strict();
+export type QualitySummary = z.infer<typeof qualitySummarySchema>;
+
+function sha256(content: string): string {
+  return createHash("sha256").update(content).digest("hex");
+}
+
+function stable(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(stable).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .filter(([, child]) => child !== undefined)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([key, child]) => `${JSON.stringify(key)}:${stable(child)}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+export function qualityBindingsEqual(left: QualityBinding, right: QualityBinding): boolean {
+  return stable(left) === stable(right);
+}
+
+export function buildQualityBinding(input: {
+  statusContent: string;
+  structuredResultContent: string;
+}): QualityBinding {
+  const raw = JSON.parse(input.structuredResultContent) as unknown;
+  const current = structuredTaskResultSchema.safeParse(raw);
+  if (!current.success) {
+    z.object({
+      task_id: z.string().min(1),
+      result_schema_version: z.literal(1),
+    }).passthrough().parse(raw);
+  }
+  const change = current.success ? current.data.repositoryChange : undefined;
+  const outcome = current.success ? current.data.repositoryOutcome : undefined;
+  const repository: QualityRepositoryBinding = qualityRepositoryBindingSchema.parse({
+    state: outcome?.state ?? (change ? "changes-present" : "unknown"),
+    baseBranch: change?.baseBranch ?? outcome?.baseBranch,
+    baseCommit: change?.baseCommit ?? outcome?.baseCommit,
+    headCommit: change?.headCommit,
+    diffSha256: change?.diffSha256,
+  });
+  return qualityBindingSchema.parse({
+    taskDocumentSha256: sha256(input.statusContent),
+    structuredResultSha256: sha256(input.structuredResultContent),
+    repository,
+  });
+}
+
+export interface BuildQualityReceiptInput {
+  taskId: string;
+  reviewerPrincipal: string;
+  reviewerIndependence: "independent" | "self" | "unknown";
+  rating: "pass" | "partial" | "redo" | "wrong";
+  ratingReason: string;
+  verificationOutcome:
+    | "accepted_unchanged"
+    | "minor_edit"
+    | "major_rewrite"
+    | "discarded"
+    | "escalated_to_claude";
+  retriesCount?: number;
+  ratedAt: string;
+  bindingAttestation: "server-bound" | "reviewer-confirmed";
+  binding: QualityBinding;
+}
+
+function qualityReceiptId(input: Omit<BuildQualityReceiptInput, "ratedAt">): string {
+  return `qr-${sha256(stable(input)).slice(0, 24)}`;
+}
+
+export function buildQualityReceipt(input: BuildQualityReceiptInput): QualityReceipt {
+  const semanticPayload: Omit<BuildQualityReceiptInput, "ratedAt"> = {
+    taskId: input.taskId,
+    reviewerPrincipal: input.reviewerPrincipal,
+    reviewerIndependence: input.reviewerIndependence,
+    rating: input.rating,
+    ratingReason: input.ratingReason,
+    verificationOutcome: input.verificationOutcome,
+    retriesCount: input.retriesCount,
+    bindingAttestation: input.bindingAttestation,
+    binding: input.binding,
+  };
+  return qualityReceiptSchema.parse({
+    schemaVersion: 1,
+    receiptId: qualityReceiptId(semanticPayload),
+    taskId: input.taskId,
+    rating: input.rating,
+    ratingReason: input.ratingReason,
+    verificationOutcome: input.verificationOutcome,
+    ...(input.retriesCount !== undefined ? { retriesCount: input.retriesCount } : {}),
+    ratedAt: input.ratedAt,
+    reviewer: {
+      principal: input.reviewerPrincipal,
+      independence: input.reviewerIndependence,
+    },
+    bindingAttestation: input.bindingAttestation,
+    binding: input.binding,
+  });
+}
+
+export class QualityReceiptConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "QualityReceiptConflictError";
+  }
+}
+
+export class QualityReceiptInvalidLedgerError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "QualityReceiptInvalidLedgerError";
+  }
+}
+
+export function foldQualityReceipt(
+  current: QualityReceiptLedger | Record<string, unknown> | null,
+  next: QualityReceipt,
+): { ledger: QualityReceiptLedger; changed: boolean } {
+  let ledger: QualityReceiptLedger;
+  const parsed = qualityReceiptLedgerSchema.safeParse(current);
+  if (parsed.success) {
+    ledger = parsed.data;
+  } else if (current && typeof current === "object" && !Array.isArray(current)) {
+    if (
+      current.schemaVersion === 1 ||
+      Object.hasOwn(current, "taskId") ||
+      Object.hasOwn(current, "receipts")
+    ) {
+      throw new QualityReceiptInvalidLedgerError(
+        "stored schema-v1 quality receipt ledger is invalid",
+      );
+    }
+    ledger = qualityReceiptLedgerSchema.parse({
+      schemaVersion: 1,
+      taskId: next.taskId,
+      receipts: [],
+      legacyFeedback: current,
+    });
+  } else {
+    ledger = qualityReceiptLedgerSchema.parse({
+      schemaVersion: 1,
+      taskId: next.taskId,
+      receipts: [],
+    });
+  }
+  if (ledger.taskId !== next.taskId) {
+    throw new QualityReceiptConflictError("quality receipt task does not match the ledger");
+  }
+  if (ledger.receipts.some((receipt) => receipt.receiptId === next.receiptId)) {
+    return { ledger, changed: false };
+  }
+  const priorVerdict = ledger.receipts.find(
+    (receipt) =>
+      receipt.reviewer.principal === next.reviewer.principal &&
+      qualityBindingsEqual(receipt.binding, next.binding),
+  );
+  if (priorVerdict) {
+    throw new QualityReceiptConflictError(
+      `reviewer ${next.reviewer.principal} already rated this exact result`,
+    );
+  }
+  return {
+    ledger: qualityReceiptLedgerSchema.parse({
+      ...ledger,
+      receipts: [...ledger.receipts, next],
+    }),
+    changed: true,
+  };
+}
+
+export function summarizeQualityReceipts(
+  feedbackContent: string | null | undefined,
+  binding: QualityBinding,
+): QualitySummary {
+  if (!feedbackContent) return qualitySummarySchema.parse({ state: "unrated" });
+  let raw: unknown;
+  try {
+    raw = JSON.parse(feedbackContent);
+  } catch {
+    return qualitySummarySchema.parse({ state: "invalid" });
+  }
+  const ledger = qualityReceiptLedgerSchema.safeParse(raw);
+  if (!ledger.success) {
+    const legacy = z.object({ rating: z.string() }).passthrough().safeParse(raw);
+    return qualitySummarySchema.parse({
+      state: legacy.success ? "legacy-unbound" : "invalid",
+    });
+  }
+  const receipts = ledger.data.receipts.filter((receipt) => qualityBindingsEqual(receipt.binding, binding));
+  if (receipts.length === 0) {
+    return qualitySummarySchema.parse({
+      state: ledger.data.legacyFeedback ? "legacy-unbound" : "invalid",
+    });
+  }
+  const verdicts = receipts.map((receipt) => {
+    if (
+      receipt.rating === "wrong" ||
+      receipt.rating === "redo" ||
+      receipt.verificationOutcome === "discarded"
+    ) return "rejected" as const;
+    if (
+      receipt.rating === "pass" &&
+      receipt.verificationOutcome === "accepted_unchanged"
+    ) return "accepted" as const;
+    return "partial" as const;
+  });
+  const distinct = new Set(verdicts);
+  const state = distinct.size === 1 ? verdicts[0]! : "conflicted";
+  return qualitySummarySchema.parse({
+    state,
+    receiptIds: receipts.map((receipt) => receipt.receiptId),
+    reviewers: [...new Set(receipts.map((receipt) => receipt.reviewer.principal))].sort(),
+    independentAccepted:
+      state === "accepted" && receipts.some(
+        (receipt) => receipt.reviewer.independence === "independent",
+      ),
+  });
+}

--- a/src/task-helpers.ts
+++ b/src/task-helpers.ts
@@ -461,6 +461,38 @@ export interface BranchFinalizeResult {
   error?: string;
 }
 
+export interface RepositoryOutcomeEvidence {
+  state:
+    | "not-managed"
+    | "checkout-failed"
+    | "not-finalized"
+    | "no-changes"
+    | "changes-present"
+    | "publication-failed";
+  baseBranch?: string;
+  baseCommit?: string;
+}
+
+/** Derive the machine-readable repository outcome without trusting agent prose. */
+export function deriveRepositoryOutcome(
+  branch: TaskBranchResult,
+  finalizeAction?: BranchFinalizeResult["action"],
+): RepositoryOutcomeEvidence {
+  if (branch.action === "skipped") return { state: "not-managed" };
+  if (branch.action === "fetch-failed") return { state: "checkout-failed" };
+  const base = {
+    ...(branch.baseBranch ? { baseBranch: branch.baseBranch } : {}),
+    ...(branch.baseCommit ? { baseCommit: branch.baseCommit } : {}),
+  };
+  if (!branch.baseBranch || !branch.baseCommit) {
+    return { state: "not-finalized", ...base };
+  }
+  if (finalizeAction === "no-changes") return { state: "no-changes", ...base };
+  if (finalizeAction === "pr-created") return { state: "changes-present", ...base };
+  if (finalizeAction === "push-failed") return { state: "publication-failed", ...base };
+  return { state: "not-finalized", ...base };
+}
+
 /**
  * Content-blind binding for turning a completed managed-repository task into a
  * reproducible evaluation candidate. The task prompt/result remain in Munin;

--- a/src/task-result-schema.ts
+++ b/src/task-result-schema.ts
@@ -338,6 +338,32 @@ export const repositoryChangeEvidenceSchema = z.object({
 });
 export type RepositoryChangeEvidence = z.infer<typeof repositoryChangeEvidenceSchema>;
 
+// Execution and publication are separate facts from semantic acceptance.
+// Current writers always emit this content-blind repository outcome, including
+// an explicit no-op. It remains optional so historical schema-v1 results parse.
+export const repositoryOutcomeSchema = z.object({
+  state: z.enum([
+    "not-managed",
+    "checkout-failed",
+    "not-finalized",
+    "no-changes",
+    "changes-present",
+    "publication-failed",
+  ]),
+  baseBranch: repositoryChangeEvidenceSchema.shape.baseBranch,
+  baseCommit: z.string().regex(/^[0-9a-f]{40,64}$/).optional(),
+}).strict().superRefine((value, ctx) => {
+  if (["no-changes", "changes-present", "publication-failed"].includes(value.state)) {
+    if (!value.baseBranch) {
+      ctx.addIssue({ code: "custom", path: ["baseBranch"], message: "managed outcome requires baseBranch" });
+    }
+    if (!value.baseCommit) {
+      ctx.addIssue({ code: "custom", path: ["baseCommit"], message: "managed outcome requires baseCommit" });
+    }
+  }
+});
+export type RepositoryOutcome = z.infer<typeof repositoryOutcomeSchema>;
+
 export const structuredTaskResultSchema = z.object({
   schemaVersion: z.literal(1),
   taskId: z.string().min(1),
@@ -365,6 +391,7 @@ export const structuredTaskResultSchema = z.object({
   bodyText: z.string(),
   errorMessage: z.string().min(1).optional(),
   prUrl: z.string().url().optional(),
+  repositoryOutcome: repositoryOutcomeSchema.optional(),
   repositoryChange: repositoryChangeEvidenceSchema.optional(),
   runtimeMetadata: taskExecutionRuntimeMetadataSchema.optional(),
   pipeline: taskExecutionPipelineContextSchema.optional(),

--- a/tests/broker/handlers.test.ts
+++ b/tests/broker/handlers.test.ts
@@ -9,6 +9,7 @@ import { DelegationJournal } from "../../src/broker/journal.js";
 import { IdempotencyIndex } from "../../src/broker/idempotency.js";
 import { brokerExecutorCapabilities } from "../../src/broker/executor-capabilities.js";
 import type { MuninClient } from "../../src/munin-client.js";
+import { buildStructuredTaskResult } from "../../src/task-result-schema.js";
 
 const SECRET = "a".repeat(64);
 const OTHER_SECRET = "b".repeat(64);
@@ -118,6 +119,24 @@ function otherAuthHeader(): Record<string, string> {
 
 function historicalBrokerStatus(principal = "claude-code"): string {
   return JSON.stringify({ broker_principal: principal });
+}
+
+function structuredTaskResultContent(taskId: string): string {
+  return JSON.stringify(buildStructuredTaskResult({
+    schemaVersion: 1,
+    taskId,
+    taskNamespace: `tasks/${taskId}`,
+    lifecycle: "completed",
+    outcome: "completed",
+    runtime: "homeserver",
+    executor: "homeserver-delegate",
+    resultSource: "homeserver-delegate",
+    exitCode: 0,
+    completedAt: "2026-07-15T10:00:00.000Z",
+    bodyKind: "response",
+    bodyText: "ok",
+    repositoryOutcome: { state: "not-managed" },
+  }));
 }
 
 function validRequest(overrides: Record<string, unknown> = {}) {
@@ -788,6 +807,12 @@ describe("POST /v1/delegate/rate", () => {
       created_at: "ts",
       updated_at: "ts",
     };
+    harness.munin.reads["tasks/t1/result-structured"] = {
+      content: JSON.stringify({ task_id: "t1", result_schema_version: 1, response: "ok" }),
+      tags: ["type:task-result-structured"],
+      created_at: "ts",
+      updated_at: "ts",
+    };
     const res = await fetch(`${harness.url}/v1/delegate/rate`, {
       method: "POST",
       headers: authHeader(),
@@ -801,10 +826,105 @@ describe("POST /v1/delegate/rate", () => {
     expect(res.status).toBe(204);
     expect(harness.munin.writes.at(-1)?.key).toBe("feedback");
     expect(JSON.parse(harness.munin.writes.at(-1)!.content)).toMatchObject({
-      task_id: "t1",
-      rating: "pass",
-      rated_by: "claude-code",
+      schemaVersion: 1,
+      taskId: "t1",
+      receipts: [{
+        rating: "pass",
+        reviewer: { principal: "claude-code", independence: "self" },
+      }],
     });
+  });
+
+  it("rates an ordinary terminal Hugin task and rejects a stale reviewed binding", async () => {
+    harness.munin.reads["tasks/general-1/status"] = {
+      content: "## Task: general\n\n### Prompt\nFix it.",
+      tags: ["completed", "runtime:codex"],
+      created_at: "ts",
+      updated_at: "ts",
+    };
+    harness.munin.reads["tasks/general-1/result-structured"] = {
+      content: structuredTaskResultContent("general-1"),
+      tags: ["type:task-result-structured"],
+      created_at: "ts",
+      updated_at: "ts",
+    };
+    const stale = await fetch(`${harness.url}/v1/delegate/rate`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify({
+        task_id: "general-1",
+        rating: "pass",
+        rating_reason: "reviewed exact result",
+        verification_outcome: "accepted_unchanged",
+        reviewer_role: "independent",
+        expected_binding: {
+          task_document_sha256: "a".repeat(64),
+          structured_result_sha256: "b".repeat(64),
+        },
+      }),
+    });
+    expect(stale.status).toBe(409);
+
+    const accepted = await fetch(`${harness.url}/v1/delegate/rate`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify({
+        task_id: "general-1",
+        rating: "pass",
+        rating_reason: "reviewed current server-bound result",
+        verification_outcome: "accepted_unchanged",
+        reviewer_role: "independent",
+      }),
+    });
+    expect(accepted.status).toBe(204);
+    expect(JSON.parse(harness.munin.writes.at(-1)!.content).receipts[0]).toMatchObject({
+      reviewer: { principal: "claude-code", independence: "independent" },
+      bindingAttestation: "server-bound",
+    });
+  });
+
+  it("makes an identical rating retry idempotent and rejects a changed verdict", async () => {
+    harness.munin.reads["tasks/general-retry/status"] = {
+      content: "## Task: retry\n\n### Prompt\nFix it.",
+      tags: ["completed", "runtime:codex"],
+      created_at: "ts",
+      updated_at: "ts",
+    };
+    harness.munin.reads["tasks/general-retry/result-structured"] = {
+      content: structuredTaskResultContent("general-retry"),
+      tags: ["type:task-result-structured"],
+      created_at: "ts",
+      updated_at: "ts",
+    };
+    const payload = {
+      task_id: "general-retry",
+      rating: "pass",
+      rating_reason: "exact result accepted",
+      verification_outcome: "accepted_unchanged",
+      reviewer_role: "independent",
+    };
+    for (let index = 0; index < 2; index += 1) {
+      const response = await fetch(`${harness.url}/v1/delegate/rate`, {
+        method: "POST",
+        headers: authHeader(),
+        body: JSON.stringify(payload),
+      });
+      expect(response.status).toBe(204);
+    }
+    expect(harness.munin.writes.filter((write) => write.key === "feedback")).toHaveLength(1);
+
+    const conflict = await fetch(`${harness.url}/v1/delegate/rate`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify({
+        ...payload,
+        rating: "wrong",
+        rating_reason: "changed verdict",
+        verification_outcome: "discarded",
+      }),
+    });
+    expect(conflict.status).toBe(409);
+    expect(harness.munin.writes.filter((write) => write.key === "feedback")).toHaveLength(1);
   });
 
   it("returns 404 if task not found", async () => {
@@ -1358,6 +1478,12 @@ describe("GET /v1/delegate/list", () => {
     };
     // Mark it terminal so hugin_rate is allowed to write feedback.
     harness.munin.reads[`tasks/${task_id}/status`] = { ...statusEntry, tags: ["completed"] };
+    harness.munin.reads[`tasks/${task_id}/result-structured`] = {
+      content: structuredTaskResultContent(task_id),
+      tags: ["type:task-result-structured"],
+      created_at: "ts",
+      updated_at: "ts",
+    };
 
     const rate = await fetch(`${harness.url}/v1/delegate/rate`, {
       method: "POST",

--- a/tests/daily-task-exam-factory.test.ts
+++ b/tests/daily-task-exam-factory.test.ts
@@ -4,6 +4,7 @@ import {
   applyCrossClientExposure,
   buildDailyExamCandidate,
   buildDailyExamManifest,
+  type DailyTaskHarvestSource,
 } from "../src/learning/daily-task-exam-factory.js";
 import {
   REQUIRED_TASK_EXPOSURE_LANES,
@@ -11,6 +12,11 @@ import {
   type TaskExposureSnapshot,
 } from "../src/learning/m5-task-exposure.js";
 import { buildStructuredTaskResult } from "../src/task-result-schema.js";
+import {
+  buildQualityBinding,
+  buildQualityReceipt,
+  foldQualityReceipt,
+} from "../src/quality-receipt.js";
 
 const BASE = "a".repeat(40);
 const HEAD = "b".repeat(40);
@@ -53,6 +59,11 @@ function resultContent(runtime: "claude" | "homeserver" = "claude"): string {
     bodyKind: "response",
     bodyText: "Sensitive answer text that must not enter the candidate manifest",
     prUrl: "https://github.com/Magnus-Gille/demo/pull/42",
+    repositoryOutcome: {
+      state: "changes-present",
+      baseBranch: "master",
+      baseCommit: BASE,
+    },
     repositoryChange: {
       baseBranch: "master",
       baseCommit: BASE,
@@ -78,7 +89,7 @@ function resultContent(runtime: "claude" | "homeserver" = "claude"): string {
   }));
 }
 
-function source(runtime: "claude" | "homeserver" = "claude") {
+function source(runtime: "claude" | "homeserver" = "claude"): DailyTaskHarvestSource {
   return {
     status: entry({
       namespace: "tasks/daily-1",
@@ -93,6 +104,34 @@ function source(runtime: "claude" | "homeserver" = "claude") {
       tags: ["type:task-result", "type:task-result-structured"],
     }),
   };
+}
+
+function addQualityReceipt(
+  candidateSource: DailyTaskHarvestSource,
+  input: { rating?: "pass" | "wrong"; verificationOutcome?: "accepted_unchanged" | "discarded" } = {},
+): DailyTaskHarvestSource {
+  const structuredResultContent = candidateSource.resultStructured!.content;
+  const receipt = buildQualityReceipt({
+    taskId: "daily-1",
+    reviewerPrincipal: "codex-review",
+    reviewerIndependence: "independent",
+    rating: input.rating ?? "pass",
+    ratingReason: "Reviewed the exact diff and checks.",
+    verificationOutcome: input.verificationOutcome ?? "accepted_unchanged",
+    ratedAt: "2026-07-14T11:30:00.000Z",
+    bindingAttestation: "reviewer-confirmed",
+    binding: buildQualityBinding({
+      statusContent: candidateSource.status.content,
+      structuredResultContent,
+    }),
+  });
+  candidateSource.feedback = entry({
+    namespace: "tasks/daily-1",
+    key: "feedback",
+    content: JSON.stringify(foldQualityReceipt(null, receipt).ledger),
+    tags: ["feedback", "quality:receipt-v1"],
+  });
+  return candidateSource;
 }
 
 function snapshot(fingerprint: string, input: {
@@ -165,6 +204,30 @@ describe("daily task exam factory", () => {
     expect(candidate.reasons).toContain("already-exposed-to-m5-use-only-as-regression");
   });
 
+  it("preserves independent accepted quality without treating completion alone as acceptance", () => {
+    const unrated = buildDailyExamCandidate(source("claude"));
+    expect(unrated.quality).toMatchObject({ state: "unrated", independentAccepted: false });
+    expect(unrated.readiness).toBe("needs-independent-verifier");
+
+    const accepted = buildDailyExamCandidate(addQualityReceipt(source("claude")));
+    expect(accepted.quality).toMatchObject({ state: "accepted", independentAccepted: true });
+    expect(accepted.readiness).toBe("needs-independent-verifier");
+    expect(accepted.reasons).toContain("independent-quality-receipt-present");
+    expect(accepted.reasons).toContain("independent-verifier-required");
+    expect(accepted.source.qualityReceiptLedgerSha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("quarantines explicitly rejected quality evidence", () => {
+    const candidate = buildDailyExamCandidate(addQualityReceipt(source("claude"), {
+      rating: "wrong",
+      verificationOutcome: "discarded",
+    }));
+    expect(candidate.quality?.state).toBe("rejected");
+    expect(candidate.lane).toBe("quarantine");
+    expect(candidate.readiness).toBe("quarantined");
+    expect(candidate.reasons).toContain("quality-receipt-rejected");
+  });
+
   it("quarantines historical tasks without exact repository evidence", () => {
     const historical = source("claude");
     const parsed = JSON.parse(historical.resultStructured.content) as Record<string, unknown>;
@@ -173,6 +236,24 @@ describe("daily task exam factory", () => {
     const candidate = buildDailyExamCandidate(historical);
     expect(candidate.lane).toBe("quarantine");
     expect(candidate.readiness).toBe("quarantined");
+    expect(candidate.reasons).toContain("repository-change-evidence-missing");
+  });
+
+  it("preserves a managed no-op as an explicit repository outcome", () => {
+    const noOp = source("claude");
+    const parsed = JSON.parse(noOp.resultStructured!.content) as Record<string, unknown>;
+    delete parsed.repositoryChange;
+    delete parsed.prUrl;
+    parsed.repositoryOutcome = {
+      state: "no-changes",
+      baseBranch: "master",
+      baseCommit: BASE,
+    };
+    noOp.resultStructured!.content = JSON.stringify(parsed);
+
+    const candidate = buildDailyExamCandidate(noOp);
+    expect(candidate.source.repositoryOutcome).toBe("no-changes");
+    expect(candidate.lane).toBe("quarantine");
     expect(candidate.reasons).toContain("repository-change-evidence-missing");
   });
 

--- a/tests/learning-experiment.test.ts
+++ b/tests/learning-experiment.test.ts
@@ -316,6 +316,36 @@ describe("LearningExperimentStore", () => {
     })).reused).toBe(true);
   });
 
+  it("refuses promotion-ready evidence with no explicit accepted product outcome", async () => {
+    const munin = new FakeMunin();
+    const store = new LearningExperimentStore(munin as unknown as MuninClient);
+    const input = makeExperimentInput({
+      experiment_id: "mechanical-only",
+      gates: {
+        ...makeExperimentInput().gates,
+        minRatedCoverage: 0,
+      },
+    });
+    const created = await store.create("codex", input);
+    for (const sample of ["case-1", "case-2"]) {
+      await store.observe("codex", makeObservation(sample, "champion", {
+        experiment_id: "mechanical-only",
+        product_outcome: "unrated",
+      }));
+      await store.observe("codex", makeObservation(sample, "challenger", {
+        experiment_id: "mechanical-only",
+        product_outcome: "unrated",
+      }));
+    }
+    expect((await store.read("codex", "mechanical-only")).status).toBe("promotion-ready");
+
+    await expect(store.promote("codex", {
+      experiment_id: "mechanical-only",
+      configuration_fingerprint: created.state.challenger.fingerprint,
+      applied_ref: "gille-inference@abc123",
+    })).rejects.toMatchObject({ code: "invalid-state" });
+  });
+
   it("reuses an identical run_id but rejects conflicting evidence", async () => {
     const store = new LearningExperimentStore(new FakeMunin() as unknown as MuninClient);
     await store.create("codex", makeExperimentInput());

--- a/tests/learning-loop-collector.test.ts
+++ b/tests/learning-loop-collector.test.ts
@@ -4,6 +4,12 @@ import type { MuninClient } from "../src/munin-client.js";
 import type { Ledger, LedgerClientLike } from "../src/orchestrator/ledger-client.js";
 import { evaluateLearningExperiment } from "../src/learning/experiment-evaluator.js";
 import { makeExperimentInput } from "./fixtures/learning.js";
+import { buildStructuredTaskResult } from "../src/task-result-schema.js";
+import {
+  buildQualityBinding,
+  buildQualityReceipt,
+  foldQualityReceipt,
+} from "../src/quality-receipt.js";
 
 const ENVELOPE = (submitter: string) =>
   `## Task\n\n### Broker envelope\n\`\`\`json\n${JSON.stringify({
@@ -114,6 +120,94 @@ describe("LearningLoopCollector", () => {
     expect(t.durableHandoff).toBe(true);
     expect(t.delegation?.policyMode).toBe("shadow");
     expect(evidence.ledger).toEqual(okLedger);
+  });
+
+  it("collects only a receipt bound to the current task and structured result", async () => {
+    const statusContent = ENVELOPE("claude-code");
+    const structuredContent = JSON.stringify(buildStructuredTaskResult({
+      schemaVersion: 1,
+      taskId: "mcp-m5-receipt",
+      taskNamespace: "tasks/mcp-m5-receipt",
+      lifecycle: "completed",
+      outcome: "completed",
+      runtime: "homeserver",
+      executor: "homeserver-delegate",
+      resultSource: "homeserver-delegate",
+      exitCode: 0,
+      completedAt: "2026-07-15T10:00:00.000Z",
+      bodyKind: "response",
+      bodyText: "ok",
+      repositoryOutcome: { state: "not-managed" },
+    }));
+    const receipt = buildQualityReceipt({
+      taskId: "mcp-m5-receipt",
+      reviewerPrincipal: "codex-review",
+      reviewerIndependence: "independent",
+      rating: "partial",
+      ratingReason: "Useful but needs an edit.",
+      verificationOutcome: "minor_edit",
+      ratedAt: "2026-07-15T10:05:00.000Z",
+      bindingAttestation: "reviewer-confirmed",
+      binding: buildQualityBinding({ statusContent, structuredResultContent: structuredContent }),
+    });
+    const munin = fakeMunin({
+      "tasks/mcp-m5-receipt/status": { content: statusContent, tags: ["completed"] },
+      "tasks/mcp-m5-receipt/result-structured": { content: structuredContent },
+      "tasks/mcp-m5-receipt/feedback": {
+        content: JSON.stringify(foldQualityReceipt(null, receipt).ledger),
+      },
+    });
+
+    const evidence = await new LearningLoopCollector({
+      munin,
+      ledgerClient: fakeLedgerClient(null),
+    }).refresh();
+    expect(evidence.tasks[0]).toMatchObject({
+      rating: "partial",
+      verificationOutcome: "minor_edit",
+    });
+  });
+
+  it("does not turn conflicting exact-bound reviews into a useful product rating", async () => {
+    const statusContent = ENVELOPE("claude-code");
+    const structuredContent = JSON.stringify(buildStructuredTaskResult({
+      schemaVersion: 1,
+      taskId: "mcp-m5-conflict",
+      taskNamespace: "tasks/mcp-m5-conflict",
+      lifecycle: "completed",
+      outcome: "completed",
+      runtime: "homeserver",
+      executor: "homeserver-delegate",
+      resultSource: "homeserver-delegate",
+      exitCode: 0,
+      completedAt: "2026-07-15T10:00:00.000Z",
+      bodyKind: "response",
+      bodyText: "ok",
+      repositoryOutcome: { state: "not-managed" },
+    }));
+    const binding = buildQualityBinding({ statusContent, structuredResultContent: structuredContent });
+    const accepted = buildQualityReceipt({
+      taskId: "mcp-m5-conflict", reviewerPrincipal: "reviewer-a",
+      reviewerIndependence: "independent", rating: "pass", ratingReason: "accepted",
+      verificationOutcome: "accepted_unchanged", ratedAt: "2026-07-15T10:05:00.000Z",
+      bindingAttestation: "reviewer-confirmed", binding,
+    });
+    const rejected = buildQualityReceipt({
+      taskId: "mcp-m5-conflict", reviewerPrincipal: "reviewer-b",
+      reviewerIndependence: "independent", rating: "wrong", ratingReason: "rejected",
+      verificationOutcome: "discarded", ratedAt: "2026-07-15T10:06:00.000Z",
+      bindingAttestation: "reviewer-confirmed", binding,
+    });
+    const ledger = foldQualityReceipt(foldQualityReceipt(null, accepted).ledger, rejected).ledger;
+    const evidence = await new LearningLoopCollector({
+      munin: fakeMunin({
+        "tasks/mcp-m5-conflict/status": { content: statusContent, tags: ["completed"] },
+        "tasks/mcp-m5-conflict/result-structured": { content: structuredContent },
+        "tasks/mcp-m5-conflict/feedback": { content: JSON.stringify(ledger) },
+      }),
+      ledgerClient: fakeLedgerClient(null),
+    }).refresh();
+    expect(evidence.tasks[0]).toMatchObject({ rating: null, verificationOutcome: null });
   });
 
   // Caught against REAL production data: the one existing broker task predates

--- a/tests/quality-receipt.test.ts
+++ b/tests/quality-receipt.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import { buildStructuredTaskResult } from "../src/task-result-schema.js";
+import {
+  QualityReceiptConflictError,
+  QualityReceiptInvalidLedgerError,
+  buildQualityBinding,
+  buildQualityReceipt,
+  foldQualityReceipt,
+  qualityReceiptLedgerSchema,
+  summarizeQualityReceipts,
+} from "../src/quality-receipt.js";
+
+const BASE = "a".repeat(40);
+const HEAD = "b".repeat(40);
+const DIFF = "c".repeat(64);
+
+function resultContent(): string {
+  return JSON.stringify(buildStructuredTaskResult({
+    schemaVersion: 1,
+    taskId: "task-1",
+    taskNamespace: "tasks/task-1",
+    lifecycle: "completed",
+    outcome: "completed",
+    runtime: "codex",
+    executor: "codex-spawn",
+    resultSource: "stdout",
+    exitCode: 0,
+    completedAt: "2026-07-15T10:00:00.000Z",
+    bodyKind: "response",
+    bodyText: "ok",
+    prUrl: "https://github.com/Magnus-Gille/demo/pull/1",
+    repositoryOutcome: {
+      state: "changes-present",
+      baseBranch: "main",
+      baseCommit: BASE,
+    },
+    repositoryChange: {
+      baseBranch: "main",
+      baseCommit: BASE,
+      headCommit: HEAD,
+      changedFiles: ["src/demo.ts"],
+      diffSha256: DIFF,
+    },
+  }));
+}
+
+function receipt(overrides: Partial<Parameters<typeof buildQualityReceipt>[0]> = {}) {
+  const statusContent = "## Task: demo\n\n### Prompt\nFix it.";
+  const structuredResultContent = resultContent();
+  return buildQualityReceipt({
+    taskId: "task-1",
+    reviewerPrincipal: "claude-code",
+    reviewerIndependence: "independent",
+    rating: "pass",
+    ratingReason: "Reviewed the exact diff and green checks.",
+    verificationOutcome: "accepted_unchanged",
+    ratedAt: "2026-07-15T10:05:00.000Z",
+    binding: buildQualityBinding({ statusContent, structuredResultContent }),
+    bindingAttestation: "reviewer-confirmed",
+    ...overrides,
+  });
+}
+
+describe("quality receipt v1", () => {
+  it("binds the exact task document, structured result, and repository diff", () => {
+    const binding = buildQualityBinding({
+      statusContent: "task bytes",
+      structuredResultContent: resultContent(),
+    });
+
+    expect(binding.taskDocumentSha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(binding.structuredResultSha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(binding.repository).toEqual({
+      state: "changes-present",
+      baseBranch: "main",
+      baseCommit: BASE,
+      headCommit: HEAD,
+      diffSha256: DIFF,
+    });
+  });
+
+  it("folds identical retries idempotently and rejects a changed verdict from the same reviewer", () => {
+    const first = receipt();
+    const initial = foldQualityReceipt(null, first);
+    expect(initial.changed).toBe(true);
+    expect(initial.ledger.receipts).toHaveLength(1);
+
+    const replay = foldQualityReceipt(initial.ledger, receipt({
+      ratedAt: "2026-07-15T10:06:00.000Z",
+    }));
+    expect(replay.changed).toBe(false);
+    expect(replay.ledger).toEqual(initial.ledger);
+
+    expect(() => foldQualityReceipt(initial.ledger, receipt({
+      rating: "wrong",
+      ratingReason: "Changed my mind.",
+      verificationOutcome: "discarded",
+    }))).toThrow(QualityReceiptConflictError);
+  });
+
+  it("keeps independent reviewers append-only and summarizes only exact-binding receipts", () => {
+    const first = foldQualityReceipt(null, receipt()).ledger;
+    const second = foldQualityReceipt(first, receipt({
+      reviewerPrincipal: "codex-review",
+      ratedAt: "2026-07-15T10:07:00.000Z",
+    })).ledger;
+    expect(qualityReceiptLedgerSchema.parse(second).receipts).toHaveLength(2);
+
+    const binding = receipt().binding;
+    expect(summarizeQualityReceipts(JSON.stringify(second), binding)).toMatchObject({
+      state: "accepted",
+      receiptIds: expect.arrayContaining([
+        first.receipts[0]!.receiptId,
+        second.receipts[1]!.receiptId,
+      ]),
+      independentAccepted: true,
+    });
+
+    const stale = { ...binding, structuredResultSha256: "d".repeat(64) };
+    expect(summarizeQualityReceipts(JSON.stringify(second), stale).state).toBe("invalid");
+  });
+
+  it("never upgrades legacy unbound feedback into accepted quality evidence", () => {
+    const summary = summarizeQualityReceipts(
+      JSON.stringify({
+        rating: "pass",
+        rating_reason: "looked right",
+        verification_outcome: "accepted_unchanged",
+      }),
+      receipt().binding,
+    );
+    expect(summary).toMatchObject({ state: "legacy-unbound", independentAccepted: false });
+  });
+
+  it("rejects a receipt whose semantic verdict no longer matches its identity", () => {
+    const original = receipt();
+    const tampered = {
+      schemaVersion: 1,
+      taskId: "task-1",
+      receipts: [{ ...original, rating: "wrong", verificationOutcome: "discarded" }],
+    };
+    expect(summarizeQualityReceipts(JSON.stringify(tampered), original.binding).state).toBe("invalid");
+    expect(() => foldQualityReceipt(tampered, receipt({
+      reviewerPrincipal: "another-reviewer",
+    }))).toThrow(QualityReceiptInvalidLedgerError);
+  });
+});

--- a/tests/repo-sync.test.ts
+++ b/tests/repo-sync.test.ts
@@ -51,6 +51,7 @@ vi.mock("node:child_process", () => ({
 // Import after mocking
 const {
   checkoutTaskBranch,
+  deriveRepositoryOutcome,
   finalizeTaskBranch,
   isValidBaseBranchName,
   parseBaseBranchOverride,
@@ -61,6 +62,26 @@ beforeEach(() => {
   spawnBehaviors = [];
   spawnCallIndex = 0;
   autoResolveMain = true;
+});
+
+describe("deriveRepositoryOutcome", () => {
+  const managed = {
+    action: "created" as const,
+    branchName: "hugin/t1",
+    baseBranch: "master",
+    baseCommit: "a".repeat(40),
+  };
+
+  it("distinguishes managed no-op, changes, and publication failure", () => {
+    expect(deriveRepositoryOutcome(managed, "no-changes").state).toBe("no-changes");
+    expect(deriveRepositoryOutcome(managed, "pr-created").state).toBe("changes-present");
+    expect(deriveRepositoryOutcome(managed, "push-failed").state).toBe("publication-failed");
+  });
+
+  it("fails closed when a created branch lacks pinned base evidence", () => {
+    expect(deriveRepositoryOutcome({ action: "created", branchName: "hugin/t2" }, "no-changes"))
+      .toEqual({ state: "not-finalized" });
+  });
 });
 
 // Sequences for checkoutTaskBranch:

--- a/tests/task-result-schema.test.ts
+++ b/tests/task-result-schema.test.ts
@@ -15,12 +15,47 @@ describe("structured task result schema", () => {
         changedFiles: ["src/parser.ts", "tests/parser.test.ts"],
         diffSha256: "c".repeat(64),
       },
+      repositoryOutcome: {
+        state: "changes-present",
+        baseBranch: "master",
+        baseCommit: "a".repeat(40),
+      },
     });
     expect(result.repositoryChange?.changedFiles).toEqual([
       "src/parser.ts",
       "tests/parser.test.ts",
     ]);
     expect(result.repositoryChange?.baseBranch).toBe("master");
+    expect(result.repositoryOutcome?.state).toBe("changes-present");
+  });
+
+  it("makes a managed-repository no-op explicit without inventing change evidence", () => {
+    const result = buildStructuredTaskResult({
+      schemaVersion: 1,
+      taskId: "noop",
+      taskNamespace: "tasks/noop",
+      lifecycle: "completed",
+      outcome: "completed",
+      runtime: "codex",
+      executor: "codex-spawn",
+      resultSource: "stdout",
+      exitCode: 0,
+      completedAt: "2026-07-15T12:00:00Z",
+      bodyKind: "response",
+      bodyText: "No changes needed.",
+      repositoryOutcome: {
+        state: "no-changes",
+        baseBranch: "master",
+        baseCommit: "a".repeat(40),
+      },
+    });
+
+    expect(result.repositoryOutcome).toEqual({
+      state: "no-changes",
+      baseBranch: "master",
+      baseCommit: "a".repeat(40),
+    });
+    expect(result.repositoryChange).toBeUndefined();
   });
 
   it("preserves M5 delegation provenance on canonical homeserver results", () => {


### PR DESCRIPTION
Closes #216.

Summary:
- records explicit repository outcomes, including managed no-op and publication failure
- replaces mutable feedback with authenticated, exact-bound, append-only quality receipts while preserving legacy reads
- joins receipt state into daily exam candidates and quarantines rejected, conflicted, stale, or invalid evidence
- refuses champion promotion without independent accepted challenger product evidence
- documents that completed is execution state, never semantic acceptance

Verification:
- npm run build
- npm test: 112 files, 1842 tests passed
- bash scripts/deploy-pi.test.sh
- bash scripts/lib/claude-config-bootstrap.test.sh
- git diff --check

Review:
- native Codex adversarial review: no blockers after fixes for undefined-field canonicalization, corrupt-ledger fail-closed handling, conflicting-review aggregation, and candidate readiness wording
- Claude Fable unavailable due monthly spend limit
- Claude Opus high started but produced no output through two bounded polls and was stopped