### PR TITLE
Preserve Broker task taxonomy in learning candidates

### DIFF
--- a/docs/daily-exam-factory.md
+++ b/docs/daily-exam-factory.md
@@ -34,6 +34,27 @@ terminal update or result completion time. That distinction is load-bearing: a
 task created before M5's complete capture window cannot become fresh merely
 because it completed after the window opened.
 
+Broker task type has one canonical persisted representation: the pair
+`task-type:<value>` and
+`task-taxonomy:gille-inference-task-types-2026-07-19-v1`. The version is pinned
+to the accepted Grimnir LearningTaskContract v1 taxonomy fixture. The factory
+validates the value against Hugin's mirrored M5 taxonomy and carries it as
+`source.taskType`, `source.taskTypeTaxonomyVersion`, and `source.taskTypeSource`.
+Existing Broker rows with an unversioned `task-type:*` tag and older Hugin rows
+with a single `type:*` tag remain readable as `legacy-unversioned`; they are
+never rewritten in place. Conflicting tags, unknown values, and unsupported
+taxonomy versions quarantine the candidate with a specific reason instead of
+collapsing it into `other`. Hugin #191 separately owns the additive `draft` and
+`conversation` enum mirror; once that schema lands, both values use this same
+v1 persistence path without another format change.
+
+Legacy `type:*` compatibility ignores Hugin's structural marker tags:
+`pipeline`, `pipeline-phase`, `pipeline-spec`, `pipeline-summary`,
+`approval-request`, `pipeline-approval-request`, and the `task-result` family.
+A phase or approval row carrying only those markers has missing task-type
+metadata; it is not misreported as an unknown taxonomy value. A separate valid
+legacy task type may coexist with those markers and is still harvested.
+
 ## Candidate lanes
 
 `npm run harvest:daily-exams` reads completed `tasks/` entries from Munin and

--- a/docs/orchestrator-verdict-layer.md
+++ b/docs/orchestrator-verdict-layer.md
@@ -25,7 +25,9 @@ errors, successRate, frozen, recommendation: delegate-local|escalate-frontier|ex
 avgLatencyMs, avgTokPerSec}`. The live probe's `report` array only showed 21 distinct
 task types that day — it's data-dependent, listing only types actually attempted so
 far — but the gateway's own `taxonomy.ts` (the authoritative full enumeration, see V1
-below) defines 22, including `claim-verify`, which simply hadn't been exercised yet.
+below) included 22 at that time, including `claim-verify`, which simply had not been
+exercised yet. Later coordinated additive values are consumed through Hugin's shared
+Broker schema rather than copied into a second orchestrator list.
 
 ## Decisions
 
@@ -33,11 +35,11 @@ below) defines 22, including `claim-verify`, which simply hadn't been exercised 
 
 Hugin's cloud-worker verdict store uses the **same task-type taxonomy** and the **same
 aggregate row shape** as the gateway ledger. D5's "converge to a single KB later"
-becomes a merge, not a migration. Task types: **22 values including `other`**
-(`TASK_TYPES` in `plan.ts`, includes `claim-verify`). The gateway's **`taxonomy.ts`** —
-not the data-dependent `/ledger` report, which only lists task types that have actually
-been attempted at least once — is the authoritative source of truth for the full
-enumeration; Hugin's `TASK_TYPES` mirrors it 1:1 (Fix #6).
+becomes a merge, not a migration. The gateway's **`taxonomy.ts`** — not the
+data-dependent `/ledger` report, which only lists task types actually attempted — is
+the cross-repo authority. Inside Hugin, `taskTypeSchema` in `broker/types.ts` is the one
+local mirror; orchestrator `TASK_TYPES`, Broker submit validation, and persisted
+learning metadata all consume it rather than maintaining separate enum lists.
 
 ### V2 — Task-type is planner-emitted per subtask
 

--- a/src/broker/task-store.ts
+++ b/src/broker/task-store.ts
@@ -40,6 +40,7 @@ import {
   foldQualityReceipt,
   type NativeQualityReceipt,
 } from "../quality-receipt.js";
+import { buildBrokerTaskTypeTags } from "./task-type-metadata.js";
 
 export { MUNIN_QUERY_MAX } from "../munin-pagination.js";
 
@@ -645,7 +646,7 @@ export function buildSubmitTags(envelope: DelegationEnvelope): string[] {
     "runtime:homeserver",
     `runtime-row:${envelope.alias_resolved.runtime_row_id}`,
     `alias:${envelope.alias_resolved.alias}`,
-    `task-type:${envelope.task_type}`,
+    ...buildBrokerTaskTypeTags(envelope.task_type),
     "broker:mcp-v2",
     `idempotency:${createHash("sha256").update(`${envelope.broker_principal}\0${envelope.idempotency_key}`).digest("hex")}`,
   ];

--- a/src/broker/task-type-metadata.ts
+++ b/src/broker/task-type-metadata.ts
@@ -1,0 +1,141 @@
+import { taskTypeSchema, type TaskType } from "./types.js";
+
+/**
+ * Version of the M5 task-type taxonomy mirrored by Hugin's Broker schema.
+ *
+ * The taxonomy calls itself v1 in gille-inference. Additive enum values (such
+ * as draft/conversation in Hugin #191) remain v1 and flow through this module
+ * automatically when taskTypeSchema is updated. A semantic taxonomy change
+ * must introduce a new version and an explicit reader branch.
+ */
+export const BROKER_TASK_TYPE_TAXONOMY_ID = "gille-inference/task-types" as const;
+export const BROKER_TASK_TYPE_TAXONOMY_VERSION =
+  "gille-inference-task-types-2026-07-19-v1" as const;
+export const LEGACY_TASK_TYPE_TAXONOMY_VERSION = "legacy-unversioned" as const;
+
+export const BROKER_TASK_TYPE_TAG_PREFIX = "task-type:";
+export const BROKER_TASK_TAXONOMY_TAG_PREFIX = "task-taxonomy:";
+
+export type PersistedTaskTypeSource =
+  | "broker-canonical"
+  | "broker-unversioned"
+  | "legacy-type-tag";
+
+export type PersistedTaskTypeMetadata =
+  | { state: "missing" }
+  | {
+      state: "known";
+      taskType: TaskType;
+      taxonomyVersion:
+        | typeof BROKER_TASK_TYPE_TAXONOMY_VERSION
+        | typeof LEGACY_TASK_TYPE_TAXONOMY_VERSION;
+      source: PersistedTaskTypeSource;
+    }
+  | {
+      state: "invalid";
+      reason:
+        | "task-type-metadata-conflicting-values"
+        | "task-type-metadata-unknown-value"
+        | "task-type-taxonomy-missing-type"
+        | "task-type-taxonomy-conflicting-versions"
+        | "task-type-taxonomy-unsupported-version"
+        | "legacy-task-type-metadata-conflicting-values"
+        | "legacy-task-type-metadata-unknown-value";
+    };
+
+export function buildBrokerTaskTypeTags(taskType: TaskType): string[] {
+  return [
+    `${BROKER_TASK_TYPE_TAG_PREFIX}${taskType}`,
+    `${BROKER_TASK_TAXONOMY_TAG_PREFIX}${BROKER_TASK_TYPE_TAXONOMY_VERSION}`,
+  ];
+}
+
+function valuesWithPrefix(tags: readonly string[], prefix: string): string[] {
+  return [...new Set(
+    tags
+      .filter((tag) => tag.startsWith(prefix))
+      .map((tag) => tag.slice(prefix.length)),
+  )];
+}
+
+/**
+ * Read task-type metadata from persisted status tags.
+ *
+ * Canonical Broker metadata is authoritative. Existing Broker rows predate
+ * the taxonomy-version tag, while older/general Hugin rows used `type:*`.
+ * Both compatibility paths are labeled `legacy-unversioned`; malformed,
+ * conflicting, future-version, and unknown values stay invalid so harvest can
+ * quarantine them instead of silently teaching the `other` bucket.
+ */
+export function readPersistedTaskTypeMetadata(
+  tags: readonly string[],
+): PersistedTaskTypeMetadata {
+  const brokerValues = valuesWithPrefix(tags, BROKER_TASK_TYPE_TAG_PREFIX);
+  const taxonomyVersions = valuesWithPrefix(tags, BROKER_TASK_TAXONOMY_TAG_PREFIX);
+
+  if (brokerValues.length > 0) {
+    if (brokerValues.length !== 1) {
+      return { state: "invalid", reason: "task-type-metadata-conflicting-values" };
+    }
+    const parsed = taskTypeSchema.safeParse(brokerValues[0]);
+    if (!parsed.success) {
+      return { state: "invalid", reason: "task-type-metadata-unknown-value" };
+    }
+    if (taxonomyVersions.length === 0) {
+      return {
+        state: "known",
+        taskType: parsed.data,
+        taxonomyVersion: LEGACY_TASK_TYPE_TAXONOMY_VERSION,
+        source: "broker-unversioned",
+      };
+    }
+    if (taxonomyVersions.length !== 1) {
+      return { state: "invalid", reason: "task-type-taxonomy-conflicting-versions" };
+    }
+    if (taxonomyVersions[0] !== BROKER_TASK_TYPE_TAXONOMY_VERSION) {
+      return { state: "invalid", reason: "task-type-taxonomy-unsupported-version" };
+    }
+    return {
+      state: "known",
+      taskType: parsed.data,
+      taxonomyVersion: BROKER_TASK_TYPE_TAXONOMY_VERSION,
+      source: "broker-canonical",
+    };
+  }
+
+  if (taxonomyVersions.length > 0) {
+    return { state: "invalid", reason: "task-type-taxonomy-missing-type" };
+  }
+
+  const legacyValues = valuesWithPrefix(tags, "type:")
+    .filter((value) => !isHuginMarkerType(value));
+  if (legacyValues.length === 0) return { state: "missing" };
+  if (legacyValues.length !== 1) {
+    return { state: "invalid", reason: "legacy-task-type-metadata-conflicting-values" };
+  }
+  const parsed = taskTypeSchema.safeParse(legacyValues[0]);
+  if (!parsed.success) {
+    return { state: "invalid", reason: "legacy-task-type-metadata-unknown-value" };
+  }
+  return {
+    state: "known",
+    taskType: parsed.data,
+    taxonomyVersion: LEGACY_TASK_TYPE_TAXONOMY_VERSION,
+    source: "legacy-type-tag",
+  };
+}
+
+const HUGIN_MARKER_TYPES = new Set([
+  "pipeline",
+  "pipeline-phase",
+  "pipeline-spec",
+  "pipeline-summary",
+  "approval-request",
+  "pipeline-approval-request",
+]);
+
+function isHuginMarkerType(value: string): boolean {
+  return HUGIN_MARKER_TYPES.has(value)
+    || value === "task-result"
+    || value.startsWith("task-result-");
+}

--- a/src/learning/daily-task-exam-factory.ts
+++ b/src/learning/daily-task-exam-factory.ts
@@ -18,6 +18,12 @@ import {
   qualitySummarySchema,
   summarizeQualityReceipts,
 } from "../quality-receipt.js";
+import { taskTypeSchema } from "../broker/types.js";
+import {
+  BROKER_TASK_TYPE_TAXONOMY_VERSION,
+  LEGACY_TASK_TYPE_TAXONOMY_VERSION,
+  readPersistedTaskTypeMetadata,
+} from "../broker/task-type-metadata.js";
 
 const sha256Schema = z.string().regex(/^[0-9a-f]{64}$/);
 const gitCommitSchema = z.string().regex(/^[0-9a-f]{40,64}$/);
@@ -36,7 +42,20 @@ export const dailyExamCandidateSchema = z.object({
     structuredResultSha256: sha256Schema.optional(),
     qualityReceiptLedgerSha256: sha256Schema.optional(),
     runtime: z.string().min(1).optional(),
+    // schema-v2 manifests emitted before task taxonomy metadata was versioned
+    // may contain only an arbitrary non-empty taskType string. Keep those
+    // historical documents parseable; new emitted candidates use the validated
+    // three-field form enforced below.
     taskType: z.string().min(1).optional(),
+    taskTypeTaxonomyVersion: z.enum([
+      BROKER_TASK_TYPE_TAXONOMY_VERSION,
+      LEGACY_TASK_TYPE_TAXONOMY_VERSION,
+    ]).optional(),
+    taskTypeSource: z.enum([
+      "broker-canonical",
+      "broker-unversioned",
+      "legacy-type-tag",
+    ]).optional(),
     sensitivity: z.enum(["public", "internal", "private"]).optional(),
     repositoryOutcome: z.enum([
       "not-managed",
@@ -46,7 +65,48 @@ export const dailyExamCandidateSchema = z.object({
       "changes-present",
       "publication-failed",
     ]).optional(),
-  }).strict(),
+  }).strict().superRefine((value, ctx) => {
+    const taskTypeFields = [
+      value.taskType,
+      value.taskTypeTaxonomyVersion,
+      value.taskTypeSource,
+    ];
+    const present = taskTypeFields.filter((fieldValue) => fieldValue !== undefined).length;
+    const hasVersionedMetadata = value.taskTypeTaxonomyVersion !== undefined
+      || value.taskTypeSource !== undefined;
+    if (hasVersionedMetadata && present !== taskTypeFields.length) {
+      ctx.addIssue({
+        code: "custom",
+        message: "task type, taxonomy version, and source must be carried together",
+      });
+      return;
+    }
+    if (hasVersionedMetadata && !taskTypeSchema.safeParse(value.taskType).success) {
+      ctx.addIssue({
+        code: "custom",
+        message: "versioned task type must be a known Hugin Broker taxonomy value",
+      });
+      return;
+    }
+    if (
+      value.taskTypeSource === "broker-canonical"
+      && value.taskTypeTaxonomyVersion !== BROKER_TASK_TYPE_TAXONOMY_VERSION
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "canonical Broker task type requires the current taxonomy version",
+      });
+    }
+    if (
+      (value.taskTypeSource === "broker-unversioned" || value.taskTypeSource === "legacy-type-tag")
+      && value.taskTypeTaxonomyVersion !== LEGACY_TASK_TYPE_TAXONOMY_VERSION
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "legacy task type source requires the legacy-unversioned marker",
+      });
+    }
+  }),
   repository: z.object({
     githubRepository: z.string().regex(/^[^/\s]+\/[^/\s]+$/),
     contextAlias: z.string().regex(/^repo:[A-Za-z0-9._-]+$/).optional(),
@@ -230,12 +290,6 @@ function exposureFor(result: StructuredTaskResult | undefined): DailyExamCandida
   return { state: "unknown", models: [...models].sort(), evidence: ["runtime-exposure-ambiguous"] };
 }
 
-function taskTypeFromTags(tags: readonly string[]): string | undefined {
-  return tags
-    .find((tag) => tag.startsWith("type:") && !tag.startsWith("type:task-result"))
-    ?.slice("type:".length);
-}
-
 /**
  * Convert one completed daily task into content-blind exam-candidate metadata.
  * "No M5 evidence" is intentionally only provisional: Hugin cannot prove the
@@ -279,6 +333,7 @@ export function buildDailyExamCandidate(source: DailyTaskHarvestSource): DailyEx
   const taskCreatedAt = typeof source.status.created_at === "string"
     ? source.status.created_at
     : "";
+  const taskTypeMetadata = readPersistedTaskTypeMetadata(source.status.tags);
   const reasons: string[] = [];
 
   if (!source.status.tags.includes("completed")) reasons.push("source-task-not-completed");
@@ -298,6 +353,7 @@ export function buildDailyExamCandidate(source: DailyTaskHarvestSource): DailyEx
   if (["partial", "rejected", "conflicted", "invalid"].includes(quality.state)) {
     reasons.push(`quality-receipt-${quality.state}`);
   }
+  if (taskTypeMetadata.state === "invalid") reasons.push(taskTypeMetadata.reason);
 
   const repository = sensitivity !== "private" && !sourceClassificationIsPrivate && change && result?.prUrl && githubRepository
     ? {
@@ -350,8 +406,12 @@ export function buildDailyExamCandidate(source: DailyTaskHarvestSource): DailyEx
       ...(resultContent ? { structuredResultSha256: sha256(resultContent) } : {}),
       ...(feedbackContent ? { qualityReceiptLedgerSha256: sha256(feedbackContent) } : {}),
       ...(result?.runtime ? { runtime: result.runtime } : {}),
-      ...(taskTypeFromTags(source.status.tags)
-        ? { taskType: taskTypeFromTags(source.status.tags) }
+      ...(taskTypeMetadata.state === "known"
+        ? {
+            taskType: taskTypeMetadata.taskType,
+            taskTypeTaxonomyVersion: taskTypeMetadata.taxonomyVersion,
+            taskTypeSource: taskTypeMetadata.source,
+          }
         : {}),
       ...(sensitivity ? { sensitivity } : {}),
       ...(result?.repositoryOutcome ? { repositoryOutcome: result.repositoryOutcome.state } : {}),

--- a/src/orchestrator/plan.ts
+++ b/src/orchestrator/plan.ts
@@ -1,41 +1,24 @@
 import { z } from "zod";
+import {
+  taskTypeSchema,
+  type TaskType as BrokerTaskType,
+} from "../broker/types.js";
 
 export type OrchestratorRole = "planner" | "worker" | "verifier" | "synthesizer";
 
 /**
  * Task-type taxonomy (verdict layer, V1 — docs/orchestrator-verdict-layer.md).
  *
- * Adopted VERBATIM from the M5 gateway's `/ledger` taxonomy so Hugin's own
- * cloud-worker verdict store shares the same `(taskType × modelId)` row shape
- * from day one — a merge, not a migration, when the two stores converge later
- * (D5's "converge to a single KB later").
+ * Hugin has one local mirror of the M5 taxonomy: broker/types.ts. Reusing its
+ * schema here prevents planner/verdict labels from drifting from Broker submit
+ * and persisted harvest metadata. Additive values owned by Hugin #191 will
+ * flow through this alias when they land in the shared schema.
  */
-export const TASK_TYPES = [
-  "claim-verify",
-  "classify",
-  "code-edit",
-  "code-implement",
-  "code-review",
-  "data-transform",
-  "extract",
-  "gap-check",
-  "other",
-  "plan-decompose",
-  "qa-factual",
-  "reason-hard",
-  "reason-math",
-  "regex",
-  "research-plan",
-  "rewrite",
-  "source-distill",
-  "sql",
-  "summarize",
-  "synthesis",
-  "translate",
-  "unit-test-gen",
-] as const;
+export const TASK_TYPES: readonly BrokerTaskType[] = Object.freeze([
+  ...taskTypeSchema.options,
+]);
 
-export type TaskType = (typeof TASK_TYPES)[number];
+export type TaskType = BrokerTaskType;
 
 const TASK_TYPE_SET: ReadonlySet<string> = new Set(TASK_TYPES);
 

--- a/src/task-status-tags.ts
+++ b/src/task-status-tags.ts
@@ -11,6 +11,7 @@ const ROUTING_PREFIX = "routing:";
 const BROKER_PREFIX = "broker:";
 const ALIAS_PREFIX = "alias:";
 const TASK_TYPE_PREFIX = "task-type:";
+const TASK_TAXONOMY_PREFIX = "task-taxonomy:";
 const RUNTIME_ROW_PREFIX = "runtime-row:";
 const IDEMPOTENCY_PREFIX = "idempotency:";
 // Runtime-owned artefact delivery (issue #68). `delivery:*` must survive lease
@@ -50,6 +51,7 @@ export function getPersistentStatusTags(
   const brokerTags = tags.filter((tag) => tag.startsWith(BROKER_PREFIX));
   const aliasTags = tags.filter((tag) => tag.startsWith(ALIAS_PREFIX));
   const taskTypeTags = tags.filter((tag) => tag.startsWith(TASK_TYPE_PREFIX));
+  const taskTaxonomyTags = tags.filter((tag) => tag.startsWith(TASK_TAXONOMY_PREFIX));
   const runtimeRowTags = tags.filter((tag) => tag.startsWith(RUNTIME_ROW_PREFIX));
   const idempotencyTags = tags.filter((tag) => tag.startsWith(IDEMPOTENCY_PREFIX));
 
@@ -64,6 +66,7 @@ export function getPersistentStatusTags(
     ...brokerTags,
     ...aliasTags,
     ...taskTypeTags,
+    ...taskTaxonomyTags,
     ...runtimeRowTags,
     ...idempotencyTags,
   ]);

--- a/tests/broker/task-store.test.ts
+++ b/tests/broker/task-store.test.ts
@@ -10,6 +10,7 @@ import {
   parseCanonicalEnvelope,
   serializeEnvelope,
 } from "../../src/broker/task-store.js";
+import { BROKER_TASK_TYPE_TAXONOMY_VERSION } from "../../src/broker/task-type-metadata.js";
 import { MuninWriteRejectedError, type MuninClient } from "../../src/munin-client.js";
 import type { DelegationEnvelope } from "../../src/broker/types.js";
 import {
@@ -131,6 +132,7 @@ describe("buildSubmitTags", () => {
     expect(tags).toContain("runtime-row:homeserver-m5");
     expect(tags).toContain("alias:m5");
     expect(tags).toContain("task-type:summarize");
+    expect(tags).toContain(`task-taxonomy:${BROKER_TASK_TYPE_TAXONOMY_VERSION}`);
     expect(tags).toContain("broker:mcp-v2");
     expect(tags).not.toContain(ORCH_V1_TAG);
   });

--- a/tests/broker/task-type-harvest.test.ts
+++ b/tests/broker/task-type-harvest.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import type { MuninEntry, MuninClient } from "../../src/munin-client.js";
+import { BrokerTaskStore } from "../../src/broker/task-store.js";
+import { BROKER_TASK_TYPE_TAXONOMY_VERSION } from "../../src/broker/task-type-metadata.js";
+import type { DelegationEnvelope } from "../../src/broker/types.js";
+import { buildDailyExamCandidate } from "../../src/learning/daily-task-exam-factory.js";
+import { buildTerminalStatusTags } from "../../src/task-status-tags.js";
+
+class PersistingMunin {
+  status: MuninEntry | null = null;
+
+  async write(
+    namespace: string,
+    key: string,
+    content: string,
+    tags: string[] = [],
+    _expectedUpdatedAt?: string,
+    classification = "internal",
+  ): Promise<Record<string, unknown>> {
+    if (key === "status") {
+      this.status = {
+        id: `${namespace}/${key}`,
+        namespace,
+        key,
+        content,
+        tags,
+        classification,
+        created_at: "2026-07-18T10:00:00.000Z",
+        updated_at: "2026-07-18T10:00:00.000Z",
+      };
+    }
+    return { ok: true };
+  }
+}
+
+function brokerEnvelope(): DelegationEnvelope {
+  return {
+    envelope_version: 2,
+    idempotency_key: "11111111-1111-4111-8111-111111111111",
+    orchestrator_session_id: "sess-1",
+    orchestrator_submitter: "claude-code",
+    task_type: "summarize",
+    prompt: "Summarize the release notes.",
+    alias_requested: "m5",
+    alias_map_version: 2,
+    sensitivity: "internal",
+    timeout_ms: 300_000,
+    max_output_tokens: 4_096,
+    acceptance: { mode: "l1_review" },
+    allowed_destinations: ["m5"],
+    tool_policy: { mode: "none" },
+    budget: { max_attempts: 1, max_cost_usd: 0 },
+    durability: "required",
+    delivery: { mode: "munin" },
+    escalation: { mode: "return_to_l1" },
+    task_id: "broker-summarize-1",
+    broker_principal: "claude-code",
+    received_at: "2026-07-18T10:00:00.000Z",
+    alias_resolved: {
+      alias: "m5",
+      family: "one-shot",
+      model_requested: "gateway-selected",
+      runtime: "homeserver",
+      runtime_row_id: "homeserver-m5",
+      host: "m5",
+    },
+    policy_version: "zdr-v1+rlv-v1",
+  };
+}
+
+describe("Broker task type submit to harvest contract", () => {
+  it("harvests summarize from the real Broker persistence path without a synthetic type tag", async () => {
+    const munin = new PersistingMunin();
+    const store = new BrokerTaskStore(munin as unknown as MuninClient);
+
+    await store.submit({ envelope: brokerEnvelope() });
+
+    expect(munin.status).not.toBeNull();
+    const persisted = munin.status!;
+    expect(persisted.tags).toContain("task-type:summarize");
+    expect(persisted.tags).not.toContain("type:summarize");
+    persisted.tags = buildTerminalStatusTags("completed", persisted.tags);
+
+    const candidate = buildDailyExamCandidate({ status: persisted });
+
+    expect(candidate.source).toMatchObject({
+      taskType: "summarize",
+      taskTypeTaxonomyVersion: BROKER_TASK_TYPE_TAXONOMY_VERSION,
+      taskTypeSource: "broker-canonical",
+    });
+  });
+});

--- a/tests/broker/task-type-metadata.test.ts
+++ b/tests/broker/task-type-metadata.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { taskTypeSchema } from "../../src/broker/types.js";
+import {
+  BROKER_TASK_TYPE_TAXONOMY_ID,
+  BROKER_TASK_TYPE_TAXONOMY_VERSION,
+  buildBrokerTaskTypeTags,
+  readPersistedTaskTypeMetadata,
+} from "../../src/broker/task-type-metadata.js";
+
+const acceptedTaxonomy = JSON.parse(readFileSync(
+  new URL("../fixtures/learning-task-taxonomy-v1.json", import.meta.url),
+  "utf8",
+)) as {
+  taxonomy_id: string;
+  taxonomy_version: string;
+  task_types: string[];
+};
+
+describe("persisted Broker task-type metadata", () => {
+  it("pins identifiers and local values to the accepted LearningTaskContract fixture", () => {
+    expect(BROKER_TASK_TYPE_TAXONOMY_ID).toBe(acceptedTaxonomy.taxonomy_id);
+    expect(BROKER_TASK_TYPE_TAXONOMY_VERSION).toBe(acceptedTaxonomy.taxonomy_version);
+    expect(new Set(acceptedTaxonomy.task_types).size).toBe(acceptedTaxonomy.task_types.length);
+    expect(taskTypeSchema.options).toHaveLength(26);
+    expect(taskTypeSchema.options).toEqual(acceptedTaxonomy.task_types);
+  });
+
+  it.each(taskTypeSchema.options)(
+    "round-trips the canonical taxonomy value %s",
+    (taskType) => {
+      expect(readPersistedTaskTypeMetadata(buildBrokerTaskTypeTags(taskType))).toEqual({
+        state: "known",
+        taskType,
+        taxonomyVersion: BROKER_TASK_TYPE_TAXONOMY_VERSION,
+        source: "broker-canonical",
+      });
+    },
+  );
+
+  it("labels an existing unversioned Broker tag as legacy", () => {
+    expect(readPersistedTaskTypeMetadata(["task-type:summarize"])).toEqual({
+      state: "known",
+      taskType: "summarize",
+      taxonomyVersion: "legacy-unversioned",
+      source: "broker-unversioned",
+    });
+  });
+
+  it("rejects unknown values and future taxonomy versions visibly", () => {
+    expect(readPersistedTaskTypeMetadata([
+      "task-type:not-real",
+      `task-taxonomy:${BROKER_TASK_TYPE_TAXONOMY_VERSION}`,
+    ])).toEqual({ state: "invalid", reason: "task-type-metadata-unknown-value" });
+    expect(readPersistedTaskTypeMetadata([
+      "task-type:summarize",
+      "task-taxonomy:gille-inference-task-types-2099-01-01-v2",
+    ])).toEqual({ state: "invalid", reason: "task-type-taxonomy-unsupported-version" });
+  });
+
+  it("rejects conflicting values instead of choosing tag order", () => {
+    expect(readPersistedTaskTypeMetadata([
+      "task-type:summarize",
+      "task-type:extract",
+      `task-taxonomy:${BROKER_TASK_TYPE_TAXONOMY_VERSION}`,
+    ])).toEqual({ state: "invalid", reason: "task-type-metadata-conflicting-values" });
+    expect(readPersistedTaskTypeMetadata([
+      "type:summarize",
+      "type:extract",
+    ])).toEqual({ state: "invalid", reason: "legacy-task-type-metadata-conflicting-values" });
+  });
+
+  it("rejects conflicting versions, a version without a type, and unknown legacy values", () => {
+    expect(readPersistedTaskTypeMetadata([
+      "task-type:summarize",
+      `task-taxonomy:${BROKER_TASK_TYPE_TAXONOMY_VERSION}`,
+      "task-taxonomy:gille-inference-task-types-2099-01-01-v2",
+    ])).toEqual({ state: "invalid", reason: "task-type-taxonomy-conflicting-versions" });
+    expect(readPersistedTaskTypeMetadata([
+      `task-taxonomy:${BROKER_TASK_TYPE_TAXONOMY_VERSION}`,
+    ])).toEqual({ state: "invalid", reason: "task-type-taxonomy-missing-type" });
+    expect(readPersistedTaskTypeMetadata([
+      "type:not-a-real-task-type",
+    ])).toEqual({ state: "invalid", reason: "legacy-task-type-metadata-unknown-value" });
+  });
+
+  it.each([
+    ["pipeline phase", ["type:pipeline", "type:pipeline-phase"]],
+    ["pipeline documents", ["type:pipeline-spec", "type:pipeline-summary"]],
+    ["approval phase", [
+      "type:pipeline",
+      "type:pipeline-phase",
+      "type:approval-request",
+      "type:pipeline-approval-request",
+    ]],
+    ["task result", ["type:task-result", "type:task-result-structured"]],
+  ])("treats Hugin's %s marker tags as missing task metadata", (_name, tags) => {
+    expect(readPersistedTaskTypeMetadata(tags)).toEqual({ state: "missing" });
+  });
+
+  it("reads a valid legacy task type alongside structural pipeline markers", () => {
+    expect(readPersistedTaskTypeMetadata([
+      "type:pipeline",
+      "type:pipeline-phase",
+      "type:summarize",
+    ])).toEqual({
+      state: "known",
+      taskType: "summarize",
+      taxonomyVersion: "legacy-unversioned",
+      source: "legacy-type-tag",
+    });
+  });
+});

--- a/tests/daily-task-exam-factory.test.ts
+++ b/tests/daily-task-exam-factory.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
+import { BROKER_TASK_TYPE_TAXONOMY_VERSION } from "../src/broker/task-type-metadata.js";
 import type { MuninEntry } from "../src/munin-client.js";
 import {
   applyCrossClientExposure,
   buildDailyExamCandidate,
   buildDailyExamManifest,
+  dailyExamCandidateSchema,
   type DailyTaskHarvestSource,
 } from "../src/learning/daily-task-exam-factory.js";
 import {
@@ -96,7 +98,7 @@ function source(runtime: "claude" | "homeserver" = "claude"): DailyTaskHarvestSo
       namespace: "tasks/daily-1",
       key: "status",
       content: taskDocument(runtime),
-      tags: ["completed", "runtime:claude", "type:code-repair"],
+      tags: ["completed", "runtime:claude", "type:code-edit"],
     }),
     resultStructured: entry({
       namespace: "tasks/daily-1",
@@ -190,11 +192,86 @@ describe("daily task exam factory", () => {
     expect(candidate.reasons).toContain("requires-cross-client-exposure-check-before-holdout-seal");
     expect(candidate.schemaVersion).toBe(2);
     expect(candidate.source.taskCreatedAt).toBe("2026-07-14T10:00:00.000Z");
+    expect(candidate.source).toMatchObject({
+      taskType: "code-edit",
+      taskTypeTaxonomyVersion: "legacy-unversioned",
+      taskTypeSource: "legacy-type-tag",
+    });
     expect(candidate.crossClientExposure).toEqual(expect.objectContaining({
       state: "not-checked",
       fingerprintVersion: TASK_EXPOSURE_FINGERPRINT_VERSION,
       fingerprintSha256: candidate.source.promptSha256,
     }));
+  });
+
+  it("quarantines an unknown canonical Broker task type instead of collapsing it to other", () => {
+    const candidateSource = source("claude");
+    candidateSource.status.tags = [
+      "completed",
+      "runtime:homeserver",
+      "broker:mcp-v2",
+      "task-type:not-in-the-taxonomy",
+      `task-taxonomy:${BROKER_TASK_TYPE_TAXONOMY_VERSION}`,
+    ];
+
+    const candidate = buildDailyExamCandidate(candidateSource);
+
+    expect(candidate.lane).toBe("quarantine");
+    expect(candidate.source.taskType).toBeUndefined();
+    expect(candidate.reasons).toContain("task-type-metadata-unknown-value");
+  });
+
+  it("reads historical unversioned Broker task-type tags through the explicit compatibility path", () => {
+    const candidateSource = source("homeserver");
+    candidateSource.status.tags = [
+      "completed",
+      "runtime:homeserver",
+      "broker:mcp-v2",
+      "task-type:summarize",
+    ];
+
+    const candidate = buildDailyExamCandidate(candidateSource);
+
+    expect(candidate.source).toMatchObject({
+      taskType: "summarize",
+      taskTypeTaxonomyVersion: "legacy-unversioned",
+      taskTypeSource: "broker-unversioned",
+    });
+  });
+
+  it("keeps old schema-v2 taskType-only manifests parseable but rejects a partial new triplet", () => {
+    const candidate = buildDailyExamCandidate(source("claude"));
+    const legacy = structuredClone(candidate) as Record<string, unknown>;
+    const legacySource = legacy.source as Record<string, unknown>;
+    delete legacySource.taskTypeTaxonomyVersion;
+    delete legacySource.taskTypeSource;
+    legacySource.taskType = "historical-free-form-type";
+    expect(dailyExamCandidateSchema.safeParse(legacy).success).toBe(true);
+
+    const incomplete = structuredClone(candidate) as Record<string, unknown>;
+    const candidateSource = incomplete.source as Record<string, unknown>;
+    delete candidateSource.taskTypeTaxonomyVersion;
+
+    expect(dailyExamCandidateSchema.safeParse(incomplete).success).toBe(false);
+  });
+
+  it.each([
+    ["pipeline phase", ["type:pipeline", "type:pipeline-phase"]],
+    ["approval phase", [
+      "type:pipeline",
+      "type:pipeline-phase",
+      "type:approval-request",
+      "type:pipeline-approval-request",
+    ]],
+  ])("does not quarantine a realistic %s row as an unknown task type", (_name, markerTags) => {
+    const candidateSource = source("claude");
+    candidateSource.status.tags = ["completed", "runtime:claude", ...markerTags];
+
+    const candidate = buildDailyExamCandidate(candidateSource);
+
+    expect(candidate.lane).toBe("provisional-holdout");
+    expect(candidate.source.taskType).toBeUndefined();
+    expect(candidate.reasons.some((reason) => reason.includes("task-type-metadata"))).toBe(false);
   });
 
   it("routes a task already seen by M5 to regression rather than a holdout", () => {

--- a/tests/fixtures/learning-task-taxonomy-v1.json
+++ b/tests/fixtures/learning-task-taxonomy-v1.json
@@ -1,0 +1,33 @@
+{
+  "contract": "Grimnir LearningTaskContract/v1 schema_revision 1",
+  "taxonomy_id": "gille-inference/task-types",
+  "taxonomy_version": "gille-inference-task-types-2026-07-19-v1",
+  "task_types": [
+    "draft",
+    "code-implement",
+    "code-edit",
+    "code-review",
+    "unit-test-gen",
+    "summarize",
+    "extract",
+    "classify",
+    "data-transform",
+    "regex",
+    "sql",
+    "reason-math",
+    "reason-hard",
+    "rewrite",
+    "translate",
+    "plan-decompose",
+    "qa-factual",
+    "triage",
+    "memory-decision",
+    "research-plan",
+    "source-distill",
+    "claim-verify",
+    "gap-check",
+    "synthesis",
+    "conversation",
+    "other"
+  ]
+}

--- a/tests/orchestrator/plan.test.ts
+++ b/tests/orchestrator/plan.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { parsePlan, TASK_TYPES } from "../../src/orchestrator/plan.js";
+import { taskTypeSchema } from "../../src/broker/types.js";
 
 const FALLBACK_PROMPT = "Do the whole task yourself.";
 
@@ -77,10 +78,12 @@ describe("parsePlan", () => {
 });
 
 describe("parsePlan — taskType taxonomy (V2)", () => {
-  it("TASK_TYPES is the 22-value taxonomy including 'other' and 'claim-verify' (Fix #6), with no duplicates", () => {
+  it("uses the shared Broker task-type schema without a second enum mirror", () => {
+    expect(TASK_TYPES).toEqual(taskTypeSchema.options);
     expect(TASK_TYPES).toContain("other");
     expect(TASK_TYPES).toContain("claim-verify");
-    expect(TASK_TYPES).toHaveLength(22);
+    expect(TASK_TYPES).toContain("memory-decision");
+    expect(TASK_TYPES).toContain("triage");
     const unique = new Set(TASK_TYPES);
     expect(unique.size).toBe(TASK_TYPES.length);
   });

--- a/tests/task-status-tags.test.ts
+++ b/tests/task-status-tags.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { BROKER_TASK_TYPE_TAXONOMY_VERSION } from "../src/broker/task-type-metadata.js";
 import {
   buildAwaitingApprovalTags,
   buildPipelineParentCancelledTags,
@@ -15,6 +16,7 @@ describe("task status tag helpers", () => {
       "broker:mcp-v2",
       "alias:m5",
       "task-type:extract",
+      `task-taxonomy:${BROKER_TASK_TYPE_TAXONOMY_VERSION}`,
       "runtime-row:homeserver-m5",
       "idempotency:abc123",
       "claimed_by:hugin-pi",
@@ -25,6 +27,7 @@ describe("task status tag helpers", () => {
       "broker:mcp-v2",
       "alias:m5",
       "task-type:extract",
+      `task-taxonomy:${BROKER_TASK_TYPE_TAXONOMY_VERSION}`,
       "runtime-row:homeserver-m5",
       "idempotency:abc123",
     ];


### PR DESCRIPTION
Closes #235

Adds one canonical persisted Broker task-type/taxonomy representation, explicit legacy compatibility, visible quarantine for unknown or conflicting metadata, and a real submit-to-persist-to-terminalize-to-harvest contract test. The Hugin runtime enum now matches gille-inference exactly: 26 ordered values under the pinned taxonomy identity/version.

Verification:
- independent fallback review: APPROVE, no findings
- root review: approved
- focused: 135 tests
- full: 116 files / 1,912 tests
- TypeScript build
- staged diff check