### PR TITLE
feat: make quality receipts atomic and correction-aware

### DIFF
--- a/docs/daily-exam-factory.md
+++ b/docs/daily-exam-factory.md
@@ -47,11 +47,16 @@ classifies them without running a model or writing any learning state:
 
 `completed` means that the executor lifecycle finished successfully; it is not
 proof that the solution was accepted. The factory reads each task's optional
-`feedback` document and joins only schema-v1 quality receipts whose hashes bind
-the exact task document, structured result, and repository state/diff. It
-preserves the receipt IDs, authenticated reviewer principals, and whether an
-independent reviewer explicitly accepted the unchanged result. Legacy flat
-feedback is labeled `legacy-unbound` and never upgraded into acceptance.
+`feedback` document and joins only valid native-v1/v2 quality receipts whose
+hashes bind the exact task document, structured result, and repository
+state/diff. It collapses a valid correction chain to its unique unsuperseded
+leaf. The content-blind quality view preserves receipt IDs, authenticated
+reviewer principals, reason digests, and—on native v2—attempt, predecessor,
+stable correction group, rubric/verifier, structured failure, available
+producing-configuration identities, and successor references. It never copies
+the text rating reason. Native v1 remains exact and does not acquire fabricated
+attempt or rubric fields. Legacy flat feedback is labeled `legacy-unbound` and
+never upgraded into acceptance. See `docs/quality-receipts.md`.
 
 Every non-quarantined candidate remains `needs-independent-verifier`, including
 one whose product output has an exact independent acceptance: accepting the

--- a/docs/orchestrator-v1-data-model.md
+++ b/docs/orchestrator-v1-data-model.md
@@ -355,9 +355,13 @@ interface DelegationRatedEvent {
 ```
 
 > Historical note: this section specifies the retired orch-v1 JSONL event.
-> Current canonical tasks persist schema-v1 append-only quality receipts in
-> Munin `feedback`, bound to the exact task/result/repository evidence. Legacy
-> flat feedback remains readable but is never treated as bound acceptance.
+> Current canonical tasks persist append-only native Quality Receipts in Munin
+> `feedback`, bound to the exact task/result/repository evidence. Native v1 is
+> frozen; same-reviewer corrections use native v2 with a new id and explicit
+> predecessor/correction group. Emission currently fails closed until #240
+> persists an authoritative attempt id; `task_id` is not substituted for it.
+> Legacy flat feedback remains readable but is
+> never treated as bound acceptance. See `docs/quality-receipts.md`.
 
 **Forward-compat rule:** projection code MUST tolerate unknown `event_schema_version` values by skipping the event (with a logged warning) rather than crashing. Producers MUST bump the version on any breaking shape change; additive field changes do not require a bump.
 

--- a/docs/quality-receipts.md
+++ b/docs/quality-receipts.md
@@ -1,0 +1,205 @@
+# Quality Receipts
+
+Quality Receipts separate successful execution from product acceptance. They are
+authenticated, exact-bound, append-only evidence written by `hugin_rate` or
+`POST /v1/delegate/rate` after a task becomes terminal.
+
+## Native v1 is frozen
+
+Native `quality:receipt-v1` remains byte/field compatible with the format shipped
+in PR #227. Its fields are exactly:
+
+- content-derived `receiptId` and `schemaVersion: 1`;
+- task id, rating, text `ratingReason`, verification outcome, and optional retry count;
+- rating clock, authenticated reviewer principal, and independence attestation; and
+- binding attestation plus exact task-document, structured-result, and repository binding.
+
+Attempt, rubric, predecessor, correction-group, failure-taxonomy, and producing-
+configuration fields are not native-v1 claims. A normal `hugin_rate` call still
+emits v1 and a v1-only ledger remains `schemaVersion: 1`.
+
+## Concurrent append protocol
+
+`feedback` is a read/fold/write ledger. Both an existing-entry append and the
+missing-entry first write are compare-and-swap guarded:
+
+1. read `feedback`;
+2. validate and fold the immutable receipt;
+3. if the entry exists, write with its exact `updated_at`;
+4. if it is absent, write with Munin's explicit `create_if_absent: true`
+   precondition and require the success result to say exactly `status: "created"`;
+   and
+5. on the matching typed conflict (`already_exists` for first create or
+   `version_mismatch` for existing-entry CAS), re-read and re-fold, up to three
+   attempts. Any untyped or mismatched failure fails closed.
+
+This means two first reviewers cannot replace each other. An identical receipt
+id is an idempotent retry. For native v2, the complete persisted artifacts must
+also be canonically identical; reusing an id with a different clock or extension
+field is an identity collision. A changed native-v1 verdict from the same
+reviewer for the same binding remains a conflict.
+
+This depends on the explicit Munin create-if-absent API from Munin #211. Hugin
+does not invent a timestamp and does not assume that candidate is deployed:
+deploy Munin first, verify `memory_write` accepts `create_if_absent: true` and
+returns `conflict_reason: "already_exists"` to the loser, then deploy Hugin.
+Existing-ledger reconciliation continues to use ordinary `expected_updated_at`
+CAS and expects `conflict_reason: "version_mismatch"`. A pre-#211 server that
+ignores the new field and returns anything other than `status: "created"` fails
+loudly instead of receiving a false atomicity assumption.
+
+## Native v2 corrections
+
+Native v2 is only for append-only correction semantics. It never mutates or
+relabels a v1 receipt. A correction:
+
+- gets a new content-derived `receiptId` and `schemaVersion: 2`;
+- names the predecessor as `correctsReceiptId`, matching the accepted Grimnir
+  native-v2 bridge contract;
+- binds an authoritative Hugin execution attempt distinct from the logical task
+  instance;
+- retains one SHA-256 `quality-correction-group-jcs-v1` fingerprint over task,
+  attempt, authenticated reviewer, exact normalized rubric, and exact normalized
+  result binding;
+- carries the rubric as Grimnir's exact normalized `versionedConfigIdentity`
+  (`id`, `version`, and a typed immutable `config_digest`), while retaining the
+  verifier identity separately and losslessly;
+- may carry content-blind prompt, harness, model/config, and tool-policy identities;
+- may point to an exact corrected-successor result, follow-up task, PR, or
+  replacement commit; and
+- must advance the review clock and extend the unique current leaf. Missing
+  predecessors, forks, cycles, reviewer/binding changes, and mid-chain rubric or
+  attempt changes fail closed.
+
+The closed failure codes are `none`, `incorrect-answer`, `incomplete-answer`,
+`format-invalid`, `instruction-noncompliance`, `unsafe-output`,
+`unsupported-claim`, `tool-failure`, `harness-failure`, `infrastructure`,
+`verification-failure`, and `other`. Only `pass` plus `accepted_unchanged` may
+use `none`; every other correction must identify a non-`none` failure.
+
+The first correction upgrades the containing ledger to `schemaVersion: 2` while
+preserving every native-v1 object unchanged. Both `quality:receipt-v1` and
+`quality:receipt-v2` tags remain on a mixed ledger.
+
+### Activation boundary: authoritative attempts
+
+The native-v2 schema, fold, storage, and harvest path are implemented, but the
+authenticated rate endpoint currently rejects every `correction` with HTTP 409.
+Hugin does not yet persist an authoritative execution-attempt id in its task
+result. Its claim-time MCP session UUID is process-local, while startup and lease
+recovery can terminalize the task after that process disappears. The task id is
+the logical task instance and must not be copied into `attemptId` as invented
+provenance.
+
+Hugin issue #240 owns starting and durably identifying the attempt. Once that
+evidence is present in the exact structured result, the rate handler may bind
+native v2 to it. Callers cannot supply an attempt id themselves. Until then,
+native v1 remains fully operational and v2 fails closed.
+
+The `quality-correction-group-jcs-v1` key uses a dedicated RFC 8785 canonicalizer:
+ECMAScript number/string serialization, raw UTF-16 property ordering, and
+rejection of non-finite numbers, lone surrogates, sparse arrays, and non-JSON
+values. Its canonical payload is the exact normalized Grimnir bridge object
+`{ task_id, attempt_id, reviewer: { principal, independence }, rubric, binding }`,
+including snake-case binding fields and the full rubric `config_digest`. The
+stored fingerprint is `{ algorithm: "sha256", version:
+"quality-correction-group-jcs-v1", digest }`; those labels are not part of the
+hashed payload. Native-v1 identity intentionally retains its frozen serializer.
+
+The native-v2 `receiptId` follows Grimnir #86's independently executable bridge
+construction: SHA-256 over the JCS-native common body containing task, attempt,
+verdict, optional retries, rating clock, nested reviewer, rubric, binding
+attestation, native binding, and predecessor. It excludes `schemaVersion`, the
+receipt id itself, and Hugin-only extensions such as correction group, verifier,
+failure, producing configuration, and references. Those extensions remain part
+of the immutable stored artifact, so a same-id replay is accepted only when the
+entire native-v2 object is canonically equal.
+
+Native repository fields unavailable to the normalized group payload use the
+contract's explicit unknown object. Fields that cannot apply to `not-managed`,
+and `head_commit`/`diff_sha256` for `no-changes`, use `not-applicable`; other
+unavailable repository fields use `not-observed`. A present native diff digest
+becomes the normalized `git-binary-diff-sha256-v1` fingerprint.
+
+Example correction input (hashes abbreviated here only for readability):
+
+```json
+{
+  "task_id": "20260719t120000z-parser-fix",
+  "rating": "wrong",
+  "rating_reason": "The Unicode regression remains.",
+  "verification_outcome": "discarded",
+  "correction": {
+    "predecessor_receipt_id": "qr-0123456789abcdef01234567",
+    "rubric": {
+      "id": "code-review",
+      "version": "2.1.0",
+      "config_digest": {
+        "algorithm": "sha256",
+        "canonicalization": "jcs-rfc8785-utf8-v1",
+        "source_ref": "source-doc:rubric/code-review-2.1.0",
+        "source_type": "rubric-config",
+        "source_version": "rubric-source-2.1.0",
+        "digest": "<64 lowercase hex>"
+      }
+    },
+    "verifier": { "id": "claude-opus", "version": "2026-07-19" },
+    "failure": {
+      "taxonomy": { "id": "hugin-quality-failure", "version": "1" },
+      "code": "incorrect-answer"
+    },
+    "references": {
+      "corrected_successor": {
+        "task_id": "20260719t130000z-parser-fix-followup",
+        "structured_result_sha256": "<64 lowercase hex>"
+      }
+    }
+  }
+}
+```
+
+## Harvest semantics
+
+Consumers validate the complete ledger, collapse each correction chain to its
+unique unsuperseded leaf, and summarize only exact-bound leaves. Harvested
+`effectiveReceipts` never includes the text reason; it includes its SHA-256 and,
+for v2, the attempt, predecessor, correction group, rubric/verifier, failure,
+optional producing configuration, and optional successor references. Native v1
+evidence does not fabricate attempt or rubric fields.
+
+Different reviewers remain independent receipt groups and may conflict. A new
+rubric is not newest-wins evidence. LearningTaskContract v1 must fail closed when
+more than one binding/rubric cohort is available because it has no governed
+cohort selector. That multi-cohort state means the evidence is incomparable
+under v1; it does not by itself mean the reviewers disagreed on the verdict.
+
+`tests/fixtures/grimnir-quality-v2-contract.json` vendors the accepted Grimnir
+#86 normalized fixture and its independently validated native receipt id and
+correction-group digest. The Hugin contract test checks native v2 against that
+cross-repository fixture, rather than merely recomputing expected values with
+Hugin's own code.
+
+## Post-deploy operational acceptance
+
+These checks intentionally require deployed, authenticated services and are not
+part of a source-only PR review:
+
+Prerequisite: merge and deploy Munin #211 first, then probe one winning
+`create_if_absent` write and one typed `already_exists` loser before deploying
+this Hugin change.
+
+1. rate one real terminal managed-repository success with native v1;
+2. concurrently submit two different authenticated first reviews for a fresh
+   terminal task and verify both immutable ids remain in `feedback`;
+3. replay one identical request and verify the ledger and receipt count do not change;
+4. after #240 has deployed authoritative attempt evidence, rate a real rejection,
+   then append a native-v2 correction naming that receipt and an exact corrected-
+   successor result;
+5. verify the v1 predecessor bytes are unchanged, the v2 leaf has a new id and
+   stable correction group, and an attempted fork returns HTTP 409; and
+6. run the durable learning collector and next daily harvest, verifying the
+   effective v2 leaf retains rubric/verifier, structured failure, available
+   configuration identities, and successor references without prompt, result,
+   diff, or reason text.
+
+No receipt automatically promotes a model, prompt, harness, route, or artifact.

--- a/src/broker/handlers.ts
+++ b/src/broker/handlers.ts
@@ -528,6 +528,21 @@ export function createRateHandler(deps: BrokerHandlerDependencies) {
       res.status(409).json({ error: "policy_rejected", message: "reviewed binding is stale or mismatched" });
       return;
     }
+    // LearningTaskContract v1 distinguishes the durable task instance from an
+    // execution attempt. Hugin's current structured result has no
+    // authoritative attempt identity: the per-claim MCP session UUID is not
+    // persisted as attempt evidence, and startup/lease recovery can finalize a
+    // task after that process has disappeared. Native v2 requires the exact
+    // attempt, so using `task_id` here would fabricate provenance. Issue #240
+    // owns creation and persistence of that evidence; until it lands, retain
+    // the schema/storage seam but fail closed before emitting a v2 receipt.
+    if (parsed.correction) {
+      res.status(409).json({
+        error: "policy_rejected",
+        message: "native v2 correction requires authoritative execution attempt evidence; this task result does not provide it",
+      });
+      return;
+    }
     const principal = authenticatedPrincipal;
     const brokerOwner = canonical.ok
       ? canonical.envelope.broker_principal
@@ -542,12 +557,12 @@ export function createRateHandler(deps: BrokerHandlerDependencies) {
       });
       return;
     }
-    const independence = parsed.reviewer_role === "independent"
+    const independence: "independent" | "self" | "unknown" = parsed.reviewer_role === "independent"
       ? "independent"
       : parsed.reviewer_role === "self" || reviewerIsOwner
         ? "self"
         : "unknown";
-    const receipt = buildQualityReceipt({
+    const commonReceipt = {
       taskId: parsed.task_id,
       reviewerPrincipal: principal,
       reviewerIndependence: independence,
@@ -556,9 +571,10 @@ export function createRateHandler(deps: BrokerHandlerDependencies) {
       verificationOutcome: parsed.verification_outcome,
       retriesCount: parsed.retries_count,
       ratedAt: nowFn(deps)().toISOString(),
-      bindingAttestation: expected ? "reviewer-confirmed" : "server-bound",
+      bindingAttestation: expected ? "reviewer-confirmed" as const : "server-bound" as const,
       binding,
-    });
+    };
+    const receipt = buildQualityReceipt(commonReceipt);
     try {
       await deps.taskStore.writeQualityReceipt(parsed.task_id, receipt);
     } catch (err) {

--- a/src/broker/task-store.ts
+++ b/src/broker/task-store.ts
@@ -16,7 +16,7 @@
  */
 
 import { createHash } from "node:crypto";
-import type { MuninClient } from "../munin-client.js";
+import { MuninWriteRejectedError, type MuninClient } from "../munin-client.js";
 import type {
   AwaitRequest,
   DelegationEnvelope,
@@ -38,7 +38,7 @@ import {
 } from "../friction/munin-key.js";
 import {
   foldQualityReceipt,
-  type QualityReceipt,
+  type NativeQualityReceipt,
 } from "../quality-receipt.js";
 
 export { MUNIN_QUERY_MAX } from "../munin-pagination.js";
@@ -307,7 +307,7 @@ export class BrokerTaskStore {
 
   async writeQualityReceipt(
     taskId: string,
-    receipt: QualityReceipt,
+    receipt: NativeQualityReceipt,
   ): Promise<{ changed: boolean }> {
     const status = await this.readStatus(taskId);
     const envelope = status ? parseStoredEnvelope(status.content) : null;
@@ -324,22 +324,35 @@ export class BrokerTaskStore {
       }
       const folded = foldQualityReceipt(existing, receipt);
       if (!folded.changed) return { changed: false };
+      const receiptVersionTags = [...new Set(
+        folded.ledger.receipts.map((item) => `quality:receipt-v${item.schemaVersion}`),
+      )];
+      const expectedConflictReason = current ? "version_mismatch" : "already_exists";
       try {
-        await this.munin.write(
+        const result = await this.munin.write(
           namespace,
           "feedback",
           JSON.stringify(folded.ledger),
           envelope
-            ? ["broker:mcp-v2", "feedback", "quality:receipt-v1"]
-            : ["feedback", "quality:receipt-v1"],
+            ? ["broker:mcp-v2", "feedback", ...receiptVersionTags]
+            : ["feedback", ...receiptVersionTags],
           current?.updated_at,
           envelope?.sensitivity === "private"
             ? "client-restricted"
             : current?.classification ?? status?.classification ?? "internal",
+          current === null ? true : undefined,
         );
+        if (current === null && result.status !== "created") {
+          throw new Error(
+            "Munin create_if_absent did not return status created; refusing to trust first-write atomicity",
+          );
+        }
         return { changed: true };
       } catch (err) {
-        if (attempt === 2) throw err;
+        const expectedConflict = err instanceof MuninWriteRejectedError &&
+          err.errorCode === "conflict" &&
+          err.conflictReason === expectedConflictReason;
+        if (!expectedConflict || attempt === 2) throw err;
       }
     }
     throw new Error("quality receipt update lost repeated CAS races");

--- a/src/broker/types.ts
+++ b/src/broker/types.ts
@@ -8,6 +8,11 @@
  */
 
 import { z } from "zod";
+import {
+  qualityFailureCodeSchema,
+  qualityRubricSchema,
+  qualityVerifierIdentitySchema,
+} from "../quality-receipt.js";
 
 export const aliasSchema = z.enum([
   "m5",
@@ -173,6 +178,49 @@ export const verificationOutcomeSchema = z.enum([
   "escalated_to_claude",
 ]);
 
+const qualityWireConfigurationIdentitySchema = z.object({
+  id: z.string().min(1).max(200),
+  version: z.string().min(1).max(200),
+  sha256: z.string().regex(/^[0-9a-f]{64}$/),
+}).strict();
+
+export const qualityCorrectionRequestSchema = z.object({
+  predecessor_receipt_id: z.string().regex(/^qr-[0-9a-f]{24}$/),
+  rubric: qualityRubricSchema,
+  verifier: qualityVerifierIdentitySchema,
+  failure: z.object({
+    taxonomy: z.object({
+      id: z.string().min(1).max(200),
+      version: z.string().min(1).max(200),
+    }).strict(),
+    code: qualityFailureCodeSchema,
+  }).strict(),
+  producing_configuration: z.object({
+    prompt: qualityWireConfigurationIdentitySchema.optional(),
+    harness: qualityWireConfigurationIdentitySchema.optional(),
+    model: z.object({
+      id: z.string().min(1).max(200),
+      configuration_sha256: z.string().regex(/^[0-9a-f]{64}$/),
+    }).strict().optional(),
+    tool_policy: qualityWireConfigurationIdentitySchema.optional(),
+  }).strict().refine(
+    (value) => Object.values(value).some((child) => child !== undefined),
+    "producing_configuration must contain at least one identity",
+  ).optional(),
+  references: z.object({
+    corrected_successor: z.object({
+      task_id: z.string().min(1).max(200),
+      structured_result_sha256: z.string().regex(/^[0-9a-f]{64}$/),
+    }).strict().optional(),
+    follow_up_task_id: z.string().min(1).max(200).optional(),
+    pull_request_url: z.string().url().optional(),
+    replacement_commit: z.string().regex(/^[0-9a-f]{40,64}$/).optional(),
+  }).strict().refine(
+    (value) => Object.values(value).some((child) => child !== undefined),
+    "references must contain at least one reference",
+  ).optional(),
+}).strict();
+
 export const rateRequestSchema = z.object({
   task_id: z.string().min(1),
   rating: ratingSchema,
@@ -180,12 +228,30 @@ export const rateRequestSchema = z.object({
   verification_outcome: verificationOutcomeSchema,
   retries_count: z.number().int().nonnegative().optional(),
   reviewer_role: z.enum(["independent", "self"]).optional(),
+  correction: qualityCorrectionRequestSchema.optional(),
   expected_binding: z.object({
     task_document_sha256: z.string().regex(/^[0-9a-f]{64}$/),
     structured_result_sha256: z.string().regex(/^[0-9a-f]{64}$/),
     repository_diff_sha256: z.string().regex(/^[0-9a-f]{64}$/).optional(),
   }).strict().optional(),
-}).strict();
+}).strict().superRefine((value, ctx) => {
+  const fullyAccepted = value.rating === "pass" &&
+    value.verification_outcome === "accepted_unchanged";
+  if (value.correction && !fullyAccepted && value.correction.failure.code === "none") {
+    ctx.addIssue({
+      code: "custom",
+      path: ["correction", "failure", "code"],
+      message: "a non-accepted correction requires a structured failure code",
+    });
+  }
+  if (value.correction && fullyAccepted && value.correction.failure.code !== "none") {
+    ctx.addIssue({
+      code: "custom",
+      path: ["correction", "failure", "code"],
+      message: "an accepted unchanged correction must use failure code none",
+    });
+  }
+});
 export type RateRequest = z.infer<typeof rateRequestSchema>;
 
 export const awaitRequestSchema = z.object({

--- a/src/jcs.ts
+++ b/src/jcs.ts
@@ -1,0 +1,79 @@
+/** RFC 8785 JSON Canonicalization Scheme for already-materialized JSON values. */
+
+function assertUnicodeScalarString(value: string): void {
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        throw new TypeError("JCS rejects lone high surrogates");
+      }
+      index += 1;
+      continue;
+    }
+    if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff) {
+      throw new TypeError("JCS rejects lone low surrogates");
+    }
+  }
+}
+
+/** RFC 8785 sorts property names by their raw UTF-16 code units. */
+export function compareUtf16CodeUnits(left: string, right: string): number {
+  const length = Math.min(left.length, right.length);
+  for (let index = 0; index < length; index += 1) {
+    const difference = left.charCodeAt(index) - right.charCodeAt(index);
+    if (difference !== 0) return difference;
+  }
+  return left.length - right.length;
+}
+
+/**
+ * Canonicalize an I-JSON-compatible value using RFC 8785.
+ *
+ * Numbers and string escaping deliberately use ECMAScript JSON serialization,
+ * as required by JCS. Optional object properties whose value is `undefined`
+ * are treated as absent before canonicalization, matching JSON object
+ * materialization; every other non-JSON value fails closed.
+ */
+export function canonicalizeJcs(value: unknown): string {
+  if (value === null) return "null";
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new TypeError("JCS rejects non-finite numbers");
+    }
+    return JSON.stringify(value);
+  }
+  if (typeof value === "string") {
+    assertUnicodeScalarString(value);
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    const children: string[] = [];
+    for (let index = 0; index < value.length; index += 1) {
+      if (!Object.hasOwn(value, index) || value[index] === undefined) {
+        throw new TypeError("JCS rejects sparse arrays and undefined array values");
+      }
+      children.push(canonicalizeJcs(value[index]));
+    }
+    return `[${children.join(",")}]`;
+  }
+  if (typeof value === "object") {
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new TypeError("JCS accepts only plain JSON objects");
+    }
+    if (Object.getOwnPropertySymbols(value).length > 0) {
+      throw new TypeError("JCS rejects symbol-keyed properties");
+    }
+    const object = value as Record<string, unknown>;
+    const keys = Object.keys(object)
+      .filter((key) => object[key] !== undefined)
+      .sort(compareUtf16CodeUnits);
+    return `{${keys.map((key) => {
+      assertUnicodeScalarString(key);
+      return `${JSON.stringify(key)}:${canonicalizeJcs(object[key])}`;
+    }).join(",")}}`;
+  }
+  throw new TypeError(`JCS rejects non-JSON value of type ${typeof value}`);
+}

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -22,6 +22,7 @@ import {
   aliasSchema,
   type Alias,
   ratingSchema,
+  qualityCorrectionRequestSchema,
   sensitivitySchema,
   taskTypeSchema,
   verificationOutcomeSchema,
@@ -150,6 +151,9 @@ export const rateInputShape = {
   retries_count: z.number().int().nonnegative().optional(),
   reviewer_role: z.enum(["independent", "self"]).optional()
     .describe("Authenticated reviewer attestation. Same-task owners cannot claim independent."),
+  correction: qualityCorrectionRequestSchema.optional().describe(
+    "Append-only native v2 correction shape. Names the predecessor and carries content-blind rubric, failure, configuration, and successor provenance. The Broker currently fails closed until authoritative execution-attempt evidence lands; callers cannot provide or infer it.",
+  ),
   expected_binding: z.object({
     task_document_sha256: z.string().regex(/^[0-9a-f]{64}$/),
     structured_result_sha256: z.string().regex(/^[0-9a-f]{64}$/),

--- a/src/munin-client.ts
+++ b/src/munin-client.ts
@@ -45,6 +45,37 @@ export type MuninReadResult =
   | (MuninEntry & { found: true })
   | { namespace: string; key: string; found: false };
 
+export type MuninWriteConflictReason = "already_exists" | "version_mismatch";
+
+export interface MuninWriteRejection {
+  error: string;
+  message?: string;
+  conflict_reason?: unknown;
+  current_updated_at?: unknown;
+  [key: string]: unknown;
+}
+
+/** Typed application-level rejection returned by Munin's memory_write tool. */
+export class MuninWriteRejectedError extends Error {
+  readonly errorCode: string;
+  readonly conflictReason?: MuninWriteConflictReason;
+  readonly currentUpdatedAt?: string;
+
+  constructor(namespace: string, key: string, rejection: MuninWriteRejection) {
+    const detail = rejection.message ?? JSON.stringify(rejection);
+    super(`Munin write rejected for ${namespace}/${key}: ${rejection.error} — ${detail}`);
+    this.name = "MuninWriteRejectedError";
+    this.errorCode = rejection.error;
+    this.conflictReason = rejection.conflict_reason === "already_exists" ||
+      rejection.conflict_reason === "version_mismatch"
+      ? rejection.conflict_reason
+      : undefined;
+    this.currentUpdatedAt = typeof rejection.current_updated_at === "string"
+      ? rejection.current_updated_at
+      : undefined;
+  }
+}
+
 let rpcId = 0;
 
 function sleep(ms: number): Promise<void> {
@@ -256,22 +287,27 @@ export class MuninClient {
     tags?: string[],
     expectedUpdatedAt?: string,
     classification?: string,
+    createIfAbsent?: boolean,
   ): Promise<Record<string, unknown>> {
+    if (createIfAbsent === true && expectedUpdatedAt !== undefined) {
+      throw new Error("Munin write preconditions createIfAbsent and expectedUpdatedAt are mutually exclusive");
+    }
     const args: Record<string, unknown> = { namespace, key, content };
     if (tags) args.tags = tags;
     if (expectedUpdatedAt) args.expected_updated_at = expectedUpdatedAt;
     if (classification) args.classification = classification;
+    if (createIfAbsent === true) args.create_if_absent = true;
     const result = (await this.callTool("memory_write", args)) as
       | Record<string, unknown>
       | undefined
       | null;
     if (result && result.ok === false) {
       const error = typeof result.error === "string" ? result.error : "unknown";
-      const message =
-        typeof result.message === "string" ? result.message : JSON.stringify(result);
-      throw new Error(
-        `Munin write rejected for ${namespace}/${key}: ${error} — ${message}`,
-      );
+      throw new MuninWriteRejectedError(namespace, key, {
+        ...result,
+        error,
+        ...(typeof result.message === "string" ? { message: result.message } : {}),
+      });
     }
     return (result ?? {}) as Record<string, unknown>;
   }

--- a/src/quality-receipt.ts
+++ b/src/quality-receipt.ts
@@ -2,10 +2,14 @@
 
 import { createHash } from "node:crypto";
 import { z } from "zod";
+import { canonicalizeJcs } from "./jcs.js";
 import { structuredTaskResultSchema } from "./task-result-schema.js";
 
 const sha256Schema = z.string().regex(/^[0-9a-f]{64}$/);
 const commitSchema = z.string().regex(/^[0-9a-f]{40,64}$/);
+const learningContractTimestampSchema = z.string()
+  .regex(/^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(?:\.[0-9]{1,3})?Z$/)
+  .datetime();
 
 export const qualityRepositoryBindingSchema = z.object({
   state: z.enum([
@@ -49,6 +53,97 @@ export const qualityBindingSchema = z.object({
 }).strict();
 export type QualityBinding = z.infer<typeof qualityBindingSchema>;
 
+const qualityReviewerSchema = z.object({
+  principal: z.string().min(1).max(200),
+  independence: z.enum(["independent", "self", "unknown"]),
+}).strict();
+
+const qualitySourceDocumentDigestSchema = z.object({
+  algorithm: z.literal("sha256"),
+  canonicalization: z.literal("jcs-rfc8785-utf8-v1"),
+  source_ref: z.string().regex(/^source-doc:[a-z0-9][a-z0-9._/-]*$/),
+  source_type: z.literal("rubric-config"),
+  source_version: z.string().min(1),
+  digest: sha256Schema,
+}).strict();
+
+const qualityConfigurationIdentitySchema = z.object({
+  id: z.string().min(1).max(200),
+  version: z.string().min(1).max(200),
+  sha256: sha256Schema,
+}).strict();
+
+const qualityModelConfigurationSchema = z.object({
+  id: z.string().min(1).max(200),
+  configurationSha256: sha256Schema,
+}).strict();
+
+export const qualityRubricSchema = z.object({
+  id: z.string().min(1).max(200),
+  version: z.string().min(1).max(200),
+  config_digest: qualitySourceDocumentDigestSchema,
+}).strict();
+export type QualityRubric = z.infer<typeof qualityRubricSchema>;
+
+export const qualityVerifierIdentitySchema = z.object({
+  id: z.string().min(1).max(200),
+  version: z.string().min(1).max(200),
+}).strict();
+export type QualityVerifierIdentity = z.infer<typeof qualityVerifierIdentitySchema>;
+
+export const qualityFailureCodeSchema = z.enum([
+  "none",
+  "incorrect-answer",
+  "incomplete-answer",
+  "format-invalid",
+  "instruction-noncompliance",
+  "unsafe-output",
+  "unsupported-claim",
+  "tool-failure",
+  "harness-failure",
+  "infrastructure",
+  "verification-failure",
+  "other",
+]);
+
+export const qualityFailureSchema = z.object({
+  taxonomy: z.object({
+    id: z.string().min(1).max(200),
+    version: z.string().min(1).max(200),
+  }).strict(),
+  code: qualityFailureCodeSchema,
+}).strict();
+export type QualityFailure = z.infer<typeof qualityFailureSchema>;
+
+export const qualityProducingConfigurationSchema = z.object({
+  prompt: qualityConfigurationIdentitySchema.optional(),
+  harness: qualityConfigurationIdentitySchema.optional(),
+  model: qualityModelConfigurationSchema.optional(),
+  toolPolicy: qualityConfigurationIdentitySchema.optional(),
+}).strict().refine(
+  (value) => Object.values(value).some((child) => child !== undefined),
+  "producing configuration must contain at least one identity",
+);
+export type QualityProducingConfiguration = z.infer<
+  typeof qualityProducingConfigurationSchema
+>;
+
+export const qualityCorrectionReferencesSchema = z.object({
+  correctedSuccessor: z.object({
+    taskId: z.string().min(1).max(200),
+    structuredResultSha256: sha256Schema,
+  }).strict().optional(),
+  followUpTaskId: z.string().min(1).max(200).optional(),
+  pullRequestUrl: z.string().url().optional(),
+  replacementCommit: commitSchema.optional(),
+}).strict().refine(
+  (value) => Object.values(value).some((child) => child !== undefined),
+  "correction references must contain at least one reference",
+);
+export type QualityCorrectionReferences = z.infer<
+  typeof qualityCorrectionReferencesSchema
+>;
+
 const qualityReceiptBaseSchema = z.object({
   schemaVersion: z.literal(1),
   receiptId: z.string().regex(/^qr-[0-9a-f]{24}$/),
@@ -64,10 +159,7 @@ const qualityReceiptBaseSchema = z.object({
   ]),
   retriesCount: z.number().int().nonnegative().optional(),
   ratedAt: z.string().datetime(),
-  reviewer: z.object({
-    principal: z.string().min(1).max(200),
-    independence: z.enum(["independent", "self", "unknown"]),
-  }).strict(),
+  reviewer: qualityReviewerSchema,
   bindingAttestation: z.enum(["server-bound", "reviewer-confirmed"]),
   binding: qualityBindingSchema,
 }).strict();
@@ -93,13 +185,126 @@ export const qualityReceiptSchema = qualityReceiptBaseSchema.superRefine((value,
 });
 export type QualityReceipt = z.infer<typeof qualityReceiptSchema>;
 
-export const qualityReceiptLedgerSchema = z.object({
+const qualityCorrectionGroupSchema = z.object({
+  algorithm: z.literal("sha256"),
+  version: z.literal("quality-correction-group-jcs-v1"),
+  digest: sha256Schema,
+}).strict();
+
+const qualityReceiptV2BaseSchema = z.object({
+  schemaVersion: z.literal(2),
+  receiptId: z.string().regex(/^qr-[0-9a-f]{24}$/),
+  taskId: z.string().min(1).max(200),
+  attemptId: z.string().min(1).max(200),
+  correctsReceiptId: z.string().regex(/^qr-[0-9a-f]{24}$/),
+  correctionGroup: qualityCorrectionGroupSchema,
+  rating: z.enum(["pass", "partial", "redo", "wrong"]),
+  ratingReason: z.string().min(1).max(10_000),
+  verificationOutcome: z.enum([
+    "accepted_unchanged",
+    "minor_edit",
+    "major_rewrite",
+    "discarded",
+    "escalated_to_claude",
+  ]),
+  retriesCount: z.number().int().nonnegative().optional(),
+  ratedAt: learningContractTimestampSchema,
+  reviewer: qualityReviewerSchema,
+  rubric: qualityRubricSchema,
+  verifier: qualityVerifierIdentitySchema,
+  failure: qualityFailureSchema,
+  producingConfiguration: qualityProducingConfigurationSchema.optional(),
+  references: qualityCorrectionReferencesSchema.optional(),
+  bindingAttestation: z.enum(["server-bound", "reviewer-confirmed"]),
+  binding: qualityBindingSchema,
+}).strict();
+
+export const qualityReceiptV2Schema = qualityReceiptV2BaseSchema.superRefine(
+  (value, ctx) => {
+    const expectedGroup = qualityCorrectionGroupKey({
+      taskId: value.taskId,
+      attemptId: value.attemptId,
+      reviewerPrincipal: value.reviewer.principal,
+      reviewerIndependence: value.reviewer.independence,
+      rubric: value.rubric,
+      binding: value.binding,
+    });
+    if (value.correctionGroup.digest !== expectedGroup) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["correctionGroup", "digest"],
+        message: `correction group mismatch; expected ${expectedGroup}`,
+      });
+    }
+    if (value.receiptId === value.correctsReceiptId) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["correctsReceiptId"],
+        message: "quality correction cannot name itself as predecessor",
+      });
+    }
+    const expectedId = qualityCorrectionReceiptId({
+      taskId: value.taskId,
+      attemptId: value.attemptId,
+      rating: value.rating,
+      ratingReason: value.ratingReason,
+      verificationOutcome: value.verificationOutcome,
+      retriesCount: value.retriesCount,
+      ratedAt: value.ratedAt,
+      reviewer: value.reviewer,
+      rubric: value.rubric,
+      bindingAttestation: value.bindingAttestation,
+      binding: value.binding,
+      correctsReceiptId: value.correctsReceiptId,
+    });
+    if (value.receiptId !== expectedId) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["receiptId"],
+        message: `receipt identity mismatch; expected ${expectedId}`,
+      });
+    }
+    const fullyAccepted = value.rating === "pass" &&
+      value.verificationOutcome === "accepted_unchanged";
+    if (!fullyAccepted && value.failure.code === "none") {
+      ctx.addIssue({
+        code: "custom",
+        path: ["failure", "code"],
+        message: "a non-accepted correction requires a structured failure code",
+      });
+    }
+    if (fullyAccepted && value.failure.code !== "none") {
+      ctx.addIssue({
+        code: "custom",
+        path: ["failure", "code"],
+        message: "an accepted unchanged correction must use failure code none",
+      });
+    }
+  },
+);
+export type QualityReceiptV2 = z.infer<typeof qualityReceiptV2Schema>;
+export type NativeQualityReceipt = QualityReceipt | QualityReceiptV2;
+
+const qualityReceiptLedgerV1Schema = z.object({
   schemaVersion: z.literal(1),
   taskId: z.string().min(1).max(200),
   receipts: z.array(qualityReceiptSchema).max(1_000),
   legacyFeedback: z.record(z.string(), z.unknown()).optional(),
-}).strict().superRefine((value, ctx) => {
+}).strict();
+
+const qualityReceiptLedgerV2Schema = z.object({
+  schemaVersion: z.literal(2),
+  taskId: z.string().min(1).max(200),
+  receipts: z.array(z.union([qualityReceiptSchema, qualityReceiptV2Schema])).max(1_000),
+  legacyFeedback: z.record(z.string(), z.unknown()).optional(),
+}).strict();
+
+export const qualityReceiptLedgerSchema = z.union([
+  qualityReceiptLedgerV1Schema,
+  qualityReceiptLedgerV2Schema,
+]).superRefine((value, ctx) => {
   const ids = new Set<string>();
+  const successors = new Set<string>();
   value.receipts.forEach((receipt, index) => {
     if (receipt.taskId !== value.taskId) {
       ctx.addIssue({
@@ -116,9 +321,110 @@ export const qualityReceiptLedgerSchema = z.object({
       });
     }
     ids.add(receipt.receiptId);
+    if (receipt.schemaVersion === 2) {
+      if (successors.has(receipt.correctsReceiptId)) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["receipts", index, "correctsReceiptId"],
+          message: "quality correction lineage cannot fork",
+        });
+      }
+      successors.add(receipt.correctsReceiptId);
+    }
+  });
+  value.receipts.forEach((receipt, index) => {
+    if (receipt.schemaVersion !== 2) return;
+    const predecessorIndex = value.receipts.findIndex(
+      (candidate) => candidate.receiptId === receipt.correctsReceiptId,
+    );
+    const predecessor = predecessorIndex >= 0 ? value.receipts[predecessorIndex] : undefined;
+    if (!predecessor) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["receipts", index, "correctsReceiptId"],
+        message: "quality correction predecessor is missing",
+      });
+      return;
+    }
+    if (predecessorIndex >= index) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["receipts", index, "correctsReceiptId"],
+        message: "quality correction predecessor must appear earlier in the immutable ledger",
+      });
+    }
+    if (
+      predecessor.taskId !== receipt.taskId ||
+      predecessor.reviewer.principal !== receipt.reviewer.principal ||
+      predecessor.reviewer.independence !== receipt.reviewer.independence ||
+      !qualityBindingsEqual(predecessor.binding, receipt.binding)
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["receipts", index, "correctsReceiptId"],
+        message: "quality correction predecessor must retain task, reviewer, and binding",
+      });
+    }
+    if (
+      predecessor.schemaVersion === 2 &&
+      (
+        predecessor.attemptId !== receipt.attemptId ||
+        stable(predecessor.rubric) !== stable(receipt.rubric) ||
+        predecessor.correctionGroup.digest !== receipt.correctionGroup.digest
+      )
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["receipts", index, "correctionGroup"],
+        message: "quality correction chain cannot change attempt, rubric, or correction group",
+      });
+    }
+    if (Date.parse(receipt.ratedAt) <= Date.parse(predecessor.ratedAt)) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["receipts", index, "ratedAt"],
+        message: "quality correction clock must advance beyond its predecessor",
+      });
+    }
   });
 });
 export type QualityReceiptLedger = z.infer<typeof qualityReceiptLedgerSchema>;
+
+const qualityReceiptEvidenceV1Schema = z.object({
+  nativeSchemaVersion: z.literal(1),
+  receiptId: z.string().regex(/^qr-[0-9a-f]{24}$/),
+  rating: z.enum(["pass", "partial", "redo", "wrong"]),
+  verificationOutcome: z.enum([
+    "accepted_unchanged",
+    "minor_edit",
+    "major_rewrite",
+    "discarded",
+    "escalated_to_claude",
+  ]),
+  ratingReasonSha256: sha256Schema,
+  ratedAt: z.string().datetime(),
+  reviewer: qualityReviewerSchema,
+}).strict();
+
+const qualityReceiptEvidenceV2Schema = qualityReceiptEvidenceV1Schema.omit({
+  nativeSchemaVersion: true,
+}).extend({
+  nativeSchemaVersion: z.literal(2),
+  attemptId: z.string().min(1).max(200),
+  correctsReceiptId: z.string().regex(/^qr-[0-9a-f]{24}$/),
+  correctionGroup: qualityCorrectionGroupSchema,
+  rubric: qualityRubricSchema,
+  verifier: qualityVerifierIdentitySchema,
+  failure: qualityFailureSchema,
+  producingConfiguration: qualityProducingConfigurationSchema.optional(),
+  references: qualityCorrectionReferencesSchema.optional(),
+}).strict();
+
+export const qualityReceiptEvidenceSchema = z.union([
+  qualityReceiptEvidenceV1Schema,
+  qualityReceiptEvidenceV2Schema,
+]);
+export type QualityReceiptEvidence = z.infer<typeof qualityReceiptEvidenceSchema>;
 
 export const qualitySummarySchema = z.object({
   state: z.enum([
@@ -133,6 +439,7 @@ export const qualitySummarySchema = z.object({
   receiptIds: z.array(z.string()).default([]),
   reviewers: z.array(z.string()).default([]),
   independentAccepted: z.boolean().default(false),
+  effectiveReceipts: z.array(qualityReceiptEvidenceSchema).default([]),
 }).strict();
 export type QualitySummary = z.infer<typeof qualitySummarySchema>;
 
@@ -154,6 +461,43 @@ function stable(value: unknown): string {
 
 export function qualityBindingsEqual(left: QualityBinding, right: QualityBinding): boolean {
   return stable(left) === stable(right);
+}
+
+function normalizedMissingRepositoryField(
+  state: QualityRepositoryBinding["state"],
+  field: "baseBranch" | "baseCommit" | "headCommit" | "diffSha256",
+): { value: null; unknown_reason: "not-applicable" | "not-observed" } {
+  const notApplicable = state === "not-managed" ||
+    (state === "no-changes" && (field === "headCommit" || field === "diffSha256"));
+  return {
+    value: null,
+    unknown_reason: notApplicable ? "not-applicable" : "not-observed",
+  };
+}
+
+/** Exact snake-case binding used by Grimnir's learning-quality-normalized/v2 projection. */
+export function normalizedQualityBinding(binding: QualityBinding) {
+  const repository = binding.repository;
+  return {
+    task_document_sha256: binding.taskDocumentSha256,
+    structured_result_sha256: binding.structuredResultSha256,
+    repository: {
+      state: repository.state,
+      base_branch: repository.baseBranch ??
+        normalizedMissingRepositoryField(repository.state, "baseBranch"),
+      base_commit: repository.baseCommit ??
+        normalizedMissingRepositoryField(repository.state, "baseCommit"),
+      head_commit: repository.headCommit ??
+        normalizedMissingRepositoryField(repository.state, "headCommit"),
+      diff_sha256: repository.diffSha256
+        ? {
+            algorithm: "sha256" as const,
+            version: "git-binary-diff-sha256-v1" as const,
+            digest: repository.diffSha256,
+          }
+        : normalizedMissingRepositoryField(repository.state, "diffSha256"),
+    },
+  };
 }
 
 export function buildQualityBinding(input: {
@@ -236,6 +580,135 @@ export function buildQualityReceipt(input: BuildQualityReceiptInput): QualityRec
   });
 }
 
+export interface BuildQualityCorrectionReceiptInput {
+  taskId: string;
+  attemptId: string;
+  correctsReceiptId: string;
+  reviewerPrincipal: string;
+  reviewerIndependence: "independent" | "self" | "unknown";
+  rating: "pass" | "partial" | "redo" | "wrong";
+  ratingReason: string;
+  verificationOutcome:
+    | "accepted_unchanged"
+    | "minor_edit"
+    | "major_rewrite"
+    | "discarded"
+    | "escalated_to_claude";
+  retriesCount?: number;
+  ratedAt: string;
+  rubric: QualityRubric;
+  verifier: QualityVerifierIdentity;
+  failure: QualityFailure;
+  producingConfiguration?: QualityProducingConfiguration;
+  references?: QualityCorrectionReferences;
+  bindingAttestation: "server-bound" | "reviewer-confirmed";
+  binding: QualityBinding;
+}
+
+function qualityCorrectionGroupKey(input: {
+  taskId: string;
+  attemptId: string;
+  reviewerPrincipal: string;
+  reviewerIndependence: "independent" | "self" | "unknown";
+  rubric: QualityRubric;
+  binding: QualityBinding;
+}): string {
+  return sha256(canonicalizeJcs({
+    task_id: input.taskId,
+    attempt_id: input.attemptId,
+    reviewer: {
+      principal: input.reviewerPrincipal,
+      independence: input.reviewerIndependence,
+    },
+    rubric: input.rubric,
+    binding: normalizedQualityBinding(input.binding),
+  }));
+}
+
+interface QualityCorrectionReceiptIdentityPayload {
+  taskId: string;
+  attemptId: string;
+  rating: BuildQualityCorrectionReceiptInput["rating"];
+  ratingReason: string;
+  verificationOutcome: BuildQualityCorrectionReceiptInput["verificationOutcome"];
+  retriesCount?: number;
+  ratedAt: string;
+  reviewer: {
+    principal: string;
+    independence: BuildQualityCorrectionReceiptInput["reviewerIndependence"];
+  };
+  rubric: QualityRubric;
+  bindingAttestation: BuildQualityCorrectionReceiptInput["bindingAttestation"];
+  binding: QualityBinding;
+  correctsReceiptId: string;
+}
+
+/** Exact future-native-v2 identity body accepted by Grimnir #86. */
+function qualityCorrectionReceiptId(
+  input: QualityCorrectionReceiptIdentityPayload,
+): string {
+  return `qr-${sha256(canonicalizeJcs(input)).slice(0, 24)}`;
+}
+
+export function buildQualityCorrectionReceipt(
+  input: BuildQualityCorrectionReceiptInput,
+): QualityReceiptV2 {
+  const identityPayload: QualityCorrectionReceiptIdentityPayload = {
+    taskId: input.taskId,
+    attemptId: input.attemptId,
+    rating: input.rating,
+    ratingReason: input.ratingReason,
+    verificationOutcome: input.verificationOutcome,
+    retriesCount: input.retriesCount,
+    ratedAt: input.ratedAt,
+    reviewer: {
+      principal: input.reviewerPrincipal,
+      independence: input.reviewerIndependence,
+    },
+    rubric: input.rubric,
+    bindingAttestation: input.bindingAttestation,
+    binding: input.binding,
+    correctsReceiptId: input.correctsReceiptId,
+  };
+  return qualityReceiptV2Schema.parse({
+    schemaVersion: 2,
+    receiptId: qualityCorrectionReceiptId(identityPayload),
+    taskId: input.taskId,
+    attemptId: input.attemptId,
+    correctsReceiptId: input.correctsReceiptId,
+    correctionGroup: {
+      algorithm: "sha256",
+      version: "quality-correction-group-jcs-v1",
+      digest: qualityCorrectionGroupKey({
+        taskId: input.taskId,
+        attemptId: input.attemptId,
+        reviewerPrincipal: input.reviewerPrincipal,
+        reviewerIndependence: input.reviewerIndependence,
+        rubric: input.rubric,
+        binding: input.binding,
+      }),
+    },
+    rating: input.rating,
+    ratingReason: input.ratingReason,
+    verificationOutcome: input.verificationOutcome,
+    ...(input.retriesCount !== undefined ? { retriesCount: input.retriesCount } : {}),
+    ratedAt: input.ratedAt,
+    reviewer: {
+      principal: input.reviewerPrincipal,
+      independence: input.reviewerIndependence,
+    },
+    rubric: input.rubric,
+    verifier: input.verifier,
+    failure: input.failure,
+    ...(input.producingConfiguration
+      ? { producingConfiguration: input.producingConfiguration }
+      : {}),
+    ...(input.references ? { references: input.references } : {}),
+    bindingAttestation: input.bindingAttestation,
+    binding: input.binding,
+  });
+}
+
 export class QualityReceiptConflictError extends Error {
   constructor(message: string) {
     super(message);
@@ -252,7 +725,7 @@ export class QualityReceiptInvalidLedgerError extends Error {
 
 export function foldQualityReceipt(
   current: QualityReceiptLedger | Record<string, unknown> | null,
-  next: QualityReceipt,
+  next: NativeQualityReceipt,
 ): { ledger: QualityReceiptLedger; changed: boolean } {
   let ledger: QualityReceiptLedger;
   const parsed = qualityReceiptLedgerSchema.safeParse(current);
@@ -261,11 +734,17 @@ export function foldQualityReceipt(
   } else if (current && typeof current === "object" && !Array.isArray(current)) {
     if (
       current.schemaVersion === 1 ||
+      current.schemaVersion === 2 ||
       Object.hasOwn(current, "taskId") ||
       Object.hasOwn(current, "receipts")
     ) {
       throw new QualityReceiptInvalidLedgerError(
-        "stored schema-v1 quality receipt ledger is invalid",
+        "stored quality receipt ledger is invalid",
+      );
+    }
+    if (next.schemaVersion === 2) {
+      throw new QualityReceiptConflictError(
+        "quality correction predecessor is missing",
       );
     }
     ledger = qualityReceiptLedgerSchema.parse({
@@ -275,6 +754,11 @@ export function foldQualityReceipt(
       legacyFeedback: current,
     });
   } else {
+    if (next.schemaVersion === 2) {
+      throw new QualityReceiptConflictError(
+        "quality correction predecessor is missing",
+      );
+    }
     ledger = qualityReceiptLedgerSchema.parse({
       schemaVersion: 1,
       taskId: next.taskId,
@@ -284,22 +768,82 @@ export function foldQualityReceipt(
   if (ledger.taskId !== next.taskId) {
     throw new QualityReceiptConflictError("quality receipt task does not match the ledger");
   }
-  if (ledger.receipts.some((receipt) => receipt.receiptId === next.receiptId)) {
+  const replayedReceipt = ledger.receipts.find(
+    (receipt) => receipt.receiptId === next.receiptId,
+  );
+  if (replayedReceipt) {
+    if (
+      (replayedReceipt.schemaVersion === 2 || next.schemaVersion === 2) &&
+      canonicalizeJcs(replayedReceipt) !== canonicalizeJcs(next)
+    ) {
+      throw new QualityReceiptConflictError(
+        `quality receipt identity collision for ${next.receiptId}: canonical artifacts differ`,
+      );
+    }
     return { ledger, changed: false };
   }
-  const priorVerdict = ledger.receipts.find(
-    (receipt) =>
-      receipt.reviewer.principal === next.reviewer.principal &&
-      qualityBindingsEqual(receipt.binding, next.binding),
-  );
-  if (priorVerdict) {
-    throw new QualityReceiptConflictError(
-      `reviewer ${next.reviewer.principal} already rated this exact result`,
+  if (next.schemaVersion === 1) {
+    const priorVerdict = ledger.receipts.find(
+      (receipt) =>
+        receipt.reviewer.principal === next.reviewer.principal &&
+        qualityBindingsEqual(receipt.binding, next.binding),
     );
+    if (priorVerdict) {
+      throw new QualityReceiptConflictError(
+        `reviewer ${next.reviewer.principal} already rated this exact result`,
+      );
+    }
+  } else {
+    const predecessor = ledger.receipts.find(
+      (receipt) => receipt.receiptId === next.correctsReceiptId,
+    );
+    if (!predecessor) {
+      throw new QualityReceiptConflictError(
+        `quality correction predecessor ${next.correctsReceiptId} is missing`,
+      );
+    }
+    if (
+      predecessor.taskId !== next.taskId ||
+      predecessor.reviewer.principal !== next.reviewer.principal ||
+      predecessor.reviewer.independence !== next.reviewer.independence ||
+      !qualityBindingsEqual(predecessor.binding, next.binding)
+    ) {
+      throw new QualityReceiptConflictError(
+        "quality correction predecessor must retain task, reviewer, and binding",
+      );
+    }
+    if (ledger.receipts.some(
+      (receipt) =>
+        receipt.schemaVersion === 2 &&
+        receipt.correctsReceiptId === next.correctsReceiptId,
+    )) {
+      throw new QualityReceiptConflictError(
+        `quality correction predecessor ${next.correctsReceiptId} already has a successor`,
+      );
+    }
+    if (
+      predecessor.schemaVersion === 2 &&
+      (
+        predecessor.attemptId !== next.attemptId ||
+        stable(predecessor.rubric) !== stable(next.rubric) ||
+        predecessor.correctionGroup.digest !== next.correctionGroup.digest
+      )
+    ) {
+      throw new QualityReceiptConflictError(
+        "quality correction chain cannot change attempt, rubric, or correction group",
+      );
+    }
+    if (Date.parse(next.ratedAt) <= Date.parse(predecessor.ratedAt)) {
+      throw new QualityReceiptConflictError(
+        "quality correction clock must advance beyond its predecessor",
+      );
+    }
   }
+  const schemaVersion = ledger.schemaVersion === 2 || next.schemaVersion === 2 ? 2 : 1;
   return {
     ledger: qualityReceiptLedgerSchema.parse({
       ...ledger,
+      schemaVersion,
       receipts: [...ledger.receipts, next],
     }),
     changed: true,
@@ -330,7 +874,12 @@ export function summarizeQualityReceipts(
       state: ledger.data.legacyFeedback ? "legacy-unbound" : "invalid",
     });
   }
-  const verdicts = receipts.map((receipt) => {
+  const superseded = new Set(
+    receipts.flatMap((receipt) =>
+      receipt.schemaVersion === 2 ? [receipt.correctsReceiptId] : []),
+  );
+  const effective = receipts.filter((receipt) => !superseded.has(receipt.receiptId));
+  const verdicts = effective.map((receipt) => {
     if (
       receipt.rating === "wrong" ||
       receipt.rating === "redo" ||
@@ -342,15 +891,54 @@ export function summarizeQualityReceipts(
     ) return "accepted" as const;
     return "partial" as const;
   });
-  const distinct = new Set(verdicts);
-  const state = distinct.size === 1 ? verdicts[0]! : "conflicted";
+  const fullVerdicts = new Set(
+    effective.map((receipt) => `${receipt.rating}\0${receipt.verificationOutcome}`),
+  );
+  const rubricCohorts = new Set(
+    effective.map((receipt) => receipt.schemaVersion === 1
+      ? "native-v1-unversioned"
+      : stable(receipt.rubric)),
+  );
+  // Multiple rubric cohorts are incomparable under LearningTaskContract v1.
+  // Fail closed even when their verdicts agree; this is not evidence that the
+  // reviewers themselves disagreed.
+  const state = fullVerdicts.size === 1 && rubricCohorts.size === 1
+    ? verdicts[0]!
+    : "conflicted";
   return qualitySummarySchema.parse({
     state,
-    receiptIds: receipts.map((receipt) => receipt.receiptId),
-    reviewers: [...new Set(receipts.map((receipt) => receipt.reviewer.principal))].sort(),
+    receiptIds: effective.map((receipt) => receipt.receiptId),
+    reviewers: [...new Set(effective.map((receipt) => receipt.reviewer.principal))].sort(),
     independentAccepted:
-      state === "accepted" && receipts.some(
+      state === "accepted" && effective.some(
         (receipt) => receipt.reviewer.independence === "independent",
       ),
+    effectiveReceipts: effective.map((receipt): QualityReceiptEvidence => {
+      const common = {
+        nativeSchemaVersion: receipt.schemaVersion,
+        receiptId: receipt.receiptId,
+        rating: receipt.rating,
+        verificationOutcome: receipt.verificationOutcome,
+        ratingReasonSha256: sha256(receipt.ratingReason),
+        ratedAt: receipt.ratedAt,
+        reviewer: receipt.reviewer,
+      };
+      if (receipt.schemaVersion === 1) {
+        return qualityReceiptEvidenceSchema.parse(common);
+      }
+      return qualityReceiptEvidenceSchema.parse({
+        ...common,
+        attemptId: receipt.attemptId,
+        correctsReceiptId: receipt.correctsReceiptId,
+        correctionGroup: receipt.correctionGroup,
+        rubric: receipt.rubric,
+        verifier: receipt.verifier,
+        failure: receipt.failure,
+        ...(receipt.producingConfiguration
+          ? { producingConfiguration: receipt.producingConfiguration }
+          : {}),
+        ...(receipt.references ? { references: receipt.references } : {}),
+      });
+    }),
   });
 }

--- a/tests/broker/handlers.test.ts
+++ b/tests/broker/handlers.test.ts
@@ -35,6 +35,7 @@ class FakeMunin {
     tags?: string[],
     _expectedUpdatedAt?: string,
     classification?: string,
+    createIfAbsent?: boolean,
   ): Promise<Record<string, unknown>> {
     this.writes.push({ namespace, key, content, tags, classification });
     this.reads[`${namespace}/${key}`] = {
@@ -43,7 +44,7 @@ class FakeMunin {
       created_at: "2026-07-11T12:00:00.000Z",
       updated_at: "2026-07-11T12:00:00.000Z",
     };
-    return { ok: true };
+    return { ok: true, status: createIfAbsent ? "created" : "updated" };
   }
   async read(namespace: string, key: string): Promise<unknown> {
     return this.reads[`${namespace}/${key}`] ?? null;
@@ -925,6 +926,145 @@ describe("POST /v1/delegate/rate", () => {
     });
     expect(conflict.status).toBe(409);
     expect(harness.munin.writes.filter((write) => write.key === "feedback")).toHaveLength(1);
+  });
+
+  it("fails closed instead of fabricating a task id as native-v2 attempt identity", async () => {
+    harness.munin.reads["tasks/general-correction/status"] = {
+      content: "## Task: correction\n\n### Prompt\nFix it.",
+      tags: ["completed", "runtime:codex"],
+      created_at: "ts",
+      updated_at: "ts",
+    };
+    harness.munin.reads["tasks/general-correction/result-structured"] = {
+      content: structuredTaskResultContent("general-correction"),
+      tags: ["type:task-result-structured"],
+      created_at: "ts",
+      updated_at: "ts",
+    };
+    const initial = {
+      task_id: "general-correction",
+      rating: "pass",
+      rating_reason: "Initially accepted.",
+      verification_outcome: "accepted_unchanged",
+      reviewer_role: "independent",
+    };
+    expect((await fetch(`${harness.url}/v1/delegate/rate`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify(initial),
+    })).status).toBe(204);
+    const firstLedger = JSON.parse(harness.munin.writes.at(-1)!.content);
+    const predecessor = firstLedger.receipts[0];
+    // Make the immutable lineage clock deterministic rather than relying on
+    // two loopback HTTP requests landing in different milliseconds.
+    predecessor.ratedAt = "2026-07-18T10:00:00.000Z";
+    (harness.munin.reads["tasks/general-correction/feedback"] as { content: string }).content =
+      JSON.stringify(firstLedger);
+
+    const correctionPayload = {
+      ...initial,
+      rating: "wrong",
+      rating_reason: "Unicode regression remained.",
+      verification_outcome: "discarded",
+      correction: {
+        predecessor_receipt_id: predecessor.receiptId,
+        rubric: {
+          id: "code-review",
+          version: "2.1.0",
+          config_digest: {
+            algorithm: "sha256",
+            canonicalization: "jcs-rfc8785-utf8-v1",
+            source_ref: "source-doc:rubric/code-review-2.1.0",
+            source_type: "rubric-config",
+            source_version: "rubric-source-2.1.0",
+            digest: "d".repeat(64),
+          },
+        },
+        verifier: { id: "claude-opus", version: "2026-07-19" },
+        failure: {
+          taxonomy: { id: "hugin-quality-failure", version: "1" },
+          code: "incorrect-answer",
+        },
+        producing_configuration: {
+          harness: { id: "codex", version: "1", sha256: "e".repeat(64) },
+          model: { id: "gpt-5", configuration_sha256: "f".repeat(64) },
+        },
+        references: {
+          corrected_successor: {
+            task_id: "general-correction-fix",
+            structured_result_sha256: "1".repeat(64),
+          },
+          pull_request_url: "https://github.com/Magnus-Gille/demo/pull/2",
+          replacement_commit: "2".repeat(40),
+        },
+      },
+    };
+    const correctionResponse = await fetch(`${harness.url}/v1/delegate/rate`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify(correctionPayload),
+    });
+    expect(correctionResponse.status).toBe(409);
+    expect(await correctionResponse.json()).toMatchObject({
+      error: "policy_rejected",
+      message: expect.stringContaining("authoritative execution attempt"),
+    });
+    expect(harness.munin.writes.filter((write) => write.key === "feedback")).toHaveLength(1);
+    expect(JSON.parse(
+      (harness.munin.reads["tasks/general-correction/feedback"] as { content: string }).content,
+    )).toEqual(firstLedger);
+  });
+
+  it("enforces failure code none iff a v2 correction is accepted unchanged", async () => {
+    const correction = {
+      predecessor_receipt_id: "qr-" + "a".repeat(24),
+      rubric: {
+        id: "code-review",
+        version: "2",
+        config_digest: {
+          algorithm: "sha256",
+          canonicalization: "jcs-rfc8785-utf8-v1",
+          source_ref: "source-doc:rubric/code-review-2",
+          source_type: "rubric-config",
+          source_version: "rubric-source-2",
+          digest: "b".repeat(64),
+        },
+      },
+      verifier: { id: "claude-opus", version: "2026-07-19" },
+      failure: {
+        taxonomy: { id: "hugin-quality-failure", version: "1" },
+        code: "none",
+      },
+    };
+    const missingFailure = await fetch(`${harness.url}/v1/delegate/rate`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify({
+        task_id: "missing-is-not-reached",
+        rating: "wrong",
+        rating_reason: "Bad output.",
+        verification_outcome: "discarded",
+        correction,
+      }),
+    });
+
+    expect(missingFailure.status).toBe(400);
+    const contradictoryFailure = await fetch(`${harness.url}/v1/delegate/rate`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify({
+        task_id: "missing-is-not-reached",
+        rating: "pass",
+        rating_reason: "Accepted output.",
+        verification_outcome: "accepted_unchanged",
+        correction: {
+          ...correction,
+          failure: { ...correction.failure, code: "verification-failure" },
+        },
+      }),
+    });
+    expect(contradictoryFailure.status).toBe(400);
+    expect(harness.munin.writes).toHaveLength(0);
   });
 
   it("returns 404 if task not found", async () => {

--- a/tests/broker/task-store.test.ts
+++ b/tests/broker/task-store.test.ts
@@ -10,8 +10,12 @@ import {
   parseCanonicalEnvelope,
   serializeEnvelope,
 } from "../../src/broker/task-store.js";
-import type { MuninClient } from "../../src/munin-client.js";
+import { MuninWriteRejectedError, type MuninClient } from "../../src/munin-client.js";
 import type { DelegationEnvelope } from "../../src/broker/types.js";
+import {
+  buildQualityBinding,
+  buildQualityReceipt,
+} from "../../src/quality-receipt.js";
 
 interface WriteCall {
   namespace: string;
@@ -20,6 +24,7 @@ interface WriteCall {
   tags?: string[];
   expectedUpdatedAt?: string;
   classification?: string;
+  createIfAbsent?: boolean;
 }
 
 class FakeMunin {
@@ -43,9 +48,18 @@ class FakeMunin {
     tags?: string[],
     expectedUpdatedAt?: string,
     classification?: string,
+    createIfAbsent?: boolean,
   ): Promise<Record<string, unknown>> {
-    this.writes.push({ namespace, key, content, tags, expectedUpdatedAt, classification });
-    return { ok: true };
+    this.writes.push({
+      namespace,
+      key,
+      content,
+      tags,
+      expectedUpdatedAt,
+      classification,
+      createIfAbsent,
+    });
+    return { ok: true, status: createIfAbsent ? "created" : "updated" };
   }
   async read(namespace: string, key: string): Promise<unknown> {
     this.reads.push({ namespace, key });
@@ -596,5 +610,183 @@ describe("BrokerTaskStore.recordAwait — durable-handoff evidence (#164)", () =
 
     // Five polls, ONE write: only the first carried new evidence.
     expect(munin.writes.filter((w) => w.key === "await-observation")).toHaveLength(1);
+  });
+});
+
+describe("BrokerTaskStore.writeQualityReceipt — concurrent append safety (#231)", () => {
+  function qualityReceipt(reviewerPrincipal: string) {
+    return buildQualityReceipt({
+      taskId: "t1",
+      reviewerPrincipal,
+      reviewerIndependence: "independent",
+      rating: "pass",
+      ratingReason: `Reviewed by ${reviewerPrincipal}`,
+      verificationOutcome: "accepted_unchanged",
+      ratedAt: "2026-07-19T10:00:00.000Z",
+      bindingAttestation: "server-bound",
+      binding: buildQualityBinding({
+        statusContent: ENVELOPE_CONTENT,
+        structuredResultContent: JSON.stringify({ task_id: "t1", result_schema_version: 1 }),
+      }),
+    });
+  }
+
+  const ENVELOPE_CONTENT = `## Task\n\n### Broker envelope\n\`\`\`json\n${JSON.stringify({
+    envelope_version: 2,
+    orchestrator_submitter: "claude-code",
+    orchestrator_session_id: "session-A",
+    sensitivity: "internal",
+  })}\n\`\`\`\n`;
+
+  function concurrentMunin() {
+    const entries: Record<string, { content: string; updated_at: string }> = {
+      "tasks/t1/status": { content: ENVELOPE_CONTENT, updated_at: "s1" },
+    };
+    let feedbackReads = 0;
+    let releaseFirstReads!: () => void;
+    const firstReadsReady = new Promise<void>((resolve) => { releaseFirstReads = resolve; });
+    let version = 0;
+    const writes: WriteCall[] = [];
+    return {
+      entries,
+      writes,
+      read: async (namespace: string, key: string) => {
+        if (key === "feedback" && feedbackReads < 2) {
+          feedbackReads += 1;
+          if (feedbackReads === 2) releaseFirstReads();
+          await firstReadsReady;
+          return null;
+        }
+        return entries[`${namespace}/${key}`] ?? null;
+      },
+      write: async (
+        namespace: string,
+        key: string,
+        content: string,
+        tags?: string[],
+        expectedUpdatedAt?: string,
+        classification?: string,
+        createIfAbsent?: boolean,
+      ) => {
+        const storageKey = `${namespace}/${key}`;
+        const existing = entries[storageKey];
+        if (createIfAbsent && existing) {
+          throw new MuninWriteRejectedError(namespace, key, {
+            error: "conflict",
+            message: "Entry already exists.",
+            conflict_reason: "already_exists",
+            current_updated_at: existing.updated_at,
+          });
+        }
+        if (expectedUpdatedAt && existing && existing.updated_at !== expectedUpdatedAt) {
+          throw new MuninWriteRejectedError(namespace, key, {
+            error: "conflict",
+            message: "Entry version changed.",
+            conflict_reason: "version_mismatch",
+            current_updated_at: existing.updated_at,
+          });
+        }
+        version += 1;
+        writes.push({
+          namespace,
+          key,
+          content,
+          tags,
+          expectedUpdatedAt,
+          classification,
+          createIfAbsent,
+        });
+        entries[storageKey] = { content, updated_at: `v${version}` };
+        return {
+          ok: true,
+          status: createIfAbsent ? "created" : "updated",
+          updated_at: `v${version}`,
+        };
+      },
+    };
+  }
+
+  it("cannot lose either of two simultaneous first reviewers", async () => {
+    const munin = concurrentMunin();
+    const store = new BrokerTaskStore(munin as unknown as MuninClient);
+
+    await Promise.all([
+      store.writeQualityReceipt("t1", qualityReceipt("reviewer-a")),
+      store.writeQualityReceipt("t1", qualityReceipt("reviewer-b")),
+    ]);
+
+    const ledger = JSON.parse(munin.entries["tasks/t1/feedback"]!.content) as {
+      receipts: Array<{ reviewer: { principal: string } }>;
+    };
+    expect(ledger.receipts.map((item) => item.reviewer.principal).sort()).toEqual([
+      "reviewer-a",
+      "reviewer-b",
+    ]);
+    expect(munin.writes[0]!.createIfAbsent).toBe(true);
+    expect(munin.writes[0]!.expectedUpdatedAt).toBeUndefined();
+    const reconciliation = munin.writes.find((write) => write.expectedUpdatedAt === "v1");
+    expect(reconciliation).toBeDefined();
+    expect(reconciliation!.createIfAbsent).toBeUndefined();
+  });
+
+  it("makes an identical retry idempotent after the create CAS loses", async () => {
+    const munin = concurrentMunin();
+    const store = new BrokerTaskStore(munin as unknown as MuninClient);
+    const next = qualityReceipt("reviewer-a");
+
+    const results = await Promise.all([
+      store.writeQualityReceipt("t1", next),
+      store.writeQualityReceipt("t1", next),
+    ]);
+
+    expect(results.map((result) => result.changed).sort()).toEqual([false, true]);
+    const ledger = JSON.parse(munin.entries["tasks/t1/feedback"]!.content) as { receipts: unknown[] };
+    expect(ledger.receipts).toHaveLength(1);
+  });
+
+  it("fails closed on a typed conflict that does not match the attempted write mode", async () => {
+    let feedbackReads = 0;
+    const munin = {
+      read: async (namespace: string, key: string) => {
+        if (key === "status") {
+          return { content: ENVELOPE_CONTENT, updated_at: "s1", classification: "internal" };
+        }
+        feedbackReads += 1;
+        return null;
+      },
+      write: async (namespace: string, key: string) => {
+        throw new MuninWriteRejectedError(namespace, key, {
+          error: "conflict",
+          message: "Unexpected version conflict for an absent-key create.",
+          conflict_reason: "version_mismatch",
+          current_updated_at: "v1",
+        });
+      },
+    };
+    const store = new BrokerTaskStore(munin as unknown as MuninClient);
+
+    await expect(
+      store.writeQualityReceipt("t1", qualityReceipt("reviewer-a")),
+    ).rejects.toMatchObject({
+      errorCode: "conflict",
+      conflictReason: "version_mismatch",
+    });
+    expect(feedbackReads).toBe(1);
+  });
+
+  it("fails closed when Munin does not confirm an atomic first create", async () => {
+    const munin = {
+      read: async (_namespace: string, key: string) => key === "status"
+        ? { content: ENVELOPE_CONTENT, updated_at: "s1", classification: "internal" }
+        : null,
+      write: async () => ({ ok: true, status: "updated" }),
+    };
+    const store = new BrokerTaskStore(munin as unknown as MuninClient);
+
+    await expect(
+      store.writeQualityReceipt("t1", qualityReceipt("reviewer-a")),
+    ).rejects.toThrow(
+      "Munin create_if_absent did not return status created; refusing to trust first-write atomicity",
+    );
   });
 });

--- a/tests/daily-task-exam-factory.test.ts
+++ b/tests/daily-task-exam-factory.test.ts
@@ -14,6 +14,7 @@ import {
 import { buildStructuredTaskResult } from "../src/task-result-schema.js";
 import {
   buildQualityBinding,
+  buildQualityCorrectionReceipt,
   buildQualityReceipt,
   foldQualityReceipt,
 } from "../src/quality-receipt.js";
@@ -226,6 +227,72 @@ describe("daily task exam factory", () => {
     expect(candidate.lane).toBe("quarantine");
     expect(candidate.readiness).toBe("quarantined");
     expect(candidate.reasons).toContain("quality-receipt-rejected");
+  });
+
+  it("preserves actionable v2 correction provenance in content-blind harvested quality", () => {
+    const correctedSource = addQualityReceipt(source("claude"));
+    const firstLedger = JSON.parse(correctedSource.feedback!.content);
+    const predecessor = firstLedger.receipts[0];
+    const correction = buildQualityCorrectionReceipt({
+      taskId: "daily-1",
+      attemptId: "daily-1",
+      correctsReceiptId: predecessor.receiptId,
+      reviewerPrincipal: predecessor.reviewer.principal,
+      reviewerIndependence: predecessor.reviewer.independence,
+      rating: "wrong",
+      ratingReason: "The delivered parser still mishandles decomposed Unicode.",
+      verificationOutcome: "discarded",
+      ratedAt: "2026-07-14T12:00:00.000Z",
+      bindingAttestation: predecessor.bindingAttestation,
+      binding: predecessor.binding,
+      rubric: {
+        id: "parser-review",
+        version: "2",
+        config_digest: {
+          algorithm: "sha256",
+          canonicalization: "jcs-rfc8785-utf8-v1",
+          source_ref: "source-doc:rubric/parser-review-2",
+          source_type: "rubric-config",
+          source_version: "rubric-source-2",
+          digest: "d".repeat(64),
+        },
+      },
+      verifier: { id: "claude-opus", version: "2026-07-19" },
+      failure: {
+        taxonomy: { id: "hugin-quality-failure", version: "1" },
+        code: "incorrect-answer",
+      },
+      producingConfiguration: {
+        harness: { id: "claude-code", version: "1", sha256: "e".repeat(64) },
+      },
+      references: {
+        correctedSuccessor: {
+          taskId: "daily-1-fix",
+          structuredResultSha256: "f".repeat(64),
+        },
+      },
+    });
+    correctedSource.feedback!.content = JSON.stringify(
+      foldQualityReceipt(firstLedger, correction).ledger,
+    );
+
+    const candidate = buildDailyExamCandidate(correctedSource);
+    expect(candidate.quality).toMatchObject({
+      state: "rejected",
+      receiptIds: [correction.receiptId],
+      effectiveReceipts: [{
+        nativeSchemaVersion: 2,
+        rubric: correction.rubric,
+        verifier: correction.verifier,
+        failure: correction.failure,
+        producingConfiguration: correction.producingConfiguration,
+        references: correction.references,
+      }],
+    });
+    const serialized = JSON.stringify(candidate);
+    expect(serialized).not.toContain(correction.ratingReason);
+    expect(serialized).toContain("parser-review");
+    expect(serialized).toContain("daily-1-fix");
   });
 
   it("quarantines historical tasks without exact repository evidence", () => {

--- a/tests/fixtures/grimnir-quality-v2-contract.json
+++ b/tests/fixtures/grimnir-quality-v2-contract.json
@@ -1,0 +1,56 @@
+{
+  "$comment": "Vendored executable fixture from grimnir#86 tests/fixtures/learning-task-contract/positive.json and tests/scripts/validate-learning-task-contract.mjs. The expected receipt id and correction-group digest are produced by Grimnir's independent native-v2/JCS validator construction.",
+  "contract_source": {
+    "repository": "Magnus-Gille/grimnir",
+    "issue": 86,
+    "schema": "docs/learning-task-contract-v1.schema.json#/$defs/qualityReceipt",
+    "validator": "tests/scripts/validate-learning-task-contract.mjs"
+  },
+  "predecessor_receipt_id": "qr-cfb94bcb44ec647526263aef",
+  "expected_receipt_id": "qr-c47ee672b5044013ae90e948",
+  "rated_at": "2026-07-19T10:02:01Z",
+  "verifier": {
+    "id": "claude-opus",
+    "version": "2026-07-19"
+  },
+  "normalized_group_payload": {
+    "task_id": "task-001",
+    "attempt_id": "attempt-1",
+    "reviewer": {
+      "principal": "principal:reviewer-1",
+      "independence": "independent"
+    },
+    "rubric": {
+      "id": "quality-rubric",
+      "version": "v1",
+      "config_digest": {
+        "algorithm": "sha256",
+        "canonicalization": "jcs-rfc8785-utf8-v1",
+        "source_ref": "source-doc:rubric/quality-v1",
+        "source_type": "rubric-config",
+        "source_version": "rubric-source-v1",
+        "digest": "2e1a3ff4b58995e03aedcc3e4fca9f73db9e0bb8ccf8db12458129b1932d081d"
+      }
+    },
+    "binding": {
+      "task_document_sha256": "247b64d04a2308dc9ab56109ef4fc3e7e3c4da091361c6fbe8ef18710ddf1540",
+      "structured_result_sha256": "3cb419ee88b4ded261d747a05745c7c2a8161bb98a048fe761cd3419fd8e9af1",
+      "repository": {
+        "state": "changes-present",
+        "base_branch": "main",
+        "base_commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "head_commit": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "diff_sha256": {
+          "algorithm": "sha256",
+          "version": "git-binary-diff-sha256-v1",
+          "digest": "8888888888888888888888888888888888888888888888888888888888888888"
+        }
+      }
+    }
+  },
+  "expected_correction_group": {
+    "algorithm": "sha256",
+    "version": "quality-correction-group-jcs-v1",
+    "digest": "d7810217367d212f713e5362fbf6b234e7438d8adb7a77b9a35236b2e7a40f29"
+  }
+}

--- a/tests/grimnir-quality-v2-contract.test.ts
+++ b/tests/grimnir-quality-v2-contract.test.ts
@@ -1,0 +1,108 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import {
+  buildQualityCorrectionReceipt,
+  normalizedQualityBinding,
+} from "../src/quality-receipt.js";
+
+interface GrimnirQualityFixture {
+  predecessor_receipt_id: string;
+  expected_receipt_id: string;
+  rated_at: string;
+  verifier: { id: string; version: string };
+  normalized_group_payload: {
+    task_id: string;
+    attempt_id: string;
+    reviewer: {
+      principal: string;
+      independence: "independent" | "self" | "unknown";
+    };
+    rubric: {
+      id: string;
+      version: string;
+      config_digest: {
+        algorithm: "sha256";
+        canonicalization: "jcs-rfc8785-utf8-v1";
+        source_ref: string;
+        source_type: "rubric-config";
+        source_version: string;
+        digest: string;
+      };
+    };
+    binding: {
+      task_document_sha256: string;
+      structured_result_sha256: string;
+      repository: {
+        state: "changes-present";
+        base_branch: string;
+        base_commit: string;
+        head_commit: string;
+        diff_sha256: {
+          algorithm: "sha256";
+          version: "git-binary-diff-sha256-v1";
+          digest: string;
+        };
+      };
+    };
+  };
+  expected_correction_group: {
+    algorithm: "sha256";
+    version: "quality-correction-group-jcs-v1";
+    digest: string;
+  };
+}
+
+const fixture = JSON.parse(readFileSync(
+  new URL("./fixtures/grimnir-quality-v2-contract.json", import.meta.url),
+  "utf8",
+)) as GrimnirQualityFixture;
+
+describe("Grimnir learning contract — native Hugin v2 bridge", () => {
+  it("matches the accepted normalized rubric, binding, and correction-group digest", () => {
+    const expected = fixture.normalized_group_payload;
+    const receipt = buildQualityCorrectionReceipt({
+      taskId: expected.task_id,
+      attemptId: expected.attempt_id,
+      correctsReceiptId: fixture.predecessor_receipt_id,
+      reviewerPrincipal: expected.reviewer.principal,
+      reviewerIndependence: expected.reviewer.independence,
+      rating: "pass",
+      ratingReason: "Fixture correction accepted unchanged.",
+      verificationOutcome: "accepted_unchanged",
+      ratedAt: fixture.rated_at,
+      rubric: expected.rubric,
+      verifier: fixture.verifier,
+      failure: {
+        taxonomy: { id: "hugin-quality-failure", version: "1" },
+        code: "none",
+      },
+      bindingAttestation: "server-bound",
+      binding: {
+        taskDocumentSha256: expected.binding.task_document_sha256,
+        structuredResultSha256: expected.binding.structured_result_sha256,
+        repository: {
+          state: expected.binding.repository.state,
+          baseBranch: expected.binding.repository.base_branch,
+          baseCommit: expected.binding.repository.base_commit,
+          headCommit: expected.binding.repository.head_commit,
+          diffSha256: expected.binding.repository.diff_sha256.digest,
+        },
+      },
+    });
+
+    expect(receipt.rubric).toEqual(expected.rubric);
+    expect(Object.keys(receipt.rubric).sort()).toEqual(["config_digest", "id", "version"]);
+    expect(normalizedQualityBinding(receipt.binding)).toEqual(expected.binding);
+    expect({
+      task_id: receipt.taskId,
+      attempt_id: receipt.attemptId,
+      reviewer: receipt.reviewer,
+      rubric: receipt.rubric,
+      binding: normalizedQualityBinding(receipt.binding),
+    }).toEqual(expected);
+    expect(receipt.correctionGroup).toEqual(fixture.expected_correction_group);
+    expect(receipt.receiptId).toBe(fixture.expected_receipt_id);
+    expect(receipt.verifier).toEqual(fixture.verifier);
+    expect(receipt.rubric).not.toHaveProperty("verifier");
+  });
+});

--- a/tests/jcs.test.ts
+++ b/tests/jcs.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { canonicalizeJcs } from "../src/jcs.js";
+
+describe("canonicalizeJcs", () => {
+  it("matches the RFC 8785 section 3.2.2 sample", () => {
+    expect(canonicalizeJcs({
+      numbers: [333333333.33333329, 1e30, 4.50, 2e-3, 1e-27],
+      string: "€$\u000f\nA'B\"\\\"/",
+      literals: [null, true, false],
+    })).toBe(
+      "{\"literals\":[null,true,false],\"numbers\":[333333333.3333333,1e+30,4.5,0.002,1e-27],\"string\":\"€$\\u000f\\nA'B\\\"\\\\\\\"/\"}",
+    );
+  });
+
+  it("uses RFC 8785 UTF-16 property ordering independent of insertion order", () => {
+    const value = {
+      "\ue000": 1,
+      "😀": 2,
+      "€": 3,
+      "1": 4,
+      "\r": 5,
+    };
+
+    expect(canonicalizeJcs(value)).toBe(
+      "{\"\\r\":5,\"1\":4,\"€\":3,\"😀\":2,\"\":1}",
+    );
+    expect(canonicalizeJcs({ b: { y: 2, x: 1 }, a: true })).toBe(
+      "{\"a\":true,\"b\":{\"x\":1,\"y\":2}}",
+    );
+  });
+
+  it("uses ECMAScript number serialization and rejects non-I-JSON values", () => {
+    expect(canonicalizeJcs([-0, 1e30, 0.002, 1e-27])).toBe(
+      "[0,1e+30,0.002,1e-27]",
+    );
+    expect(() => canonicalizeJcs(Number.NaN)).toThrow("non-finite");
+    expect(() => canonicalizeJcs("\ud800")).toThrow("lone high surrogate");
+    expect(() => canonicalizeJcs([undefined])).toThrow("undefined array");
+  });
+});

--- a/tests/mcp/tools.test.ts
+++ b/tests/mcp/tools.test.ts
@@ -383,6 +383,49 @@ describe("buildTools — hugin_rate", () => {
       verification_outcome: "accepted_unchanged",
     });
   });
+
+  it("forwards native v2 correction provenance", async () => {
+    const rate = vi.fn(async () => ({}));
+    const broker = fakeBroker({ rate });
+    const tools = buildTools({ broker, sessionId: "sess", submitter: "claude-code" });
+    const correction = {
+      predecessor_receipt_id: "qr-" + "a".repeat(24),
+      rubric: {
+        id: "code-review",
+        version: "2",
+        config_digest: {
+          algorithm: "sha256" as const,
+          canonicalization: "jcs-rfc8785-utf8-v1" as const,
+          source_ref: "source-doc:rubric/code-review-2",
+          source_type: "rubric-config" as const,
+          source_version: "rubric-source-2",
+          digest: "b".repeat(64),
+        },
+      },
+      verifier: { id: "claude-opus", version: "2026-07-19" },
+      failure: {
+        taxonomy: { id: "hugin-quality-failure", version: "1" },
+        code: "incorrect-answer" as const,
+      },
+      references: {
+        corrected_successor: {
+          task_id: "t-2",
+          structured_result_sha256: "c".repeat(64),
+        },
+      },
+    };
+
+    const result = await tools.rate.handler({
+      task_id: "t-1",
+      rating: "wrong",
+      rating_reason: "The correction is required.",
+      verification_outcome: "discarded",
+      correction,
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(rate).toHaveBeenCalledWith(expect.objectContaining({ correction }));
+  });
 });
 
 describe("buildTools — hugin_report_friction", () => {

--- a/tests/munin-client.test.ts
+++ b/tests/munin-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, afterEach } from "vitest";
-import { MuninClient } from "../src/munin-client.js";
+import { MuninClient, MuninWriteRejectedError } from "../src/munin-client.js";
 
 function rpcResponse(payload: unknown): Response {
   return new Response(
@@ -177,6 +177,64 @@ describe("MuninClient", () => {
     expect(request).toBeDefined();
     const body = JSON.parse(String((request as RequestInit).body));
     expect(body.params.arguments.classification).toBe("private");
+  });
+
+  it("passes the explicit create-if-absent precondition through memory_write", async () => {
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(rpcResponse({ status: "created" }));
+    const client = new MuninClient({
+      baseUrl: "http://munin.test",
+      apiKey: "test-key",
+      minRequestSpacingMs: 0,
+    });
+
+    await client.write(
+      "tasks/demo",
+      "feedback",
+      "{}",
+      ["feedback"],
+      undefined,
+      "internal",
+      true,
+    );
+
+    const request = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const body = JSON.parse(String(request.body));
+    expect(body.params.arguments).toMatchObject({ create_if_absent: true });
+    expect(body.params.arguments).not.toHaveProperty("expected_updated_at");
+  });
+
+  it("preserves typed memory_write conflict details", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(rpcResponse({
+      ok: false,
+      error: "conflict",
+      conflict_reason: "already_exists",
+      current_updated_at: "2026-07-19T18:00:00.000Z",
+      message: "Entry already exists.",
+    }));
+    const client = new MuninClient({
+      baseUrl: "http://munin.test",
+      apiKey: "test-key",
+      minRequestSpacingMs: 0,
+    });
+
+    const rejected = await client.write(
+      "tasks/demo",
+      "feedback",
+      "{}",
+      undefined,
+      undefined,
+      "internal",
+      true,
+    ).catch((error: unknown) => error);
+
+    expect(rejected).toBeInstanceOf(MuninWriteRejectedError);
+    expect(rejected).toMatchObject({
+      errorCode: "conflict",
+      conflictReason: "already_exists",
+      currentUpdatedAt: "2026-07-19T18:00:00.000Z",
+    });
   });
 
   it("throws when memory_write responds with ok:false", async () => {

--- a/tests/quality-receipt.test.ts
+++ b/tests/quality-receipt.test.ts
@@ -4,6 +4,7 @@ import {
   QualityReceiptConflictError,
   QualityReceiptInvalidLedgerError,
   buildQualityBinding,
+  buildQualityCorrectionReceipt,
   buildQualityReceipt,
   foldQualityReceipt,
   qualityReceiptLedgerSchema,
@@ -62,6 +63,47 @@ function receipt(overrides: Partial<Parameters<typeof buildQualityReceipt>[0]> =
 }
 
 describe("quality receipt v1", () => {
+  it("keeps the shipped native v1 artifact byte-for-field compatible", () => {
+    const native = receipt();
+    expect(Object.keys(native)).toEqual([
+      "schemaVersion",
+      "receiptId",
+      "taskId",
+      "rating",
+      "ratingReason",
+      "verificationOutcome",
+      "ratedAt",
+      "reviewer",
+      "bindingAttestation",
+      "binding",
+    ]);
+    expect(native).toEqual({
+      schemaVersion: 1,
+      receiptId: "qr-294eff66629b38102d0648d5",
+      taskId: "task-1",
+      rating: "pass",
+      ratingReason: "Reviewed the exact diff and green checks.",
+      verificationOutcome: "accepted_unchanged",
+      ratedAt: "2026-07-15T10:05:00.000Z",
+      reviewer: {
+        principal: "claude-code",
+        independence: "independent",
+      },
+      bindingAttestation: "reviewer-confirmed",
+      binding: {
+        taskDocumentSha256: "7f6d21c234402c8c91133e2e31e1ab3e9e4fc662ebd882ebaa7c9e2b34b555c5",
+        structuredResultSha256: expect.stringMatching(/^[0-9a-f]{64}$/),
+        repository: {
+          state: "changes-present",
+          baseBranch: "main",
+          baseCommit: BASE,
+          headCommit: HEAD,
+          diffSha256: DIFF,
+        },
+      },
+    });
+  });
+
   it("binds the exact task document, structured result, and repository diff", () => {
     const binding = buildQualityBinding({
       statusContent: "task bytes",
@@ -120,6 +162,24 @@ describe("quality receipt v1", () => {
     expect(summarizeQualityReceipts(JSON.stringify(second), stale).state).toBe("invalid");
   });
 
+  it("treats disagreement in the full rating/disposition tuple as conflicted", () => {
+    const first = foldQualityReceipt(null, receipt({
+      rating: "partial",
+      verificationOutcome: "minor_edit",
+    })).ledger;
+    const second = foldQualityReceipt(first, receipt({
+      reviewerPrincipal: "codex-review",
+      rating: "partial",
+      verificationOutcome: "major_rewrite",
+      ratedAt: "2026-07-15T10:07:00.000Z",
+    })).ledger;
+
+    expect(summarizeQualityReceipts(
+      JSON.stringify(second),
+      receipt().binding,
+    ).state).toBe("conflicted");
+  });
+
   it("never upgrades legacy unbound feedback into accepted quality evidence", () => {
     const summary = summarizeQualityReceipts(
       JSON.stringify({
@@ -143,5 +203,218 @@ describe("quality receipt v1", () => {
     expect(() => foldQualityReceipt(tampered, receipt({
       reviewerPrincipal: "another-reviewer",
     }))).toThrow(QualityReceiptInvalidLedgerError);
+  });
+});
+
+describe("quality receipt v2 corrections", () => {
+  function correction(
+    correctsReceiptId: string,
+    overrides: Partial<Parameters<typeof buildQualityCorrectionReceipt>[0]> = {},
+  ) {
+    const original = receipt();
+    return buildQualityCorrectionReceipt({
+      taskId: original.taskId,
+      attemptId: original.taskId,
+      correctsReceiptId,
+      reviewerPrincipal: original.reviewer.principal,
+      reviewerIndependence: original.reviewer.independence,
+      rating: "wrong",
+      ratingReason: "The accepted patch still fails the Unicode case.",
+      verificationOutcome: "discarded",
+      ratedAt: "2026-07-15T10:15:00.000Z",
+      bindingAttestation: original.bindingAttestation,
+      binding: original.binding,
+      rubric: {
+        id: "code-review",
+        version: "2.1.0",
+        config_digest: {
+          algorithm: "sha256",
+          canonicalization: "jcs-rfc8785-utf8-v1",
+          source_ref: "source-doc:rubric/code-review-2.1.0",
+          source_type: "rubric-config",
+          source_version: "rubric-source-2.1.0",
+          digest: "d".repeat(64),
+        },
+      },
+      verifier: { id: "claude-opus", version: "2026-07-15" },
+      failure: {
+        taxonomy: { id: "hugin-quality-failure", version: "1" },
+        code: "incorrect-answer",
+      },
+      producingConfiguration: {
+        prompt: { id: "task-envelope", version: "4", sha256: "e".repeat(64) },
+        harness: { id: "claude-code", version: "1.0", sha256: "f".repeat(64) },
+        model: { id: "claude-opus", configurationSha256: "1".repeat(64) },
+        toolPolicy: { id: "trusted-code", version: "3", sha256: "2".repeat(64) },
+      },
+      references: {
+        correctedSuccessor: {
+          taskId: "task-1-fix",
+          structuredResultSha256: "3".repeat(64),
+        },
+        followUpTaskId: "task-1-fix",
+        pullRequestUrl: "https://github.com/Magnus-Gille/demo/pull/2",
+        replacementCommit: "4".repeat(40),
+      },
+      ...overrides,
+    });
+  }
+
+  it("appends a distinct correction that names v1 and retains a stable correction group", () => {
+    const original = receipt();
+    const first = correction(original.receiptId);
+    const correctionAtAnotherClock = correction(original.receiptId, {
+      ratedAt: "2026-07-15T10:16:00.000Z",
+    });
+
+    expect(first).toMatchObject({
+      schemaVersion: 2,
+      receiptId: expect.stringMatching(/^qr-[0-9a-f]{24}$/),
+      correctsReceiptId: original.receiptId,
+      attemptId: "task-1",
+      correctionGroup: {
+        algorithm: "sha256",
+        version: "quality-correction-group-jcs-v1",
+        digest: expect.stringMatching(/^[0-9a-f]{64}$/),
+      },
+      verifier: { id: "claude-opus", version: "2026-07-15" },
+    });
+    expect(first.receiptId).not.toBe(original.receiptId);
+    expect(first).not.toHaveProperty("predecessorReceiptId");
+    expect(correctionAtAnotherClock.receiptId).not.toBe(first.receiptId);
+    expect(correctionAtAnotherClock.correctionGroup).toEqual(first.correctionGroup);
+
+    const ledger = foldQualityReceipt(
+      foldQualityReceipt(null, original).ledger,
+      first,
+    ).ledger;
+    expect(ledger.schemaVersion).toBe(2);
+    expect(ledger.receipts).toEqual([original, first]);
+    expect(foldQualityReceipt(ledger, structuredClone(first))).toEqual({
+      ledger,
+      changed: false,
+    });
+
+    const correctedSuccess = correction(first.receiptId, {
+      rating: "pass",
+      ratingReason: "The successor now passes the same rubric.",
+      verificationOutcome: "accepted_unchanged",
+      failure: {
+        taxonomy: { id: "hugin-quality-failure", version: "1" },
+        code: "none",
+      },
+      ratedAt: "2026-07-15T10:30:00.000Z",
+    });
+    expect(correctedSuccess.correctionGroup).toEqual(first.correctionGroup);
+    expect(foldQualityReceipt(ledger, correctedSuccess).ledger.receipts).toEqual([
+      original,
+      first,
+      correctedSuccess,
+    ]);
+  });
+
+  it("rejects same-id v2 replays unless the complete canonical artifact is identical", () => {
+    const original = receipt();
+    const first = correction(original.receiptId);
+    const ledger = foldQualityReceipt(
+      foldQualityReceipt(null, original).ledger,
+      first,
+    ).ledger;
+
+    expect(() => foldQualityReceipt(ledger, {
+      ...first,
+      ratedAt: "2026-07-15T10:16:00.000Z",
+    })).toThrow(/identity collision/);
+    expect(() => foldQualityReceipt(ledger, {
+      ...first,
+      verifier: { ...first.verifier, version: "2026-07-16" },
+    })).toThrow(/identity collision/);
+  });
+
+  it("rejects correction forks and changed correction replays", () => {
+    const original = receipt();
+    const first = correction(original.receiptId);
+    const originalLedger = foldQualityReceipt(null, original).ledger;
+    const ledger = foldQualityReceipt(originalLedger, first).ledger;
+
+    expect(() => foldQualityReceipt(originalLedger, correction(original.receiptId, {
+      reviewerIndependence: "self",
+    }))).toThrow(QualityReceiptConflictError);
+
+    expect(() => foldQualityReceipt(ledger, correction(original.receiptId, {
+      ratingReason: "A different attempted fork.",
+    }))).toThrow(QualityReceiptConflictError);
+    expect(() => foldQualityReceipt(ledger, correction(first.receiptId, {
+      rubric: {
+        id: "another-rubric",
+        version: "1",
+        config_digest: {
+          algorithm: "sha256",
+          canonicalization: "jcs-rfc8785-utf8-v1",
+          source_ref: "source-doc:rubric/another-1",
+          source_type: "rubric-config",
+          source_version: "rubric-source-1",
+          digest: "5".repeat(64),
+        },
+      },
+    }))).toThrow(QualityReceiptConflictError);
+  });
+
+  it("harvests only the correction leaf with rubric, failure, config, and successor provenance", () => {
+    const original = receipt();
+    const corrected = correction(original.receiptId);
+    const ledger = foldQualityReceipt(
+      foldQualityReceipt(null, original).ledger,
+      corrected,
+    ).ledger;
+
+    const summary = summarizeQualityReceipts(JSON.stringify(ledger), original.binding);
+    expect(summary).toMatchObject({
+      state: "rejected",
+      receiptIds: [corrected.receiptId],
+      effectiveReceipts: [{
+        nativeSchemaVersion: 2,
+        receiptId: corrected.receiptId,
+        correctsReceiptId: original.receiptId,
+        attemptId: "task-1",
+        rubric: corrected.rubric,
+        verifier: corrected.verifier,
+        failure: corrected.failure,
+        producingConfiguration: corrected.producingConfiguration,
+        references: corrected.references,
+      }],
+    });
+    expect(JSON.stringify(summary)).not.toContain(corrected.ratingReason);
+  });
+
+  it("requires failure code none exactly for pass plus accepted unchanged", () => {
+    const original = receipt();
+    expect(() => correction(original.receiptId, {
+      failure: {
+        taxonomy: { id: "hugin-quality-failure", version: "1" },
+        code: "none",
+      },
+    })).toThrow(/non-accepted correction/);
+    expect(() => correction(original.receiptId, {
+      rating: "pass",
+      verificationOutcome: "accepted_unchanged",
+      failure: {
+        taxonomy: { id: "hugin-quality-failure", version: "1" },
+        code: "verification-failure",
+      },
+    })).toThrow(/accepted unchanged correction must use failure code none/);
+  });
+
+  it("accepts only Grimnir v1 timestamps with zero to three fractional digits", () => {
+    const original = receipt();
+    expect(correction(original.receiptId, {
+      ratedAt: "2026-07-15T10:15:00Z",
+    }).ratedAt).toBe("2026-07-15T10:15:00Z");
+    expect(() => correction(original.receiptId, {
+      ratedAt: "2026-07-15T10:15:00.1234Z",
+    })).toThrow();
+    expect(() => correction(original.receiptId, {
+      ratedAt: "2026-07-15T12:15:00+02:00",
+    })).toThrow();
   });
 });


### PR DESCRIPTION
Refs #231

## What
- preserve native v1 exactly while making first writes atomic with Munin create-if-absent and typed CAS retry
- add native v2 append-only corrections, exact lineage/group identity, structured rubric/verifier/failure provenance, and effective-leaf harvesting
- pin the accepted Grimnir native-v2 ID and correction-group fixture
- keep v2 endpoint activation fail-closed until Hugin #240 provides authoritative attempt identity

## Verification
- focused independent re-review: 167 tests passed
- full suite: 114 files, 1,864 tests passed
- npm run build
- git diff --check
- independent fallback reviewer: APPROVE
- root review: APPROVE

## Rollout gate
Munin #211 is deployed and its live create-if-absent/typed-conflict probe passed. This PR can deploy atomic v1 writes and dormant v2 support. Keep issue #231 open until #240 is deployed and the documented real receipt/correction dogfood succeeds.