### PR TITLE
Add authenticated LearningTaskContract attempt handshake

### DIFF
--- a/docs/canonical-task-identity.md
+++ b/docs/canonical-task-identity.md
@@ -1,8 +1,9 @@
 # Canonical Hugin task identity
 
-**Status:** producer projection implemented for Hugin's direct homeserver
-executor `/delegate` lane; authenticated gateway admission/capture and the
-orchestrator worker lane are pending `gille-inference` #2/#4 and Hugin #240.
+**Status:** producer projection and LearningTaskContract v1 handshake are
+implemented for Hugin's direct homeserver `/delegate` lane. End-to-end use
+still requires the matching `gille-inference` #2 deployment; canonical
+exposure capture remains `gille-inference` #4 work.
 
 Hugin's logical task is the parsed `### Prompt` text before context injection,
 the `## Task` wrapper, a system prompt, gateway orchestration, or a runtime chat
@@ -48,13 +49,12 @@ producer-owned projection:
 }
 ```
 
-`renderedPromptFingerprint` identifies the exact UTF-8 bytes in the legacy
+`renderedPromptFingerprint` identifies the exact UTF-8 bytes in the
 `/delegate.prompt` field. It does not trim or normalize them. It is separate
 from the raw identity because injected context and wrapper bytes legitimately
-change it. It is also narrower than the future three-stage prompt provenance:
-an optional `systemPrompt`, gateway canonical envelope, and runtime chat
-template are not represented by this field and remain Hugin #240 / Gille #2
-work.
+change it. The LearningTaskContract stamp additionally content-addresses the
+Hugin envelope and the prompt, harness, and tool-policy configurations. Gille
+owns the later gateway-envelope and runtime-chat-template stages.
 
 The task document cannot supply `huginTaskIdentity`; the serializer always
 recomputes it from Hugin's accepted logical prompt and lifecycle task id. The
@@ -68,27 +68,25 @@ The in-process orchestrator's homeserver worker uses a separate serializer in
 `src/orchestrator/worker-executor.ts`. It remains on the legacy rendered-prompt
 identity and does not emit `huginTaskIdentity`. Extending that lane requires an
 authoritative outer task/attempt binding rather than copying this direct-runtime
-field into an independently fanned-out subtask. Hugin #240 owns that common
-attempt/stamp integration.
+field into an independently fanned-out subtask. It is not evidence-eligible.
 
 ## Trust and legacy boundary
 
-This projection is Hugin producer evidence, not yet gateway evidence. The
-current public Gille `/delegate` parser ignores unknown fields and its exposure
-recorder still hashes the rendered `prompt`; orchestrator worker calls do not
-yet carry the projection at all. A body claim—even one sent over a
-Bearer-authenticated request—is not proof that Gille bound it to the actual
-transport principal, admitted it once, recorded it, or echoed it unchanged.
-No consumer may infer any of those facts from
-`runtimeMetadata.huginTaskIdentity` alone.
+This projection alone is Hugin producer evidence, not gateway evidence. A body
+claim—even one sent over a Bearer-authenticated request—is not proof that Gille
+bound it to the actual transport principal, admitted it once, recorded it, or
+echoed it unchanged. No consumer may infer any of those facts from
+`runtimeMetadata.huginTaskIdentity` alone. Hugin accepts gateway evidence only
+when the v1 stamp is returned exactly in a principal-bound gateway echo; see
+[`learning-task-handshake.md`](learning-task-handshake.md).
 
-End-to-end trust requires:
+End-to-end trust additionally requires:
 
 - Gille #2 to authenticate the actual caller, validate the versioned Hugin
   request stamp, bind it to admission, and return an exact echo;
-- Hugin #240 to create the authoritative attempt before dispatch, embed this
-  identity in that preflight-bound stamp, and reject a missing or mismatched
-  echo; and
+- the deployed Hugin direct lane to create the authoritative attempt before
+  dispatch, embed this identity in the preflight-bound stamp, and reject a
+  missing or mismatched echo; and
 - Gille #4 to record the stamped raw fingerprint as the exposure identity and
   establish a new coverage epoch whose start is no earlier than canonical
   capture becoming effective.
@@ -100,7 +98,8 @@ backfilled, or treated as exact canonical Hugin exposure. Positive exact raw
 matches remain conservative evidence of prior exposure; a negative lookup over
 the legacy Hugin-delegate period is not canonical freshness proof.
 
-The fixture intentionally stops at the current repository boundary: it drives
-Hugin's real serializer and supplies the exact byte/hash/lookup values that
-Gille #4 must consume. It does not mock a successful Gille capture or echo that
-the current Gille implementation cannot produce.
+The fixture in `tests/fixtures/hugin-learning-task-serializer-v1.json` drives
+Hugin's real serializer and pins the contract capabilities, raw bytes, raw
+fingerprint, task taxonomy, and production config identities. The matching
+Gille fixture must be updated from this serializer before the two changes are
+deployed together.

--- a/docs/learning-task-handshake.md
+++ b/docs/learning-task-handshake.md
@@ -1,0 +1,137 @@
+# LearningTaskContract v1 producer handshake
+
+**Status:** implemented for the managed direct homeserver `/delegate` lane.
+The matching Gille consumer is `gille-inference` #2. A joint live smoke is a
+deployment gate, not evidence supplied by Hugin's unit tests.
+
+Hugin is the authority for the managed task and its attempt. Gille is the
+authority for the authenticated transport principal and model admission. The
+v1 handshake joins those facts without treating a caller-provided JSON claim as
+gateway evidence.
+
+## Ordered lifecycle
+
+For every direct M5 attempt Hugin:
+
+1. computes the raw logical-task and rendered-prompt identities;
+2. writes an immutable UUID-keyed attempt start under the task namespace;
+3. resolves the owner key alias through authenticated `/portal/me` and fetches
+   authenticated `/v1/capabilities/learning-task` evidence;
+4. constructs the request stamp, writes a content-blind immutable prepared
+   receipt, and writes the exact request body to a separately classified replay
+   payload;
+5. sends the persisted request as
+   `/delegate.learningTaskStamp` with an explicit canonical task type;
+6. accepts output and provenance only after validating the exact
+   `learningTaskGatewayEcho`; and
+7. writes the terminal admitted, not-admitted, or join-failed attempt evidence
+   before publishing the task result.
+
+The start write is awaited before either authenticated M5 read. Hugin fetches a
+fresh advertisement for every attempt, so it does not rely on a capability
+cache across restart or serving-epoch changes. The stamp clock is checked after
+attempt start and before the advertisement expires. Gille performs its own
+admission-time freshness and serving-epoch validation.
+
+The durable records are:
+
+- `tasks/<task-id>/learning-attempt-<uuid>` — immutable attempt start;
+- `tasks/<task-id>/learning-attempt-<uuid>-replay` — separately classified,
+  exact request bytes retained only for crash recovery;
+- `tasks/<task-id>/learning-attempt-<uuid>-prepared` — content-blind request
+  stamp plus digest/reference for the replay payload;
+- `tasks/<task-id>/learning-attempt-<uuid>-outcome` — exact stamp/echo and
+  admission state; and
+- `tasks/<task-id>/result-structured` — canonical task outcome with the same
+  learning-task evidence references.
+
+The start, prepared, outcome, and structured-result projections contain hashes,
+IDs, timestamps, classification, and contract evidence, but no prompt or
+response bytes. Only the replay payload contains request bytes; it inherits the
+task's classification and is not learning evidence.
+
+## Authenticated source and transport
+
+The source principal comes from either a verified task signature or a canonical
+Broker envelope carrying Hugin's server-side HMAC attestation. The attestation
+binds the authenticated Broker principal, derived task ID, exact namespace,
+and exact envelope. Its domain-separated key is derived from Hugin's server-only
+Munin service credential, never from the caller-held Broker bearer token. A
+prose `Submitted by` value and an unattested embedded
+Broker envelope are not authentication. A verified normal task signer always
+wins over embedded Broker claims. Existing unattested `/delegate` tasks remain
+operational on the explicit legacy/ineligible lane, but they emit no learning
+stamp or evidence.
+
+The expected transport principal is the owner alias returned by authenticated
+`/portal/me`; the bearer token is never persisted. Hugin accepts the response
+only when Gille's echo:
+
+- reproduces the complete request stamp exactly;
+- reports that same authenticated principal with `gateway-owner-auth`;
+- carries the complete, undowngraded v1 feature set;
+- has a valid admission clock; and
+- has the correct JCS principal/request binding digest.
+
+Unsupported or stale advertisements, feature downgrade, source or transport
+principal substitution, missing/malformed echoes, and stamp mutation all
+produce negative evidence and no accepted inference output.
+
+## Replay boundary
+
+Each attempt gets new UUID-derived attempt, prepared, replay, request, and
+idempotency identities. On restart Hugin may send only the exact classified
+replay payload with the exact persisted stamp. It accepts only Gille's durable
+stored-admission response (`recovered: true`, `outcomeAvailable: false`) and its
+exact authenticated echo; a fresh/full result is discarded rather than treated
+as recovered output. Gille performs this exact lookup before current epoch,
+quota, or GPU admission gates and never starts a second inference for a stored
+admission. Conflicting joins remain rejected by authenticated principal,
+idempotency key, request ID, and task/attempt pair.
+
+Recovery first reloads the immutable attempt start and preserves its complete
+Hugin task identity, including the rendered-prompt identity. One canonical join
+then binds the prepared receipt to the task, attempt, start time, every evidence
+reference, replay digest, raw fingerprint, complete request stamp and digest,
+and any gateway echo and digest. The attempt start, prepared receipt, replay
+payload, and existing outcome must all have the same classification as the task
+status. Classification drift fails closed, and newly recovered attempt outcomes
+plus `result-structured` retain that exact status classification.
+
+Startup selects the newest immutable attempt start and reads only the prepared
+row derived from that attempt ID; it never falls back to an older prepared
+attempt. If the newest attempt stopped before prepared persistence, recovery
+emits content-blind pre-dispatch failure evidence for that attempt. Even when an
+outcome row already exists, Hugin reloads the classified replay, recomputes its
+digest, schema-validates the stored delegate prompt, recomputes its #230
+rendered-prompt fingerprint, and exact-binds the replay's complete Hugin
+identity to the attempt start before considering the outcome. A malformed or
+differently classified outcome, or a failed immutable outcome write, is
+reported as outcome-persistence failure without an `attemptOutcomeRef`; startup
+continues with the ordinary failed task result rather than pointing at an
+unusable row.
+
+This contract does not create the learning registry, choose a model, or promote
+evidence. Those remain Hugin #232 and Gille policy/capture responsibilities.
+
+## Joint live-smoke gate
+
+After the matching Hugin and Gille revisions are deployed, submit one
+authenticated Broker `homeserver` task with an innocuous unique prompt and an
+explicit canonical task type. Await the ordinary task result, then verify:
+
+1. the start, classified replay, and content-blind prepared keys exist, and the
+   start timestamp precedes the embedded stamp;
+2. the prepared, outcome, and `result-structured` rows name the same task and
+   attempt, and every recorded digest recomputes exactly;
+3. the exact gateway echo validates and the state is `m5-admitted`;
+4. the M5 admission/model clocks follow the stamp clock; and
+5. learning-task attempt/admission rows and health views expose only
+   IDs/digests—not the smoke prompt or response bytes. The ordinary Hugin task
+   result and task log retain their existing output semantics and are outside
+   this content-blind evidence projection.
+
+Repeat once with an intentionally unsupported preflight fixture or isolated
+stale advertisement in a non-production test gateway. It must create negative
+attempt evidence, make no model call, and publish no accepted output. Do not
+simulate downgrade or replay against the production gateway epoch.

--- a/src/broker/attestation.ts
+++ b/src/broker/attestation.ts
@@ -1,0 +1,138 @@
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
+import { z } from "zod";
+
+import {
+  delegationEnvelopeSchema,
+  type DelegationEnvelope,
+} from "./types.js";
+
+export const BROKER_ATTESTATION_VERSION = "hugin-broker-attestation/v1" as const;
+
+const sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
+
+export const brokerAttestationSchema = z.object({
+  version: z.literal(BROKER_ATTESTATION_VERSION),
+  namespace: z.string().regex(/^tasks\/[A-Za-z0-9._:-]+$/),
+  task_id: z.string().min(1),
+  broker_principal: z.string().min(1),
+  envelope_digest: sha256Schema,
+  issued_at: z.string().datetime({ offset: true }),
+  hmac_sha256: sha256Schema,
+}).strict();
+
+export type BrokerAttestation = z.infer<typeof brokerAttestationSchema>;
+
+function canonicalize(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`;
+  if (value !== null && typeof value === "object") {
+    const object = value as Record<string, unknown>;
+    return `{${Object.keys(object).sort().map((key) => {
+      const child = object[key];
+      if (child === undefined) throw new Error("Broker attestation cannot canonicalize undefined");
+      return `${JSON.stringify(key)}:${canonicalize(child)}`;
+    }).join(",")}}`;
+  }
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "number" && Number.isFinite(value)) return JSON.stringify(value);
+  throw new Error("Broker attestation accepts only JSON values");
+}
+
+function sha256(value: unknown): string {
+  return createHash("sha256").update(canonicalize(value), "utf8").digest("hex");
+}
+
+function derivedTaskId(principal: string, idempotencyKey: string): string {
+  return `mcp-m5-${createHash("sha256")
+    .update(`${principal}\0${idempotencyKey}`)
+    .digest("hex")
+    .slice(0, 24)}`;
+}
+
+function unsignedAttestation(
+  envelope: DelegationEnvelope,
+): Omit<BrokerAttestation, "hmac_sha256"> {
+  return {
+    version: BROKER_ATTESTATION_VERSION,
+    namespace: `tasks/${envelope.task_id}`,
+    task_id: envelope.task_id,
+    broker_principal: envelope.broker_principal,
+    envelope_digest: sha256(delegationEnvelopeSchema.parse(envelope)),
+    issued_at: envelope.received_at,
+  };
+}
+
+function attestationKey(serverSecret: string): Buffer {
+  return createHmac("sha256", serverSecret)
+    .update("hugin-broker-attestation/server-key/v1", "utf8")
+    .digest();
+}
+
+export function createBrokerAttestation(
+  envelope: DelegationEnvelope,
+  secret: string,
+): BrokerAttestation {
+  if (secret.length === 0) throw new Error("Broker attestation secret is empty");
+  const parsed = delegationEnvelopeSchema.parse(envelope);
+  if (parsed.task_id !== derivedTaskId(parsed.broker_principal, parsed.idempotency_key)) {
+    throw new Error("Broker attestation requires the principal-scoped derived task id");
+  }
+  const unsigned = unsignedAttestation(parsed);
+  return brokerAttestationSchema.parse({
+    ...unsigned,
+    hmac_sha256: createHmac("sha256", attestationKey(secret))
+      .update(canonicalize(unsigned), "utf8")
+      .digest("hex"),
+  });
+}
+
+export function validateBrokerAttestation(input: {
+  envelope: DelegationEnvelope;
+  attestation: unknown;
+  serverSecret: string;
+  expectedNamespace?: string;
+}): { ok: true; principal: string; attestation: BrokerAttestation } | { ok: false; error: string } {
+  const envelope = delegationEnvelopeSchema.safeParse(input.envelope);
+  const attestation = brokerAttestationSchema.safeParse(input.attestation);
+  if (!envelope.success || !attestation.success) {
+    return { ok: false, error: "Broker attestation is missing or malformed" };
+  }
+  const expectedTaskId = derivedTaskId(
+    envelope.data.broker_principal,
+    envelope.data.idempotency_key,
+  );
+  const expected = unsignedAttestation(envelope.data);
+  const value = attestation.data;
+  if (envelope.data.task_id !== expectedTaskId
+    || value.namespace !== expected.namespace
+    || value.task_id !== expected.task_id
+    || value.broker_principal !== expected.broker_principal
+    || value.envelope_digest !== expected.envelope_digest
+    || value.issued_at !== expected.issued_at
+    || (input.expectedNamespace !== undefined && value.namespace !== input.expectedNamespace)) {
+    return { ok: false, error: "Broker attestation binding mismatch" };
+  }
+  if (!input.serverSecret) return { ok: false, error: "Broker attestation server key is not configured" };
+  const expectedMac = Buffer.from(
+    createHmac("sha256", attestationKey(input.serverSecret))
+      .update(canonicalize(expected), "utf8")
+      .digest("hex"),
+    "hex",
+  );
+  const actualMac = Buffer.from(value.hmac_sha256, "hex");
+  if (expectedMac.length !== actualMac.length || !timingSafeEqual(expectedMac, actualMac)) {
+    return { ok: false, error: "Broker attestation signature mismatch" };
+  }
+  return { ok: true, principal: value.broker_principal, attestation: value };
+}
+
+export function parseStoredBrokerAttestation(content: string): unknown | null {
+  const match = content.match(/### Broker attestation\s*\n```json\s*\n([\s\S]*?)\n```/i);
+  if (!match?.[1]) return null;
+  try {
+    return JSON.parse(match[1]);
+  } catch {
+    return null;
+  }
+}

--- a/src/broker/task-store.ts
+++ b/src/broker/task-store.ts
@@ -17,6 +17,10 @@
 
 import { createHash } from "node:crypto";
 import { MuninWriteRejectedError, type MuninClient } from "../munin-client.js";
+import {
+  createBrokerAttestation,
+  type BrokerAttestation,
+} from "./attestation.js";
 import type {
   AwaitRequest,
   DelegationEnvelope,
@@ -177,12 +181,19 @@ export class BrokerTaskStore {
   /** Serialize same-process writes for one friction event identity. */
   private readonly frictionWritesInFlight = new Map<string, Promise<FrictionWriteResult>>();
 
-  constructor(private readonly munin: MuninClient) {}
+  constructor(
+    private readonly munin: MuninClient,
+    private readonly options: { attestationSecret?: string } = {},
+  ) {}
 
   async submit(params: SubmitTaskParams): Promise<void> {
     const ns = namespaceForTaskId(params.envelope.task_id);
     const tags = buildSubmitTags(params.envelope);
-    const content = serializeEnvelope(params.envelope);
+    const secret = this.options.attestationSecret;
+    const attestation = secret
+      ? createBrokerAttestation(params.envelope, secret)
+      : undefined;
+    const content = serializeEnvelope(params.envelope, attestation);
     await this.munin.write(
       ns,
       STATUS_KEY,
@@ -662,7 +673,10 @@ export function flipLifecycleTags(
   return [next, ...filtered];
 }
 
-export function serializeEnvelope(envelope: DelegationEnvelope): string {
+export function serializeEnvelope(
+  envelope: DelegationEnvelope,
+  attestation?: BrokerAttestation,
+): string {
   const verifier = envelope.acceptance.mode === "verifier"
     ? JSON.stringify(envelope.acceptance.verifier)
     : "none";
@@ -692,6 +706,15 @@ export function serializeEnvelope(envelope: DelegationEnvelope): string {
     "```json",
     JSON.stringify(envelope, null, 2),
     "```",
+    ...(attestation
+      ? [
+          "",
+          "### Broker attestation",
+          "```json",
+          JSON.stringify(attestation, null, 2),
+          "```",
+        ]
+      : []),
     "",
     "### Prompt",
     envelope.prompt,

--- a/src/broker/task-type-metadata.ts
+++ b/src/broker/task-type-metadata.ts
@@ -1,4 +1,35 @@
-import { taskTypeSchema, type TaskType } from "./types.js";
+import { z } from "zod";
+
+/** Canonical Hugin mirror of the ordered gille-inference task-type taxonomy. */
+export const taskTypeSchema = z.enum([
+  "draft",
+  "code-implement",
+  "code-edit",
+  "code-review",
+  "unit-test-gen",
+  "summarize",
+  "extract",
+  "classify",
+  "data-transform",
+  "regex",
+  "sql",
+  "reason-math",
+  "reason-hard",
+  "rewrite",
+  "translate",
+  "plan-decompose",
+  "qa-factual",
+  "triage",
+  "memory-decision",
+  "research-plan",
+  "source-distill",
+  "claim-verify",
+  "gap-check",
+  "synthesis",
+  "conversation",
+  "other",
+]);
+export type TaskType = z.infer<typeof taskTypeSchema>;
 
 /**
  * Version of the M5 task-type taxonomy mirrored by Hugin's Broker schema.

--- a/src/broker/types.ts
+++ b/src/broker/types.ts
@@ -13,6 +13,12 @@ import {
   qualityRubricSchema,
   qualityVerifierIdentitySchema,
 } from "../quality-receipt.js";
+import {
+  taskTypeSchema,
+  type TaskType,
+} from "./task-type-metadata.js";
+
+export { taskTypeSchema, type TaskType } from "./task-type-metadata.js";
 
 export const aliasSchema = z.enum([
   "m5",
@@ -22,36 +28,6 @@ export const aliasSchema = z.enum([
   "pi-large-coder",
 ]);
 export type Alias = z.infer<typeof aliasSchema>;
-
-export const taskTypeSchema = z.enum([
-  "draft",
-  "code-implement",
-  "code-edit",
-  "code-review",
-  "unit-test-gen",
-  "summarize",
-  "extract",
-  "classify",
-  "data-transform",
-  "regex",
-  "sql",
-  "reason-math",
-  "reason-hard",
-  "rewrite",
-  "translate",
-  "plan-decompose",
-  "qa-factual",
-  "triage",
-  "memory-decision",
-  "research-plan",
-  "source-distill",
-  "claim-verify",
-  "gap-check",
-  "synthesis",
-  "conversation",
-  "other",
-]);
-export type TaskType = z.infer<typeof taskTypeSchema>;
 
 export const sensitivitySchema = z.enum(["public", "internal", "private"]);
 export type DelegationSensitivity = z.infer<typeof sensitivitySchema>;

--- a/src/homeserver-executor.ts
+++ b/src/homeserver-executor.ts
@@ -28,6 +28,17 @@ import {
   buildHuginTaskIdentity,
   type HuginTaskIdentity,
 } from "./task-identity.js";
+import {
+  buildLearningTaskRequestStamp,
+  gatewayEchoDigest,
+  learningTaskExecutionEvidenceSchema,
+  requestStampDigest,
+  validateLearningTaskGatewayEcho,
+  validateLearningTaskReplayPayload,
+  type LearningTaskExecutionEvidence,
+  type LearningTaskPreparation,
+  type LearningTaskRequestContext,
+} from "./learning-task-handshake.js";
 
 // --- Types ---
 
@@ -75,6 +86,12 @@ export interface HomeserverTaskConfig {
   timeoutMs: number;
   maxOutputChars: number;
   injectedContext?: string;
+  /**
+   * Internal producer context. It is created only after Hugin durably starts
+   * the attempt and accepts an authenticated preflight. Task documents cannot
+   * supply this object. Direct `/delegate` refuses to run without it.
+   */
+  learningTask?: LearningTaskPreparation | { kind: "ineligible" };
 }
 
 export type Backpressure = "none" | "quota" | "admission";
@@ -114,6 +131,8 @@ export interface HomeserverExecutorResult {
   provenance: M5DelegationProvenance | null;
   /** Hugin-produced raw-task/rendered-prompt identity; not a gateway admission echo. */
   huginTaskIdentity: HuginTaskIdentity | null;
+  /** Exact producer stamp/join evidence for this authoritative Hugin attempt. */
+  learningTask: LearningTaskExecutionEvidence | null;
 }
 
 export interface HomeserverExecutorOptions {
@@ -191,6 +210,45 @@ export function renderHomeserverUserMessage(task: HomeserverTaskConfig): string 
 export interface HomeserverRequestBody extends Record<string, unknown> {
   prompt?: string;
   huginTaskIdentity?: HuginTaskIdentity;
+  learningTaskStamp?: ReturnType<typeof buildLearningTaskRequestStamp>;
+}
+
+/** Build the exact candidate body before its classified replay copy is persisted. */
+export function buildFreshHomeserverDelegateRequestBody(
+  task: HomeserverTaskConfig,
+  taskId: string,
+  context: LearningTaskRequestContext,
+): HomeserverRequestBody {
+  if (!task.taskType) {
+    throw new Error("LearningTaskContract delegation requires a canonical task type");
+  }
+  const userMessage = renderHomeserverUserMessage(task);
+  const huginTaskIdentity = buildHuginTaskIdentity({
+    taskId,
+    rawTaskText: task.prompt,
+    renderedPrompt: userMessage,
+  });
+  return {
+    prompt: userMessage,
+    taskType: task.taskType,
+    ...(task.systemPrompt !== undefined ? { systemPrompt: task.systemPrompt } : {}),
+    ...(task.maxTokens !== undefined ? { maxTokens: task.maxTokens } : {}),
+    ...(task.modelId !== undefined ? { modelId: task.modelId } : {}),
+    ...(task.frontierModelId !== undefined ? { frontierModelId: task.frontierModelId } : {}),
+    ...(task.verifier !== undefined ? { verifier: task.verifier } : {}),
+    ...(task.responseFormat !== undefined ? { responseFormat: task.responseFormat } : {}),
+    ...(task.delegatorModelId !== undefined ? { delegatorModelId: task.delegatorModelId } : {}),
+    ...(task.premiumBaselineModelId !== undefined
+      ? { premiumBaselineModelId: task.premiumBaselineModelId }
+      : {}),
+    huginTaskIdentity,
+    learningTaskStamp: buildLearningTaskRequestStamp({
+      context,
+      taskType: task.taskType,
+      rawTaskText: task.prompt,
+      renderedPrompt: userMessage,
+    }),
+  };
 }
 
 /**
@@ -204,25 +262,44 @@ export function buildHomeserverRequestBody(
 ): HomeserverRequestBody {
   const userMessage = renderHomeserverUserMessage(task);
   if (task.path === "delegate") {
-    return {
-      prompt: userMessage,
-      ...(task.taskType ? { taskType: task.taskType } : {}),
-      ...(task.systemPrompt !== undefined ? { systemPrompt: task.systemPrompt } : {}),
-      ...(task.maxTokens !== undefined ? { maxTokens: task.maxTokens } : {}),
-      ...(task.modelId !== undefined ? { modelId: task.modelId } : {}),
-      ...(task.frontierModelId !== undefined ? { frontierModelId: task.frontierModelId } : {}),
-      ...(task.verifier !== undefined ? { verifier: task.verifier } : {}),
-      ...(task.responseFormat !== undefined ? { responseFormat: task.responseFormat } : {}),
-      ...(task.delegatorModelId !== undefined ? { delegatorModelId: task.delegatorModelId } : {}),
-      ...(task.premiumBaselineModelId !== undefined
-        ? { premiumBaselineModelId: task.premiumBaselineModelId }
-        : {}),
-      huginTaskIdentity: buildHuginTaskIdentity({
-        taskId,
-        rawTaskText: task.prompt,
-        renderedPrompt: userMessage,
-      }),
-    };
+    if (task.learningTask?.kind === "ineligible") {
+      if (!task.taskType) throw new Error("Legacy homeserver delegation requires a task type");
+      return {
+        prompt: userMessage,
+        taskType: task.taskType,
+        ...(task.systemPrompt !== undefined ? { systemPrompt: task.systemPrompt } : {}),
+        ...(task.maxTokens !== undefined ? { maxTokens: task.maxTokens } : {}),
+        ...(task.modelId !== undefined ? { modelId: task.modelId } : {}),
+        ...(task.frontierModelId !== undefined ? { frontierModelId: task.frontierModelId } : {}),
+        ...(task.verifier !== undefined ? { verifier: task.verifier } : {}),
+        ...(task.responseFormat !== undefined ? { responseFormat: task.responseFormat } : {}),
+        ...(task.delegatorModelId !== undefined ? { delegatorModelId: task.delegatorModelId } : {}),
+        ...(task.premiumBaselineModelId !== undefined
+          ? { premiumBaselineModelId: task.premiumBaselineModelId }
+          : {}),
+        huginTaskIdentity: buildHuginTaskIdentity({
+          taskId,
+          rawTaskText: task.prompt,
+          renderedPrompt: userMessage,
+        }),
+      };
+    }
+    if (task.learningTask?.kind !== "ready") {
+      throw new Error("Direct homeserver delegation requires a durable LearningTaskContract attempt and accepted preflight");
+    }
+    const fresh = buildFreshHomeserverDelegateRequestBody(
+      task,
+      taskId,
+      task.learningTask.context,
+    );
+    const replay = validateLearningTaskReplayPayload(
+      task.learningTask.preparedDispatch,
+      task.learningTask.replayPayload,
+    );
+    if (JSON.stringify(fresh) !== JSON.stringify(replay.requestBody)) {
+      throw new Error("task request bytes changed after immutable dispatch preparation");
+    }
+    return structuredClone(replay.requestBody) as HomeserverRequestBody;
   }
   return {
     model: task.model,
@@ -302,6 +379,7 @@ export async function executeHomeserverTask(
     nodeId: null,
     provenance: null,
     huginTaskIdentity: null,
+    learningTask: null,
   };
 
   const finish = async (): Promise<HomeserverExecutorResult> => {
@@ -336,11 +414,76 @@ export async function executeHomeserverTask(
   if (task.apiKey) headers.Authorization = `Bearer ${task.apiKey}`;
 
   try {
+    if (task.path === "delegate" && task.learningTask?.kind === "preflight-failed") {
+      const { attempt, attemptStartRef, failureReason } = task.learningTask;
+      result.huginTaskIdentity = attempt.huginTaskIdentity;
+      result.learningTask = learningTaskExecutionEvidenceSchema.parse({
+        schemaVersion: 1,
+        contractVersion: "grimnir.learning-task/v1",
+        state: "preflight-failed",
+        evidenceAccepted: false,
+        taskId: attempt.taskId,
+        attemptId: attempt.attemptId,
+        attemptStartedAt: attempt.startedAt,
+        attemptStartRef,
+        taskOutcomeRef: { namespace: `tasks/${attempt.taskId}`, key: "result-structured" },
+        rawFingerprint: attempt.huginTaskIdentity.rawTaskFingerprint,
+        failureCode: "preflight-failed",
+        failureReason,
+      });
+      appendOutput(`[LearningTaskContract preflight failed: ${failureReason}]\n`);
+      return finish();
+    }
+    if (task.path === "delegate" && task.learningTask?.kind === "dispatch-failed") {
+      const { attempt, attemptStartRef, requestStamp, requestStampDigest: digest, failureReason } = task.learningTask;
+      result.huginTaskIdentity = attempt.huginTaskIdentity;
+      result.learningTask = learningTaskExecutionEvidenceSchema.parse({
+        schemaVersion: 1,
+        contractVersion: "grimnir.learning-task/v1",
+        state: "m5-not-admitted",
+        evidenceAccepted: false,
+        taskId: attempt.taskId,
+        attemptId: attempt.attemptId,
+        attemptStartedAt: attempt.startedAt,
+        attemptStartRef,
+        taskOutcomeRef: { namespace: `tasks/${attempt.taskId}`, key: "result-structured" },
+        rawFingerprint: attempt.huginTaskIdentity.rawTaskFingerprint,
+        requestStamp,
+        requestStampDigest: digest,
+        failureCode: "prepared-dispatch-persistence-failed",
+        failureReason,
+      });
+      appendOutput(`[LearningTaskContract dispatch preparation failed: ${failureReason}]\n`);
+      return finish();
+    }
     // Keep defensive identity/serialization validation inside the executor's
     // normal failure boundary so malformed direct callers still receive a
     // closed log and structured executor result rather than an escaped throw.
     const body = buildHomeserverRequestBody(task, taskId);
     result.huginTaskIdentity = body.huginTaskIdentity ?? null;
+    if (task.path === "delegate" && task.learningTask?.kind === "ready") {
+      const stamp = body.learningTaskStamp!;
+      const context = task.learningTask as Extract<LearningTaskPreparation, { kind: "ready" }>;
+      result.learningTask = learningTaskExecutionEvidenceSchema.parse({
+        schemaVersion: 1,
+        contractVersion: "grimnir.learning-task/v1",
+        state: "m5-not-admitted",
+        evidenceAccepted: false,
+        taskId: stamp.task_instance_id,
+        attemptId: stamp.attempt_id,
+        attemptStartedAt: context.context.attempt.startedAt,
+        attemptStartRef: context.context.attemptStartRef,
+        preparedDispatchRef: context.preparedDispatch.preparedDispatchRef,
+        replayPayloadRef: context.preparedDispatch.replayPayloadRef,
+        replayPayloadDigest: context.preparedDispatch.replayPayloadDigest,
+        taskOutcomeRef: { namespace: `tasks/${stamp.task_instance_id}`, key: "result-structured" },
+        rawFingerprint: stamp.raw_fingerprint,
+        requestStamp: stamp,
+        requestStampDigest: requestStampDigest(stamp),
+        failureCode: "transport-not-admitted",
+        failureReason: "gateway admission has not been proven by an exact echo",
+      });
+    }
     const url =
       task.path === "delegate"
         ? `${task.gatewayBaseUrl}/delegate`
@@ -382,6 +525,37 @@ export async function executeHomeserverTask(
       // throw inside the downstream buildStructuredTaskResult .parse() and lose
       // the result of an already-paid run.
       const raw: unknown = await res.json();
+      if (task.learningTask?.kind === "ready") {
+        const stamp = body.learningTaskStamp!;
+        let gatewayEcho;
+        try {
+          gatewayEcho = validateLearningTaskGatewayEcho(
+            (raw as { learningTaskGatewayEcho?: unknown })?.learningTaskGatewayEcho,
+            stamp,
+          );
+        } catch (err) {
+          const reason = err instanceof Error ? err.message : "invalid gateway echo";
+          result.learningTask = learningTaskExecutionEvidenceSchema.parse({
+            ...result.learningTask!,
+            state: "join-failed",
+            evidenceAccepted: false,
+            failureCode: "gateway-echo-invalid",
+            failureReason: reason,
+          });
+          appendOutput(`[LearningTaskContract join rejected: ${reason}]\n`);
+          result.exitCode = 1;
+          return finish();
+        }
+        result.learningTask = learningTaskExecutionEvidenceSchema.parse({
+          ...result.learningTask!,
+          state: "m5-admitted",
+          evidenceAccepted: true,
+          gatewayEcho,
+          gatewayEchoDigest: gatewayEchoDigest(gatewayEcho),
+          failureCode: undefined,
+          failureReason: undefined,
+        });
+      }
       const outcome = raw as {
         output?: unknown;
         frontierOutput?: unknown;
@@ -484,6 +658,15 @@ export async function executeHomeserverTask(
     }
     return finish();
   } catch (err) {
+    if (result.learningTask?.requestStamp !== undefined
+      && result.learningTask.state === "m5-not-admitted") {
+      result.learningTask = learningTaskExecutionEvidenceSchema.parse({
+        ...result.learningTask,
+        failureReason: err instanceof Error && err.name === "AbortError"
+          ? "gateway request timed out before an exact admission echo"
+          : "gateway request failed before an exact admission echo",
+      });
+    }
     if (err instanceof Error && err.name === "AbortError") {
       result.exitCode = "TIMEOUT";
       appendOutput(`\n[Gateway request aborted after ${Math.round((Date.now() - startMs) / 1000)}s]\n`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,10 +58,28 @@ import {
 import { executeOllamaTask } from "./ollama-executor.js";
 import {
   executeHomeserverTask,
+  buildFreshHomeserverDelegateRequestBody,
   loadHomeserverGatewayConfig,
+  renderHomeserverUserMessage,
   type HomeserverExecutorResult,
   type HomeserverVerifierSpec,
 } from "./homeserver-executor.js";
+import {
+  createPreparedLearningTaskDispatch,
+  learningTaskAttemptKey,
+  learningTaskExecutionEvidenceSchema,
+  learningTaskOutcomePersistenceFailure,
+  prepareDurableLearningTaskAttempt,
+  validatePreparedLearningTaskOutcome,
+  type LearningTaskExecutionEvidence,
+  type LearningTaskSource,
+} from "./learning-task-handshake.js";
+import {
+  recoverLatestStoredLearningTaskAttempt,
+  type RecoveredStoredLearningTask,
+} from "./learning-task-recovery.js";
+import { createImmutableLearningArtifact } from "./learning-task-store.js";
+import { buildAuthenticatedLearningTaskSource } from "./learning-task-source.js";
 import {
   executeOpencodeTask,
   loadOpencodeGatewayConfig,
@@ -177,6 +195,10 @@ import { consultSkillLane } from "./skill/skill-lane-dispatch.js";
 import { readBrokerEnv, startBroker, type RunningBroker } from "./broker/server.js";
 import { brokerExecutorCapabilities } from "./broker/executor-capabilities.js";
 import { BrokerTaskStore, parseCanonicalEnvelope } from "./broker/task-store.js";
+import {
+  parseStoredBrokerAttestation,
+  validateBrokerAttestation,
+} from "./broker/attestation.js";
 import { DelegationJournal } from "./broker/journal.js";
 import { IdempotencyIndex } from "./broker/idempotency.js";
 import {
@@ -692,6 +714,11 @@ interface TaskConfig {
   homeserverVerifier?: HomeserverVerifierSpec;
   maxOutputTokens?: number;
   homeserverPolicyError?: string;
+  /** Authenticated Hugin Broker source, never parsed from free-form task prose. */
+  brokerPrincipal?: string;
+  brokerAttestedNamespace?: string;
+  /** Why an embedded Broker claim did not qualify as authenticated learning provenance. */
+  brokerAttestationError?: string;
 }
 
 type DeclaredRuntime = TaskConfig["runtime"] | "pipeline" | "auto";
@@ -858,6 +885,14 @@ function parseTask(content: string): TaskConfig | null {
     }
   }
 
+  const brokerAttestation = canonicalBrokerEnvelope
+    ? validateBrokerAttestation({
+        envelope: canonicalBrokerEnvelope,
+        attestation: parseStoredBrokerAttestation(content),
+        serverSecret: config.muninApiKey,
+      })
+    : null;
+
   if ((!prompt && !canonicalBrokerEnvelope) || (!runtime && !isAutoRoute)) return null;
 
   // Resolution priority: Context > Working dir > config.workspace
@@ -937,6 +972,13 @@ function parseTask(content: string): TaskConfig | null {
         )
       : undefined,
     homeserverPolicyError,
+    brokerPrincipal: brokerAttestation?.ok ? brokerAttestation.principal : undefined,
+    brokerAttestedNamespace: brokerAttestation?.ok
+      ? brokerAttestation.attestation.namespace
+      : undefined,
+    brokerAttestationError: brokerAttestation && !brokerAttestation.ok
+      ? brokerAttestation.error
+      : undefined,
     pipeline:
       pipelineId && pipelinePhase
         ? {
@@ -961,6 +1003,24 @@ function parseTask(content: string): TaskConfig | null {
           }
         : undefined,
   };
+}
+
+function buildLearningTaskSource(
+  task: TaskConfig,
+  taskNs: string,
+  createdAt: string,
+  acceptedAt: string,
+  provenance: TaskSubmissionProvenance,
+): LearningTaskSource {
+  return buildAuthenticatedLearningTaskSource({
+    taskNamespace: taskNs,
+    createdAt,
+    acceptedAt,
+    verifiedSubmitter: provenance.verifiedSubmitter ?? undefined,
+    brokerPrincipal: task.brokerPrincipal,
+    brokerAttestedNamespace: task.brokerAttestedNamespace,
+    brokerAttestationError: task.brokerAttestationError,
+  });
 }
 
 function buildTaskSensitivitySnapshot(
@@ -2740,6 +2800,18 @@ async function queryOperationalTaskEntries(
   return page.results;
 }
 
+async function recoverPreparedLearningAttempt(
+  taskNs: string,
+  classification?: string,
+): Promise<RecoveredStoredLearningTask | null> {
+  return recoverLatestStoredLearningTaskAttempt({
+    munin,
+    taskNamespace: taskNs,
+    taskClassification: classification,
+    gateway: loadHomeserverGatewayConfig(process.env),
+  });
+}
+
 async function recoverStaleTasks(): Promise<void> {
   try {
     const results = await queryOperationalTaskEntries(munin, ["running"], "startup recovery");
@@ -2796,17 +2868,26 @@ async function recoverStaleTasks(): Promise<void> {
       );
 
       const runtimeTag = entry.tags.find((t) => t.startsWith("runtime:"));
+      const learningRecovery = runtimeTag === "runtime:homeserver"
+        ? await recoverPreparedLearningAttempt(result.namespace, entry.classification)
+        : null;
+      const recoveryOutputClassification = learningRecovery?.classification
+        ?? entry.classification;
       await munin.write(
         result.namespace,
         "status",
         entry.content,
         buildTerminalStatusTags("failed", entry.tags),
-        entry.updated_at
+        entry.updated_at,
+        recoveryOutputClassification,
       );
       await munin.write(
         result.namespace,
         "result",
-        `## Result\n\n- **Exit code:** ${DISPATCHER_FAILURE_EXIT_CODE}\n- **Error:** Task recovered (${reason}, worker: ${claimedBy || "unknown"}, elapsed: ${elapsed}s)\n`
+        `## Result\n\n- **Exit code:** ${DISPATCHER_FAILURE_EXIT_CODE}\n- **Error:** Task recovered (${reason}, worker: ${claimedBy || "unknown"}, elapsed: ${elapsed}s)\n`,
+        undefined,
+        undefined,
+        recoveryOutputClassification,
       );
       const runtime = (runtimeTag || "runtime:claude").replace(
         /^runtime:/,
@@ -2821,8 +2902,17 @@ async function recoverStaleTasks(): Promise<void> {
           {
             executor: "dispatcher",
             resultSource: "recovery",
+            ...(learningRecovery
+              ? {
+                  runtimeMetadata: {
+                    huginTaskIdentity: learningRecovery.huginTaskIdentity,
+                    learningTask: learningRecovery.evidence,
+                  },
+                }
+              : {}),
           }
-        )
+        ),
+        recoveryOutputClassification,
       );
       await munin.log(
         result.namespace,
@@ -4424,6 +4514,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
   // one stable session (enables Munin's outcome-aware retrieval and telemetry
   // session-flow analysis). A fresh ID is set again in the finally block below.
   munin.setSessionId(randomUUID());
+  let claimAcceptedAt = entry.updated_at;
   try {
     const claimResult = await munin.write(
       taskNs,
@@ -4435,6 +4526,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     // Update entry.updated_at so subsequent CAS writes (failTaskWithMessage, etc.) use the fresh timestamp
     if (typeof claimResult.updated_at === "string") {
       entry.updated_at = claimResult.updated_at;
+      claimAcceptedAt = claimResult.updated_at;
     }
   } catch (err) {
     // Another dispatcher won the CAS. Its claim-time assessment owns the
@@ -4447,7 +4539,10 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
 
   currentTask = taskNs;
   currentCancellation = null;
-  const startedAt = new Date().toISOString();
+  const acceptedAtMs = Date.parse(claimAcceptedAt);
+  const startedAt = new Date(
+    Number.isNaN(acceptedAtMs) ? Date.now() : Math.max(Date.now(), acceptedAtMs),
+  ).toISOString();
   const taskId = extractTaskId(taskNs);
   console.log(`Executing task ${taskNs}...`);
 
@@ -4786,7 +4881,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     } else {
       const homeserverAbort = new AbortController();
       currentOllamaAbort = homeserverAbort;
-      homeserverResult = await executeHomeserverTask({
+      const renderedPrompt = renderHomeserverUserMessage({
         prompt: task.prompt,
         gatewayBaseUrl: gateway.baseUrl,
         apiKey: gateway.apiKey,
@@ -4797,7 +4892,136 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         timeoutMs: task.timeoutMs,
         maxOutputChars: config.maxOutputChars,
         injectedContext: task.contextResolution?.content || undefined,
+      });
+      const homeserverTaskConfig = {
+        prompt: task.prompt,
+        gatewayBaseUrl: gateway.baseUrl,
+        apiKey: gateway.apiKey,
+        path: "delegate" as const,
+        taskType: task.homeserverTaskType,
+        maxTokens: task.maxOutputTokens,
+        verifier: task.homeserverVerifier,
+        timeoutMs: task.timeoutMs,
+        maxOutputChars: config.maxOutputChars,
+        injectedContext: task.contextResolution?.content || undefined,
+      };
+      let authenticatedLearningSource: LearningTaskSource | undefined;
+      try {
+        authenticatedLearningSource = buildLearningTaskSource(
+          task,
+          taskNs,
+          entry.created_at,
+          claimAcceptedAt,
+          signingVerdict.provenance,
+        );
+      } catch (error) {
+        // Existing unstamped /delegate traffic remains operational but is not
+        // learning-eligible. Only authenticated source identities enter the
+        // durable harvest/join protocol.
+        console.log(
+          `LearningTaskContract ineligible for ${taskNs}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+      const preparedLearningTask = authenticatedLearningSource
+        ? await prepareDurableLearningTaskAttempt({
+        taskId,
+        startedAt,
+        rawTaskText: task.prompt,
+        renderedPrompt,
+        gatewayBaseUrl: gateway.baseUrl,
+        apiKey: gateway.apiKey,
+        buildSource: () => authenticatedLearningSource!,
+        // This immutable, UUID-keyed start is the authoritative attempt clock.
+        // It lands before capability negotiation, request stamping, admission,
+        // or any model call and contains no prompt or response bytes.
+        persistStart: async (ref, record) => {
+          await createImmutableLearningArtifact(munin, {
+            namespace: ref.namespace,
+            key: ref.key,
+            content: JSON.stringify(record),
+            tags: ["learning-task-attempt", "attempt:started", "contract:grimnir-learning-task-v1"],
+            classification: taskClassification,
+          });
+        },
+        buildPreparedDispatch: (context) => {
+          const requestBody = buildFreshHomeserverDelegateRequestBody(
+            homeserverTaskConfig,
+            taskId,
+            context,
+          );
+          return createPreparedLearningTaskDispatch({
+            context,
+            requestStamp: requestBody.learningTaskStamp!,
+            requestBody,
+          });
+        },
+        persistReplayPayload: async (ref, record) => {
+          await createImmutableLearningArtifact(munin, {
+            namespace: ref.namespace,
+            key: ref.key,
+            content: JSON.stringify(record),
+            tags: ["learning-task-replay", "attempt:prepared", "contract:grimnir-learning-task-v1"],
+            classification: taskClassification,
+          });
+        },
+        persistPrepared: async (ref, record) => {
+          await createImmutableLearningArtifact(munin, {
+            namespace: ref.namespace,
+            key: ref.key,
+            content: JSON.stringify(record),
+            tags: ["learning-task-dispatch", "attempt:prepared", "contract:grimnir-learning-task-v1"],
+            classification: taskClassification,
+          });
+        },
+      })
+        : null;
+      const learningAttempt = preparedLearningTask?.attempt;
+      const learningAttemptKey = learningAttempt
+        ? learningTaskAttemptKey(learningAttempt.attemptId)
+        : undefined;
+      homeserverResult = await executeHomeserverTask({
+        ...homeserverTaskConfig,
+        learningTask: preparedLearningTask?.preparation ?? { kind: "ineligible" },
       }, taskId, LOG_DIR, { abortController: homeserverAbort });
+      if (homeserverResult.learningTask && learningAttemptKey) {
+        const outcomeKey = `${learningAttemptKey}-outcome`;
+        const attemptOutcomeRef = { namespace: taskNs, key: outcomeKey };
+        try {
+          const parsedEvidence = learningTaskExecutionEvidenceSchema.parse({
+            ...homeserverResult.learningTask,
+            attemptOutcomeRef,
+          });
+          const durableEvidence = preparedLearningTask?.preparation.kind === "ready"
+            ? validatePreparedLearningTaskOutcome(
+                preparedLearningTask.preparation.preparedDispatch,
+                parsedEvidence,
+              )
+            : parsedEvidence;
+          await createImmutableLearningArtifact(munin, {
+            namespace: taskNs,
+            key: outcomeKey,
+            content: JSON.stringify(durableEvidence),
+            tags: [
+              "learning-task-attempt",
+              durableEvidence.state === "m5-admitted" ? "attempt:admitted" : "attempt:not-admitted",
+              "contract:grimnir-learning-task-v1",
+            ],
+            classification: taskClassification,
+          }, { allowExactExisting: true });
+          homeserverResult.learningTask = durableEvidence;
+        } catch (err) {
+          const failureReason = "durable learning-task attempt outcome write failed";
+          homeserverResult.learningTask = learningTaskOutcomePersistenceFailure(
+            homeserverResult.learningTask,
+            failureReason,
+          );
+          homeserverResult.exitCode = 1;
+          homeserverResult.resultText = null;
+          homeserverResult.provenance = null;
+          homeserverResult.output = `[LearningTaskContract evidence rejected: ${failureReason}]\n`;
+          console.error(`${failureReason} for ${taskNs}:`, err);
+        }
+      }
       currentOllamaAbort = null;
       exitCode = homeserverResult.exitCode;
       output = homeserverResult.output;
@@ -5464,6 +5688,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
               taskType: homeserverResult.taskType ?? task.homeserverTaskType,
             },
             huginTaskIdentity: homeserverResult.huginTaskIdentity ?? undefined,
+            learningTask: homeserverResult.learningTask ?? undefined,
           }
         : isOllama
         ? {
@@ -6154,7 +6379,7 @@ server.on("error", (err: NodeJS.ErrnoException) => {
 if (brokerEnv.enabled) {
   const brokerHome = path.join(HUGIN_HOME, "delegation-events.jsonl");
   const journal = new DelegationJournal({ path: brokerHome });
-  const taskStore = new BrokerTaskStore(munin);
+  const taskStore = new BrokerTaskStore(munin, { attestationSecret: config.muninApiKey });
   const learningStore = new LearningExperimentStore(learningExperimentMunin);
   const idempotency = new IdempotencyIndex();
   const homeserverReady = loadHomeserverGatewayConfig(process.env) !== null;

--- a/src/learning-task-handshake.ts
+++ b/src/learning-task-handshake.ts
@@ -1,0 +1,1398 @@
+import { createHash, randomUUID } from "node:crypto";
+import { z } from "zod";
+
+import {
+  buildHuginTaskIdentity,
+  fingerprintRenderedPrompt,
+  huginTaskIdentitySchema,
+  type HuginTaskIdentity,
+} from "./task-identity.js";
+import {
+  BROKER_TASK_TYPE_TAXONOMY_ID,
+  BROKER_TASK_TYPE_TAXONOMY_VERSION,
+  taskTypeSchema as brokerTaskTypeIdSchema,
+} from "./broker/task-type-metadata.js";
+
+export const LEARNING_TASK_CONTRACT_VERSION = "grimnir.learning-task/v1" as const;
+export const LEARNING_TASK_SCHEMA_REVISION = 1 as const;
+export const LEARNING_TASK_PREFLIGHT_ENDPOINT = "/v1/capabilities/learning-task" as const;
+export const LEARNING_TASK_PREFLIGHT_PROTOCOL = "learning-task-preflight/v1" as const;
+export const LEARNING_TASK_GATEWAY_PRINCIPAL = "service:gille-inference" as const;
+export const LEARNING_TASK_PREFLIGHT_TTL_MS = 15 * 60 * 1_000;
+export const LEARNING_TASK_FEATURES = [
+  "hugin-request-stamp-v1",
+  "gateway-echo-v1",
+  "three-stage-prompt-provenance-v1",
+  "reproducible-serving-digests-v1",
+] as const;
+
+export const LEARNING_TASK_CAPABILITIES = {
+  contract_version: LEARNING_TASK_CONTRACT_VERSION,
+  schema_revision: LEARNING_TASK_SCHEMA_REVISION,
+  features: [...LEARNING_TASK_FEATURES],
+} as const;
+
+const sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
+const opaqueIdSchema = z.string().regex(
+  /^opaque:[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+);
+const utcTimestampPattern = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?Z$/;
+
+function isExactUtcTimestamp(value: string): boolean {
+  const match = utcTimestampPattern.exec(value);
+  if (!match) return false;
+  const instant = new Date(value);
+  if (Number.isNaN(instant.getTime())) return false;
+  return instant.getUTCFullYear() === Number(match[1])
+    && instant.getUTCMonth() + 1 === Number(match[2])
+    && instant.getUTCDate() === Number(match[3])
+    && instant.getUTCHours() === Number(match[4])
+    && instant.getUTCMinutes() === Number(match[5])
+    && instant.getUTCSeconds() === Number(match[6]);
+}
+
+const timestampSchema = z.string().refine(isExactUtcTimestamp, {
+  message: "invalid RFC 3339 UTC timestamp",
+});
+const capabilitySchema = z.object({
+  contract_version: z.literal(LEARNING_TASK_CONTRACT_VERSION),
+  schema_revision: z.literal(LEARNING_TASK_SCHEMA_REVISION),
+  features: z.array(z.enum(LEARNING_TASK_FEATURES)).length(LEARNING_TASK_FEATURES.length)
+    .refine((features) => new Set(features).size === LEARNING_TASK_FEATURES.length
+      && LEARNING_TASK_FEATURES.every((feature) => features.includes(feature)), {
+      message: "learning-task features must be unique and complete",
+    }),
+}).strict();
+
+const preflightRequestSchema = z.object({
+  request_id: opaqueIdSchema,
+  endpoint: z.literal(LEARNING_TASK_PREFLIGHT_ENDPOINT),
+  protocol_version: z.literal(LEARNING_TASK_PREFLIGHT_PROTOCOL),
+  requested_at: timestampSchema,
+  requested_capabilities: capabilitySchema,
+}).strict();
+
+const preflightResponseSchema = z.object({
+  advertisement_id: opaqueIdSchema,
+  endpoint: z.literal(LEARNING_TASK_PREFLIGHT_ENDPOINT),
+  protocol_version: z.literal(LEARNING_TASK_PREFLIGHT_PROTOCOL),
+  advertised_at: timestampSchema,
+  expires_at: timestampSchema,
+  authenticated_principal_id: z.literal(LEARNING_TASK_GATEWAY_PRINCIPAL),
+  authentication: z.literal("service-auth"),
+  capabilities: capabilitySchema,
+}).strict();
+
+const sourceDocumentTypeSchema = z.enum([
+  "raw-input",
+  "prompt-stage",
+  "origin-prompt-config",
+  "origin-harness-config",
+  "origin-tool-policy-config",
+]);
+const sourceDocumentDigestSchema = z.object({
+  algorithm: z.literal("sha256"),
+  canonicalization: z.literal("jcs-rfc8785-utf8-v1"),
+  source_ref: z.string().regex(/^source-doc:[a-z0-9][a-z0-9._/-]*$/),
+  source_type: sourceDocumentTypeSchema,
+  source_version: z.string().min(1),
+  digest: sha256Schema,
+}).strict();
+
+const sourceSchema = z.object({
+  component: z.literal("hugin"),
+  system: z.string().min(1),
+  id: z.string().min(1),
+  created_at: timestampSchema,
+  accepted_at: timestampSchema,
+  principal: z.object({
+    id: z.string().min(1),
+    authentication: z.enum(["verified-signature", "gateway-owner-auth", "service-auth"]),
+    scope: z.enum(["owner", "service"]),
+  }).strict(),
+  content_owner: z.object({
+    id: z.string().min(1),
+    authority: z.enum(["authenticated-owner", "delegated-owner"]),
+  }).strict(),
+}).strict();
+
+const taskTypeSchema = z.object({
+  // #235 owns the runtime task-type registry. Learning stamps consume that
+  // schema instead of maintaining a third local list.
+  id: brokerTaskTypeIdSchema,
+  taxonomy_id: z.literal(BROKER_TASK_TYPE_TAXONOMY_ID),
+  taxonomy_version: z.literal(BROKER_TASK_TYPE_TAXONOMY_VERSION),
+}).strict();
+
+const versionedConfigSchema = z.object({
+  id: z.string().min(1),
+  version: z.string().min(1),
+  config_digest: sourceDocumentDigestSchema,
+}).strict();
+
+export const huginRequestStampSchema = z.object({
+  task_instance_id: z.string().min(1),
+  attempt_id: z.string().min(1),
+  client_id: z.literal("hugin"),
+  expected_transport_principal_id: z.string().min(1),
+  idempotency_key: opaqueIdSchema,
+  request_id: opaqueIdSchema,
+  stamped_at: timestampSchema,
+  contract_request: capabilitySchema,
+  preflight: z.object({
+    request: preflightRequestSchema,
+    response: preflightResponseSchema,
+  }).strict(),
+  source: sourceSchema,
+  task_type: taskTypeSchema,
+  raw_input: sourceDocumentDigestSchema.refine((value) => value.source_type === "raw-input"),
+  raw_fingerprint: z.object({
+    algorithm: z.literal("sha256"),
+    version: z.literal("trim-utf8-sha256-v1"),
+    digest: sha256Schema,
+  }).strict(),
+  hugin_envelope: sourceDocumentDigestSchema.refine((value) => value.source_type === "prompt-stage"),
+  origin_config: z.object({
+    prompt: versionedConfigSchema,
+    harness: versionedConfigSchema,
+    tool_policy: versionedConfigSchema,
+  }).strict(),
+  macro_decision: z.object({
+    policy_id: z.string().min(1),
+    version: z.string().min(1),
+    decision_id: z.string().min(1),
+    target: z.literal("m5"),
+    service: z.literal("gille-inference"),
+  }).strict(),
+}).strict();
+
+export const learningTaskGatewayEchoSchema = z.object({
+  echoed_request: huginRequestStampSchema,
+  gateway_request_id: opaqueIdSchema,
+  admission_id: opaqueIdSchema,
+  admitted_at: timestampSchema,
+  authenticated_principal_id: z.string().min(1),
+  authentication: z.enum(["gateway-owner-auth", "service-auth"]),
+  principal_binding_digest: z.object({
+    algorithm: z.literal("sha256"),
+    version: z.literal("gateway-principal-request-binding-jcs-v1"),
+    digest: sha256Schema,
+  }).strict(),
+  capabilities: capabilitySchema,
+}).strict();
+
+export type LearningTaskSource = z.infer<typeof sourceSchema>;
+export type LearningTaskPreflightRequest = z.infer<typeof preflightRequestSchema>;
+export type LearningTaskPreflightResponse = z.infer<typeof preflightResponseSchema>;
+export type HuginRequestStamp = z.infer<typeof huginRequestStampSchema>;
+export type LearningTaskGatewayEcho = z.infer<typeof learningTaskGatewayEchoSchema>;
+
+const evidenceRefSchema = z.object({
+  namespace: z.string().min(1),
+  key: z.string().min(1),
+}).strict();
+const requestStampDigestSchema = z.object({
+  algorithm: z.literal("sha256"),
+  version: z.literal("hugin-request-stamp-jcs-v1"),
+  digest: sha256Schema,
+}).strict();
+const gatewayEchoDigestSchema = z.object({
+  algorithm: z.literal("sha256"),
+  version: z.literal("gateway-echo-jcs-v1"),
+  digest: sha256Schema,
+}).strict();
+const replayPayloadDigestSchema = z.object({
+  algorithm: z.literal("sha256"),
+  version: z.literal("hugin-replay-payload-jcs-v1"),
+  digest: sha256Schema,
+}).strict();
+
+export const learningTaskReplayPayloadSchema = z.object({
+  schemaVersion: z.literal(1),
+  contractVersion: z.literal(LEARNING_TASK_CONTRACT_VERSION),
+  taskId: z.string().min(1),
+  attemptId: z.string().min(1),
+  requestBody: z.record(z.string(), z.unknown()),
+}).strict();
+
+const learningTaskDelegateRequestBodySchema = z.object({
+  prompt: z.string().min(1),
+  huginTaskIdentity: huginTaskIdentitySchema,
+  learningTaskStamp: huginRequestStampSchema,
+}).passthrough();
+
+export type LearningTaskReplayPayload = z.infer<typeof learningTaskReplayPayloadSchema>;
+
+export const preparedLearningTaskDispatchSchema = z.object({
+  schemaVersion: z.literal(1),
+  contractVersion: z.literal(LEARNING_TASK_CONTRACT_VERSION),
+  taskId: z.string().min(1),
+  attemptId: z.string().min(1),
+  attemptStartedAt: timestampSchema,
+  preparedAt: timestampSchema,
+  attemptStartRef: evidenceRefSchema,
+  preparedDispatchRef: evidenceRefSchema,
+  replayPayloadRef: evidenceRefSchema,
+  replayPayloadDigest: replayPayloadDigestSchema,
+  attemptOutcomeRef: evidenceRefSchema,
+  taskOutcomeRef: evidenceRefSchema,
+  requestStamp: huginRequestStampSchema,
+  requestStampDigest: requestStampDigestSchema,
+}).strict().superRefine((value, ctx) => {
+  if (value.taskId !== value.requestStamp.task_instance_id
+    || value.attemptId !== value.requestStamp.attempt_id) {
+    ctx.addIssue({ code: "custom", message: "prepared dispatch identity does not match its request stamp" });
+  }
+  if (!canonicalEqual(value.requestStampDigest, requestStampDigest(value.requestStamp))) {
+    ctx.addIssue({ code: "custom", path: ["requestStampDigest"], message: "prepared request stamp digest mismatch" });
+  }
+  let attemptKey: string | undefined;
+  try {
+    attemptKey = learningTaskAttemptKey(value.attemptId);
+  } catch {
+    ctx.addIssue({ code: "custom", path: ["attemptId"], message: "invalid Hugin learning attempt id" });
+  }
+  const namespace = `tasks/${value.taskId}`;
+  const expectedRefs: Array<[
+    "attemptStartRef" | "preparedDispatchRef" | "replayPayloadRef" | "attemptOutcomeRef" | "taskOutcomeRef",
+    string | undefined,
+  ]> = [
+    ["attemptStartRef", attemptKey],
+    ["preparedDispatchRef", attemptKey ? `${attemptKey}-prepared` : undefined],
+    ["replayPayloadRef", attemptKey ? `${attemptKey}-replay` : undefined],
+    ["attemptOutcomeRef", attemptKey ? `${attemptKey}-outcome` : undefined],
+    ["taskOutcomeRef", "result-structured"],
+  ];
+  for (const [field, key] of expectedRefs) {
+    const ref = value[field] as LearningTaskEvidenceRef;
+    if (ref.namespace !== namespace || ref.key !== key) {
+      ctx.addIssue({ code: "custom", path: [field], message: "prepared dispatch reference binding mismatch" });
+    }
+  }
+});
+
+export type PreparedLearningTaskDispatch = z.infer<typeof preparedLearningTaskDispatchSchema>;
+
+export const learningTaskExecutionEvidenceSchema = z.object({
+  schemaVersion: z.literal(1),
+  contractVersion: z.literal(LEARNING_TASK_CONTRACT_VERSION),
+  state: z.enum(["preflight-failed", "m5-not-admitted", "join-failed", "m5-admitted"]),
+  evidenceAccepted: z.boolean(),
+  taskId: z.string().min(1),
+  attemptId: z.string().min(1),
+  attemptStartedAt: timestampSchema,
+  attemptStartRef: evidenceRefSchema.optional(),
+  preparedDispatchRef: evidenceRefSchema.optional(),
+  replayPayloadRef: evidenceRefSchema.optional(),
+  replayPayloadDigest: replayPayloadDigestSchema.optional(),
+  taskOutcomeRef: evidenceRefSchema,
+  rawFingerprint: z.object({
+    algorithm: z.literal("sha256"),
+    version: z.literal("trim-utf8-sha256-v1"),
+    digest: sha256Schema,
+  }).strict(),
+  requestStamp: huginRequestStampSchema.optional(),
+  requestStampDigest: requestStampDigestSchema.optional(),
+  gatewayEcho: learningTaskGatewayEchoSchema.optional(),
+  gatewayEchoDigest: gatewayEchoDigestSchema.optional(),
+  attemptOutcomeRef: evidenceRefSchema.optional(),
+  failureCode: z.enum([
+    "preflight-failed",
+    "transport-not-admitted",
+    "gateway-echo-invalid",
+    "attempt-outcome-persistence-failed",
+    "prepared-dispatch-persistence-failed",
+    "recovery-unavailable",
+  ]).optional(),
+  failureReason: z.string().min(1).max(512).optional(),
+}).strict().superRefine((value, ctx) => {
+  const hasStamp = value.requestStamp !== undefined && value.requestStampDigest !== undefined;
+  const hasEcho = value.gatewayEcho !== undefined && value.gatewayEchoDigest !== undefined;
+  if ((value.requestStamp === undefined) !== (value.requestStampDigest === undefined)) {
+    ctx.addIssue({ code: "custom", message: "request stamp and digest must be known together" });
+  }
+  if ((value.gatewayEcho === undefined) !== (value.gatewayEchoDigest === undefined)) {
+    ctx.addIssue({ code: "custom", message: "gateway echo and digest must be known together" });
+  }
+  if (value.state === "preflight-failed" && (hasStamp || hasEcho)) {
+    ctx.addIssue({ code: "custom", message: "preflight failure cannot carry a request stamp or echo" });
+  }
+  if (value.state !== "preflight-failed" && !hasStamp) {
+    ctx.addIssue({ code: "custom", message: "post-preflight evidence requires the exact request stamp" });
+  }
+  if (value.state !== "preflight-failed" && value.attemptStartRef === undefined) {
+    ctx.addIssue({ code: "custom", message: "a stamped attempt requires its durable start reference" });
+  }
+  if (value.state !== "preflight-failed"
+    && value.failureCode !== "prepared-dispatch-persistence-failed"
+    && value.preparedDispatchRef === undefined) {
+    ctx.addIssue({ code: "custom", message: "a dispatched attempt requires its immutable prepared-dispatch reference" });
+  }
+  if ((value.replayPayloadRef === undefined) !== (value.replayPayloadDigest === undefined)) {
+    ctx.addIssue({ code: "custom", message: "replay payload reference and digest must be known together" });
+  }
+  if (value.state !== "preflight-failed"
+    && value.failureCode !== "prepared-dispatch-persistence-failed"
+    && value.replayPayloadRef === undefined) {
+    ctx.addIssue({ code: "custom", message: "a dispatched attempt requires its classified replay payload reference" });
+  }
+  const expectedNamespace = `tasks/${value.taskId}`;
+  if (value.taskOutcomeRef.namespace !== expectedNamespace || value.taskOutcomeRef.key !== "result-structured") {
+    ctx.addIssue({ code: "custom", path: ["taskOutcomeRef"], message: "task outcome reference does not bind the evidence task" });
+  }
+  let expectedAttemptKey: string | undefined;
+  try {
+    expectedAttemptKey = learningTaskAttemptKey(value.attemptId);
+  } catch {
+    ctx.addIssue({ code: "custom", path: ["attemptId"], message: "invalid Hugin learning attempt id" });
+  }
+  if (value.attemptStartRef && (value.attemptStartRef.namespace !== expectedNamespace
+    || value.attemptStartRef.key !== expectedAttemptKey)) {
+    ctx.addIssue({ code: "custom", path: ["attemptStartRef"], message: "attempt start reference does not bind this attempt" });
+  }
+  if (value.preparedDispatchRef && (value.preparedDispatchRef.namespace !== expectedNamespace
+    || value.preparedDispatchRef.key !== `${expectedAttemptKey}-prepared`)) {
+    ctx.addIssue({ code: "custom", path: ["preparedDispatchRef"], message: "prepared dispatch reference does not bind this task" });
+  }
+  if (value.replayPayloadRef && (value.replayPayloadRef.namespace !== expectedNamespace
+    || value.replayPayloadRef.key !== `${expectedAttemptKey}-replay`)) {
+    ctx.addIssue({ code: "custom", path: ["replayPayloadRef"], message: "replay payload reference does not bind this attempt" });
+  }
+  if (value.attemptOutcomeRef && (value.attemptOutcomeRef.namespace !== expectedNamespace
+    || value.attemptOutcomeRef.key !== `${expectedAttemptKey}-outcome`)) {
+    ctx.addIssue({ code: "custom", path: ["attemptOutcomeRef"], message: "attempt outcome reference does not bind this attempt" });
+  }
+  if (value.requestStamp) {
+    if (value.requestStamp.task_instance_id !== value.taskId
+      || value.requestStamp.attempt_id !== value.attemptId
+      || !canonicalEqual(value.requestStamp.raw_fingerprint, value.rawFingerprint)) {
+      ctx.addIssue({ code: "custom", path: ["requestStamp"], message: "request stamp does not bind the evidence task/attempt/raw fingerprint" });
+    }
+    if (!value.requestStampDigest
+      || !canonicalEqual(value.requestStampDigest, requestStampDigest(value.requestStamp))) {
+      ctx.addIssue({ code: "custom", path: ["requestStampDigest"], message: "request stamp digest mismatch" });
+    }
+  }
+  if (value.gatewayEcho && value.requestStamp) {
+    try {
+      validateLearningTaskGatewayEcho(
+        value.gatewayEcho,
+        value.requestStamp,
+        new Date(value.gatewayEcho.admitted_at),
+      );
+    } catch (error) {
+      ctx.addIssue({ code: "custom", path: ["gatewayEcho"], message: error instanceof Error ? error.message : "gateway echo binding mismatch" });
+    }
+    if (!value.gatewayEchoDigest
+      || !canonicalEqual(value.gatewayEchoDigest, gatewayEchoDigest(value.gatewayEcho))) {
+      ctx.addIssue({ code: "custom", path: ["gatewayEchoDigest"], message: "gateway echo digest mismatch" });
+    }
+  }
+  if (value.state === "m5-admitted" && (!hasEcho || !value.evidenceAccepted)) {
+    ctx.addIssue({ code: "custom", message: "admitted evidence requires an accepted exact echo" });
+  }
+  if (value.state !== "m5-admitted" && value.evidenceAccepted) {
+    ctx.addIssue({ code: "custom", message: "non-admitted evidence cannot be accepted" });
+  }
+});
+export type LearningTaskExecutionEvidence = z.infer<typeof learningTaskExecutionEvidenceSchema>;
+
+export class LearningTaskHandshakeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LearningTaskHandshakeError";
+  }
+}
+
+function assertUnicodeScalarString(value: string): void {
+  for (let index = 0; index < value.length; index += 1) {
+    const unit = value.charCodeAt(index);
+    if (unit >= 0xd800 && unit <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        throw new LearningTaskHandshakeError("JCS rejects a lone high surrogate");
+      }
+      index += 1;
+    } else if (unit >= 0xdc00 && unit <= 0xdfff) {
+      throw new LearningTaskHandshakeError("JCS rejects a lone low surrogate");
+    }
+  }
+}
+
+/** RFC 8785 / ECMAScript JSON canonicalization for the accepted v1 digests. */
+export function jcsCanonicalize(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(jcsCanonicalize).join(",")}]`;
+  if (value !== null && typeof value === "object") {
+    const object = value as Record<string, unknown>;
+    return `{${Object.keys(object).sort().map((key) => {
+      assertUnicodeScalarString(key);
+      const child = object[key];
+      if (child === undefined) throw new LearningTaskHandshakeError("JCS rejects undefined");
+      return `${JSON.stringify(key)}:${jcsCanonicalize(child)}`;
+    }).join(",")}}`;
+  }
+  if (typeof value === "string") assertUnicodeScalarString(value);
+  if (typeof value === "number" && !Number.isFinite(value)) {
+    throw new LearningTaskHandshakeError("JCS rejects non-finite numbers");
+  }
+  if (value === null || typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+  throw new LearningTaskHandshakeError(`JCS rejects non-JSON value ${typeof value}`);
+}
+
+function sha256Utf8(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function jcsDigest(value: unknown): string {
+  return sha256Utf8(jcsCanonicalize(value));
+}
+
+function canonicalEqual(left: unknown, right: unknown): boolean {
+  return jcsCanonicalize(left) === jcsCanonicalize(right);
+}
+
+function opaqueId(uuid: string): string {
+  return opaqueIdSchema.parse(`opaque:${uuid}`);
+}
+
+export interface LearningTaskEvidenceRef {
+  namespace: string;
+  key: string;
+}
+
+export interface LearningTaskAttemptStart {
+  schemaVersion: 1;
+  contractVersion: typeof LEARNING_TASK_CONTRACT_VERSION;
+  taskId: string;
+  attemptId: string;
+  startedAt: string;
+  huginTaskIdentity: HuginTaskIdentity;
+  /** In-memory only; the durable start projection deliberately omits prompt bytes. */
+  renderedPrompt: string;
+}
+
+export const durableLearningTaskAttemptStartSchema = z.object({
+  schemaVersion: z.literal(1),
+  contractVersion: z.literal(LEARNING_TASK_CONTRACT_VERSION),
+  taskId: z.string().min(1),
+  attemptId: z.string().min(1),
+  startedAt: timestampSchema,
+  huginTaskIdentity: huginTaskIdentitySchema,
+  taskOutcomeRef: evidenceRefSchema,
+}).strict().superRefine((value, ctx) => {
+  if (value.huginTaskIdentity.taskId !== value.taskId) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["huginTaskIdentity", "taskId"],
+      message: "attempt-start producer identity does not bind its task",
+    });
+  }
+  if (value.taskOutcomeRef.namespace !== `tasks/${value.taskId}`
+    || value.taskOutcomeRef.key !== "result-structured") {
+    ctx.addIssue({
+      code: "custom",
+      path: ["taskOutcomeRef"],
+      message: "attempt-start task outcome reference does not bind its task",
+    });
+  }
+});
+export type DurableLearningTaskAttemptStart = z.infer<
+  typeof durableLearningTaskAttemptStartSchema
+>;
+
+export function createLearningTaskAttemptStart(input: {
+  taskId: string;
+  attemptId?: string;
+  startedAt?: string;
+  rawTaskText: string;
+  renderedPrompt: string;
+}): LearningTaskAttemptStart {
+  const startedAt = timestampSchema.parse(input.startedAt ?? new Date().toISOString());
+  const attemptId = input.attemptId ?? `hugin-attempt:${randomUUID()}`;
+  return {
+    schemaVersion: 1,
+    contractVersion: LEARNING_TASK_CONTRACT_VERSION,
+    taskId: input.taskId,
+    attemptId,
+    startedAt,
+    huginTaskIdentity: buildHuginTaskIdentity({
+      taskId: input.taskId,
+      rawTaskText: input.rawTaskText,
+      renderedPrompt: input.renderedPrompt,
+    }),
+    renderedPrompt: input.renderedPrompt,
+  };
+}
+
+export function durableLearningTaskAttemptStart(
+  attempt: LearningTaskAttemptStart,
+): DurableLearningTaskAttemptStart {
+  return durableLearningTaskAttemptStartSchema.parse({
+    schemaVersion: 1,
+    contractVersion: LEARNING_TASK_CONTRACT_VERSION,
+    taskId: attempt.taskId,
+    attemptId: attempt.attemptId,
+    startedAt: attempt.startedAt,
+    huginTaskIdentity: structuredClone(attempt.huginTaskIdentity),
+    taskOutcomeRef: { namespace: `tasks/${attempt.taskId}`, key: "result-structured" },
+  });
+}
+
+export function learningTaskAttemptKey(attemptId: string): string {
+  const suffix = attemptId.replace(/^hugin-attempt:/, "");
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/.test(suffix)) {
+    throw new LearningTaskHandshakeError("learning-task attempt id is not a Hugin UUID attempt");
+  }
+  return `learning-attempt-${suffix}`;
+}
+
+export function learningTaskPreparedDispatchKey(attemptId: string): string {
+  return `${learningTaskAttemptKey(attemptId)}-prepared`;
+}
+
+export function learningTaskReplayPayloadKey(attemptId: string): string {
+  return `${learningTaskAttemptKey(attemptId)}-replay`;
+}
+
+export function validatePreparedLearningTaskAttemptStart(
+  preparedInput: PreparedLearningTaskDispatch,
+  raw: unknown,
+): DurableLearningTaskAttemptStart {
+  const prepared = preparedLearningTaskDispatchSchema.parse(preparedInput);
+  const start = durableLearningTaskAttemptStartSchema.parse(raw);
+  const bindings: Array<[unknown, unknown]> = [
+    [start.taskId, prepared.taskId],
+    [start.attemptId, prepared.attemptId],
+    [start.startedAt, prepared.attemptStartedAt],
+    [start.taskOutcomeRef, prepared.taskOutcomeRef],
+    [start.huginTaskIdentity.taskId, prepared.taskId],
+    [start.huginTaskIdentity.rawTaskFingerprint, prepared.requestStamp.raw_fingerprint],
+  ];
+  if (bindings.some(([actual, expected]) => !canonicalEqual(actual, expected))) {
+    throw new LearningTaskHandshakeError(
+      "durable attempt start does not bind the selected prepared dispatch",
+    );
+  }
+  return start;
+}
+
+export function validateStoredLearningTaskAttemptStart(input: {
+  taskNamespace: string;
+  key: string;
+  raw: unknown;
+}): DurableLearningTaskAttemptStart {
+  const start = durableLearningTaskAttemptStartSchema.parse(input.raw);
+  if (input.taskNamespace !== `tasks/${start.taskId}`
+    || input.key !== learningTaskAttemptKey(start.attemptId)) {
+    throw new LearningTaskHandshakeError(
+      "durable attempt start does not bind its storage location",
+    );
+  }
+  return start;
+}
+
+export function learningTaskPreDispatchRecoveryFailure(input: {
+  start: DurableLearningTaskAttemptStart;
+  attemptStartRef: LearningTaskEvidenceRef;
+  reason: string;
+}): LearningTaskExecutionEvidence {
+  return learningTaskExecutionEvidenceSchema.parse({
+    schemaVersion: 1,
+    contractVersion: LEARNING_TASK_CONTRACT_VERSION,
+    state: "preflight-failed",
+    evidenceAccepted: false,
+    taskId: input.start.taskId,
+    attemptId: input.start.attemptId,
+    attemptStartedAt: input.start.startedAt,
+    attemptStartRef: input.attemptStartRef,
+    taskOutcomeRef: input.start.taskOutcomeRef,
+    rawFingerprint: input.start.huginTaskIdentity.rawTaskFingerprint,
+    failureCode: "recovery-unavailable",
+    failureReason: input.reason.slice(0, 512),
+  });
+}
+
+interface ReadPreflightOptions {
+  gatewayBaseUrl: string;
+  apiKey: string;
+  attemptStartedAt: string;
+  now?: () => Date;
+  randomUuid?: () => string;
+  fetchImpl?: typeof fetch;
+}
+
+async function readBoundedJson(res: Response): Promise<unknown> {
+  const text = await res.text();
+  if (Buffer.byteLength(text, "utf8") > 64 * 1024) {
+    throw new LearningTaskHandshakeError("learning-task preflight response exceeds 64 KiB");
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new LearningTaskHandshakeError("learning-task preflight returned invalid JSON");
+  }
+}
+
+export async function fetchLearningTaskPreflight(
+  options: ReadPreflightOptions,
+): Promise<{
+  expectedTransportPrincipalId: string;
+  preflight: { request: LearningTaskPreflightRequest; response: LearningTaskPreflightResponse };
+}> {
+  if (options.apiKey.trim() === "") {
+    throw new LearningTaskHandshakeError("LearningTaskContract requires an authenticated M5 key");
+  }
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const now = options.now ?? (() => new Date());
+  const uuid = options.randomUuid ?? randomUUID;
+  const headers = { Authorization: `Bearer ${options.apiKey}`, Accept: "application/json" };
+  const principalResponse = await fetchImpl(`${options.gatewayBaseUrl}/portal/me`, {
+    method: "GET",
+    headers,
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!principalResponse.ok) {
+    throw new LearningTaskHandshakeError(`authenticated M5 principal lookup failed with HTTP ${principalResponse.status}`);
+  }
+  const principalRaw = await readBoundedJson(principalResponse);
+  const principal = z.object({ alias: z.string().min(1), tier: z.literal("owner") }).passthrough()
+    .safeParse(principalRaw);
+  if (!principal.success) {
+    throw new LearningTaskHandshakeError("M5 principal lookup did not return an owner alias");
+  }
+
+  const requestedAt = timestampSchema.parse(now().toISOString());
+  if (Date.parse(requestedAt) < Date.parse(timestampSchema.parse(options.attemptStartedAt))) {
+    throw new LearningTaskHandshakeError("learning-task preflight precedes durable attempt start");
+  }
+  const request = preflightRequestSchema.parse({
+    request_id: opaqueId(uuid()),
+    endpoint: LEARNING_TASK_PREFLIGHT_ENDPOINT,
+    protocol_version: LEARNING_TASK_PREFLIGHT_PROTOCOL,
+    requested_at: requestedAt,
+    requested_capabilities: structuredClone(LEARNING_TASK_CAPABILITIES),
+  });
+  const capabilityResponse = await fetchImpl(
+    `${options.gatewayBaseUrl}${LEARNING_TASK_PREFLIGHT_ENDPOINT}`,
+    { method: "GET", headers, signal: AbortSignal.timeout(10_000) },
+  );
+  if (!capabilityResponse.ok) {
+    throw new LearningTaskHandshakeError(`authenticated learning-task preflight failed with HTTP ${capabilityResponse.status}`);
+  }
+  const parsed = preflightResponseSchema.safeParse(await readBoundedJson(capabilityResponse));
+  if (!parsed.success) {
+    throw new LearningTaskHandshakeError("learning-task preflight advertised an unsupported or partial contract");
+  }
+  const response = parsed.data;
+  const observedAt = now().getTime();
+  const requestedMs = Date.parse(request.requested_at);
+  const advertisedMs = Date.parse(response.advertised_at);
+  const expiresMs = Date.parse(response.expires_at);
+  if (!(requestedMs <= advertisedMs && advertisedMs <= observedAt && observedAt < expiresMs)) {
+    throw new LearningTaskHandshakeError("learning-task preflight freshness does not cover observation time");
+  }
+  if (expiresMs - advertisedMs > LEARNING_TASK_PREFLIGHT_TTL_MS) {
+    throw new LearningTaskHandshakeError("learning-task preflight cache TTL exceeds fifteen minutes");
+  }
+  if (!canonicalEqual(request.requested_capabilities, response.capabilities)
+    || !canonicalEqual(response.capabilities, LEARNING_TASK_CAPABILITIES)) {
+    throw new LearningTaskHandshakeError("learning-task preflight capability downgrade");
+  }
+  return {
+    expectedTransportPrincipalId: principal.data.alias,
+    preflight: { request, response },
+  };
+}
+
+export interface LearningTaskRequestContext {
+  attempt: LearningTaskAttemptStart;
+  attemptStartRef: LearningTaskEvidenceRef;
+  expectedTransportPrincipalId: string;
+  idempotencyKey: string;
+  requestId: string;
+  source: LearningTaskSource;
+  preflight: {
+    request: LearningTaskPreflightRequest;
+    response: LearningTaskPreflightResponse;
+  };
+  /** Deterministic clock injection for fixtures; production omits it. */
+  stampedAt?: string;
+}
+
+export type LearningTaskPreparation =
+  | {
+      kind: "ready";
+      context: LearningTaskRequestContext;
+      preparedDispatch: PreparedLearningTaskDispatch;
+      replayPayload: LearningTaskReplayPayload;
+    }
+  | {
+      kind: "preflight-failed";
+      attempt: LearningTaskAttemptStart;
+      attemptStartRef?: LearningTaskEvidenceRef;
+      failureReason: string;
+    }
+  | {
+      kind: "dispatch-failed";
+      attempt: LearningTaskAttemptStart;
+      attemptStartRef: LearningTaskEvidenceRef;
+      requestStamp: HuginRequestStamp;
+      requestStampDigest: ReturnType<typeof requestStampDigest>;
+      failureReason: string;
+    };
+
+function sourceDigest(
+  sourceRef: string,
+  sourceType: z.infer<typeof sourceDocumentTypeSchema>,
+  sourceVersion: string,
+  document: unknown,
+): z.infer<typeof sourceDocumentDigestSchema> {
+  return sourceDocumentDigestSchema.parse({
+    algorithm: "sha256",
+    canonicalization: "jcs-rfc8785-utf8-v1",
+    source_ref: sourceRef,
+    source_type: sourceType,
+    source_version: sourceVersion,
+    digest: jcsDigest(document),
+  });
+}
+
+const PROMPT_CONFIG_DOCUMENT = {
+  schema_version: "config-source/v1",
+  component: "hugin",
+  config_kind: "prompt",
+  id: "hugin-direct-delegate-prompt",
+  version: "v1",
+  settings: {
+    renderer: "renderHomeserverUserMessage",
+    context_heading: "## Context",
+    task_heading: "## Task",
+    separator: "horizontal-rule-v1",
+  },
+};
+const HARNESS_CONFIG_DOCUMENT = {
+  schema_version: "config-source/v1",
+  component: "hugin",
+  config_kind: "harness",
+  id: "homeserver-executor",
+  version: "learning-task-v1",
+  settings: {
+    adapter: "m5-gateway-delegate",
+    serializer: "grimnir-learning-task-v1",
+    response_join: "exact-principal-bound-echo",
+    timeout_policy: "bounded-abort-no-automatic-replay",
+  },
+};
+const TOOL_POLICY_DOCUMENT = {
+  schema_version: "config-source/v1",
+  component: "hugin",
+  config_kind: "tool-policy",
+  id: "bounded-delegate",
+  version: "learning-task-v1",
+  settings: {
+    allow: ["delegate", "configured-verifier"],
+    deny: ["caller-stamp-override", "unbounded-shell"],
+  },
+};
+
+function originConfig(): HuginRequestStamp["origin_config"] {
+  return {
+    prompt: {
+      id: PROMPT_CONFIG_DOCUMENT.id,
+      version: PROMPT_CONFIG_DOCUMENT.version,
+      config_digest: sourceDigest(
+        "source-doc:hugin/config/direct-delegate-prompt-v1",
+        "origin-prompt-config",
+        "config-source-v1",
+        PROMPT_CONFIG_DOCUMENT,
+      ),
+    },
+    harness: {
+      id: HARNESS_CONFIG_DOCUMENT.id,
+      version: HARNESS_CONFIG_DOCUMENT.version,
+      config_digest: sourceDigest(
+        "source-doc:hugin/config/homeserver-learning-task-v1",
+        "origin-harness-config",
+        "config-source-v1",
+        HARNESS_CONFIG_DOCUMENT,
+      ),
+    },
+    tool_policy: {
+      id: TOOL_POLICY_DOCUMENT.id,
+      version: TOOL_POLICY_DOCUMENT.version,
+      config_digest: sourceDigest(
+        "source-doc:hugin/config/bounded-delegate-learning-task-v1",
+        "origin-tool-policy-config",
+        "config-source-v1",
+        TOOL_POLICY_DOCUMENT,
+      ),
+    },
+  };
+}
+
+export function buildLearningTaskRequestStamp(input: {
+  context: LearningTaskRequestContext;
+  taskType: string;
+  rawTaskText: string;
+  renderedPrompt: string;
+}): HuginRequestStamp {
+  const { context } = input;
+  const taskIdentity = buildHuginTaskIdentity({
+    taskId: context.attempt.taskId,
+    rawTaskText: input.rawTaskText,
+    renderedPrompt: input.renderedPrompt,
+  });
+  if (!canonicalEqual(taskIdentity, context.attempt.huginTaskIdentity)
+    || input.renderedPrompt !== context.attempt.renderedPrompt) {
+    throw new LearningTaskHandshakeError("task bytes changed after durable attempt start");
+  }
+  const taskType = taskTypeSchema.parse({
+    id: input.taskType,
+    taxonomy_id: BROKER_TASK_TYPE_TAXONOMY_ID,
+    taxonomy_version: BROKER_TASK_TYPE_TAXONOMY_VERSION,
+  });
+  const config = originConfig();
+  const rawDocument = {
+    schema_version: "raw-input/v1",
+    fixture_only: false,
+    origin_component: "hugin",
+    input_role: "hugin-logical-prompt",
+    encoding: "utf-8",
+    text: input.rawTaskText,
+  };
+  const rawInput = sourceDigest(
+    `source-doc:hugin/raw/${jcsDigest(rawDocument)}`,
+    "raw-input",
+    "raw-input-v1",
+    rawDocument,
+  );
+  const envelopeRef = `source-doc:hugin/prompt/${context.attempt.attemptId.replace(/^hugin-attempt:/, "")}`;
+  const envelopeDocument = {
+    schema_version: "prompt-stage/v2",
+    stage: "hugin-envelope",
+    fixture_only: false,
+    encoding: "utf-8",
+    input_source_refs: [
+      rawInput.source_ref,
+      config.prompt.config_digest.source_ref,
+      config.harness.config_digest.source_ref,
+      config.tool_policy.config_digest.source_ref,
+    ],
+    text: input.renderedPrompt,
+    byte_length: Buffer.byteLength(input.renderedPrompt, "utf8"),
+    sha256: sha256Utf8(input.renderedPrompt),
+    task_binding: context.attempt.taskId,
+  };
+  const stampedAt = timestampSchema.parse(context.stampedAt ?? new Date().toISOString());
+  const started = Date.parse(context.attempt.startedAt);
+  const accepted = Date.parse(context.source.accepted_at);
+  const requested = Date.parse(context.preflight.request.requested_at);
+  const advertised = Date.parse(context.preflight.response.advertised_at);
+  const stamped = Date.parse(stampedAt);
+  const expires = Date.parse(context.preflight.response.expires_at);
+  if (!(Date.parse(context.source.created_at) <= accepted
+    && accepted <= started
+    && started <= stamped
+    // A previously authenticated request/advertisement pair may be cached
+    // before this attempt. Its own request must still precede advertisement,
+    // and the advertisement must remain fresh at this attempt's stamp time.
+    && requested <= advertised
+    && advertised <= stamped
+    && stamped < expires)) {
+    throw new LearningTaskHandshakeError("LearningTaskContract attempt/preflight/stamp clocks are out of order");
+  }
+  if (expires - advertised > LEARNING_TASK_PREFLIGHT_TTL_MS
+    || !canonicalEqual(context.preflight.request.requested_capabilities, LEARNING_TASK_CAPABILITIES)
+    || !canonicalEqual(context.preflight.response.capabilities, LEARNING_TASK_CAPABILITIES)) {
+    throw new LearningTaskHandshakeError("LearningTaskContract preflight is stale or downgraded");
+  }
+  return huginRequestStampSchema.parse({
+    task_instance_id: context.attempt.taskId,
+    attempt_id: context.attempt.attemptId,
+    client_id: "hugin",
+    expected_transport_principal_id: context.expectedTransportPrincipalId,
+    idempotency_key: context.idempotencyKey,
+    request_id: context.requestId,
+    stamped_at: stampedAt,
+    contract_request: structuredClone(LEARNING_TASK_CAPABILITIES),
+    preflight: structuredClone(context.preflight),
+    source: structuredClone(context.source),
+    task_type: taskType,
+    raw_input: rawInput,
+    raw_fingerprint: taskIdentity.rawTaskFingerprint,
+    hugin_envelope: sourceDigest(
+      envelopeRef,
+      "prompt-stage",
+      "prompt-stage-v2",
+      envelopeDocument,
+    ),
+    origin_config: config,
+    macro_decision: {
+      policy_id: "hugin-runtime-selection",
+      version: "homeserver-delegate-learning-task-v1",
+      decision_id: `learning-task:${context.attempt.attemptId.replace(/^hugin-attempt:/, "")}`,
+      target: "m5",
+      service: "gille-inference",
+    },
+  });
+}
+
+export function requestStampDigest(stamp: HuginRequestStamp): {
+  algorithm: "sha256";
+  version: "hugin-request-stamp-jcs-v1";
+  digest: string;
+} {
+  return {
+    algorithm: "sha256",
+    version: "hugin-request-stamp-jcs-v1",
+    digest: jcsDigest(stamp),
+  };
+}
+
+export function gatewayEchoDigest(echo: LearningTaskGatewayEcho): {
+  algorithm: "sha256";
+  version: "gateway-echo-jcs-v1";
+  digest: string;
+} {
+  return {
+    algorithm: "sha256",
+    version: "gateway-echo-jcs-v1",
+    digest: jcsDigest(echo),
+  };
+}
+
+export function createPreparedLearningTaskDispatch(input: {
+  context: LearningTaskRequestContext;
+  requestStamp: HuginRequestStamp;
+  requestBody: Record<string, unknown>;
+}): {
+  preparedDispatch: PreparedLearningTaskDispatch;
+  replayPayload: LearningTaskReplayPayload;
+} {
+  const { context, requestStamp } = input;
+  const attemptKey = learningTaskAttemptKey(context.attempt.attemptId);
+  const replayPayload = learningTaskReplayPayloadSchema.parse({
+    schemaVersion: 1,
+    contractVersion: LEARNING_TASK_CONTRACT_VERSION,
+    taskId: context.attempt.taskId,
+    attemptId: context.attempt.attemptId,
+    requestBody: structuredClone(input.requestBody),
+  });
+  if (!canonicalEqual(replayPayload.requestBody.learningTaskStamp, requestStamp)) {
+    throw new LearningTaskHandshakeError("prepared replay body must carry the exact request stamp");
+  }
+  const preparedDispatch = preparedLearningTaskDispatchSchema.parse({
+    schemaVersion: 1,
+    contractVersion: LEARNING_TASK_CONTRACT_VERSION,
+    taskId: context.attempt.taskId,
+    attemptId: context.attempt.attemptId,
+    attemptStartedAt: context.attempt.startedAt,
+    preparedAt: requestStamp.stamped_at,
+    attemptStartRef: context.attemptStartRef,
+    preparedDispatchRef: {
+      namespace: `tasks/${context.attempt.taskId}`,
+      key: `${attemptKey}-prepared`,
+    },
+    replayPayloadRef: {
+      namespace: `tasks/${context.attempt.taskId}`,
+      key: `${attemptKey}-replay`,
+    },
+    replayPayloadDigest: {
+      algorithm: "sha256",
+      version: "hugin-replay-payload-jcs-v1",
+      digest: jcsDigest(replayPayload),
+    },
+    attemptOutcomeRef: {
+      namespace: `tasks/${context.attempt.taskId}`,
+      key: `${attemptKey}-outcome`,
+    },
+    taskOutcomeRef: {
+      namespace: `tasks/${context.attempt.taskId}`,
+      key: "result-structured",
+    },
+    requestStamp,
+    requestStampDigest: requestStampDigest(requestStamp),
+  });
+  validatePreparedLearningTaskReplayPayload(
+    preparedDispatch,
+    replayPayload,
+    durableLearningTaskAttemptStart(context.attempt),
+  );
+  return { preparedDispatch, replayPayload };
+}
+
+export function validateLearningTaskReplayPayload(
+  prepared: PreparedLearningTaskDispatch,
+  raw: unknown,
+): LearningTaskReplayPayload {
+  const payload = learningTaskReplayPayloadSchema.parse(raw);
+  if (payload.taskId !== prepared.taskId
+    || payload.attemptId !== prepared.attemptId
+    || !canonicalEqual(payload.requestBody.learningTaskStamp, prepared.requestStamp)) {
+    throw new LearningTaskHandshakeError("classified replay payload does not bind the prepared dispatch");
+  }
+  const actualDigest = jcsDigest(payload);
+  if (actualDigest !== prepared.replayPayloadDigest.digest) {
+    throw new LearningTaskHandshakeError("classified replay payload digest mismatch");
+  }
+  return payload;
+}
+
+export function validatePreparedLearningTaskReplayPayload(
+  prepared: PreparedLearningTaskDispatch,
+  raw: unknown,
+  attemptStart: DurableLearningTaskAttemptStart,
+): LearningTaskReplayPayload {
+  const payload = validateLearningTaskReplayPayload(prepared, raw);
+  const delegateBody = learningTaskDelegateRequestBodySchema.safeParse(payload.requestBody);
+  if (!delegateBody.success) {
+    throw new LearningTaskHandshakeError(
+      "classified replay payload does not contain a valid Hugin delegate body",
+    );
+  }
+  if (!canonicalEqual(delegateBody.data.huginTaskIdentity, attemptStart.huginTaskIdentity)) {
+    throw new LearningTaskHandshakeError(
+      "classified replay payload Hugin identity does not exactly bind the immutable attempt start",
+    );
+  }
+  const renderedPromptFingerprint = fingerprintRenderedPrompt(delegateBody.data.prompt);
+  if (!canonicalEqual(
+    renderedPromptFingerprint,
+    attemptStart.huginTaskIdentity.renderedPromptFingerprint,
+  )) {
+    throw new LearningTaskHandshakeError(
+      "classified replay prompt does not bind the immutable Hugin rendered-prompt fingerprint",
+    );
+  }
+  return payload;
+}
+
+/**
+ * Canonical prepared-dispatch ↔ attempt-outcome join.
+ *
+ * Keep every durable binding in one validator so normal completion, startup
+ * recovery, and existing-outcome reuse cannot gradually accept different
+ * subsets of the contract.
+ */
+export function validatePreparedLearningTaskOutcome(
+  preparedInput: PreparedLearningTaskDispatch,
+  raw: unknown,
+): LearningTaskExecutionEvidence {
+  const prepared = preparedLearningTaskDispatchSchema.parse(preparedInput);
+  const outcome = learningTaskExecutionEvidenceSchema.parse(raw);
+  const bindings: Array<[unknown, unknown]> = [
+    [outcome.taskId, prepared.taskId],
+    [outcome.attemptId, prepared.attemptId],
+    [outcome.attemptStartedAt, prepared.attemptStartedAt],
+    [outcome.attemptStartRef, prepared.attemptStartRef],
+    [outcome.preparedDispatchRef, prepared.preparedDispatchRef],
+    [outcome.replayPayloadRef, prepared.replayPayloadRef],
+    [outcome.replayPayloadDigest, prepared.replayPayloadDigest],
+    [outcome.attemptOutcomeRef, prepared.attemptOutcomeRef],
+    [outcome.taskOutcomeRef, prepared.taskOutcomeRef],
+    [outcome.rawFingerprint, prepared.requestStamp.raw_fingerprint],
+    [outcome.requestStamp, prepared.requestStamp],
+    [outcome.requestStampDigest, prepared.requestStampDigest],
+  ];
+  if (bindings.some(([actual, expected]) => !canonicalEqual(actual, expected))) {
+    throw new LearningTaskHandshakeError(
+      "durable learning-task outcome does not bind the selected prepared dispatch",
+    );
+  }
+  // The evidence schema already verifies the exact echo, digest, principal,
+  // capabilities, and admission clock against outcome.requestStamp. Re-run the
+  // public validator here to make that dependency explicit at the canonical
+  // prepared/outcome join.
+  if (outcome.gatewayEcho) {
+    validateLearningTaskGatewayEcho(
+      outcome.gatewayEcho,
+      prepared.requestStamp,
+      new Date(outcome.gatewayEcho.admitted_at),
+    );
+    if (!outcome.gatewayEchoDigest
+      || !canonicalEqual(outcome.gatewayEchoDigest, gatewayEchoDigest(outcome.gatewayEcho))) {
+      throw new LearningTaskHandshakeError(
+        "durable learning-task outcome gateway echo digest mismatch",
+      );
+    }
+  }
+  return outcome;
+}
+
+export function learningTaskRecoveryFailure(
+  prepared: PreparedLearningTaskDispatch,
+  reason: string,
+): LearningTaskExecutionEvidence {
+  return learningTaskExecutionEvidenceSchema.parse({
+    schemaVersion: 1,
+    contractVersion: LEARNING_TASK_CONTRACT_VERSION,
+    state: "join-failed",
+    evidenceAccepted: false,
+    taskId: prepared.taskId,
+    attemptId: prepared.attemptId,
+    attemptStartedAt: prepared.attemptStartedAt,
+    attemptStartRef: prepared.attemptStartRef,
+    preparedDispatchRef: prepared.preparedDispatchRef,
+    replayPayloadRef: prepared.replayPayloadRef,
+    replayPayloadDigest: prepared.replayPayloadDigest,
+    taskOutcomeRef: prepared.taskOutcomeRef,
+    rawFingerprint: prepared.requestStamp.raw_fingerprint,
+    requestStamp: prepared.requestStamp,
+    requestStampDigest: prepared.requestStampDigest,
+    attemptOutcomeRef: prepared.attemptOutcomeRef,
+    failureCode: "recovery-unavailable",
+    failureReason: reason.slice(0, 512),
+  });
+}
+
+export async function recoverPreparedLearningTaskDispatch(input: {
+  prepared: PreparedLearningTaskDispatch;
+  replayPayload: unknown;
+  gatewayBaseUrl: string;
+  apiKey: string;
+  fetchImpl?: typeof fetch;
+}): Promise<LearningTaskExecutionEvidence> {
+  const prepared = preparedLearningTaskDispatchSchema.parse(input.prepared);
+  const replay = validateLearningTaskReplayPayload(prepared, input.replayPayload);
+  const baseEvidence = learningTaskRecoveryFailure(
+    prepared,
+    "exact prepared-dispatch recovery has not completed",
+  );
+  try {
+    const response = await (input.fetchImpl ?? fetch)(`${input.gatewayBaseUrl}/delegate`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(input.apiKey ? { Authorization: `Bearer ${input.apiKey}` } : {}),
+      },
+      body: JSON.stringify(replay.requestBody),
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (!response.ok) {
+      return learningTaskRecoveryFailure(
+        prepared,
+        `exact prepared-dispatch recovery returned HTTP ${response.status}`,
+      );
+    }
+    const raw = await readBoundedJson(response) as {
+      learningTaskAdmission?: { recovered?: unknown; outcomeAvailable?: unknown };
+      learningTaskGatewayEcho?: unknown;
+    };
+    if (raw.learningTaskAdmission?.recovered !== true
+      || raw.learningTaskAdmission?.outcomeAvailable !== false) {
+      return learningTaskRecoveryFailure(
+        prepared,
+        "gateway did not prove exact stored-admission recovery without inference replay",
+      );
+    }
+    const echo = validateLearningTaskGatewayEcho(
+      raw.learningTaskGatewayEcho,
+      prepared.requestStamp,
+    );
+    return learningTaskExecutionEvidenceSchema.parse({
+      ...baseEvidence,
+      state: "m5-admitted",
+      evidenceAccepted: true,
+      gatewayEcho: echo,
+      gatewayEchoDigest: gatewayEchoDigest(echo),
+      failureCode: undefined,
+      failureReason: undefined,
+    });
+  } catch (error) {
+    return learningTaskRecoveryFailure(
+      prepared,
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+/** Preserve known evidence shape when the immutable outcome receipt cannot be created. */
+export function learningTaskOutcomePersistenceFailure(
+  evidence: LearningTaskExecutionEvidence,
+  reason = "durable learning-task attempt outcome write failed",
+): LearningTaskExecutionEvidence {
+  return learningTaskExecutionEvidenceSchema.parse({
+    ...evidence,
+    state: evidence.state === "preflight-failed" ? "preflight-failed" : "join-failed",
+    evidenceAccepted: false,
+    attemptOutcomeRef: undefined,
+    failureCode: "attempt-outcome-persistence-failed",
+    failureReason: reason.slice(0, 512),
+  });
+}
+
+export function validateLearningTaskGatewayEcho(
+  raw: unknown,
+  stamp: HuginRequestStamp,
+  observedAt: Date = new Date(),
+): LearningTaskGatewayEcho {
+  const parsed = learningTaskGatewayEchoSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new LearningTaskHandshakeError("gateway returned a missing or malformed LearningTaskContract echo");
+  }
+  const echo = parsed.data;
+  if (!canonicalEqual(echo.echoed_request, stamp)) {
+    throw new LearningTaskHandshakeError("gateway echo does not exactly reproduce the Hugin request stamp");
+  }
+  if (!canonicalEqual(echo.capabilities, stamp.contract_request)) {
+    throw new LearningTaskHandshakeError("gateway echo downgraded LearningTaskContract capabilities");
+  }
+  if (echo.authenticated_principal_id !== stamp.expected_transport_principal_id
+    || echo.authentication !== "gateway-owner-auth") {
+    throw new LearningTaskHandshakeError("gateway echo authenticated principal substitution");
+  }
+  const admitted = Date.parse(echo.admitted_at);
+  if (!(Date.parse(stamp.stamped_at) <= admitted && admitted <= observedAt.getTime())) {
+    throw new LearningTaskHandshakeError("gateway admission clock is outside the request/observation interval");
+  }
+  const expectedBinding = jcsDigest({
+    authenticated_principal_id: echo.authenticated_principal_id,
+    request_stamp: stamp,
+  });
+  if (echo.principal_binding_digest.digest !== expectedBinding) {
+    throw new LearningTaskHandshakeError("gateway principal/request binding digest mismatch");
+  }
+  return echo;
+}
+
+export function createLearningTaskRequestContext(input: {
+  attempt: LearningTaskAttemptStart;
+  attemptStartRef: LearningTaskEvidenceRef;
+  source: LearningTaskSource;
+  preflight: Awaited<ReturnType<typeof fetchLearningTaskPreflight>>;
+  randomUuid?: () => string;
+}): LearningTaskRequestContext {
+  const uuid = input.randomUuid ?? randomUUID;
+  return {
+    attempt: input.attempt,
+    attemptStartRef: input.attemptStartRef,
+    expectedTransportPrincipalId: input.preflight.expectedTransportPrincipalId,
+    idempotencyKey: opaqueId(uuid()),
+    requestId: opaqueId(uuid()),
+    source: sourceSchema.parse(input.source),
+    preflight: input.preflight.preflight,
+  };
+}
+
+/**
+ * Linearized producer preparation used by the dispatcher. The injected start
+ * writer must complete before this function performs either authenticated M5
+ * read, so a gateway can never observe a stamp for an attempt Hugin did not
+ * first make durable.
+ */
+export async function prepareDurableLearningTaskAttempt(input: {
+  taskId: string;
+  startedAt: string;
+  rawTaskText: string;
+  renderedPrompt: string;
+  gatewayBaseUrl: string;
+  apiKey: string;
+  buildSource: () => LearningTaskSource;
+  persistStart: (
+    ref: LearningTaskEvidenceRef,
+    record: DurableLearningTaskAttemptStart,
+  ) => Promise<void>;
+  buildPreparedDispatch: (
+    context: LearningTaskRequestContext,
+  ) => {
+    preparedDispatch: PreparedLearningTaskDispatch;
+    replayPayload: LearningTaskReplayPayload;
+  };
+  persistReplayPayload: (
+    ref: LearningTaskEvidenceRef,
+    record: LearningTaskReplayPayload,
+  ) => Promise<void>;
+  persistPrepared: (
+    ref: LearningTaskEvidenceRef,
+    record: PreparedLearningTaskDispatch,
+  ) => Promise<void>;
+  now?: () => Date;
+  randomUuid?: () => string;
+  fetchImpl?: typeof fetch;
+}): Promise<{
+  attempt: LearningTaskAttemptStart;
+  attemptStartRef: LearningTaskEvidenceRef;
+  startPersisted: boolean;
+  preparation: LearningTaskPreparation;
+}> {
+  const uuid = input.randomUuid ?? randomUUID;
+  const attempt = createLearningTaskAttemptStart({
+    taskId: input.taskId,
+    attemptId: `hugin-attempt:${uuid()}`,
+    startedAt: input.startedAt,
+    rawTaskText: input.rawTaskText,
+    renderedPrompt: input.renderedPrompt,
+  });
+  const attemptStartRef = {
+    namespace: `tasks/${input.taskId}`,
+    key: learningTaskAttemptKey(attempt.attemptId),
+  };
+  let startPersisted = false;
+  let preparedDispatch: PreparedLearningTaskDispatch | undefined;
+  let replayPayload: LearningTaskReplayPayload | undefined;
+  try {
+    await input.persistStart(attemptStartRef, durableLearningTaskAttemptStart(attempt));
+    startPersisted = true;
+    const source = input.buildSource();
+    const preflight = await fetchLearningTaskPreflight({
+      gatewayBaseUrl: input.gatewayBaseUrl,
+      apiKey: input.apiKey,
+      attemptStartedAt: attempt.startedAt,
+      now: input.now,
+      randomUuid: uuid,
+      fetchImpl: input.fetchImpl,
+    });
+    const context = createLearningTaskRequestContext({
+      attempt,
+      attemptStartRef,
+      source,
+      preflight,
+      randomUuid: uuid,
+    });
+    const prepared = input.buildPreparedDispatch(context);
+    preparedDispatch = prepared.preparedDispatch;
+    replayPayload = prepared.replayPayload;
+    await input.persistReplayPayload(preparedDispatch.replayPayloadRef, replayPayload);
+    await input.persistPrepared(preparedDispatch.preparedDispatchRef, preparedDispatch);
+    return {
+      attempt,
+      attemptStartRef,
+      startPersisted,
+      preparation: {
+        kind: "ready",
+        context,
+        preparedDispatch,
+        replayPayload,
+      },
+    };
+  } catch (err) {
+    if (preparedDispatch) {
+      return {
+        attempt,
+        attemptStartRef,
+        startPersisted,
+        preparation: {
+          kind: "dispatch-failed",
+          attempt,
+          attemptStartRef,
+          requestStamp: preparedDispatch.requestStamp,
+          requestStampDigest: preparedDispatch.requestStampDigest,
+          failureReason: (err instanceof Error ? err.message : String(err)).slice(0, 512),
+        },
+      };
+    }
+    return {
+      attempt,
+      attemptStartRef,
+      startPersisted,
+      preparation: {
+        kind: "preflight-failed",
+        attempt,
+        attemptStartRef: startPersisted ? attemptStartRef : undefined,
+        failureReason: (err instanceof Error ? err.message : String(err)).slice(0, 512),
+      },
+    };
+  }
+}

--- a/src/learning-task-recovery.ts
+++ b/src/learning-task-recovery.ts
@@ -1,0 +1,275 @@
+import type { MuninClient, MuninEntry } from "./munin-client.js";
+import type { HuginTaskIdentity } from "./task-identity.js";
+import {
+  learningTaskExecutionEvidenceSchema,
+  learningTaskOutcomePersistenceFailure,
+  learningTaskPreDispatchRecoveryFailure,
+  learningTaskPreparedDispatchKey,
+  learningTaskRecoveryFailure,
+  preparedLearningTaskDispatchSchema,
+  recoverPreparedLearningTaskDispatch,
+  validatePreparedLearningTaskAttemptStart,
+  validatePreparedLearningTaskOutcome,
+  validatePreparedLearningTaskReplayPayload,
+  validateStoredLearningTaskAttemptStart,
+  type DurableLearningTaskAttemptStart,
+  type LearningTaskExecutionEvidence,
+} from "./learning-task-handshake.js";
+import { createImmutableLearningArtifact } from "./learning-task-store.js";
+
+export interface RecoveredStoredLearningTask {
+  evidence: LearningTaskExecutionEvidence;
+  huginTaskIdentity: HuginTaskIdentity;
+  classification?: string;
+}
+
+function sameClassification(actual: string | undefined, expected: string | undefined): boolean {
+  return actual === expected;
+}
+
+function parseJson(content: string): unknown {
+  try {
+    return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Recover one selected immutable prepared dispatch.
+ *
+ * The task/status classification is the authority for every joined row and
+ * newly written artifact. A prepared row or attempt start that cannot be
+ * trusted returns no learning metadata because the full #230 producer identity
+ * cannot be reconstructed safely.
+ */
+export async function recoverStoredLearningTaskCandidate(input: {
+  munin: MuninClient;
+  taskNamespace: string;
+  taskClassification?: string;
+  preparedEntry: MuninEntry;
+  gateway: { baseUrl: string; apiKey: string } | null;
+  fetchImpl?: typeof fetch;
+}): Promise<RecoveredStoredLearningTask | null> {
+  if (!sameClassification(input.preparedEntry.classification, input.taskClassification)) {
+    return null;
+  }
+  const parsedPrepared = preparedLearningTaskDispatchSchema.safeParse(
+    parseJson(input.preparedEntry.content),
+  );
+  if (!parsedPrepared.success) return null;
+  const prepared = parsedPrepared.data;
+  if (prepared.taskId !== input.taskNamespace.replace(/^tasks\//, "")
+    || prepared.preparedDispatchRef.namespace !== input.preparedEntry.namespace
+    || prepared.preparedDispatchRef.key !== input.preparedEntry.key) {
+    return null;
+  }
+
+  const attemptStartEntry = await input.munin.read(
+    prepared.attemptStartRef.namespace,
+    prepared.attemptStartRef.key,
+  );
+  if (!attemptStartEntry
+    || !sameClassification(attemptStartEntry.classification, input.taskClassification)) {
+    return null;
+  }
+  let huginTaskIdentity: HuginTaskIdentity;
+  let attemptStart: DurableLearningTaskAttemptStart;
+  try {
+    attemptStart = validatePreparedLearningTaskAttemptStart(
+      prepared,
+      parseJson(attemptStartEntry.content),
+    );
+    huginTaskIdentity = attemptStart.huginTaskIdentity;
+  } catch {
+    return null;
+  }
+
+  const result = (evidence: LearningTaskExecutionEvidence): RecoveredStoredLearningTask => ({
+    evidence: validatePreparedLearningTaskOutcome(prepared, evidence),
+    huginTaskIdentity,
+    classification: input.taskClassification,
+  });
+  const failure = (reason: string): RecoveredStoredLearningTask => result(
+    learningTaskRecoveryFailure(prepared, reason),
+  );
+
+  const persistenceFailure = (
+    reason: string,
+    evidence: LearningTaskExecutionEvidence = learningTaskRecoveryFailure(prepared, reason),
+  ): RecoveredStoredLearningTask => ({
+    evidence: learningTaskOutcomePersistenceFailure(evidence, reason),
+    huginTaskIdentity,
+    classification: input.taskClassification,
+  });
+
+  const replayEntry = await input.munin.read(
+    prepared.replayPayloadRef.namespace,
+    prepared.replayPayloadRef.key,
+  );
+  let replay: ReturnType<typeof validatePreparedLearningTaskReplayPayload> | null = null;
+  let replayFailureReason: string | null = null;
+  if (!replayEntry) {
+    replayFailureReason = "classified replay payload is missing";
+  } else if (!sameClassification(replayEntry.classification, input.taskClassification)) {
+    replayFailureReason = "classified replay payload classification differs from task status";
+  } else {
+    try {
+      replay = validatePreparedLearningTaskReplayPayload(
+        prepared,
+        parseJson(replayEntry.content),
+        attemptStart,
+      );
+    } catch (error) {
+      replayFailureReason = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  const existingOutcome = await input.munin.read(
+    prepared.attemptOutcomeRef.namespace,
+    prepared.attemptOutcomeRef.key,
+  );
+  if (replayFailureReason) {
+    if (existingOutcome) return persistenceFailure(replayFailureReason);
+    const recovered = failure(replayFailureReason);
+    try {
+      await createImmutableLearningArtifact(input.munin, {
+        namespace: prepared.attemptOutcomeRef.namespace,
+        key: prepared.attemptOutcomeRef.key,
+        content: JSON.stringify(recovered.evidence),
+        tags: [
+          "learning-task-attempt",
+          "attempt:not-admitted",
+          "attempt:recovered",
+          "contract:grimnir-learning-task-v1",
+        ],
+        classification: input.taskClassification,
+      }, { allowExactExisting: true });
+      return recovered;
+    } catch (error) {
+      return persistenceFailure(
+        `durable learning-task attempt outcome write failed: ${error instanceof Error ? error.message : String(error)}`,
+        recovered.evidence,
+      );
+    }
+  }
+  if (existingOutcome) {
+    if (!sameClassification(existingOutcome.classification, input.taskClassification)) {
+      return persistenceFailure(
+        "durable learning-task outcome classification differs from task status",
+      );
+    }
+    try {
+      return result(learningTaskExecutionEvidenceSchema.parse(parseJson(existingOutcome.content)));
+    } catch {
+      return persistenceFailure("durable learning-task outcome is malformed or cross-bound");
+    }
+  }
+
+  let recovered: RecoveredStoredLearningTask;
+  if (!input.gateway) {
+    recovered = failure("homeserver gateway is unavailable for exact recovery");
+  } else {
+    const evidence = await recoverPreparedLearningTaskDispatch({
+      prepared,
+      replayPayload: replay!,
+      gatewayBaseUrl: input.gateway.baseUrl,
+      apiKey: input.gateway.apiKey,
+      fetchImpl: input.fetchImpl,
+    });
+    recovered = result(evidence);
+  }
+
+  try {
+    await createImmutableLearningArtifact(input.munin, {
+      namespace: prepared.attemptOutcomeRef.namespace,
+      key: prepared.attemptOutcomeRef.key,
+      content: JSON.stringify(recovered.evidence),
+      tags: [
+        "learning-task-attempt",
+        recovered.evidence.state === "m5-admitted" ? "attempt:admitted" : "attempt:not-admitted",
+        "attempt:recovered",
+        "contract:grimnir-learning-task-v1",
+      ],
+      classification: input.taskClassification,
+    }, { allowExactExisting: true });
+    return recovered;
+  } catch (error) {
+    return persistenceFailure(
+      `durable learning-task attempt outcome write failed: ${error instanceof Error ? error.message : String(error)}`,
+      recovered.evidence,
+    );
+  }
+}
+
+export async function recoverLatestStoredLearningTaskAttempt(input: {
+  munin: MuninClient;
+  taskNamespace: string;
+  taskClassification?: string;
+  gateway: { baseUrl: string; apiKey: string } | null;
+  fetchImpl?: typeof fetch;
+}): Promise<RecoveredStoredLearningTask | null> {
+  const matches = await input.munin.query({
+    tags: ["learning-task-attempt", "attempt:started"],
+    namespace: input.taskNamespace,
+    entry_type: "state",
+    limit: 20,
+  });
+  const latest = matches.results
+    .filter((entry) => entry.namespace === input.taskNamespace
+      && entry.key?.startsWith("learning-attempt-")
+      && !entry.key.endsWith("-prepared")
+      && !entry.key.endsWith("-replay")
+      && !entry.key.endsWith("-outcome"))
+    .sort((left, right) => Date.parse(right.updated_at) - Date.parse(left.updated_at))[0];
+  if (!latest?.key) return null;
+  const attemptStartEntry = await input.munin.read(input.taskNamespace, latest.key);
+  if (!attemptStartEntry
+    || !sameClassification(attemptStartEntry.classification, input.taskClassification)) {
+    return null;
+  }
+  let attemptStart: DurableLearningTaskAttemptStart;
+  try {
+    attemptStart = validateStoredLearningTaskAttemptStart({
+      taskNamespace: input.taskNamespace,
+      key: latest.key,
+      raw: parseJson(attemptStartEntry.content),
+    });
+  } catch {
+    return null;
+  }
+  const attemptStartRef = { namespace: input.taskNamespace, key: latest.key };
+  const preparedKey = learningTaskPreparedDispatchKey(attemptStart.attemptId);
+  const preparedEntry = await input.munin.read(input.taskNamespace, preparedKey);
+  if (!preparedEntry
+    || !sameClassification(preparedEntry.classification, input.taskClassification)) {
+    return {
+      evidence: learningTaskPreDispatchRecoveryFailure({
+        start: attemptStart,
+        attemptStartRef,
+        reason: preparedEntry
+          ? "latest prepared dispatch classification differs from task status"
+          : "latest attempt has no durable prepared dispatch",
+      }),
+      huginTaskIdentity: attemptStart.huginTaskIdentity,
+      classification: input.taskClassification,
+    };
+  }
+  const recovered = await recoverStoredLearningTaskCandidate({
+    munin: input.munin,
+    taskNamespace: input.taskNamespace,
+    taskClassification: input.taskClassification,
+    preparedEntry,
+    gateway: input.gateway,
+    fetchImpl: input.fetchImpl,
+  });
+  return recovered ?? {
+    evidence: learningTaskPreDispatchRecoveryFailure({
+      start: attemptStart,
+      attemptStartRef,
+      reason: "latest durable prepared dispatch is malformed or cross-bound",
+    }),
+    huginTaskIdentity: attemptStart.huginTaskIdentity,
+    classification: input.taskClassification,
+  };
+}

--- a/src/learning-task-source.ts
+++ b/src/learning-task-source.ts
@@ -1,0 +1,58 @@
+import type { LearningTaskSource } from "./learning-task-handshake.js";
+
+export function buildAuthenticatedLearningTaskSource(input: {
+  taskNamespace: string;
+  createdAt: string;
+  acceptedAt: string;
+  verifiedSubmitter?: string;
+  brokerPrincipal?: string;
+  brokerAttestedNamespace?: string;
+  brokerAttestationError?: string;
+}): LearningTaskSource {
+  const createdAt = new Date(input.createdAt).toISOString();
+  const acceptedAt = new Date(input.acceptedAt).toISOString();
+  // An ordinary signed task is owned by its verified signer. Embedded Broker
+  // claims are data, not authority, and can never override this branch.
+  if (input.verifiedSubmitter) {
+    return {
+      component: "hugin",
+      system: "munin-task",
+      id: input.taskNamespace,
+      created_at: createdAt,
+      accepted_at: acceptedAt,
+      principal: {
+        id: input.verifiedSubmitter,
+        authentication: "verified-signature",
+        scope: "owner",
+      },
+      content_owner: {
+        id: input.verifiedSubmitter,
+        authority: "authenticated-owner",
+      },
+    };
+  }
+  if (input.brokerPrincipal) {
+    if (input.brokerAttestedNamespace !== input.taskNamespace) {
+      throw new Error("LearningTaskContract Broker attestation namespace mismatch");
+    }
+    return {
+      component: "hugin",
+      system: "hugin-broker",
+      id: input.taskNamespace,
+      created_at: createdAt,
+      accepted_at: acceptedAt,
+      principal: {
+        id: input.brokerPrincipal,
+        authentication: "service-auth",
+        scope: "owner",
+      },
+      content_owner: {
+        id: input.brokerPrincipal,
+        authority: "authenticated-owner",
+      },
+    };
+  }
+  throw new Error(input.brokerAttestationError
+    ? `LearningTaskContract Broker source rejected: ${input.brokerAttestationError}`
+    : "LearningTaskContract requires an authenticated Broker principal or valid task signature");
+}

--- a/src/learning-task-store.ts
+++ b/src/learning-task-store.ts
@@ -1,0 +1,56 @@
+import {
+  MuninWriteRejectedError,
+  type MuninClient,
+} from "./munin-client.js";
+
+export interface ImmutableLearningArtifactWrite {
+  namespace: string;
+  key: string;
+  content: string;
+  tags: string[];
+  classification?: string;
+}
+
+/**
+ * Create one immutable learning artifact. A retry may reuse an existing row
+ * only when Munin reports the typed create conflict and the stored bytes are
+ * exactly identical. Any ambiguous result or divergent collision fails closed.
+ */
+export async function createImmutableLearningArtifact(
+  munin: MuninClient,
+  write: ImmutableLearningArtifactWrite,
+  options: { allowExactExisting?: boolean } = {},
+): Promise<"created" | "exact-existing"> {
+  try {
+    const result = await munin.write(
+      write.namespace,
+      write.key,
+      write.content,
+      write.tags,
+      undefined,
+      write.classification,
+      true,
+    );
+    if (result.status !== "created") {
+      throw new Error(
+        `immutable learning artifact write returned non-created status for ${write.namespace}/${write.key}`,
+      );
+    }
+    return "created";
+  } catch (error) {
+    if (!(options.allowExactExisting
+      && error instanceof MuninWriteRejectedError
+      && error.conflictReason === "already_exists")) {
+      throw error;
+    }
+    const existing = await munin.read(write.namespace, write.key);
+    if (!existing
+      || existing.content !== write.content
+      || existing.classification !== write.classification) {
+      throw new Error(
+        `immutable learning artifact collision differs at ${write.namespace}/${write.key}`,
+      );
+    }
+    return "exact-existing";
+  }
+}

--- a/src/task-result-schema.ts
+++ b/src/task-result-schema.ts
@@ -11,6 +11,7 @@ import {
   TASK_SIGNATURE_STATUSES,
 } from "./task-signing.js";
 import { huginTaskIdentitySchema } from "./task-identity.js";
+import { learningTaskExecutionEvidenceSchema } from "./learning-task-handshake.js";
 
 export const taskExecutionOutcomeSchema = z.enum([
   "completed",
@@ -147,9 +148,13 @@ export const taskExecutionRuntimeMetadataSchema = z.object({
   eliminatedRuntimes: z.array(routingEliminationSchema).optional(),
   skillRoute: skillRouteSchema.optional(),
   delegation: delegationProvenanceSchema.optional(),
-  // Producer-side identity only. Gateway-authenticated acceptance/echo is a
-  // separate future field owned by the LearningTaskContract handshake.
+  // Producer-side identity only. Gateway-authenticated acceptance/echo lives
+  // in the separate LearningTaskContract evidence field below.
   huginTaskIdentity: huginTaskIdentitySchema.optional(),
+  // Authenticated LearningTaskContract v1 producer stamp/echo and the exact
+  // durable Hugin attempt references. This remains separate from the legacy
+  // #230 identity so raw and rendered prompt semantics cannot collapse.
+  learningTask: learningTaskExecutionEvidenceSchema.optional(),
 });
 export type TaskExecutionRuntimeMetadata = z.infer<
   typeof taskExecutionRuntimeMetadataSchema
@@ -405,6 +410,60 @@ export const structuredTaskResultSchema = z.object({
   orchestratorOutcomes: z.array(orchestratorOutcomeSchema).optional(),
   savings: savingsSummarySchema.optional(),
   provenance: taskSubmissionProvenanceSchema.optional(),
+}).superRefine((value, ctx) => {
+  const learning = value.runtimeMetadata?.learningTask;
+  if (!learning) return;
+  const producerIdentity = value.runtimeMetadata?.huginTaskIdentity;
+  if (!producerIdentity) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["runtimeMetadata", "huginTaskIdentity"],
+      message: "learning evidence requires the exact Hugin producer identity",
+    });
+    return;
+  }
+  if (learning.taskId !== value.taskId) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["runtimeMetadata", "learningTask", "taskId"],
+      message: "learning evidence task id does not match the structured result",
+    });
+  }
+  if (learning.taskOutcomeRef.namespace !== value.taskNamespace
+    || learning.taskOutcomeRef.key !== "result-structured") {
+    ctx.addIssue({
+      code: "custom",
+      path: ["runtimeMetadata", "learningTask", "taskOutcomeRef"],
+      message: "learning evidence task outcome reference does not match the structured result",
+    });
+  }
+  if (producerIdentity.taskId !== value.taskId
+    || producerIdentity.taskId !== learning.taskId) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["runtimeMetadata", "huginTaskIdentity", "taskId"],
+      message: "Hugin producer identity task id does not match the structured result learning task",
+    });
+  }
+  if (producerIdentity.rawTaskFingerprint.algorithm !== learning.rawFingerprint.algorithm
+    || producerIdentity.rawTaskFingerprint.version !== learning.rawFingerprint.version
+    || producerIdentity.rawTaskFingerprint.digest !== learning.rawFingerprint.digest) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["runtimeMetadata", "huginTaskIdentity", "rawTaskFingerprint"],
+      message: "Hugin producer identity raw fingerprint does not match learning evidence",
+    });
+  }
+  if (learning.requestStamp
+    && (learning.requestStamp.raw_fingerprint.algorithm !== producerIdentity.rawTaskFingerprint.algorithm
+      || learning.requestStamp.raw_fingerprint.version !== producerIdentity.rawTaskFingerprint.version
+      || learning.requestStamp.raw_fingerprint.digest !== producerIdentity.rawTaskFingerprint.digest)) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["runtimeMetadata", "learningTask", "requestStamp", "raw_fingerprint"],
+      message: "learning request stamp raw fingerprint does not match the Hugin producer identity",
+    });
+  }
 });
 export type StructuredTaskResult = z.infer<typeof structuredTaskResultSchema>;
 

--- a/tests/broker/attestation.test.ts
+++ b/tests/broker/attestation.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createBrokerAttestation,
+  parseStoredBrokerAttestation,
+  validateBrokerAttestation,
+} from "../../src/broker/attestation.js";
+import {
+  BrokerTaskStore,
+  generateBrokerTaskId,
+  parseCanonicalEnvelope,
+} from "../../src/broker/task-store.js";
+import type { DelegationEnvelope } from "../../src/broker/types.js";
+import type { MuninClient } from "../../src/munin-client.js";
+
+const principal = "claude-code";
+const secret = "broker-secret-for-tests";
+const idempotencyKey = "11111111-1111-4111-8111-111111111111";
+
+function envelope(): DelegationEnvelope {
+  return {
+    envelope_version: 2,
+    idempotency_key: idempotencyKey,
+    orchestrator_session_id: "session-1",
+    orchestrator_submitter: principal,
+    task_type: "summarize",
+    prompt: "Summarize this.",
+    alias_requested: "m5",
+    alias_map_version: 2,
+    sensitivity: "internal",
+    timeout_ms: 30_000,
+    max_output_tokens: 1_024,
+    acceptance: { mode: "l1_review" },
+    allowed_destinations: ["m5"],
+    tool_policy: { mode: "none" },
+    budget: { max_attempts: 1, max_cost_usd: 0 },
+    durability: "required",
+    delivery: { mode: "munin" },
+    escalation: { mode: "return_to_l1" },
+    task_id: generateBrokerTaskId(principal, idempotencyKey),
+    broker_principal: principal,
+    received_at: "2026-07-19T10:00:00.000Z",
+    alias_resolved: {
+      alias: "m5",
+      family: "one-shot",
+      model_requested: "gateway-selected",
+      runtime: "homeserver",
+      runtime_row_id: "homeserver-m5",
+      host: "m5",
+    },
+    policy_version: "zdr-v1+rlv-v1",
+  };
+}
+
+describe("authenticated Broker provenance", () => {
+  it("binds the authenticated principal, derived task id, namespace, and exact envelope", () => {
+    const value = envelope();
+    const attestation = createBrokerAttestation(value, secret);
+    expect(validateBrokerAttestation({
+      envelope: value,
+      attestation,
+      serverSecret: secret,
+      expectedNamespace: `tasks/${value.task_id}`,
+    })).toMatchObject({ ok: true, principal });
+
+    const changedPrincipal = { ...value, broker_principal: "embedded-attacker" };
+    expect(validateBrokerAttestation({
+      envelope: changedPrincipal,
+      attestation,
+      serverSecret: secret,
+    })).toMatchObject({ ok: false });
+    expect(validateBrokerAttestation({
+      envelope: value,
+      attestation,
+      serverSecret: "wrong-secret",
+    })).toMatchObject({ ok: false });
+    expect(validateBrokerAttestation({
+      envelope: value,
+      attestation,
+      serverSecret: secret,
+      expectedNamespace: "tasks/substituted",
+    })).toMatchObject({ ok: false });
+    expect(() => createBrokerAttestation({ ...value, task_id: "mcp-m5-substituted" }, secret))
+      .toThrow(/derived task id/);
+  });
+
+  it("writes and round-trips an attestation only when the submitter key is server-held", async () => {
+    const writes: Array<{ content: string }> = [];
+    const munin = {
+      write: async (_ns: string, _key: string, content: string) => {
+        writes.push({ content });
+        return { status: "created" };
+      },
+    } as unknown as MuninClient;
+    await new BrokerTaskStore(munin, { attestationSecret: secret })
+      .submit({ envelope: envelope() });
+    const content = writes[0]!.content;
+    const parsedEnvelope = parseCanonicalEnvelope(content);
+    expect(parsedEnvelope.ok).toBe(true);
+    if (!parsedEnvelope.ok) return;
+    expect(validateBrokerAttestation({
+      envelope: parsedEnvelope.envelope,
+      attestation: parseStoredBrokerAttestation(content),
+      serverSecret: secret,
+    })).toMatchObject({ ok: true, principal });
+  });
+});

--- a/tests/fixtures/hugin-learning-task-serializer-v1.json
+++ b/tests/fixtures/hugin-learning-task-serializer-v1.json
@@ -1,0 +1,169 @@
+{
+  "fixture_status": "real-hugin-serializer",
+  "contract_source": "Magnus-Gille/grimnir@032acc9:docs/learning-task-contract-v1.schema.json",
+  "producer_source": "Magnus-Gille/hugin#240:buildHomeserverRequestBody",
+  "consumer_target": "Magnus-Gille/gille-inference#2:/delegate.learningTaskStamp",
+  "raw_logical_task": "  Summarize the fixture incident report.\n",
+  "observed_hugin_instruction": "## Task\n  Summarize the fixture incident report.\n",
+  "task_id": "task-001",
+  "task_type": "summarize",
+  "expected_raw_fingerprint": "7b1c423b1792795a9442c6df25d5035af9daa83dbe43c48476f9bd8baa633152",
+  "expected_contract": {
+    "contract_version": "grimnir.learning-task/v1",
+    "schema_revision": 1,
+    "features": [
+      "hugin-request-stamp-v1",
+      "gateway-echo-v1",
+      "three-stage-prompt-provenance-v1",
+      "reproducible-serving-digests-v1"
+    ]
+  },
+  "origin_config": {
+    "prompt": ["hugin-direct-delegate-prompt", "v1"],
+    "harness": ["homeserver-executor", "learning-task-v1"],
+    "tool_policy": ["bounded-delegate", "learning-task-v1"]
+  },
+  "stamp": {
+    "task_instance_id": "task-001",
+    "attempt_id": "hugin-attempt:11111111-1111-4111-8111-111111111111",
+    "client_id": "hugin",
+    "expected_transport_principal_id": "service:hugin",
+    "idempotency_key": "opaque:e1e1e1e1-e1e1-4e1e-8e1e-e1e1e1e1e1e1",
+    "request_id": "opaque:e2e2e2e2-e2e2-4e2e-8e2e-e2e2e2e2e2e2",
+    "stamped_at": "2026-07-19T10:00:02.250Z",
+    "contract_request": {
+      "contract_version": "grimnir.learning-task/v1",
+      "schema_revision": 1,
+      "features": [
+        "hugin-request-stamp-v1",
+        "gateway-echo-v1",
+        "three-stage-prompt-provenance-v1",
+        "reproducible-serving-digests-v1"
+      ]
+    },
+    "preflight": {
+      "request": {
+        "request_id": "opaque:f1f1f1f1-f1f1-4f1f-8f1f-f1f1f1f1f1f1",
+        "endpoint": "/v1/capabilities/learning-task",
+        "protocol_version": "learning-task-preflight/v1",
+        "requested_at": "2026-07-19T10:00:01.500Z",
+        "requested_capabilities": {
+          "contract_version": "grimnir.learning-task/v1",
+          "schema_revision": 1,
+          "features": [
+            "hugin-request-stamp-v1",
+            "gateway-echo-v1",
+            "three-stage-prompt-provenance-v1",
+            "reproducible-serving-digests-v1"
+          ]
+        }
+      },
+      "response": {
+        "advertisement_id": "opaque:f2f2f2f2-f2f2-4f2f-8f2f-f2f2f2f2f2f2",
+        "endpoint": "/v1/capabilities/learning-task",
+        "protocol_version": "learning-task-preflight/v1",
+        "advertised_at": "2026-07-19T10:00:02.000Z",
+        "expires_at": "2026-07-19T10:15:02.000Z",
+        "authenticated_principal_id": "service:gille-inference",
+        "authentication": "service-auth",
+        "capabilities": {
+          "contract_version": "grimnir.learning-task/v1",
+          "schema_revision": 1,
+          "features": [
+            "hugin-request-stamp-v1",
+            "gateway-echo-v1",
+            "three-stage-prompt-provenance-v1",
+            "reproducible-serving-digests-v1"
+          ]
+        }
+      }
+    },
+    "source": {
+      "component": "hugin",
+      "system": "broker",
+      "id": "broker-001",
+      "created_at": "2026-07-19T09:59:00.000Z",
+      "accepted_at": "2026-07-19T10:00:00.000Z",
+      "principal": {
+        "id": "principal:owner",
+        "authentication": "gateway-owner-auth",
+        "scope": "owner"
+      },
+      "content_owner": {
+        "id": "principal:owner",
+        "authority": "authenticated-owner"
+      }
+    },
+    "task_type": {
+      "id": "summarize",
+      "taxonomy_id": "gille-inference/task-types",
+      "taxonomy_version": "gille-inference-task-types-2026-07-19-v1"
+    },
+    "raw_input": {
+      "algorithm": "sha256",
+      "canonicalization": "jcs-rfc8785-utf8-v1",
+      "source_ref": "source-doc:hugin/raw/b0b3576c00612d06363ea20fd22ea646b129720b4502f6d8c942098a0c7aa95e",
+      "source_type": "raw-input",
+      "source_version": "raw-input-v1",
+      "digest": "b0b3576c00612d06363ea20fd22ea646b129720b4502f6d8c942098a0c7aa95e"
+    },
+    "raw_fingerprint": {
+      "algorithm": "sha256",
+      "version": "trim-utf8-sha256-v1",
+      "digest": "7b1c423b1792795a9442c6df25d5035af9daa83dbe43c48476f9bd8baa633152"
+    },
+    "hugin_envelope": {
+      "algorithm": "sha256",
+      "canonicalization": "jcs-rfc8785-utf8-v1",
+      "source_ref": "source-doc:hugin/prompt/11111111-1111-4111-8111-111111111111",
+      "source_type": "prompt-stage",
+      "source_version": "prompt-stage-v2",
+      "digest": "3792bf0a207fe200b314adf011b51de429a34c19c3846a8253353eaa5a04901d"
+    },
+    "origin_config": {
+      "prompt": {
+        "id": "hugin-direct-delegate-prompt",
+        "version": "v1",
+        "config_digest": {
+          "algorithm": "sha256",
+          "canonicalization": "jcs-rfc8785-utf8-v1",
+          "source_ref": "source-doc:hugin/config/direct-delegate-prompt-v1",
+          "source_type": "origin-prompt-config",
+          "source_version": "config-source-v1",
+          "digest": "dda8bada2f661ce23060250b0f54ff9822b690cc896d83bb60bd4a3cad1f5ef3"
+        }
+      },
+      "harness": {
+        "id": "homeserver-executor",
+        "version": "learning-task-v1",
+        "config_digest": {
+          "algorithm": "sha256",
+          "canonicalization": "jcs-rfc8785-utf8-v1",
+          "source_ref": "source-doc:hugin/config/homeserver-learning-task-v1",
+          "source_type": "origin-harness-config",
+          "source_version": "config-source-v1",
+          "digest": "b091a4a6bb10bebf79eb4d1612bb407713938aec7a44dcfb3f9878c1e172db6b"
+        }
+      },
+      "tool_policy": {
+        "id": "bounded-delegate",
+        "version": "learning-task-v1",
+        "config_digest": {
+          "algorithm": "sha256",
+          "canonicalization": "jcs-rfc8785-utf8-v1",
+          "source_ref": "source-doc:hugin/config/bounded-delegate-learning-task-v1",
+          "source_type": "origin-tool-policy-config",
+          "source_version": "config-source-v1",
+          "digest": "8eaa221e2d1b51314645d9130cb6fa6ca16650d562eae8cbcd8b36beaeb126a0"
+        }
+      }
+    },
+    "macro_decision": {
+      "policy_id": "hugin-runtime-selection",
+      "version": "homeserver-delegate-learning-task-v1",
+      "decision_id": "learning-task:11111111-1111-4111-8111-111111111111",
+      "target": "m5",
+      "service": "gille-inference"
+    }
+  }
+}

--- a/tests/helpers/learning-task.ts
+++ b/tests/helpers/learning-task.ts
@@ -1,0 +1,121 @@
+import { createHash, randomUUID } from "node:crypto";
+
+import {
+  LEARNING_TASK_CAPABILITIES,
+  createPreparedLearningTaskDispatch,
+  createLearningTaskAttemptStart,
+  jcsCanonicalize,
+  type LearningTaskRequestContext,
+} from "../../src/learning-task-handshake.js";
+import {
+  buildHomeserverRequestBody,
+  buildFreshHomeserverDelegateRequestBody,
+  renderHomeserverUserMessage,
+  type HomeserverTaskConfig,
+} from "../../src/homeserver-executor.js";
+
+/** Build trusted producer context for executor unit tests; never used by runtime code. */
+export function withLearningTaskContext(
+  task: HomeserverTaskConfig,
+  taskId: string,
+): HomeserverTaskConfig {
+  if (task.path !== "delegate") return task;
+  const base = Date.now() - 5_000;
+  const renderedPrompt = renderHomeserverUserMessage(task);
+  const attempt = createLearningTaskAttemptStart({
+    taskId,
+    attemptId: `hugin-attempt:${randomUUID()}`,
+    startedAt: new Date(base + 1_000).toISOString(),
+    rawTaskText: task.prompt,
+    renderedPrompt,
+  });
+  const context: LearningTaskRequestContext = {
+    attempt,
+    attemptStartRef: {
+      namespace: `tasks/${taskId}`,
+      key: `learning-attempt-${attempt.attemptId.replace(/^hugin-attempt:/, "")}`,
+    },
+    expectedTransportPrincipalId: "service:hugin",
+    idempotencyKey: `opaque:${randomUUID()}`,
+    requestId: `opaque:${randomUUID()}`,
+    source: {
+      component: "hugin",
+      system: "test",
+      id: `tasks/${taskId}`,
+      created_at: new Date(base - 1_000).toISOString(),
+      accepted_at: new Date(base).toISOString(),
+      principal: {
+        id: "principal:test-owner",
+        authentication: "verified-signature",
+        scope: "owner",
+      },
+      content_owner: {
+        id: "principal:test-owner",
+        authority: "authenticated-owner",
+      },
+    },
+    preflight: {
+      request: {
+        request_id: `opaque:${randomUUID()}`,
+        endpoint: "/v1/capabilities/learning-task",
+        protocol_version: "learning-task-preflight/v1",
+        requested_at: new Date(base + 2_000).toISOString(),
+        requested_capabilities: structuredClone(LEARNING_TASK_CAPABILITIES),
+      },
+      response: {
+        advertisement_id: `opaque:${randomUUID()}`,
+        endpoint: "/v1/capabilities/learning-task",
+        protocol_version: "learning-task-preflight/v1",
+        advertised_at: new Date(base + 3_000).toISOString(),
+        expires_at: new Date(base + 3_000 + 15 * 60_000).toISOString(),
+        authenticated_principal_id: "service:gille-inference",
+        authentication: "service-auth",
+        capabilities: structuredClone(LEARNING_TASK_CAPABILITIES),
+      },
+    },
+    stampedAt: new Date(base + 4_000).toISOString(),
+  };
+  const requestBody = buildFreshHomeserverDelegateRequestBody(task, taskId, context);
+  const prepared = createPreparedLearningTaskDispatch({
+    context,
+    requestStamp: requestBody.learningTaskStamp!,
+    requestBody,
+  });
+  return {
+    ...task,
+    learningTask: {
+      kind: "ready",
+      context,
+      ...prepared,
+    },
+  };
+}
+
+export function withLearningTaskGatewayEcho(
+  task: HomeserverTaskConfig,
+  taskId: string,
+  outcome: Record<string, unknown>,
+): Record<string, unknown> {
+  const stamp = buildHomeserverRequestBody(task, taskId).learningTaskStamp!;
+  const authenticatedPrincipalId = stamp.expected_transport_principal_id;
+  return {
+    ...outcome,
+    learningTaskGatewayEcho: {
+      echoed_request: structuredClone(stamp),
+      gateway_request_id: `opaque:${randomUUID()}`,
+      admission_id: `opaque:${randomUUID()}`,
+      admitted_at: new Date(Date.parse(stamp.stamped_at) + 1).toISOString(),
+      authenticated_principal_id: authenticatedPrincipalId,
+      authentication: "gateway-owner-auth",
+      principal_binding_digest: {
+        algorithm: "sha256",
+        version: "gateway-principal-request-binding-jcs-v1",
+        digest: createHash("sha256").update(jcsCanonicalize({
+          authenticated_principal_id: authenticatedPrincipalId,
+          request_stamp: stamp,
+        }), "utf8").digest("hex"),
+      },
+      capabilities: structuredClone(stamp.contract_request),
+    },
+  };
+}

--- a/tests/homeserver-executor.test.ts
+++ b/tests/homeserver-executor.test.ts
@@ -8,6 +8,10 @@ import {
   loadHomeserverGatewayConfig,
   type HomeserverTaskConfig,
 } from "../src/homeserver-executor.js";
+import {
+  withLearningTaskContext,
+  withLearningTaskGatewayEcho,
+} from "./helpers/learning-task.js";
 
 function makeTaskConfig(overrides?: Partial<HomeserverTaskConfig>): HomeserverTaskConfig {
   return {
@@ -162,8 +166,32 @@ describe("executeHomeserverTask — chat path", () => {
 
 describe("executeHomeserverTask — delegate path", () => {
   it("POSTs /delegate and maps the DelegationOutcome", async () => {
+    const task = withLearningTaskContext(makeTaskConfig({
+      path: "delegate",
+      taskType: "extract",
+      systemPrompt: "Return only the extracted year.",
+      maxTokens: 128,
+      modelId: "qwen3-coder",
+      frontierModelId: "anthropic/claude-opus-4-5",
+      verifier: { type: "numeric", expected: 1998 },
+      responseFormat: {
+        type: "json_schema",
+        json_schema: {
+          name: "year_result",
+          schema: {
+            type: "object",
+            properties: { year: { type: "number" } },
+            required: ["year"],
+            additionalProperties: false,
+          },
+          strict: true,
+        },
+      },
+      delegatorModelId: "anthropic/claude-sonnet-4-5",
+      premiumBaselineModelId: "anthropic/claude-opus-4-5",
+    }), "delegate-ok");
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      jsonResponse({
+      jsonResponse(withLearningTaskGatewayEcho(task, "delegate-ok", {
         delegated: true,
         escalate: false,
         taskType: "extract",
@@ -176,34 +204,11 @@ describe("executeHomeserverTask — delegate path", () => {
         ledgerId: "ledger-123",
         verifierNotes: "numeric match",
         metrics: { promptTokens: 45, completionTokens: 3, latencyMs: 820 },
-      }),
+      })),
     );
 
     const result = await executeHomeserverTask(
-      makeTaskConfig({
-        path: "delegate",
-        taskType: "extract",
-        systemPrompt: "Return only the extracted year.",
-        maxTokens: 128,
-        modelId: "qwen3-coder",
-        frontierModelId: "anthropic/claude-opus-4-5",
-        verifier: { type: "numeric", expected: 1998 },
-        responseFormat: {
-          type: "json_schema",
-          json_schema: {
-            name: "year_result",
-            schema: {
-              type: "object",
-              properties: { year: { type: "number" } },
-              required: ["year"],
-              additionalProperties: false,
-            },
-            strict: true,
-          },
-        },
-        delegatorModelId: "anthropic/claude-sonnet-4-5",
-        premiumBaselineModelId: "anthropic/claude-opus-4-5",
-      }),
+      task,
       "delegate-ok",
       tmpLogDir,
     );
@@ -235,6 +240,12 @@ describe("executeHomeserverTask — delegate path", () => {
         version: "hugin-delegate-prompt-utf8-sha256-v1",
       }),
     }));
+    expect(result.learningTask).toMatchObject({
+      state: "m5-admitted",
+      evidenceAccepted: true,
+      taskId: "delegate-ok",
+      gatewayEcho: { echoed_request: { attempt_id: expect.stringMatching(/^hugin-attempt:/) } },
+    });
 
     const [url, init] = fetchMock.mock.calls[0]!;
     expect(url).toBe("http://m5.test:8080/delegate");
@@ -261,6 +272,7 @@ describe("executeHomeserverTask — delegate path", () => {
     });
     expect(body.delegatorModelId).toBe("anthropic/claude-sonnet-4-5");
     expect(body.premiumBaselineModelId).toBe("anthropic/claude-opus-4-5");
+    expect(body.learningTaskStamp.raw_fingerprint).toEqual(body.huginTaskIdentity.rawTaskFingerprint);
   });
 
   // Issue #163: the direct path already carried the flat delegation fields, but
@@ -268,8 +280,12 @@ describe("executeHomeserverTask — delegate path", () => {
   // response — so a single out-of-contract value could throw inside
   // buildStructuredTaskResult and lose the result of a paid run.
   it("captures the gateway's route-policy and price-catalog provenance (#163)", async () => {
+    const task = withLearningTaskContext(
+      makeTaskConfig({ path: "delegate", taskType: "qa-factual" }),
+      "delegate-prov",
+    );
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      jsonResponse({
+      jsonResponse(withLearningTaskGatewayEcho(task, "delegate-prov", {
         delegated: true, escalate: false, outcome: "unverified", output: "PROV_OK",
         nodeId: "m5", modelId: "mellum", taskType: "qa-factual",
         ledgerId: "487bae49-e751-4fc8-a10c-8f12f6aa59a4",
@@ -282,11 +298,11 @@ describe("executeHomeserverTask — delegate path", () => {
           id: "fc5e98f9-2d7c-4792-b2c3-c936d29d44fb",
           priceCatalogVersion: "2026-07-08",
         },
-      }),
+      })),
     );
 
     const result = await executeHomeserverTask(
-      makeTaskConfig({ path: "delegate", taskType: "qa-factual" }), "delegate-prov", tmpLogDir,
+      task, "delegate-prov", tmpLogDir,
     );
 
     const p = result.provenance!;
@@ -305,15 +321,21 @@ describe("executeHomeserverTask — delegate path", () => {
   });
 
   it("drops an out-of-contract gateway score instead of poisoning the result (#163)", async () => {
+    const task = withLearningTaskContext(
+      makeTaskConfig({ path: "delegate", taskType: "extract" }),
+      "delegate-badscore",
+    );
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       // A non-numeric score would previously flow straight into
       // runtimeMetadata.delegation.score (z.number()) and throw inside
       // buildStructuredTaskResult — losing the whole result of a paid run.
-      jsonResponse({ delegated: true, outcome: "pass", score: "high", output: "ok", ledgerId: "l-1" }),
+      jsonResponse(withLearningTaskGatewayEcho(task, "delegate-badscore", {
+        delegated: true, outcome: "pass", score: "high", output: "ok", ledgerId: "l-1",
+      })),
     );
 
     const result = await executeHomeserverTask(
-      makeTaskConfig({ path: "delegate" }), "delegate-badscore", tmpLogDir,
+      task, "delegate-badscore", tmpLogDir,
     );
 
     expect(result.exitCode).toBe(0);
@@ -324,11 +346,17 @@ describe("executeHomeserverTask — delegate path", () => {
   });
 
   it("omits optional /delegate fields that are not present", async () => {
+    const task = withLearningTaskContext(
+      makeTaskConfig({ path: "delegate", taskType: "extract" }),
+      "delegate-min",
+    );
     const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      jsonResponse({ delegated: true, outcome: "unverified", output: "1998" }),
+      jsonResponse(withLearningTaskGatewayEcho(task, "delegate-min", {
+        delegated: true, outcome: "unverified", output: "1998",
+      })),
     );
 
-    await executeHomeserverTask(makeTaskConfig({ path: "delegate", taskType: "extract" }), "delegate-min", tmpLogDir);
+    await executeHomeserverTask(task, "delegate-min", tmpLogDir);
 
     const [, init] = fetchMock.mock.calls[0]!;
     const body = JSON.parse((init as RequestInit).body as string);
@@ -346,14 +374,18 @@ describe("executeHomeserverTask — delegate path", () => {
           version: "hugin-delegate-prompt-utf8-sha256-v1",
         }),
       }),
+      learningTaskStamp: expect.objectContaining({
+        task_instance_id: "delegate-min",
+        task_type: expect.objectContaining({ id: "extract" }),
+      }),
     });
   });
 
-  it("returns a logged failure when defensive identity validation rejects the request", async () => {
+  it("fails closed before fetch when durable LearningTaskContract context is missing", async () => {
     const fetchMock = vi.spyOn(globalThis, "fetch");
 
     const result = await executeHomeserverTask(
-      makeTaskConfig({ path: "delegate", prompt: " \n\t" }),
+      makeTaskConfig({ path: "delegate", taskType: "extract" }),
       "delegate-invalid-identity",
       tmpLogDir,
     );
@@ -362,32 +394,119 @@ describe("executeHomeserverTask — delegate path", () => {
     expect(result.exitCode).toBe(1);
     expect(result.huginTaskIdentity).toBeNull();
     expect(result.output).toContain(
-      "[Gateway error: Hugin task identity requires a non-empty logical task]",
+      "[Gateway error: Direct homeserver delegation requires a durable LearningTaskContract attempt",
     );
     expect(fs.readFileSync(result.logFile, "utf8")).toContain(
-      "Hugin task identity requires a non-empty logical task",
+      "Direct homeserver delegation requires a durable LearningTaskContract attempt",
     );
   });
 
-  it("maps outcome 'fail'/'error' to a non-zero exit code, but 'unverified' to 0", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      jsonResponse({ delegated: true, outcome: "fail", score: 0, output: "nope" }),
+  it("preserves explicit legacy/ineligible delegate traffic without claiming learning evidence", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse({
+      output: "1998",
+      outcome: "pass",
+    }));
+    const result = await executeHomeserverTask(makeTaskConfig({
+      path: "delegate",
+      taskType: "extract",
+      learningTask: { kind: "ineligible" },
+    }), "delegate-legacy", tmpLogDir);
+    expect(result.exitCode).toBe(0);
+    expect(result.learningTask).toBeNull();
+    const body = JSON.parse((fetchMock.mock.calls[0]?.[1] as RequestInit).body as string);
+    expect(body.learningTaskStamp).toBeUndefined();
+    expect(body.huginTaskIdentity.taskId).toBe("delegate-legacy");
+  });
+
+  it("keeps a durable preflight failure model-free and content-blind", async () => {
+    const ready = withLearningTaskContext(
+      makeTaskConfig({ path: "delegate", taskType: "extract" }),
+      "delegate-preflight-failed",
     );
-    const failR = await executeHomeserverTask(makeTaskConfig({ path: "delegate" }), "delegate-fail", tmpLogDir);
+    const context = ready.learningTask!.kind === "ready" ? ready.learningTask.context : null;
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    const result = await executeHomeserverTask({
+      ...ready,
+      learningTask: {
+        kind: "preflight-failed",
+        attempt: context!.attempt,
+        attemptStartRef: context!.attemptStartRef,
+        failureReason: "preflight capability downgrade",
+      },
+    }, "delegate-preflight-failed", tmpLogDir);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(result.exitCode).toBe(1);
+    expect(result.learningTask).toMatchObject({
+      state: "preflight-failed",
+      evidenceAccepted: false,
+      failureCode: "preflight-failed",
+    });
+    expect(result.output).not.toContain("Extract the year");
+  });
+
+  it("rejects a paid-looking response when the exact gateway echo is absent", async () => {
+    const task = withLearningTaskContext(
+      makeTaskConfig({ path: "delegate", taskType: "extract" }),
+      "delegate-no-echo",
+    );
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(jsonResponse({
+      delegated: true,
+      outcome: "pass",
+      score: 1,
+      output: "must not be accepted",
+      ledgerId: "untrusted-without-echo",
+    }));
+
+    const result = await executeHomeserverTask(task, "delegate-no-echo", tmpLogDir);
+    expect(result.exitCode).toBe(1);
+    expect(result.resultText).toBeNull();
+    expect(result.provenance).toBeNull();
+    expect(result.learningTask).toMatchObject({
+      state: "join-failed",
+      evidenceAccepted: false,
+      failureCode: "gateway-echo-invalid",
+    });
+    expect(result.output).not.toContain("must not be accepted");
+  });
+
+  it("maps outcome 'fail'/'error' to a non-zero exit code, but 'unverified' to 0", async () => {
+    const failTask = withLearningTaskContext(
+      makeTaskConfig({ path: "delegate", taskType: "extract" }),
+      "delegate-fail",
+    );
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse(withLearningTaskGatewayEcho(failTask, "delegate-fail", {
+        delegated: true, outcome: "fail", score: 0, output: "nope",
+      })),
+    );
+    const failR = await executeHomeserverTask(failTask, "delegate-fail", tmpLogDir);
     expect(failR.exitCode).toBe(1);
     expect(failR.outcome).toBe("fail");
 
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      jsonResponse({ delegated: true, outcome: "error", output: "" }),
+    const errorTask = withLearningTaskContext(
+      makeTaskConfig({ path: "delegate", taskType: "extract" }),
+      "delegate-error",
     );
-    const errR = await executeHomeserverTask(makeTaskConfig({ path: "delegate" }), "delegate-error", tmpLogDir);
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse(withLearningTaskGatewayEcho(errorTask, "delegate-error", {
+        delegated: true, outcome: "error", output: "",
+      })),
+    );
+    const errR = await executeHomeserverTask(errorTask, "delegate-error", tmpLogDir);
     expect(errR.exitCode).toBe(1);
 
     // 'unverified' is the gateway's normal success-without-grading case — must stay exit 0.
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
-      jsonResponse({ delegated: true, outcome: "unverified", output: "ran ok" }),
+    const unverifiedTask = withLearningTaskContext(
+      makeTaskConfig({ path: "delegate", taskType: "extract" }),
+      "delegate-unverified",
     );
-    const unvR = await executeHomeserverTask(makeTaskConfig({ path: "delegate" }), "delegate-unverified", tmpLogDir);
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse(withLearningTaskGatewayEcho(unverifiedTask, "delegate-unverified", {
+        delegated: true, outcome: "unverified", output: "ran ok",
+      })),
+    );
+    const unvR = await executeHomeserverTask(unverifiedTask, "delegate-unverified", tmpLogDir);
     expect(unvR.exitCode).toBe(0);
     expect(unvR.resultText).toBe("ran ok");
   });
@@ -399,8 +518,12 @@ describe("executeHomeserverTask — backpressure & errors", () => {
       new Response("owner preempted the GPU", { status: 503, headers: { "Retry-After": "5" } }),
     );
 
-    const result = await executeHomeserverTask(
+    const task = withLearningTaskContext(
       makeTaskConfig({ path: "delegate", taskType: "extract" }),
+      "bp-503",
+    );
+    const result = await executeHomeserverTask(
+      task,
       "bp-503",
       tmpLogDir,
     );

--- a/tests/homeserver-task-identity.test.ts
+++ b/tests/homeserver-task-identity.test.ts
@@ -14,6 +14,7 @@ import {
   type HomeserverTaskConfig,
 } from "../src/homeserver-executor.js";
 import { taskTextFingerprint } from "../src/learning/m5-task-exposure.js";
+import { withLearningTaskContext } from "./helpers/learning-task.js";
 
 interface FixtureCase {
   name: string;
@@ -149,7 +150,10 @@ describe("canonical Hugin task identity", () => {
         taskId: "substituted",
       },
     } as HomeserverTaskConfig;
-    const body = buildHomeserverRequestBody(configWithSpoofedExtraField, vector.taskId);
+    const body = buildHomeserverRequestBody(
+      withLearningTaskContext(configWithSpoofedExtraField, vector.taskId),
+      vector.taskId,
+    );
 
     expect(body.prompt).toBe(vector.renderedWithContext);
     expect(body.huginTaskIdentity).toEqual({
@@ -172,9 +176,15 @@ describe("canonical Hugin task identity", () => {
   });
 
   it("fails closed rather than emitting a missing or ambiguous identity", () => {
-    expect(() => buildHomeserverRequestBody(taskConfig({ prompt: " \n\t" }), "task-1"))
+    expect(() => buildHomeserverRequestBody(
+      withLearningTaskContext(taskConfig({ prompt: " \n\t" }), "task-1"),
+      "task-1",
+    ))
       .toThrow("non-empty logical task");
-    expect(() => buildHomeserverRequestBody(taskConfig({ prompt: "valid" }), " task-1"))
+    expect(() => buildHomeserverRequestBody(
+      withLearningTaskContext(taskConfig({ prompt: "valid" }), " task-1"),
+      " task-1",
+    ))
       .toThrow("non-whitespace-padded task id");
   });
 });

--- a/tests/learning-task-handshake.test.ts
+++ b/tests/learning-task-handshake.test.ts
@@ -1,0 +1,622 @@
+import { createHash, randomUUID } from "node:crypto";
+import { readFileSync } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  LEARNING_TASK_CAPABILITIES,
+  buildLearningTaskRequestStamp,
+  createPreparedLearningTaskDispatch,
+  createLearningTaskAttemptStart,
+  durableLearningTaskAttemptStart,
+  fetchLearningTaskPreflight,
+  jcsCanonicalize,
+  prepareDurableLearningTaskAttempt,
+  recoverPreparedLearningTaskDispatch,
+  learningTaskOutcomePersistenceFailure,
+  learningTaskExecutionEvidenceSchema,
+  validateLearningTaskGatewayEcho,
+  validatePreparedLearningTaskAttemptStart,
+  validatePreparedLearningTaskOutcome,
+  type LearningTaskRequestContext,
+} from "../src/learning-task-handshake.js";
+import {
+  buildHomeserverRequestBody,
+  buildFreshHomeserverDelegateRequestBody,
+  renderHomeserverUserMessage,
+  type HomeserverTaskConfig,
+} from "../src/homeserver-executor.js";
+
+function response(value: unknown, status = 200): Response {
+  return new Response(JSON.stringify(value), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const acceptedAt = "2026-07-19T10:00:00.000Z";
+const startedAt = "2026-07-19T10:00:01.000Z";
+const advertisedAt = "2026-07-19T10:00:02.000Z";
+const serializerFixture = JSON.parse(readFileSync(
+  new URL("./fixtures/hugin-learning-task-serializer-v1.json", import.meta.url),
+  "utf8",
+)) as {
+  fixture_status: string;
+  contract_source: string;
+  producer_source: string;
+  consumer_target: string;
+  raw_logical_task: string;
+  observed_hugin_instruction: string;
+  task_id: string;
+  task_type: string;
+  expected_raw_fingerprint: string;
+  expected_contract: typeof LEARNING_TASK_CAPABILITIES;
+  origin_config: Record<string, [string, string]>;
+  stamp: unknown;
+};
+
+function context(): LearningTaskRequestContext {
+  const task = {
+    prompt: "  Summarize the fixture incident report.\n",
+    gatewayBaseUrl: "https://m5.test",
+    apiKey: "private-owner-key",
+    path: "delegate",
+    taskType: "summarize",
+    timeoutMs: 30_000,
+    maxOutputChars: 4_096,
+  } satisfies HomeserverTaskConfig;
+  const renderedPrompt = renderHomeserverUserMessage(task);
+  const attempt = createLearningTaskAttemptStart({
+    taskId: "task-001",
+    attemptId: "hugin-attempt:11111111-1111-4111-8111-111111111111",
+    startedAt,
+    rawTaskText: task.prompt,
+    renderedPrompt,
+  });
+  return {
+    attempt,
+    attemptStartRef: {
+      namespace: "tasks/task-001",
+      key: "learning-attempt-11111111-1111-4111-8111-111111111111",
+    },
+    expectedTransportPrincipalId: "service:hugin",
+    idempotencyKey: "opaque:e1e1e1e1-e1e1-4e1e-8e1e-e1e1e1e1e1e1",
+    requestId: "opaque:e2e2e2e2-e2e2-4e2e-8e2e-e2e2e2e2e2e2",
+    source: {
+      component: "hugin",
+      system: "broker",
+      id: "broker-001",
+      created_at: "2026-07-19T09:59:00.000Z",
+      accepted_at: acceptedAt,
+      principal: {
+        id: "principal:owner",
+        authentication: "gateway-owner-auth",
+        scope: "owner",
+      },
+      content_owner: {
+        id: "principal:owner",
+        authority: "authenticated-owner",
+      },
+    },
+    preflight: {
+      request: {
+        request_id: "opaque:f1f1f1f1-f1f1-4f1f-8f1f-f1f1f1f1f1f1",
+        endpoint: "/v1/capabilities/learning-task",
+        protocol_version: "learning-task-preflight/v1",
+        requested_at: "2026-07-19T10:00:01.500Z",
+        requested_capabilities: structuredClone(LEARNING_TASK_CAPABILITIES),
+      },
+      response: {
+        advertisement_id: "opaque:f2f2f2f2-f2f2-4f2f-8f2f-f2f2f2f2f2f2",
+        endpoint: "/v1/capabilities/learning-task",
+        protocol_version: "learning-task-preflight/v1",
+        advertised_at: advertisedAt,
+        expires_at: "2026-07-19T10:15:02.000Z",
+        authenticated_principal_id: "service:gille-inference",
+        authentication: "service-auth",
+        capabilities: structuredClone(LEARNING_TASK_CAPABILITIES),
+      },
+    },
+    stampedAt: "2026-07-19T10:00:02.250Z",
+  };
+}
+
+function readyLearningTask(task: HomeserverTaskConfig, ctx: LearningTaskRequestContext) {
+  const requestBody = buildFreshHomeserverDelegateRequestBody(task, ctx.attempt.taskId, ctx);
+  return {
+    kind: "ready" as const,
+    context: ctx,
+    ...createPreparedLearningTaskDispatch({
+      context: ctx,
+      requestStamp: requestBody.learningTaskStamp!,
+      requestBody,
+    }),
+  };
+}
+
+function taskConfigForFixture(): HomeserverTaskConfig {
+  return {
+    prompt: "  Summarize the fixture incident report.\n",
+    gatewayBaseUrl: "https://m5.test",
+    apiKey: "private-owner-key",
+    path: "delegate",
+    taskType: "summarize",
+    timeoutMs: 30_000,
+    maxOutputChars: 4_096,
+  };
+}
+
+function gatewayEchoFor(stamp: ReturnType<typeof buildLearningTaskRequestStamp>) {
+  const authenticatedPrincipalId = stamp.expected_transport_principal_id;
+  return {
+    echoed_request: structuredClone(stamp),
+    gateway_request_id: "opaque:e3e3e3e3-e3e3-4e3e-8e3e-e3e3e3e3e3e3",
+    admission_id: "opaque:e4e4e4e4-e4e4-4e4e-8e4e-e4e4e4e4e4e4",
+    admitted_at: new Date(Date.parse(stamp.stamped_at) + 1).toISOString(),
+    authenticated_principal_id: authenticatedPrincipalId,
+    authentication: "gateway-owner-auth" as const,
+    principal_binding_digest: {
+      algorithm: "sha256" as const,
+      version: "gateway-principal-request-binding-jcs-v1" as const,
+      digest: createHash("sha256").update(jcsCanonicalize({
+        authenticated_principal_id: authenticatedPrincipalId,
+        request_stamp: stamp,
+      }), "utf8").digest("hex"),
+    },
+    capabilities: structuredClone(stamp.contract_request),
+  };
+}
+
+describe("LearningTaskContract v1 producer handshake", () => {
+  it("makes the attempt durable before either authenticated M5 read", async () => {
+    const events: string[] = [];
+    const uuids = [
+      "11111111-1111-4111-8111-111111111111",
+      "22222222-2222-4222-8222-222222222222",
+      "33333333-3333-4333-8333-333333333333",
+      "44444444-4444-4444-8444-444444444444",
+    ];
+    const clock = [
+      new Date("2026-07-19T10:00:01.500Z"),
+      new Date("2026-07-19T10:00:02.250Z"),
+    ];
+    const fetchImpl = vi.fn(async (url: string) => {
+      events.push(url.endsWith("/portal/me") ? "principal" : "preflight");
+      if (url.endsWith("/portal/me")) {
+        return response({ alias: "service:hugin", tier: "owner" });
+      }
+      return response({
+        advertisement_id: "opaque:55555555-5555-4555-8555-555555555555",
+        endpoint: "/v1/capabilities/learning-task",
+        protocol_version: "learning-task-preflight/v1",
+        advertised_at: advertisedAt,
+        expires_at: "2026-07-19T10:15:02.000Z",
+        authenticated_principal_id: "service:gille-inference",
+        authentication: "service-auth",
+        capabilities: structuredClone(LEARNING_TASK_CAPABILITIES),
+      });
+    });
+
+    const result = await prepareDurableLearningTaskAttempt({
+      taskId: "task-001",
+      startedAt,
+      rawTaskText: "raw task bytes",
+      renderedPrompt: "## Task\nraw task bytes",
+      gatewayBaseUrl: "https://m5.test",
+      apiKey: "private-owner-key",
+      buildSource: () => structuredClone(context().source),
+      persistStart: async (ref, record) => {
+        events.push("persist");
+        expect(ref.key).toBe("learning-attempt-11111111-1111-4111-8111-111111111111");
+        expect(JSON.stringify(record)).not.toContain("raw task bytes");
+      },
+      buildPreparedDispatch: (ctx) => {
+        ctx.stampedAt = "2026-07-19T10:00:02.250Z";
+        const task = {
+          prompt: "raw task bytes",
+          gatewayBaseUrl: "https://m5.test",
+          apiKey: "private-owner-key",
+          path: "delegate" as const,
+          taskType: "summarize",
+          timeoutMs: 30_000,
+          maxOutputChars: 4_096,
+        };
+        const requestBody = buildFreshHomeserverDelegateRequestBody(task, "task-001", ctx);
+        return createPreparedLearningTaskDispatch({
+          context: ctx,
+          requestStamp: requestBody.learningTaskStamp!,
+          requestBody,
+        });
+      },
+      persistReplayPayload: async () => { events.push("replay"); },
+      persistPrepared: async (_ref, record) => {
+        events.push("prepared");
+        expect(JSON.stringify(record)).not.toContain("raw task bytes");
+      },
+      now: () => clock.shift()!,
+      randomUuid: () => uuids.shift()!,
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    expect(events).toEqual(["persist", "principal", "preflight", "replay", "prepared"]);
+    expect(result.startPersisted).toBe(true);
+    expect(result.preparation.kind).toBe("ready");
+  });
+
+  it("fails closed without touching M5 when durable start persistence fails", async () => {
+    const fetchImpl = vi.fn();
+    const result = await prepareDurableLearningTaskAttempt({
+      taskId: "task-001",
+      startedAt,
+      rawTaskText: "raw task bytes",
+      renderedPrompt: "## Task\nraw task bytes",
+      gatewayBaseUrl: "https://m5.test",
+      apiKey: "private-owner-key",
+      buildSource: () => structuredClone(context().source),
+      persistStart: async () => { throw new Error("Munin unavailable"); },
+      buildPreparedDispatch: () => { throw new Error("must not build"); },
+      persistReplayPayload: async () => { throw new Error("must not persist"); },
+      persistPrepared: async () => { throw new Error("must not persist"); },
+      randomUuid: () => "11111111-1111-4111-8111-111111111111",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    expect(fetchImpl).not.toHaveBeenCalled();
+    expect(result.startPersisted).toBe(false);
+    expect(result.preparation).toMatchObject({
+      kind: "preflight-failed",
+      attemptStartRef: undefined,
+      failureReason: "Munin unavailable",
+    });
+  });
+
+  it("runs the shared cross-repository fixture through the real /delegate serializer", () => {
+    expect(serializerFixture.fixture_status).toBe("real-hugin-serializer");
+    expect(serializerFixture.contract_source).toContain("grimnir@032acc9");
+    expect(serializerFixture.producer_source).toContain("hugin#240");
+    expect(serializerFixture.consumer_target).toContain("gille-inference#2");
+    const ctx = context();
+    const task: HomeserverTaskConfig = {
+      prompt: serializerFixture.raw_logical_task,
+      gatewayBaseUrl: "https://m5.test",
+      apiKey: "private-owner-key",
+      path: "delegate",
+      taskType: serializerFixture.task_type,
+      timeoutMs: 30_000,
+      maxOutputChars: 4_096,
+      learningTask: readyLearningTask({
+        prompt: serializerFixture.raw_logical_task,
+        gatewayBaseUrl: "https://m5.test",
+        apiKey: "private-owner-key",
+        path: "delegate",
+        taskType: serializerFixture.task_type,
+        timeoutMs: 30_000,
+        maxOutputChars: 4_096,
+      }, ctx),
+    };
+    const body = buildHomeserverRequestBody(task, serializerFixture.task_id);
+    expect(body.prompt).toBe(serializerFixture.observed_hugin_instruction);
+    expect(body.learningTaskStamp).toEqual(serializerFixture.stamp);
+    expect(body.learningTaskStamp?.contract_request).toEqual(serializerFixture.expected_contract);
+    expect(body.learningTaskStamp?.raw_fingerprint.digest)
+      .toBe(serializerFixture.expected_raw_fingerprint);
+    expect([
+      body.learningTaskStamp?.origin_config.prompt.id,
+      body.learningTaskStamp?.origin_config.prompt.version,
+    ]).toEqual(serializerFixture.origin_config.prompt);
+    expect([
+      body.learningTaskStamp?.origin_config.harness.id,
+      body.learningTaskStamp?.origin_config.harness.version,
+    ]).toEqual(serializerFixture.origin_config.harness);
+    expect([
+      body.learningTaskStamp?.origin_config.tool_policy.id,
+      body.learningTaskStamp?.origin_config.tool_policy.version,
+    ]).toEqual(serializerFixture.origin_config.tool_policy);
+  });
+
+  it("persists a distinct raw identity before rendering and stamps only after attempt start", () => {
+    const ctx = context();
+    const task: HomeserverTaskConfig = {
+      prompt: "  Summarize the fixture incident report.\n",
+      gatewayBaseUrl: "https://m5.test",
+      apiKey: "private-owner-key",
+      path: "delegate",
+      taskType: "summarize",
+      timeoutMs: 30_000,
+      maxOutputChars: 4_096,
+      learningTask: readyLearningTask({
+        prompt: "  Summarize the fixture incident report.\n",
+        gatewayBaseUrl: "https://m5.test",
+        apiKey: "private-owner-key",
+        path: "delegate",
+        taskType: "summarize",
+        timeoutMs: 30_000,
+        maxOutputChars: 4_096,
+      }, ctx),
+    };
+    const body = buildHomeserverRequestBody(task, "task-001");
+
+    expect(body.learningTaskStamp).toEqual(
+      buildLearningTaskRequestStamp({
+        context: ctx,
+        taskType: "summarize",
+        rawTaskText: task.prompt,
+        renderedPrompt: renderHomeserverUserMessage(task),
+      }),
+    );
+    expect(body.learningTaskStamp?.raw_fingerprint)
+      .toEqual(body.huginTaskIdentity?.rawTaskFingerprint);
+    expect(body.learningTaskStamp?.hugin_envelope.digest)
+      .not.toBe(body.huginTaskIdentity?.renderedPromptFingerprint.digest);
+    expect(Date.parse(body.learningTaskStamp!.stamped_at))
+      .toBeGreaterThanOrEqual(Date.parse(ctx.attempt.startedAt));
+    expect(JSON.stringify(body.learningTaskStamp)).not.toContain(task.prompt.trim());
+  });
+
+  it("keeps prepared evidence content-blind and attempt-keyed while separating classified replay bytes", () => {
+    const task = taskConfigForFixture();
+    const first = readyLearningTask(task, context());
+    const secondContext = context();
+    secondContext.attempt = createLearningTaskAttemptStart({
+      taskId: "task-001",
+      attemptId: "hugin-attempt:99999999-9999-4999-8999-999999999999",
+      startedAt,
+      rawTaskText: task.prompt,
+      renderedPrompt: renderHomeserverUserMessage(task),
+    });
+    secondContext.attemptStartRef = {
+      namespace: "tasks/task-001",
+      key: "learning-attempt-99999999-9999-4999-8999-999999999999",
+    };
+    const second = readyLearningTask(task, secondContext);
+
+    expect(JSON.stringify(first.preparedDispatch)).not.toContain(task.prompt.trim());
+    expect(JSON.stringify(first.replayPayload)).toContain(task.prompt.trim());
+    expect(first.preparedDispatch.preparedDispatchRef.key)
+      .not.toBe(second.preparedDispatch.preparedDispatchRef.key);
+    expect(first.preparedDispatch.replayPayloadRef.key)
+      .not.toBe(second.preparedDispatch.replayPayloadRef.key);
+  });
+
+  it("recovers only an exact stored admission and never accepts a fresh/replayed outcome", async () => {
+    const task = taskConfigForFixture();
+    const prepared = readyLearningTask(task, context());
+    const stamp = prepared.preparedDispatch.requestStamp;
+    const echo = gatewayEchoFor(stamp);
+    const fetchImpl = vi.fn(async () => response({
+      outcome: "error",
+      learningTaskAdmission: { recovered: true, outcomeAvailable: false },
+      learningTaskGatewayEcho: echo,
+    }));
+    const recovered = await recoverPreparedLearningTaskDispatch({
+      prepared: prepared.preparedDispatch,
+      replayPayload: prepared.replayPayload,
+      gatewayBaseUrl: "https://m5.test",
+      apiKey: "owner-key",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+    expect(recovered).toMatchObject({ state: "m5-admitted", evidenceAccepted: true });
+    expect(validatePreparedLearningTaskOutcome(prepared.preparedDispatch, recovered))
+      .toEqual(recovered);
+    expect(JSON.parse((fetchImpl.mock.calls[0]?.[1] as RequestInit).body as string))
+      .toEqual(prepared.replayPayload.requestBody);
+    const crossAttempt = structuredClone(recovered);
+    crossAttempt.requestStamp!.attempt_id = "hugin-attempt:99999999-9999-4999-8999-999999999999";
+    expect(() => learningTaskExecutionEvidenceSchema.parse(crossAttempt)).toThrow();
+    const fakeDigest = structuredClone(recovered);
+    fakeDigest.requestStampDigest!.digest = "0".repeat(64);
+    expect(() => learningTaskExecutionEvidenceSchema.parse(fakeDigest)).toThrow();
+
+    const changedReplayDigest = structuredClone(recovered);
+    changedReplayDigest.replayPayloadDigest!.digest = "0".repeat(64);
+    expect(() => validatePreparedLearningTaskOutcome(
+      prepared.preparedDispatch,
+      changedReplayDigest,
+    )).toThrow(/prepared dispatch/i);
+
+    const changedStartTime = structuredClone(recovered);
+    changedStartTime.attemptStartedAt = "2026-07-19T10:00:01.001Z";
+    expect(() => validatePreparedLearningTaskOutcome(
+      prepared.preparedDispatch,
+      changedStartTime,
+    )).toThrow(/prepared dispatch/i);
+
+    const refMutations: Array<(value: typeof recovered) => void> = [
+      (value) => { value.attemptStartRef!.key += "-different"; },
+      (value) => { value.preparedDispatchRef!.key += "-different"; },
+      (value) => { value.replayPayloadRef!.key += "-different"; },
+      (value) => { value.attemptOutcomeRef!.key += "-different"; },
+      (value) => { value.taskOutcomeRef.key += "-different"; },
+    ];
+    for (const mutate of refMutations) {
+      const changedRef = structuredClone(recovered);
+      mutate(changedRef);
+      expect(() => validatePreparedLearningTaskOutcome(
+        prepared.preparedDispatch,
+        changedRef,
+      )).toThrow(/reference|prepared dispatch/i);
+    }
+
+    const fresh = await recoverPreparedLearningTaskDispatch({
+      prepared: prepared.preparedDispatch,
+      replayPayload: prepared.replayPayload,
+      gatewayBaseUrl: "https://m5.test",
+      apiKey: "owner-key",
+      fetchImpl: (async () => response({ output: "must not be trusted", learningTaskGatewayEcho: echo })) as typeof fetch,
+    });
+    expect(fresh).toMatchObject({
+      state: "join-failed",
+      evidenceAccepted: false,
+      failureCode: "recovery-unavailable",
+    });
+  });
+
+  it("cross-binds a prepared dispatch to its immutable full attempt-start identity", () => {
+    const task = taskConfigForFixture();
+    const ready = readyLearningTask(task, context());
+    const start = durableLearningTaskAttemptStart(ready.context.attempt);
+
+    expect(validatePreparedLearningTaskAttemptStart(ready.preparedDispatch, start))
+      .toEqual(start);
+
+    const crossTask = structuredClone(start);
+    crossTask.huginTaskIdentity.taskId = "another-task";
+    expect(() => validatePreparedLearningTaskAttemptStart(
+      ready.preparedDispatch,
+      crossTask,
+    )).toThrow(/attempt[- ]start/i);
+
+    const crossRaw = structuredClone(start);
+    crossRaw.huginTaskIdentity.rawTaskFingerprint.digest = "0".repeat(64);
+    expect(() => validatePreparedLearningTaskAttemptStart(
+      ready.preparedDispatch,
+      crossRaw,
+    )).toThrow(/attempt[- ]start/i);
+  });
+
+  it("keeps preflight evidence schema-valid when outcome persistence fails", () => {
+    const ctx = context();
+    const failed = learningTaskOutcomePersistenceFailure({
+      schemaVersion: 1,
+      contractVersion: "grimnir.learning-task/v1",
+      state: "preflight-failed",
+      evidenceAccepted: false,
+      taskId: ctx.attempt.taskId,
+      attemptId: ctx.attempt.attemptId,
+      attemptStartedAt: ctx.attempt.startedAt,
+      attemptStartRef: ctx.attemptStartRef,
+      taskOutcomeRef: { namespace: "tasks/task-001", key: "result-structured" },
+      rawFingerprint: ctx.attempt.huginTaskIdentity.rawTaskFingerprint,
+      failureCode: "preflight-failed",
+      failureReason: "preflight failed",
+    });
+    expect(failed).toMatchObject({
+      state: "preflight-failed",
+      failureCode: "attempt-outcome-persistence-failed",
+      attemptOutcomeRef: undefined,
+    });
+  });
+
+  it("accepts a still-fresh authenticated preflight cached before attempt start", () => {
+    const ctx = context();
+    ctx.preflight.request.requested_at = "2026-07-19T09:59:58.000Z";
+    ctx.preflight.response.advertised_at = "2026-07-19T09:59:59.000Z";
+    ctx.preflight.response.expires_at = "2026-07-19T10:14:59.000Z";
+
+    expect(() => buildLearningTaskRequestStamp({
+      context: ctx,
+      taskType: "summarize",
+      rawTaskText: "  Summarize the fixture incident report.\n",
+      renderedPrompt: ctx.attempt.renderedPrompt,
+    })).not.toThrow();
+  });
+
+  it("uses authenticated preflight and caller identity without sending the bearer token in evidence", async () => {
+    const calls: string[] = [];
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      calls.push(url);
+      expect((init?.headers as Record<string, string>).Authorization).toBe("Bearer private-owner-key");
+      if (url.endsWith("/portal/me")) {
+        return response({ alias: "service:hugin", tier: "owner" });
+      }
+      return response({
+        advertisement_id: `opaque:${randomUUID()}`,
+        endpoint: "/v1/capabilities/learning-task",
+        protocol_version: "learning-task-preflight/v1",
+        advertised_at: advertisedAt,
+        expires_at: "2026-07-19T10:15:02.000Z",
+        authenticated_principal_id: "service:gille-inference",
+        authentication: "service-auth",
+        capabilities: structuredClone(LEARNING_TASK_CAPABILITIES),
+      });
+    });
+
+    const clock = [
+      new Date("2026-07-19T10:00:01.500Z"),
+      new Date("2026-07-19T10:00:02.250Z"),
+    ];
+    const result = await fetchLearningTaskPreflight({
+      gatewayBaseUrl: "https://m5.test",
+      apiKey: "private-owner-key",
+      attemptStartedAt: startedAt,
+      now: () => clock.shift()!,
+      randomUuid: () => "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    expect(calls).toEqual([
+      "https://m5.test/portal/me",
+      "https://m5.test/v1/capabilities/learning-task",
+    ]);
+    expect(result.expectedTransportPrincipalId).toBe("service:hugin");
+    expect(JSON.stringify(result)).not.toContain("private-owner-key");
+    expect(result.preflight.request.requested_at).toBe("2026-07-19T10:00:01.500Z");
+  });
+
+  it.each([
+    ["feature downgrade", (value: any) => value.capabilities.features.pop()],
+    ["stale response", (value: any) => { value.expires_at = advertisedAt; }],
+    ["wrong service", (value: any) => { value.authenticated_principal_id = "service:other"; }],
+  ])("fails closed on %s", async (_name, mutate) => {
+    const fetchImpl = vi.fn(async (url: string) => {
+      if (url.endsWith("/portal/me")) return response({ alias: "service:hugin", tier: "owner" });
+      const value: any = {
+        advertisement_id: `opaque:${randomUUID()}`,
+        endpoint: "/v1/capabilities/learning-task",
+        protocol_version: "learning-task-preflight/v1",
+        advertised_at: advertisedAt,
+        expires_at: "2026-07-19T10:15:02.000Z",
+        authenticated_principal_id: "service:gille-inference",
+        authentication: "service-auth",
+        capabilities: structuredClone(LEARNING_TASK_CAPABILITIES),
+      };
+      mutate(value);
+      return response(value);
+    });
+    await expect(fetchLearningTaskPreflight({
+      gatewayBaseUrl: "https://m5.test",
+      apiKey: "key",
+      attemptStartedAt: startedAt,
+      now: () => new Date("2026-07-19T10:00:02.250Z"),
+      fetchImpl: fetchImpl as typeof fetch,
+    })).rejects.toThrow();
+  });
+
+  it("validates exact echo, authenticated principal, capability set, and JCS binding", () => {
+    const ctx = context();
+    const stamp = buildLearningTaskRequestStamp({
+      context: ctx,
+      taskType: "summarize",
+      rawTaskText: ctx.attempt.huginTaskIdentity.rawTaskFingerprint.digest === "never" ? "" : "  Summarize the fixture incident report.\n",
+      renderedPrompt: ctx.attempt.renderedPrompt,
+    });
+    const binding = {
+      authenticated_principal_id: "service:hugin",
+      request_stamp: stamp,
+    };
+    const echo = {
+      echoed_request: structuredClone(stamp),
+      gateway_request_id: "opaque:e3e3e3e3-e3e3-4e3e-8e3e-e3e3e3e3e3e3",
+      admission_id: "opaque:e4e4e4e4-e4e4-4e4e-8e4e-e4e4e4e4e4e4",
+      admitted_at: "2026-07-19T10:00:03.000Z",
+      authenticated_principal_id: "service:hugin",
+      authentication: "gateway-owner-auth",
+      principal_binding_digest: {
+        algorithm: "sha256",
+        version: "gateway-principal-request-binding-jcs-v1",
+        digest: createHash("sha256").update(jcsCanonicalize(binding), "utf8").digest("hex"),
+      },
+      capabilities: structuredClone(LEARNING_TASK_CAPABILITIES),
+    };
+
+    expect(validateLearningTaskGatewayEcho(echo, stamp, new Date("2026-07-19T10:00:04Z")))
+      .toEqual(echo);
+
+    const changed = structuredClone(echo);
+    changed.echoed_request.attempt_id = "hugin-attempt:other";
+    expect(() => validateLearningTaskGatewayEcho(changed, stamp)).toThrow(/echo/i);
+
+    const substituted = structuredClone(echo);
+    substituted.authenticated_principal_id = "service:other";
+    expect(() => validateLearningTaskGatewayEcho(substituted, stamp)).toThrow(/principal/i);
+  });
+});

--- a/tests/learning-task-recovery.test.ts
+++ b/tests/learning-task-recovery.test.ts
@@ -1,0 +1,429 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it, vi } from "vitest";
+
+import type { MuninClient, MuninEntry } from "../src/munin-client.js";
+import {
+  createLearningTaskAttemptStart,
+  durableLearningTaskAttemptStart,
+  jcsCanonicalize,
+  learningTaskAttemptKey,
+} from "../src/learning-task-handshake.js";
+import {
+  recoverLatestStoredLearningTaskAttempt,
+  recoverStoredLearningTaskCandidate,
+} from "../src/learning-task-recovery.js";
+import {
+  withLearningTaskContext,
+  withLearningTaskGatewayEcho,
+} from "./helpers/learning-task.js";
+import type { HomeserverTaskConfig } from "../src/homeserver-executor.js";
+
+const TASK_ID = "learning-recovery-1";
+const CLASSIFICATION = "client-confidential";
+
+function entry(
+  key: string,
+  content: unknown,
+  classification = CLASSIFICATION,
+): MuninEntry {
+  return {
+    id: `tasks/${TASK_ID}/${key}`,
+    namespace: `tasks/${TASK_ID}`,
+    key,
+    content: JSON.stringify(content),
+    tags: [],
+    classification,
+    created_at: "2026-07-19T10:00:00.000Z",
+    updated_at: "2026-07-19T10:00:01.000Z",
+  };
+}
+
+function fixture() {
+  const base = {
+    prompt: "Recover the exact durable learning attempt.",
+    gatewayBaseUrl: "https://m5.test",
+    apiKey: "owner-key",
+    path: "delegate",
+    taskType: "summarize",
+    timeoutMs: 30_000,
+    maxOutputChars: 4_096,
+  } satisfies HomeserverTaskConfig;
+  const task = withLearningTaskContext(base, TASK_ID);
+  if (task.learningTask?.kind !== "ready") throw new Error("fixture is not learning-ready");
+  const prepared = task.learningTask.preparedDispatch;
+  const start = durableLearningTaskAttemptStart(task.learningTask.context.attempt);
+  const replay = task.learningTask.replayPayload;
+  const entries = new Map<string, MuninEntry>([
+    [prepared.attemptStartRef.key, entry(prepared.attemptStartRef.key, start)],
+    [prepared.replayPayloadRef.key, entry(prepared.replayPayloadRef.key, replay)],
+  ]);
+  const writes: unknown[][] = [];
+  const client = {
+    read: async (_namespace: string, key: string) => entries.get(key) ?? null,
+    write: async (...args: unknown[]) => {
+      writes.push(args);
+      const [namespace, key, content, tags, , classification] = args as [
+        string,
+        string,
+        string,
+        string[],
+        string | undefined,
+        string | undefined,
+      ];
+      entries.set(key, {
+        ...entry(key, JSON.parse(content), classification),
+        namespace,
+        tags,
+      });
+      return { status: "created" };
+    },
+  } as unknown as MuninClient;
+  const responseBody = withLearningTaskGatewayEcho(task, TASK_ID, {
+    learningTaskAdmission: { recovered: true, outcomeAvailable: false },
+  });
+  const fetchImpl = vi.fn(async () => new Response(JSON.stringify(responseBody), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  }));
+  return { task, prepared, start, entries, writes, client, fetchImpl };
+}
+
+async function recover(input: ReturnType<typeof fixture>) {
+  return recoverStoredLearningTaskCandidate({
+    munin: input.client,
+    taskNamespace: `tasks/${TASK_ID}`,
+    taskClassification: CLASSIFICATION,
+    preparedEntry: entry(
+      input.prepared.preparedDispatchRef.key,
+      input.prepared,
+    ),
+    gateway: { baseUrl: "https://m5.test", apiKey: "owner-key" },
+    fetchImpl: input.fetchImpl as typeof fetch,
+  });
+}
+
+describe("stored LearningTaskContract recovery", () => {
+  it("loads the immutable attempt start, preserves its full identity, and classifies output", async () => {
+    const input = fixture();
+    const recovered = await recover(input);
+
+    expect(recovered?.huginTaskIdentity).toEqual(input.start.huginTaskIdentity);
+    expect(recovered?.evidence).toMatchObject({
+      state: "m5-admitted",
+      evidenceAccepted: true,
+    });
+    expect(recovered?.classification).toBe(CLASSIFICATION);
+    expect(input.writes).toHaveLength(1);
+    expect(input.writes[0]?.[1]).toBe(input.prepared.attemptOutcomeRef.key);
+    expect(input.writes[0]?.[5]).toBe(CLASSIFICATION);
+  });
+
+  it("fails closed on prepared and replay classification drift", async () => {
+    const preparedDrift = fixture();
+    const preparedResult = await recoverStoredLearningTaskCandidate({
+      munin: preparedDrift.client,
+      taskNamespace: `tasks/${TASK_ID}`,
+      taskClassification: CLASSIFICATION,
+      preparedEntry: entry(
+        preparedDrift.prepared.preparedDispatchRef.key,
+        preparedDrift.prepared,
+        "public",
+      ),
+      gateway: { baseUrl: "https://m5.test", apiKey: "owner-key" },
+      fetchImpl: preparedDrift.fetchImpl as typeof fetch,
+    });
+    expect(preparedResult).toBeNull();
+    expect(preparedDrift.fetchImpl).not.toHaveBeenCalled();
+    expect(preparedDrift.writes).toHaveLength(0);
+
+    const replayDrift = fixture();
+    const replay = replayDrift.entries.get(replayDrift.prepared.replayPayloadRef.key)!;
+    replay.classification = "public";
+    const replayResult = await recover(replayDrift);
+    expect(replayResult?.evidence).toMatchObject({
+      state: "join-failed",
+      evidenceAccepted: false,
+      failureCode: "recovery-unavailable",
+    });
+    expect(replayResult?.evidence.failureReason).toMatch(/classification/i);
+    expect(replayDrift.fetchImpl).not.toHaveBeenCalled();
+    expect(replayDrift.writes[0]?.[5]).toBe(CLASSIFICATION);
+  });
+
+  it("rejects a differently classified existing outcome instead of trusting it", async () => {
+    const first = fixture();
+    const accepted = await recover(first);
+    expect(accepted).not.toBeNull();
+
+    const second = fixture();
+    second.entries.set(
+      second.prepared.attemptOutcomeRef.key,
+      entry(second.prepared.attemptOutcomeRef.key, accepted!.evidence, "public"),
+    );
+    const rejected = await recover(second);
+
+    expect(rejected?.evidence).toMatchObject({
+      state: "join-failed",
+      evidenceAccepted: false,
+      failureCode: "attempt-outcome-persistence-failed",
+      attemptOutcomeRef: undefined,
+    });
+    expect(rejected?.evidence.failureReason).toMatch(/classification/i);
+    expect(second.fetchImpl).not.toHaveBeenCalled();
+    expect(second.writes).toHaveLength(0);
+
+    const malformed = fixture();
+    malformed.entries.set(
+      malformed.prepared.attemptOutcomeRef.key,
+      { ...entry(malformed.prepared.attemptOutcomeRef.key, {}), content: "not-json" },
+    );
+    const malformedResult = await recover(malformed);
+    expect(malformedResult?.evidence).toMatchObject({
+      evidenceAccepted: false,
+      failureCode: "attempt-outcome-persistence-failed",
+      attemptOutcomeRef: undefined,
+    });
+    expect(malformed.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("validates stored replay bytes and the complete attempt-start identity before an existing outcome", async () => {
+    const digestMismatch = fixture();
+    const accepted = await recover(digestMismatch);
+    expect(accepted?.evidence.evidenceAccepted).toBe(true);
+    const storedReplay = JSON.parse(
+      digestMismatch.entries.get(digestMismatch.prepared.replayPayloadRef.key)!.content,
+    ) as { requestBody: { prompt: string } };
+    storedReplay.requestBody.prompt += " tampered";
+    digestMismatch.entries.set(
+      digestMismatch.prepared.replayPayloadRef.key,
+      entry(digestMismatch.prepared.replayPayloadRef.key, storedReplay),
+    );
+    digestMismatch.fetchImpl.mockClear();
+    const digestRejected = await recover(digestMismatch);
+    expect(digestRejected?.evidence.evidenceAccepted).toBe(false);
+    expect(digestMismatch.fetchImpl).not.toHaveBeenCalled();
+
+    const identityMismatch = fixture();
+    const identityAccepted = await recover(identityMismatch);
+    expect(identityAccepted?.evidence.evidenceAccepted).toBe(true);
+    const identityReplay = JSON.parse(
+      identityMismatch.entries.get(identityMismatch.prepared.replayPayloadRef.key)!.content,
+    ) as {
+      requestBody: {
+        huginTaskIdentity: {
+          renderedPromptFingerprint: { digest: string };
+        };
+      };
+    };
+    identityReplay.requestBody.huginTaskIdentity.renderedPromptFingerprint.digest = "f".repeat(64);
+    const replayDigest = createHash("sha256")
+      .update(jcsCanonicalize(identityReplay), "utf8")
+      .digest("hex");
+    identityMismatch.prepared.replayPayloadDigest.digest = replayDigest;
+    identityMismatch.entries.set(
+      identityMismatch.prepared.replayPayloadRef.key,
+      entry(identityMismatch.prepared.replayPayloadRef.key, identityReplay),
+    );
+    const apparentlyBoundOutcome = structuredClone(identityAccepted!.evidence);
+    apparentlyBoundOutcome.replayPayloadDigest!.digest = replayDigest;
+    identityMismatch.entries.set(
+      identityMismatch.prepared.attemptOutcomeRef.key,
+      entry(identityMismatch.prepared.attemptOutcomeRef.key, apparentlyBoundOutcome),
+    );
+    identityMismatch.fetchImpl.mockClear();
+    const identityRejected = await recover(identityMismatch);
+    expect(identityRejected?.evidence.evidenceAccepted).toBe(false);
+    expect(identityMismatch.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("rejects a changed stored prompt even when replay and outcome digests are updated consistently", async () => {
+    const input = fixture();
+    const accepted = await recover(input);
+    expect(accepted?.evidence.evidenceAccepted).toBe(true);
+
+    const changedReplay = JSON.parse(
+      input.entries.get(input.prepared.replayPayloadRef.key)!.content,
+    ) as {
+      requestBody: {
+        prompt: string;
+        huginTaskIdentity: {
+          rawTaskFingerprint: { digest: string };
+        };
+      };
+    };
+    const originalRawDigest = changedReplay.requestBody.huginTaskIdentity.rawTaskFingerprint.digest;
+    changedReplay.requestBody.prompt += " attacker-controlled suffix";
+    const changedReplayDigest = createHash("sha256")
+      .update(jcsCanonicalize(changedReplay), "utf8")
+      .digest("hex");
+    input.prepared.replayPayloadDigest.digest = changedReplayDigest;
+    input.entries.set(
+      input.prepared.replayPayloadRef.key,
+      entry(input.prepared.replayPayloadRef.key, changedReplay),
+    );
+    const consistentlyUpdatedOutcome = structuredClone(accepted!.evidence);
+    consistentlyUpdatedOutcome.replayPayloadDigest!.digest = changedReplayDigest;
+    input.entries.set(
+      input.prepared.attemptOutcomeRef.key,
+      entry(input.prepared.attemptOutcomeRef.key, consistentlyUpdatedOutcome),
+    );
+    input.fetchImpl.mockClear();
+
+    const rejected = await recover(input);
+    expect(rejected?.evidence).toMatchObject({
+      evidenceAccepted: false,
+      failureCode: "attempt-outcome-persistence-failed",
+      attemptOutcomeRef: undefined,
+    });
+    expect(changedReplay.requestBody.huginTaskIdentity.rawTaskFingerprint.digest)
+      .toBe(originalRawDigest);
+    expect(input.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("keeps the replay-provided raw identity bound to the immutable attempt start", async () => {
+    const input = fixture();
+    const accepted = await recover(input);
+    expect(accepted?.evidence.evidenceAccepted).toBe(true);
+
+    const changedReplay = JSON.parse(
+      input.entries.get(input.prepared.replayPayloadRef.key)!.content,
+    ) as {
+      requestBody: {
+        huginTaskIdentity: {
+          rawTaskFingerprint: { digest: string };
+        };
+      };
+    };
+    changedReplay.requestBody.huginTaskIdentity.rawTaskFingerprint.digest = "e".repeat(64);
+    const changedReplayDigest = createHash("sha256")
+      .update(jcsCanonicalize(changedReplay), "utf8")
+      .digest("hex");
+    input.prepared.replayPayloadDigest.digest = changedReplayDigest;
+    input.entries.set(
+      input.prepared.replayPayloadRef.key,
+      entry(input.prepared.replayPayloadRef.key, changedReplay),
+    );
+    const consistentlyUpdatedOutcome = structuredClone(accepted!.evidence);
+    consistentlyUpdatedOutcome.replayPayloadDigest!.digest = changedReplayDigest;
+    input.entries.set(
+      input.prepared.attemptOutcomeRef.key,
+      entry(input.prepared.attemptOutcomeRef.key, consistentlyUpdatedOutcome),
+    );
+    input.fetchImpl.mockClear();
+
+    const rejected = await recover(input);
+    expect(rejected?.evidence).toMatchObject({
+      evidenceAccepted: false,
+      failureCode: "attempt-outcome-persistence-failed",
+      attemptOutcomeRef: undefined,
+    });
+    expect(input.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("anchors recovery on the latest attempt start and never falls back to an older prepared attempt", async () => {
+    const input = fixture();
+    const latestAttempt = createLearningTaskAttemptStart({
+      taskId: TASK_ID,
+      attemptId: "hugin-attempt:99999999-9999-4999-8999-999999999999",
+      startedAt: "2026-07-19T10:00:02.000Z",
+      rawTaskText: input.task.prompt,
+      renderedPrompt: input.task.learningTask!.kind === "ready"
+        ? input.task.learningTask.context.attempt.renderedPrompt
+        : "unreachable",
+    });
+    const latestKey = learningTaskAttemptKey(latestAttempt.attemptId);
+    const latestEntry = {
+      ...entry(latestKey, durableLearningTaskAttemptStart(latestAttempt)),
+      tags: ["learning-task-attempt", "attempt:started"],
+      updated_at: "2026-07-19T10:00:03.000Z",
+    };
+    input.entries.set(latestKey, latestEntry);
+    const olderStart = input.entries.get(input.prepared.attemptStartRef.key)!;
+    Object.assign(input.client as object, {
+      query: async () => ({
+        results: [
+          { ...olderStart, entry_type: "state", content_preview: "" },
+          { ...latestEntry, entry_type: "state", content_preview: "" },
+        ],
+        total: 2,
+      }),
+    });
+
+    const recovered = await recoverLatestStoredLearningTaskAttempt({
+      munin: input.client,
+      taskNamespace: `tasks/${TASK_ID}`,
+      taskClassification: CLASSIFICATION,
+      gateway: { baseUrl: "https://m5.test", apiKey: "owner-key" },
+      fetchImpl: input.fetchImpl as typeof fetch,
+    });
+
+    expect(recovered?.evidence).toMatchObject({
+      taskId: TASK_ID,
+      attemptId: latestAttempt.attemptId,
+      state: "preflight-failed",
+      evidenceAccepted: false,
+      failureCode: "recovery-unavailable",
+    });
+    expect(recovered?.evidence.requestStamp).toBeUndefined();
+    expect(recovered?.evidence.attemptOutcomeRef).toBeUndefined();
+    expect(recovered?.huginTaskIdentity).toEqual(latestAttempt.huginTaskIdentity);
+    expect(input.fetchImpl).not.toHaveBeenCalled();
+    expect(input.writes).toHaveLength(0);
+  });
+
+  it("recovers only the prepared row derived from the authoritative latest start", async () => {
+    const input = fixture();
+    const startEntry = {
+      ...input.entries.get(input.prepared.attemptStartRef.key)!,
+      tags: ["learning-task-attempt", "attempt:started"],
+    };
+    input.entries.set(
+      input.prepared.preparedDispatchRef.key,
+      {
+        ...entry(input.prepared.preparedDispatchRef.key, input.prepared),
+        tags: ["learning-task-dispatch", "attempt:prepared"],
+      },
+    );
+    Object.assign(input.client as object, {
+      query: async () => ({
+        results: [{ ...startEntry, entry_type: "state", content_preview: "" }],
+        total: 1,
+      }),
+    });
+
+    const recovered = await recoverLatestStoredLearningTaskAttempt({
+      munin: input.client,
+      taskNamespace: `tasks/${TASK_ID}`,
+      taskClassification: CLASSIFICATION,
+      gateway: { baseUrl: "https://m5.test", apiKey: "owner-key" },
+      fetchImpl: input.fetchImpl as typeof fetch,
+    });
+
+    expect(recovered?.evidence).toMatchObject({
+      attemptId: input.start.attemptId,
+      state: "m5-admitted",
+      evidenceAccepted: true,
+    });
+    expect(recovered?.huginTaskIdentity).toEqual(input.start.huginTaskIdentity);
+  });
+
+  it("turns a new immutable outcome write failure into truthful no-ref evidence", async () => {
+    const input = fixture();
+    Object.assign(input.client as object, {
+      write: async () => {
+        throw new Error(`Munin unavailable ${"x".repeat(600)}`);
+      },
+    });
+
+    const recovered = await recover(input);
+    expect(recovered).toMatchObject({
+      evidence: {
+        state: "join-failed",
+        evidenceAccepted: false,
+        failureCode: "attempt-outcome-persistence-failed",
+        attemptOutcomeRef: undefined,
+      },
+    });
+    expect(recovered?.evidence.failureReason).toHaveLength(512);
+  });
+});

--- a/tests/learning-task-source.test.ts
+++ b/tests/learning-task-source.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+
+import { buildAuthenticatedLearningTaskSource } from "../src/learning-task-source.js";
+
+const common = {
+  taskNamespace: "tasks/task-1",
+  createdAt: "2026-07-19T10:00:00.000Z",
+  acceptedAt: "2026-07-19T10:00:01.000Z",
+};
+
+describe("learning-task source authority", () => {
+  it("never lets an embedded Broker claim override a verified normal submitter", () => {
+    expect(buildAuthenticatedLearningTaskSource({
+      ...common,
+      verifiedSubmitter: "signed-owner",
+      brokerPrincipal: "embedded-broker",
+      brokerAttestedNamespace: common.taskNamespace,
+    })).toMatchObject({
+      system: "munin-task",
+      principal: { id: "signed-owner", authentication: "verified-signature" },
+    });
+  });
+
+  it("accepts Broker provenance only with exact namespace binding", () => {
+    expect(buildAuthenticatedLearningTaskSource({
+      ...common,
+      brokerPrincipal: "broker-owner",
+      brokerAttestedNamespace: common.taskNamespace,
+    })).toMatchObject({
+      system: "hugin-broker",
+      principal: { id: "broker-owner", authentication: "service-auth" },
+    });
+    expect(() => buildAuthenticatedLearningTaskSource({
+      ...common,
+      brokerPrincipal: "broker-owner",
+      brokerAttestedNamespace: "tasks/other",
+    })).toThrow(/namespace mismatch/);
+  });
+});

--- a/tests/learning-task-store.test.ts
+++ b/tests/learning-task-store.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { createImmutableLearningArtifact } from "../src/learning-task-store.js";
+import { MuninWriteRejectedError, type MuninClient } from "../src/munin-client.js";
+
+const write = {
+  namespace: "tasks/task-1",
+  key: "learning-attempt-11111111-1111-4111-8111-111111111111",
+  content: '{"immutable":true}',
+  tags: ["learning-task-attempt"],
+  classification: "internal",
+};
+
+describe("immutable learning artifacts", () => {
+  it("requires create-if-absent and an exact created acknowledgement", async () => {
+    const calls: unknown[][] = [];
+    const client = {
+      write: async (...args: unknown[]) => {
+        calls.push(args);
+        return { status: "updated" };
+      },
+    } as unknown as MuninClient;
+    await expect(createImmutableLearningArtifact(client, write)).rejects.toThrow(/non-created/);
+    expect(calls[0]?.[6]).toBe(true);
+  });
+
+  it("accepts only a typed already-exists conflict with byte-identical readback", async () => {
+    const exact = {
+      write: async () => {
+        throw new MuninWriteRejectedError(write.namespace, write.key, {
+          error: "conflict",
+          conflict_reason: "already_exists",
+        });
+      },
+      read: async () => ({ content: write.content, classification: write.classification }),
+    } as unknown as MuninClient;
+    await expect(createImmutableLearningArtifact(exact, write, { allowExactExisting: true }))
+      .resolves.toBe("exact-existing");
+
+    const divergent = {
+      ...exact,
+      read: async () => ({ content: '{"immutable":false}' }),
+    } as unknown as MuninClient;
+    await expect(createImmutableLearningArtifact(divergent, write, { allowExactExisting: true }))
+      .rejects.toThrow(/collision differs/);
+
+    const classificationDrift = {
+      ...exact,
+      read: async () => ({ content: write.content, classification: "public" }),
+    } as unknown as MuninClient;
+    await expect(createImmutableLearningArtifact(
+      classificationDrift,
+      write,
+      { allowExactExisting: true },
+    )).rejects.toThrow(/collision differs/);
+  });
+});

--- a/tests/task-result-schema.test.ts
+++ b/tests/task-result-schema.test.ts
@@ -187,6 +187,234 @@ describe("structured task result schema", () => {
     expect(result.runtimeMetadata?.huginTaskIdentity?.renderedPromptFingerprint.digest)
       .toBe("b".repeat(64));
   });
+
+  it("preserves a durable preflight-failed attempt without inventing a stamp or echo", () => {
+    const result = buildStructuredTaskResult({
+      schemaVersion: 1,
+      taskId: "task-learning-1",
+      taskNamespace: "tasks/task-learning-1",
+      lifecycle: "failed",
+      outcome: "failed",
+      runtime: "homeserver",
+      executor: "homeserver-delegate",
+      resultSource: "homeserver-delegate",
+      exitCode: 1,
+      completedAt: "2026-07-19T12:00:00.000Z",
+      bodyKind: "error",
+      bodyText: "preflight failed",
+      runtimeMetadata: {
+        huginTaskIdentity: {
+          schemaVersion: 1,
+          producer: "hugin",
+          taskId: "task-learning-1",
+          rawTaskFingerprint: {
+            algorithm: "sha256",
+            version: "trim-utf8-sha256-v1",
+            digest: "a".repeat(64),
+          },
+          renderedPromptFingerprint: {
+            algorithm: "sha256",
+            version: "hugin-delegate-prompt-utf8-sha256-v1",
+            digest: "b".repeat(64),
+            utf8Bytes: 123,
+          },
+        },
+        learningTask: {
+          schemaVersion: 1,
+          contractVersion: "grimnir.learning-task/v1",
+          state: "preflight-failed",
+          evidenceAccepted: false,
+          taskId: "task-learning-1",
+          attemptId: "hugin-attempt:11111111-1111-4111-8111-111111111111",
+          attemptStartedAt: "2026-07-19T11:59:58.000Z",
+          attemptStartRef: {
+            namespace: "tasks/task-learning-1",
+            key: "learning-attempt-11111111-1111-4111-8111-111111111111",
+          },
+          taskOutcomeRef: {
+            namespace: "tasks/task-learning-1",
+            key: "result-structured",
+          },
+          rawFingerprint: {
+            algorithm: "sha256",
+            version: "trim-utf8-sha256-v1",
+            digest: "a".repeat(64),
+          },
+          failureCode: "preflight-failed",
+          failureReason: "unsupported feature set",
+        },
+      },
+    });
+    expect(result.runtimeMetadata?.learningTask?.state).toBe("preflight-failed");
+    expect(result.runtimeMetadata?.learningTask?.requestStamp).toBeUndefined();
+    expect(result.runtimeMetadata?.learningTask?.gatewayEcho).toBeUndefined();
+  });
+
+  it("requires one cross-bound Hugin producer identity for learning evidence", () => {
+    const base = {
+      schemaVersion: 1 as const,
+      taskId: "task-learning-bound",
+      taskNamespace: "tasks/task-learning-bound",
+      lifecycle: "failed" as const,
+      outcome: "failed" as const,
+      runtime: "homeserver" as const,
+      executor: "homeserver-delegate",
+      resultSource: "recovery",
+      exitCode: 1,
+      completedAt: "2026-07-19T12:00:00.000Z",
+      bodyKind: "error" as const,
+      bodyText: "recovered",
+      runtimeMetadata: {
+        huginTaskIdentity: {
+          schemaVersion: 1 as const,
+          producer: "hugin" as const,
+          taskId: "task-learning-bound",
+          rawTaskFingerprint: {
+            algorithm: "sha256" as const,
+            version: "trim-utf8-sha256-v1" as const,
+            digest: "a".repeat(64),
+          },
+          renderedPromptFingerprint: {
+            algorithm: "sha256" as const,
+            version: "hugin-delegate-prompt-utf8-sha256-v1" as const,
+            digest: "b".repeat(64),
+            utf8Bytes: 123,
+          },
+        },
+        learningTask: {
+          schemaVersion: 1 as const,
+          contractVersion: "grimnir.learning-task/v1" as const,
+          state: "preflight-failed" as const,
+          evidenceAccepted: false,
+          taskId: "task-learning-bound",
+          attemptId: "hugin-attempt:11111111-1111-4111-8111-111111111111",
+          attemptStartedAt: "2026-07-19T11:59:58.000Z",
+          attemptStartRef: {
+            namespace: "tasks/task-learning-bound",
+            key: "learning-attempt-11111111-1111-4111-8111-111111111111",
+          },
+          taskOutcomeRef: {
+            namespace: "tasks/task-learning-bound",
+            key: "result-structured",
+          },
+          rawFingerprint: {
+            algorithm: "sha256" as const,
+            version: "trim-utf8-sha256-v1" as const,
+            digest: "a".repeat(64),
+          },
+          failureCode: "preflight-failed" as const,
+          failureReason: "unsupported feature set",
+        },
+      },
+    };
+
+    expect(() => buildStructuredTaskResult(base)).not.toThrow();
+
+    const missingIdentity = structuredClone(base) as typeof base & {
+      runtimeMetadata: { huginTaskIdentity?: typeof base.runtimeMetadata.huginTaskIdentity };
+    };
+    delete missingIdentity.runtimeMetadata.huginTaskIdentity;
+    expect(() => buildStructuredTaskResult(missingIdentity as typeof base)).toThrow(/producer identity/i);
+
+    const crossTask = structuredClone(base);
+    crossTask.runtimeMetadata.huginTaskIdentity.taskId = "another-task";
+    expect(() => buildStructuredTaskResult(crossTask)).toThrow(/producer identity|task id/i);
+
+    const crossRaw = structuredClone(base);
+    crossRaw.runtimeMetadata.huginTaskIdentity.rawTaskFingerprint.digest = "c".repeat(64);
+    expect(() => buildStructuredTaskResult(crossRaw)).toThrow(/raw fingerprint/i);
+  });
+
+  it("rejects learning evidence bound to a different outer structured task", () => {
+    expect(() => buildStructuredTaskResult({
+      schemaVersion: 1,
+      taskId: "outer-task",
+      taskNamespace: "tasks/outer-task",
+      lifecycle: "failed",
+      outcome: "failed",
+      runtime: "homeserver",
+      executor: "homeserver-delegate",
+      resultSource: "homeserver-delegate",
+      exitCode: 1,
+      completedAt: "2026-07-19T12:00:00.000Z",
+      bodyKind: "error",
+      bodyText: "must reject",
+      runtimeMetadata: {
+        huginTaskIdentity: {
+          schemaVersion: 1,
+          producer: "hugin",
+          taskId: "cross-task",
+          rawTaskFingerprint: {
+            algorithm: "sha256",
+            version: "trim-utf8-sha256-v1",
+            digest: "a".repeat(64),
+          },
+          renderedPromptFingerprint: {
+            algorithm: "sha256",
+            version: "hugin-delegate-prompt-utf8-sha256-v1",
+            digest: "b".repeat(64),
+            utf8Bytes: 123,
+          },
+        },
+        learningTask: {
+          schemaVersion: 1,
+          contractVersion: "grimnir.learning-task/v1",
+          state: "preflight-failed",
+          evidenceAccepted: false,
+          taskId: "cross-task",
+          attemptId: "hugin-attempt:11111111-1111-4111-8111-111111111111",
+          attemptStartedAt: "2026-07-19T11:59:58.000Z",
+          attemptStartRef: {
+            namespace: "tasks/cross-task",
+            key: "learning-attempt-11111111-1111-4111-8111-111111111111",
+          },
+          taskOutcomeRef: { namespace: "tasks/cross-task", key: "result-structured" },
+          rawFingerprint: {
+            algorithm: "sha256",
+            version: "trim-utf8-sha256-v1",
+            digest: "a".repeat(64),
+          },
+          failureCode: "preflight-failed",
+          failureReason: "preflight failed",
+        },
+      },
+    })).toThrow(/structured result/i);
+  });
+
+  it("rejects an admitted LearningTaskContract result without an exact echo", () => {
+    expect(() => buildStructuredTaskResult({
+      schemaVersion: 1,
+      taskId: "task-learning-invalid",
+      taskNamespace: "tasks/task-learning-invalid",
+      lifecycle: "completed",
+      outcome: "completed",
+      runtime: "homeserver",
+      executor: "homeserver-delegate",
+      resultSource: "homeserver-delegate",
+      exitCode: 0,
+      completedAt: "2026-07-19T12:00:00.000Z",
+      bodyKind: "response",
+      bodyText: "must reject",
+      runtimeMetadata: {
+        learningTask: {
+          schemaVersion: 1,
+          contractVersion: "grimnir.learning-task/v1",
+          state: "m5-admitted",
+          evidenceAccepted: true,
+          taskId: "task-learning-invalid",
+          attemptId: "hugin-attempt:11111111-1111-4111-8111-111111111111",
+          attemptStartedAt: "2026-07-19T11:59:58.000Z",
+          attemptStartRef: { namespace: "tasks/task-learning-invalid", key: "attempt" },
+          taskOutcomeRef: { namespace: "tasks/task-learning-invalid", key: "result-structured" },
+          rawFingerprint: {
+            algorithm: "sha256",
+            version: "trim-utf8-sha256-v1",
+            digest: "a".repeat(64),
+          },
+        } as never,
+      },
+    })).toThrow(/echo|stamp/i);
+  });
   it("accepts completed pipeline phase results", () => {
     const result = buildStructuredTaskResult({
       schemaVersion: 1,


### PR DESCRIPTION
Refs #240

## Summary

- authenticate Broker-origin learning sources and bind them to exact Hugin task/namespace/envelope identity
- perform fresh Gille capability preflight and emit the exact v1 request stamp/echo join
- persist immutable attempt-start, classified replay, content-blind prepared, and attempt-outcome evidence
- validate complete task/attempt/ref/stamp/echo/replay/classification bindings on normal completion and startup recovery
- recover only the newest authoritative attempt and fail closed with truthful no-reference evidence on corrupt or unwritable joins
- preserve legacy/ineligible unstamped traffic without claiming learning evidence

## Dependency and live gate

- based on merged/deployed canonical task identity #230 (`01253d2`)
- matching Gille consumer #20 is merged/deployed (`8caf400`)
- issue remains open until the joint authenticated live smoke validates the ordinary Broker → Hugin → Gille → Munin path

## Verification

- red/green regressions for identity, replay-byte, digest, attempt-selection, classification, and persistence-failure counterexamples
- focused Hugin: 14 files / 191 tests
- full Hugin: 122 files / 1,954 tests
- TypeScript build
- Gille cross-repo contract/admission: 16 tests
- byte-identical serializer fixture SHA-256 `c905050c9e8242353984a4ce2958ff955e29f003124ac6b6673cf05674c9e4b7`
- independent fallback review: APPROVE after three adversarial correction rounds and post-rebase confirmation
- root review: APPROVE
- clean one-commit diff atop current main