### PR TITLE
feat: add canonical Hugin task identity

### DIFF
--- a/docs/canonical-task-identity.md
+++ b/docs/canonical-task-identity.md
@@ -1,0 +1,106 @@
+# Canonical Hugin task identity
+
+**Status:** producer projection implemented for Hugin's direct homeserver
+executor `/delegate` lane; authenticated gateway admission/capture and the
+orchestrator worker lane are pending `gille-inference` #2/#4 and Hugin #240.
+
+Hugin's logical task is the parsed `### Prompt` text before context injection,
+the `## Task` wrapper, a system prompt, gateway orchestration, or a runtime chat
+template. That text is the only input to the canonical raw-task fingerprint:
+
+1. apply JavaScript `String.trim()`;
+2. do not normalize Unicode or internal whitespace;
+3. encode the result as UTF-8; and
+4. SHA-256 those bytes as lowercase hexadecimal.
+
+The version is `trim-utf8-sha256-v1`, matching LearningTaskContract v1 and the
+existing content-blind exposure lookup. `src/task-identity.ts` is Hugin's
+canonical implementation. The exact ASCII and deliberately non-normalized
+Unicode vectors are in
+`tests/fixtures/hugin-gille-task-identity-v1.json`.
+
+## Real `/delegate` serialization
+
+`buildHomeserverRequestBody()` is the serializer used by
+`executeHomeserverTask()`. For the direct homeserver executor's `/delegate`
+call, it continues to send the rendered user prompt in `prompt` and adds this
+producer-owned projection:
+
+```json
+{
+  "prompt": "## Context\n...\n\n---\n\n## Task\n...",
+  "huginTaskIdentity": {
+    "schemaVersion": 1,
+    "producer": "hugin",
+    "taskId": "task-123",
+    "rawTaskFingerprint": {
+      "algorithm": "sha256",
+      "version": "trim-utf8-sha256-v1",
+      "digest": "..."
+    },
+    "renderedPromptFingerprint": {
+      "algorithm": "sha256",
+      "version": "hugin-delegate-prompt-utf8-sha256-v1",
+      "digest": "...",
+      "utf8Bytes": 123
+    }
+  }
+}
+```
+
+`renderedPromptFingerprint` identifies the exact UTF-8 bytes in the legacy
+`/delegate.prompt` field. It does not trim or normalize them. It is separate
+from the raw identity because injected context and wrapper bytes legitimately
+change it. It is also narrower than the future three-stage prompt provenance:
+an optional `systemPrompt`, gateway canonical envelope, and runtime chat
+template are not represented by this field and remain Hugin #240 / Gille #2
+work.
+
+The task document cannot supply `huginTaskIdentity`; the serializer always
+recomputes it from Hugin's accepted logical prompt and lifecycle task id. The
+wire projection contains hashes, version, task id, and rendered byte count—not
+a second copy of the raw logical task. Hugin preserves the same projection as
+`result-structured.runtimeMetadata.huginTaskIdentity`, including failed
+gateway calls, so later joins do not need to reconstruct it from a rendered
+prompt.
+
+The in-process orchestrator's homeserver worker uses a separate serializer in
+`src/orchestrator/worker-executor.ts`. It remains on the legacy rendered-prompt
+identity and does not emit `huginTaskIdentity`. Extending that lane requires an
+authoritative outer task/attempt binding rather than copying this direct-runtime
+field into an independently fanned-out subtask. Hugin #240 owns that common
+attempt/stamp integration.
+
+## Trust and legacy boundary
+
+This projection is Hugin producer evidence, not yet gateway evidence. The
+current public Gille `/delegate` parser ignores unknown fields and its exposure
+recorder still hashes the rendered `prompt`; orchestrator worker calls do not
+yet carry the projection at all. A body claim—even one sent over a
+Bearer-authenticated request—is not proof that Gille bound it to the actual
+transport principal, admitted it once, recorded it, or echoed it unchanged.
+No consumer may infer any of those facts from
+`runtimeMetadata.huginTaskIdentity` alone.
+
+End-to-end trust requires:
+
+- Gille #2 to authenticate the actual caller, validate the versioned Hugin
+  request stamp, bind it to admission, and return an exact echo;
+- Hugin #240 to create the authoritative attempt before dispatch, embed this
+  identity in that preflight-bound stamp, and reject a missing or mismatched
+  echo; and
+- Gille #4 to record the stamped raw fingerprint as the exposure identity and
+  establish a new coverage epoch whose start is no earlier than canonical
+  capture becoming effective.
+
+Until those land, current Gille rows remain honest legacy rendered-prompt
+rows. They use the same `trim-utf8-sha256-v1` algorithm label but identify
+different bytes for a context-wrapped Hugin request. They must not be relabeled,
+backfilled, or treated as exact canonical Hugin exposure. Positive exact raw
+matches remain conservative evidence of prior exposure; a negative lookup over
+the legacy Hugin-delegate period is not canonical freshness proof.
+
+The fixture intentionally stops at the current repository boundary: it drives
+Hugin's real serializer and supplies the exact byte/hash/lookup values that
+Gille #4 must consume. It does not mock a successful Gille capture or echo that
+the current Gille implementation cannot produce.

--- a/docs/daily-exam-factory.md
+++ b/docs/daily-exam-factory.md
@@ -70,6 +70,12 @@ Hugin computes the exact M5 fingerprint contract:
 3. UTF-8 bytes; then
 4. lowercase SHA-256, version `trim-utf8-sha256-v1`.
 
+The same calculation now lives in Hugin's real homeserver serializer as
+`huginTaskIdentity.rawTaskFingerprint`; see
+[`canonical-task-identity.md`](canonical-task-identity.md). That producer
+projection is deliberately separate from the exact rendered `/delegate.prompt`
+identity, which changes when context is injected.
+
 The CLI deduplicates fingerprints and sends batches of at most 100 to
 `POST /admin/task-exposures/lookup`, using the existing
 `HOMESERVER_GATEWAY_URL` and minted-owner `HOMESERVER_GATEWAY_API_KEY` from the
@@ -109,6 +115,18 @@ and the content-blind match metadata. It is not durable freshness. A task may be
 shown to M5 after the daily sweep. Any future packager or runner **must repeat
 the same owner-only lookup immediately before freezing and again immediately
 before running a holdout**. Nothing in schema v2 is named or treated as sealed.
+
+There is an additional migration boundary for Hugin-delegated traffic. The
+current public Gille capture hashes the rendered `/delegate.prompt`, while the
+factory queries the logical raw-task hash. Hugin's direct homeserver executor
+now emits both identities, but its orchestrator homeserver worker remains
+legacy until #240, and Gille does not yet authenticate or capture the raw
+projection. Therefore an `unseen-covered` snapshot from the legacy lookup is
+not, by itself, canonical
+negative evidence across Hugin delegation history. No packager may admit it as
+a holdout until Gille #2/#4 and Hugin #240 establish authenticated stamp/echo,
+canonical raw capture, and a new post-cutover coverage epoch. Legacy rows stay
+rendered/inexact; they are never silently upgraded.
 
 ## Run it
 
@@ -155,5 +173,9 @@ immediately before execution. The reusable Gate D corpus and M5 capability
 ledger remain owned by `gille-inference`; this Hugin-side factory owns daily
 task discovery and reproducibility evidence.
 
-The owner-side registry and lookup contract shipped in
-[`gille-inference#257`](https://github.com/Magnus-Gille/gille-inference/issues/257).
+The legacy owner-side registry and lookup contract shipped in the former
+private repository. Public follow-up
+[`gille-inference#4`](https://github.com/Magnus-Gille/gille-inference/issues/4)
+owns canonical capture and holdout coverage; authenticated stamp admission is
+owned by [`gille-inference#2`](https://github.com/Magnus-Gille/gille-inference/issues/2)
+and Hugin [#240](https://github.com/Magnus-Gille/hugin/issues/240).

--- a/src/homeserver-executor.ts
+++ b/src/homeserver-executor.ts
@@ -24,6 +24,10 @@ import * as path from "node:path";
 import { extractM5Provenance, sanitizeProviderTokenCount } from "./m5-provenance.js";
 import type { M5DelegationProvenance } from "./m5-provenance.js";
 import { resolveGatewayRootUrl } from "./orchestrator/provider-config.js";
+import {
+  buildHuginTaskIdentity,
+  type HuginTaskIdentity,
+} from "./task-identity.js";
 
 // --- Types ---
 
@@ -108,6 +112,8 @@ export interface HomeserverExecutorResult {
    * carried.
    */
   provenance: M5DelegationProvenance | null;
+  /** Hugin-produced raw-task/rendered-prompt identity; not a gateway admission echo. */
+  huginTaskIdentity: HuginTaskIdentity | null;
 }
 
 export interface HomeserverExecutorOptions {
@@ -175,11 +181,57 @@ function parseRetryAfter(res: Response): number | null {
   return null;
 }
 
-function buildUserMessage(task: HomeserverTaskConfig): string {
+export function renderHomeserverUserMessage(task: HomeserverTaskConfig): string {
   const parts: string[] = [];
   if (task.injectedContext) parts.push("## Context\n" + task.injectedContext);
   parts.push("## Task\n" + task.prompt);
   return parts.join("\n\n---\n\n");
+}
+
+export interface HomeserverRequestBody extends Record<string, unknown> {
+  prompt?: string;
+  huginTaskIdentity?: HuginTaskIdentity;
+}
+
+/**
+ * The one real serializer used by the executor and cross-repository fixtures.
+ * The canonical identity is always recomputed here; no config/body override is
+ * accepted from the task document.
+ */
+export function buildHomeserverRequestBody(
+  task: HomeserverTaskConfig,
+  taskId: string,
+): HomeserverRequestBody {
+  const userMessage = renderHomeserverUserMessage(task);
+  if (task.path === "delegate") {
+    return {
+      prompt: userMessage,
+      ...(task.taskType ? { taskType: task.taskType } : {}),
+      ...(task.systemPrompt !== undefined ? { systemPrompt: task.systemPrompt } : {}),
+      ...(task.maxTokens !== undefined ? { maxTokens: task.maxTokens } : {}),
+      ...(task.modelId !== undefined ? { modelId: task.modelId } : {}),
+      ...(task.frontierModelId !== undefined ? { frontierModelId: task.frontierModelId } : {}),
+      ...(task.verifier !== undefined ? { verifier: task.verifier } : {}),
+      ...(task.responseFormat !== undefined ? { responseFormat: task.responseFormat } : {}),
+      ...(task.delegatorModelId !== undefined ? { delegatorModelId: task.delegatorModelId } : {}),
+      ...(task.premiumBaselineModelId !== undefined
+        ? { premiumBaselineModelId: task.premiumBaselineModelId }
+        : {}),
+      huginTaskIdentity: buildHuginTaskIdentity({
+        taskId,
+        rawTaskText: task.prompt,
+        renderedPrompt: userMessage,
+      }),
+    };
+  }
+  return {
+    model: task.model,
+    messages: [
+      { role: "system", content: SYSTEM_PROMPT },
+      { role: "user", content: userMessage },
+    ],
+    stream: true,
+  };
 }
 
 // --- Executor ---
@@ -192,7 +244,7 @@ export async function executeHomeserverTask(
 ): Promise<HomeserverExecutorResult> {
   const logFile = path.join(logDir, `${taskId}.log`);
   const startedAt = new Date().toISOString();
-  const userMessage = buildUserMessage(task);
+  const userMessage = renderHomeserverUserMessage(task);
   const promptChars = SYSTEM_PROMPT.length + userMessage.length;
 
   fs.mkdirSync(logDir, { recursive: true });
@@ -249,6 +301,7 @@ export async function executeHomeserverTask(
     verifierNotes: null,
     nodeId: null,
     provenance: null,
+    huginTaskIdentity: null,
   };
 
   const finish = async (): Promise<HomeserverExecutorResult> => {
@@ -283,35 +336,15 @@ export async function executeHomeserverTask(
   if (task.apiKey) headers.Authorization = `Bearer ${task.apiKey}`;
 
   try {
+    // Keep defensive identity/serialization validation inside the executor's
+    // normal failure boundary so malformed direct callers still receive a
+    // closed log and structured executor result rather than an escaped throw.
+    const body = buildHomeserverRequestBody(task, taskId);
+    result.huginTaskIdentity = body.huginTaskIdentity ?? null;
     const url =
       task.path === "delegate"
         ? `${task.gatewayBaseUrl}/delegate`
         : `${task.gatewayBaseUrl}/v1/chat/completions`;
-
-    const body: Record<string, unknown> =
-      task.path === "delegate"
-        ? {
-            prompt: userMessage,
-            ...(task.taskType ? { taskType: task.taskType } : {}),
-            ...(task.systemPrompt !== undefined ? { systemPrompt: task.systemPrompt } : {}),
-            ...(task.maxTokens !== undefined ? { maxTokens: task.maxTokens } : {}),
-            ...(task.modelId !== undefined ? { modelId: task.modelId } : {}),
-            ...(task.frontierModelId !== undefined ? { frontierModelId: task.frontierModelId } : {}),
-            ...(task.verifier !== undefined ? { verifier: task.verifier } : {}),
-            ...(task.responseFormat !== undefined ? { responseFormat: task.responseFormat } : {}),
-            ...(task.delegatorModelId !== undefined ? { delegatorModelId: task.delegatorModelId } : {}),
-            ...(task.premiumBaselineModelId !== undefined
-              ? { premiumBaselineModelId: task.premiumBaselineModelId }
-              : {}),
-          }
-        : {
-            model: task.model,
-            messages: [
-              { role: "system", content: SYSTEM_PROMPT },
-              { role: "user", content: userMessage },
-            ],
-            stream: true,
-          };
 
     const res = await fetch(url, {
       method: "POST",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5463,6 +5463,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
               ...(homeserverResult.provenance ?? {}),
               taskType: homeserverResult.taskType ?? task.homeserverTaskType,
             },
+            huginTaskIdentity: homeserverResult.huginTaskIdentity ?? undefined,
           }
         : isOllama
         ? {

--- a/src/learning/m5-task-exposure.ts
+++ b/src/learning/m5-task-exposure.ts
@@ -1,8 +1,11 @@
-import { createHash } from "node:crypto";
 import { z } from "zod";
 import { resolveGatewayRootUrl } from "../orchestrator/provider-config.js";
+import {
+  fingerprintRawTask,
+  TASK_EXPOSURE_FINGERPRINT_VERSION,
+} from "../task-identity.js";
 
-export const TASK_EXPOSURE_FINGERPRINT_VERSION = "trim-utf8-sha256-v1" as const;
+export { TASK_EXPOSURE_FINGERPRINT_VERSION } from "../task-identity.js";
 export const TASK_EXPOSURE_LOOKUP_MAX = 100;
 // SHA-256("hugin-task-exposure-lookup-healthcheck-v1"). This is never derived
 // from a task and exists only to prove endpoint/auth/schema health on an empty
@@ -71,7 +74,7 @@ export class TaskExposureLookupError extends Error {
 
 /** Exact shared v1 contract: String.trim(), raw UTF-8, lowercase SHA-256. */
 export function taskTextFingerprint(taskText: string): string {
-  return createHash("sha256").update(taskText.trim(), "utf8").digest("hex");
+  return fingerprintRawTask(taskText).digest;
 }
 
 /**

--- a/src/task-identity.ts
+++ b/src/task-identity.ts
@@ -1,0 +1,89 @@
+import { createHash } from "node:crypto";
+import { z } from "zod";
+
+/** Normative LearningTaskContract v1 raw-task fingerprint. */
+export const TASK_EXPOSURE_FINGERPRINT_VERSION = "trim-utf8-sha256-v1" as const;
+/** Exact bytes of Hugin's rendered user message, without trim or normalization. */
+export const RENDERED_PROMPT_FINGERPRINT_VERSION =
+  "hugin-delegate-prompt-utf8-sha256-v1" as const;
+export const HUGIN_TASK_IDENTITY_SCHEMA_VERSION = 1 as const;
+
+const sha256Schema = z.string().regex(/^[0-9a-f]{64}$/);
+
+export const rawTaskFingerprintSchema = z.object({
+  algorithm: z.literal("sha256"),
+  version: z.literal(TASK_EXPOSURE_FINGERPRINT_VERSION),
+  digest: sha256Schema,
+}).strict();
+
+export const renderedPromptFingerprintSchema = z.object({
+  algorithm: z.literal("sha256"),
+  version: z.literal(RENDERED_PROMPT_FINGERPRINT_VERSION),
+  digest: sha256Schema,
+  utf8Bytes: z.number().int().nonnegative(),
+}).strict();
+
+/**
+ * Hugin-owned identity projected onto the legacy `/delegate` request.
+ *
+ * It is deliberately constructed inside the executor from the accepted logical
+ * task and lifecycle task id. Task authors cannot supply or override it. The
+ * gateway must still authenticate and bind this producer claim before treating
+ * it as exposure evidence; that stamp/echo handshake belongs to Hugin #240 and
+ * gille-inference #2.
+ */
+export const huginTaskIdentitySchema = z.object({
+  schemaVersion: z.literal(HUGIN_TASK_IDENTITY_SCHEMA_VERSION),
+  producer: z.literal("hugin"),
+  taskId: z.string().min(1).max(512),
+  rawTaskFingerprint: rawTaskFingerprintSchema,
+  renderedPromptFingerprint: renderedPromptFingerprintSchema,
+}).strict();
+
+export type HuginTaskIdentity = z.infer<typeof huginTaskIdentitySchema>;
+
+/** JavaScript String.trim(), no Unicode normalization, then exact UTF-8 bytes. */
+export function canonicalRawTaskBytes(rawTaskText: string): Buffer {
+  return Buffer.from(rawTaskText.trim(), "utf8");
+}
+
+export function fingerprintRawTask(rawTaskText: string): HuginTaskIdentity["rawTaskFingerprint"] {
+  const bytes = canonicalRawTaskBytes(rawTaskText);
+  return {
+    algorithm: "sha256",
+    version: TASK_EXPOSURE_FINGERPRINT_VERSION,
+    digest: createHash("sha256").update(bytes).digest("hex"),
+  };
+}
+
+export function fingerprintRenderedPrompt(
+  renderedPrompt: string,
+): HuginTaskIdentity["renderedPromptFingerprint"] {
+  const bytes = Buffer.from(renderedPrompt, "utf8");
+  return {
+    algorithm: "sha256",
+    version: RENDERED_PROMPT_FINGERPRINT_VERSION,
+    digest: createHash("sha256").update(bytes).digest("hex"),
+    utf8Bytes: bytes.byteLength,
+  };
+}
+
+export function buildHuginTaskIdentity(input: {
+  taskId: string;
+  rawTaskText: string;
+  renderedPrompt: string;
+}): HuginTaskIdentity {
+  if (input.taskId !== input.taskId.trim()) {
+    throw new Error("Hugin task identity requires an exact non-whitespace-padded task id");
+  }
+  if (input.rawTaskText.trim() === "") {
+    throw new Error("Hugin task identity requires a non-empty logical task");
+  }
+  return huginTaskIdentitySchema.parse({
+    schemaVersion: HUGIN_TASK_IDENTITY_SCHEMA_VERSION,
+    producer: "hugin",
+    taskId: input.taskId,
+    rawTaskFingerprint: fingerprintRawTask(input.rawTaskText),
+    renderedPromptFingerprint: fingerprintRenderedPrompt(input.renderedPrompt),
+  });
+}

--- a/src/task-result-schema.ts
+++ b/src/task-result-schema.ts
@@ -10,6 +10,7 @@ import {
   SIGNING_POLICIES,
   TASK_SIGNATURE_STATUSES,
 } from "./task-signing.js";
+import { huginTaskIdentitySchema } from "./task-identity.js";
 
 export const taskExecutionOutcomeSchema = z.enum([
   "completed",
@@ -146,6 +147,9 @@ export const taskExecutionRuntimeMetadataSchema = z.object({
   eliminatedRuntimes: z.array(routingEliminationSchema).optional(),
   skillRoute: skillRouteSchema.optional(),
   delegation: delegationProvenanceSchema.optional(),
+  // Producer-side identity only. Gateway-authenticated acceptance/echo is a
+  // separate future field owned by the LearningTaskContract handshake.
+  huginTaskIdentity: huginTaskIdentitySchema.optional(),
 });
 export type TaskExecutionRuntimeMetadata = z.infer<
   typeof taskExecutionRuntimeMetadataSchema

--- a/tests/fixtures/hugin-gille-task-identity-v1.json
+++ b/tests/fixtures/hugin-gille-task-identity-v1.json
@@ -1,0 +1,38 @@
+{
+  "schemaVersion": 1,
+  "producer": "hugin",
+  "normativeRawVectorSource": "grimnir/tests/fixtures/learning-task-contract/raw-fingerprint-vectors.json",
+  "rawFingerprintVersion": "trim-utf8-sha256-v1",
+  "renderedFingerprintVersion": "hugin-delegate-prompt-utf8-sha256-v1",
+  "cases": [
+    {
+      "name": "ASCII task with optional injected context",
+      "taskId": "fixture-task-230",
+      "rawTaskText": "  Summarize the fixture incident report.\n",
+      "canonicalRawUtf8Hex": "53756d6d6172697a6520746865206669787475726520696e636964656e74207265706f72742e",
+      "canonicalRawUtf8Bytes": 38,
+      "expectedRawSha256": "7b1c423b1792795a9442c6df25d5035af9daa83dbe43c48476f9bd8baa633152",
+      "injectedContext": "Incident severity: SEV-2.",
+      "renderedWithoutContext": "## Task\n  Summarize the fixture incident report.\n",
+      "renderedWithoutContextUtf8Bytes": 49,
+      "renderedWithoutContextSha256": "d0846c9a9de32ee9708e8ed7dd039b0156465807252a65f68304822919264969",
+      "currentGilleLegacyWithoutContextSha256": "5ca59329d305e062b90bac8d13a36cb91bc10412b489e69902f86db0a41c682d",
+      "renderedWithContext": "## Context\nIncident severity: SEV-2.\n\n---\n\n## Task\n  Summarize the fixture incident report.\n",
+      "renderedWithContextUtf8Bytes": 92,
+      "renderedWithContextSha256": "3171013936122536e14f5608f94a49d84d9c9cf9999bd2a41a9cec669557b691",
+      "currentGilleLegacyWithContextSha256": "602d867064f12080fc2accc5c9fd24d3eee803fcfe5701e5d0ceb35cf05ad618",
+      "expectedRawLookupRequest": {
+        "fingerprint_version": "trim-utf8-sha256-v1",
+        "fingerprints": ["7b1c423b1792795a9442c6df25d5035af9daa83dbe43c48476f9bd8baa633152"]
+      }
+    },
+    {
+      "name": "Unicode trim without normalization",
+      "taskId": "fixture-task-unicode",
+      "rawTaskText": "\tÅngström \n",
+      "canonicalRawUtf8Hex": "41cc8a6e677374726fcc886d",
+      "canonicalRawUtf8Bytes": 12,
+      "expectedRawSha256": "d27607e4723af34d42f72e65d29314aa7ffa372d39a5440cce37e260c4a4138b"
+    }
+  ]
+}

--- a/tests/homeserver-executor.test.ts
+++ b/tests/homeserver-executor.test.ts
@@ -136,6 +136,7 @@ describe("executeHomeserverTask — chat path", () => {
     expect(result.totalTokens).toBe(14);
     expect(result.backpressure).toBe("none");
     expect(result.delegated).toBeNull(); // chat path carries no delegate metadata
+    expect(result.huginTaskIdentity).toBeNull();
 
     const [url, init] = fetchMock.mock.calls[0]!;
     expect(url).toBe("http://m5.test:8080/v1/chat/completions");
@@ -223,6 +224,17 @@ describe("executeHomeserverTask — delegate path", () => {
     expect(result.completionTokens).toBe(3);
     expect(result.totalTokens).toBe(48);
     expect(result.inferenceMs).toBe(820);
+    expect(result.huginTaskIdentity).toEqual(expect.objectContaining({
+      schemaVersion: 1,
+      producer: "hugin",
+      taskId: "delegate-ok",
+      rawTaskFingerprint: expect.objectContaining({
+        version: "trim-utf8-sha256-v1",
+      }),
+      renderedPromptFingerprint: expect.objectContaining({
+        version: "hugin-delegate-prompt-utf8-sha256-v1",
+      }),
+    }));
 
     const [url, init] = fetchMock.mock.calls[0]!;
     expect(url).toBe("http://m5.test:8080/delegate");
@@ -323,7 +335,38 @@ describe("executeHomeserverTask — delegate path", () => {
     expect(body).toEqual({
       prompt: expect.any(String),
       taskType: "extract",
+      huginTaskIdentity: expect.objectContaining({
+        schemaVersion: 1,
+        producer: "hugin",
+        taskId: "delegate-min",
+        rawTaskFingerprint: expect.objectContaining({
+          version: "trim-utf8-sha256-v1",
+        }),
+        renderedPromptFingerprint: expect.objectContaining({
+          version: "hugin-delegate-prompt-utf8-sha256-v1",
+        }),
+      }),
     });
+  });
+
+  it("returns a logged failure when defensive identity validation rejects the request", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+
+    const result = await executeHomeserverTask(
+      makeTaskConfig({ path: "delegate", prompt: " \n\t" }),
+      "delegate-invalid-identity",
+      tmpLogDir,
+    );
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.exitCode).toBe(1);
+    expect(result.huginTaskIdentity).toBeNull();
+    expect(result.output).toContain(
+      "[Gateway error: Hugin task identity requires a non-empty logical task]",
+    );
+    expect(fs.readFileSync(result.logFile, "utf8")).toContain(
+      "Hugin task identity requires a non-empty logical task",
+    );
   });
 
   it("maps outcome 'fail'/'error' to a non-zero exit code, but 'unverified' to 0", async () => {

--- a/tests/homeserver-executor.test.ts
+++ b/tests/homeserver-executor.test.ts
@@ -399,12 +399,25 @@ describe("executeHomeserverTask — backpressure & errors", () => {
       new Response("owner preempted the GPU", { status: 503, headers: { "Retry-After": "5" } }),
     );
 
-    const result = await executeHomeserverTask(makeTaskConfig(), "bp-503", tmpLogDir);
+    const result = await executeHomeserverTask(
+      makeTaskConfig({ path: "delegate", taskType: "extract" }),
+      "bp-503",
+      tmpLogDir,
+    );
 
     expect(result.exitCode).toBe(1);
     expect(result.backpressure).toBe("admission");
     expect(result.retryAfterS).toBe(5);
     expect(result.resultText).toBeNull();
+    expect(result.huginTaskIdentity).toEqual(expect.objectContaining({
+      taskId: "bp-503",
+      rawTaskFingerprint: expect.objectContaining({
+        version: "trim-utf8-sha256-v1",
+      }),
+      renderedPromptFingerprint: expect.objectContaining({
+        version: "hugin-delegate-prompt-utf8-sha256-v1",
+      }),
+    }));
   });
 
   it("flags 429 as quota backpressure", async () => {

--- a/tests/homeserver-task-identity.test.ts
+++ b/tests/homeserver-task-identity.test.ts
@@ -1,0 +1,180 @@
+import { readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildHuginTaskIdentity,
+  HUGIN_TASK_IDENTITY_SCHEMA_VERSION,
+  RENDERED_PROMPT_FINGERPRINT_VERSION,
+  TASK_EXPOSURE_FINGERPRINT_VERSION,
+} from "../src/task-identity.js";
+import {
+  buildHomeserverRequestBody,
+  renderHomeserverUserMessage,
+  type HomeserverTaskConfig,
+} from "../src/homeserver-executor.js";
+import { taskTextFingerprint } from "../src/learning/m5-task-exposure.js";
+
+interface FixtureCase {
+  name: string;
+  taskId: string;
+  rawTaskText: string;
+  canonicalRawUtf8Hex: string;
+  canonicalRawUtf8Bytes: number;
+  expectedRawSha256: string;
+  injectedContext?: string;
+  renderedWithoutContext?: string;
+  renderedWithoutContextUtf8Bytes?: number;
+  renderedWithoutContextSha256?: string;
+  currentGilleLegacyWithoutContextSha256?: string;
+  renderedWithContext?: string;
+  renderedWithContextUtf8Bytes?: number;
+  renderedWithContextSha256?: string;
+  currentGilleLegacyWithContextSha256?: string;
+  expectedRawLookupRequest?: {
+    fingerprint_version: string;
+    fingerprints: string[];
+  };
+}
+
+interface Fixture {
+  schemaVersion: number;
+  producer: string;
+  normativeRawVectorSource: string;
+  rawFingerprintVersion: string;
+  renderedFingerprintVersion: string;
+  cases: FixtureCase[];
+}
+
+const fixture = JSON.parse(readFileSync(
+  new URL("./fixtures/hugin-gille-task-identity-v1.json", import.meta.url),
+  "utf8",
+)) as Fixture;
+
+function taskConfig(overrides: Partial<HomeserverTaskConfig> = {}): HomeserverTaskConfig {
+  return {
+    prompt: "fixture",
+    gatewayBaseUrl: "https://m5.test",
+    apiKey: "owner-key",
+    path: "delegate",
+    taskType: "summarize",
+    timeoutMs: 30_000,
+    maxOutputChars: 4_096,
+    ...overrides,
+  };
+}
+
+describe("canonical Hugin task identity", () => {
+  it("recomputes the shared exact UTF-8 vectors without Unicode normalization", () => {
+    expect(fixture.schemaVersion).toBe(HUGIN_TASK_IDENTITY_SCHEMA_VERSION);
+    expect(fixture.producer).toBe("hugin");
+    expect(fixture.normativeRawVectorSource).toBe(
+      "grimnir/tests/fixtures/learning-task-contract/raw-fingerprint-vectors.json",
+    );
+    expect(fixture.rawFingerprintVersion).toBe(TASK_EXPOSURE_FINGERPRINT_VERSION);
+    expect(fixture.renderedFingerprintVersion).toBe(RENDERED_PROMPT_FINGERPRINT_VERSION);
+
+    for (const vector of fixture.cases) {
+      const canonicalBytes = Buffer.from(vector.rawTaskText.trim(), "utf8");
+      expect(canonicalBytes.toString("hex"), vector.name).toBe(vector.canonicalRawUtf8Hex);
+      expect(canonicalBytes.byteLength, vector.name).toBe(vector.canonicalRawUtf8Bytes);
+      expect(createHash("sha256").update(canonicalBytes).digest("hex"), vector.name)
+        .toBe(vector.expectedRawSha256);
+    }
+  });
+
+  it("keeps raw identity stable across context rendering and preserves each rendered identity", () => {
+    const vector = fixture.cases[0]!;
+    const withoutContext = renderHomeserverUserMessage(taskConfig({ prompt: vector.rawTaskText }));
+    const withContext = renderHomeserverUserMessage(taskConfig({
+      prompt: vector.rawTaskText,
+      injectedContext: vector.injectedContext,
+    }));
+
+    expect(withoutContext).toBe(vector.renderedWithoutContext);
+    expect(withContext).toBe(vector.renderedWithContext);
+
+    const bareIdentity = buildHuginTaskIdentity({
+      taskId: vector.taskId,
+      rawTaskText: vector.rawTaskText,
+      renderedPrompt: withoutContext,
+    });
+    const contextIdentity = buildHuginTaskIdentity({
+      taskId: vector.taskId,
+      rawTaskText: vector.rawTaskText,
+      renderedPrompt: withContext,
+    });
+
+    expect(bareIdentity.rawTaskFingerprint.digest).toBe(vector.expectedRawSha256);
+    expect(contextIdentity.rawTaskFingerprint).toEqual(bareIdentity.rawTaskFingerprint);
+    expect(bareIdentity.renderedPromptFingerprint).toEqual({
+      algorithm: "sha256",
+      version: RENDERED_PROMPT_FINGERPRINT_VERSION,
+      digest: vector.renderedWithoutContextSha256,
+      utf8Bytes: vector.renderedWithoutContextUtf8Bytes,
+    });
+    expect(contextIdentity.renderedPromptFingerprint).toEqual({
+      algorithm: "sha256",
+      version: RENDERED_PROMPT_FINGERPRINT_VERSION,
+      digest: vector.renderedWithContextSha256,
+      utf8Bytes: vector.renderedWithContextUtf8Bytes,
+    });
+
+    // Current public Gille v1 records taskTextFingerprint(/delegate.prompt).
+    // Keep this executable mismatch visible until Gille #4 consumes the raw
+    // identity: the legacy digests vary with context and neither equals raw.
+    expect(taskTextFingerprint(withoutContext)).toBe(
+      vector.currentGilleLegacyWithoutContextSha256,
+    );
+    expect(taskTextFingerprint(withContext)).toBe(
+      vector.currentGilleLegacyWithContextSha256,
+    );
+    expect(taskTextFingerprint(withContext)).not.toBe(vector.expectedRawSha256);
+    expect(vector.expectedRawLookupRequest).toEqual({
+      fingerprint_version: TASK_EXPOSURE_FINGERPRINT_VERSION,
+      fingerprints: [vector.expectedRawSha256],
+    });
+  });
+
+  it("uses the real delegate serializer and offers no caller-supplied identity override", () => {
+    const vector = fixture.cases[0]!;
+    const configWithSpoofedExtraField = {
+      ...taskConfig({
+        prompt: vector.rawTaskText,
+        injectedContext: vector.injectedContext,
+      }),
+      huginTaskIdentity: {
+        schemaVersion: 999,
+        producer: "attacker",
+        taskId: "substituted",
+      },
+    } as HomeserverTaskConfig;
+    const body = buildHomeserverRequestBody(configWithSpoofedExtraField, vector.taskId);
+
+    expect(body.prompt).toBe(vector.renderedWithContext);
+    expect(body.huginTaskIdentity).toEqual({
+      schemaVersion: HUGIN_TASK_IDENTITY_SCHEMA_VERSION,
+      producer: "hugin",
+      taskId: vector.taskId,
+      rawTaskFingerprint: {
+        algorithm: "sha256",
+        version: TASK_EXPOSURE_FINGERPRINT_VERSION,
+        digest: vector.expectedRawSha256,
+      },
+      renderedPromptFingerprint: {
+        algorithm: "sha256",
+        version: RENDERED_PROMPT_FINGERPRINT_VERSION,
+        digest: vector.renderedWithContextSha256,
+        utf8Bytes: vector.renderedWithContextUtf8Bytes,
+      },
+    });
+    expect(JSON.stringify(body.huginTaskIdentity)).not.toContain(vector.rawTaskText.trim());
+  });
+
+  it("fails closed rather than emitting a missing or ambiguous identity", () => {
+    expect(() => buildHomeserverRequestBody(taskConfig({ prompt: " \n\t" }), "task-1"))
+      .toThrow("non-empty logical task");
+    expect(() => buildHomeserverRequestBody(taskConfig({ prompt: "valid" }), " task-1"))
+      .toThrow("non-whitespace-padded task id");
+  });
+});

--- a/tests/orchestrator/worker-executor.test.ts
+++ b/tests/orchestrator/worker-executor.test.ts
@@ -491,6 +491,9 @@ describe("HomeserverDelegateWorkerExecutor — /delegate worker path", () => {
     });
     expect(body.verifier).toBeUndefined();
     expect(body.responseFormat).toBeUndefined();
+    // #230 is currently scoped to the direct homeserver runtime serializer.
+    // Orchestrator worker identity/stamping remains legacy until #240.
+    expect(body.huginTaskIdentity).toBeUndefined();
 
     // Issue #163: the ledger id must survive onto the result, not just be parsed
     // and dropped — it is the join key back to M5's authoritative evidence row.

--- a/tests/task-result-schema.test.ts
+++ b/tests/task-result-schema.test.ts
@@ -147,6 +147,46 @@ describe("structured task result schema", () => {
     expect(result.runtimeMetadata?.delegation?.priceCatalogVersion).toBe("2026-07-08");
     expect(result.runtimeMetadata?.delegation?.costTraceId).toBe("ct-1");
   });
+
+  it("preserves Hugin raw-task and rendered-prompt identity as separate provenance", () => {
+    const result = buildStructuredTaskResult({
+      schemaVersion: 1,
+      taskId: "task-identity-1",
+      taskNamespace: "tasks/task-identity-1",
+      lifecycle: "completed",
+      outcome: "completed",
+      runtime: "homeserver",
+      executor: "homeserver-delegate",
+      resultSource: "homeserver-delegate",
+      exitCode: 0,
+      completedAt: "2026-07-19T12:00:00.000Z",
+      bodyKind: "response",
+      bodyText: "ok",
+      runtimeMetadata: {
+        huginTaskIdentity: {
+          schemaVersion: 1,
+          producer: "hugin",
+          taskId: "task-identity-1",
+          rawTaskFingerprint: {
+            algorithm: "sha256",
+            version: "trim-utf8-sha256-v1",
+            digest: "a".repeat(64),
+          },
+          renderedPromptFingerprint: {
+            algorithm: "sha256",
+            version: "hugin-delegate-prompt-utf8-sha256-v1",
+            digest: "b".repeat(64),
+            utf8Bytes: 123,
+          },
+        },
+      },
+    });
+
+    expect(result.runtimeMetadata?.huginTaskIdentity?.rawTaskFingerprint.digest)
+      .toBe("a".repeat(64));
+    expect(result.runtimeMetadata?.huginTaskIdentity?.renderedPromptFingerprint.digest)
+      .toBe("b".repeat(64));
+  });
   it("accepts completed pipeline phase results", () => {
     const result = buildStructuredTaskResult({
       schemaVersion: 1,


### PR DESCRIPTION
Refs #230

## What
- hash exact trimmed logical-task UTF-8 bytes before wrapping
- keep rendered prompt identity separate
- serialize producer-owned identity on the real direct homeserver /delegate path
- retain identity in structured results and normal failure paths
- document the orchestrator and gille activation boundaries honestly

## Verification
- npm test -- --reporter=dot (113 files, 1,848 tests)
- npm run build
- git diff --check
- independent Claude Fable review: approved the full private patch; final follow-up fixes addressed its only documentation/failure-path observations
- root review: approved exact commit 6df22c53e554dfa0a56bb06cd7e18e1bb5423b39

## Merge gate
Draft until Hugin #240 and gille-inference #2/#4 prove the real stamp/echo/capture path with the shared fixture. The orchestrator worker intentionally remains legacy until #240.