### PR TITLE
feat: activate authoritative quality corrections

### DIFF
--- a/docs/quality-receipts.md
+++ b/docs/quality-receipts.md
@@ -39,6 +39,16 @@ also be canonically identical; reusing an id with a different clock or extension
 field is an identity collision. A changed native-v1 verdict from the same
 reviewer for the same binding remains a conflict.
 
+Native-v2 request recovery also accounts for the server-owned clock: while each
+CAS snapshot is held, Hugin advances a first correction to at least one
+millisecond after its immutable predecessor. If a successful response is lost
+and the authenticated caller retries the exact correction later, Hugin matches
+the existing successor canonically while ignoring only `ratedAt` and its derived
+`receiptId`, returns success, and preserves the first stored artifact byte for
+byte. A changed verdict, reason, rubric, verifier, failure, configuration,
+reference, binding, reviewer, task, or attempt remains a conflicting fork. The
+same-ID/different-artifact collision check still runs first and remains strict.
+
 This depends on the explicit Munin create-if-absent API from Munin #211. Hugin
 does not invent a timestamp and does not assume that candidate is deployed:
 deploy Munin first, verify `memory_write` accepts `create_if_absent: true` and
@@ -83,18 +93,19 @@ preserving every native-v1 object unchanged. Both `quality:receipt-v1` and
 
 ### Activation boundary: authoritative attempts
 
-The native-v2 schema, fold, storage, and harvest path are implemented, but the
-authenticated rate endpoint currently rejects every `correction` with HTTP 409.
-Hugin does not yet persist an authoritative execution-attempt id in its task
-result. Its claim-time MCP session UUID is process-local, while startup and lease
-recovery can terminalize the task after that process disappears. The task id is
-the logical task instance and must not be copied into `attemptId` as invented
-provenance.
+The authenticated rate endpoint activates native v2 only when the exact current
+`result-structured` document passes Hugin's full schema and contains
+`runtimeMetadata.learningTask` with `state: "m5-admitted"` and
+`evidenceAccepted: true`. That nested schema cross-validates the logical task,
+authoritative attempt, request stamp, authenticated gateway echo, digests, and
+durable start/prepared/replay/outcome/result references before the handler may
+derive `attemptId`.
 
-Hugin issue #240 owns starting and durably identifying the attempt. Once that
-evidence is present in the exact structured result, the rate handler may bind
-native v2 to it. Callers cannot supply an attempt id themselves. Until then,
-native v1 remains fully operational and v2 fails closed.
+Callers cannot supply or override an attempt id, and Hugin never copies the
+logical task id into `attemptId`. Legacy results, missing or malformed learning
+evidence, non-admitted attempts, unaccepted evidence, and task/ref mismatches
+return HTTP 409 without a feedback write. Native v1 remains byte/field compatible
+and available for every otherwise-rateable terminal task.
 
 The `quality-correction-group-jcs-v1` key uses a dedicated RFC 8785 canonicalizer:
 ECMAScript number/string serialization, raw UTF-16 property ordering, and

--- a/src/broker/handlers.ts
+++ b/src/broker/handlers.ts
@@ -488,11 +488,13 @@ export function createRateHandler(deps: BrokerHandlerDependencies) {
     }
     let structuredTaskId: string;
     let verifiedSubmitter: string | null;
+    let currentStructuredResult: z.infer<typeof structuredTaskResultSchema> | null = null;
     let binding;
     try {
       const raw = JSON.parse(structuredEntry.content) as unknown;
       const current = structuredTaskResultSchema.safeParse(raw);
       if (current.success) {
+        currentStructuredResult = current.data;
         structuredTaskId = current.data.taskId;
         verifiedSubmitter = current.data.provenance?.verifiedSubmitter ?? null;
       } else {
@@ -528,20 +530,51 @@ export function createRateHandler(deps: BrokerHandlerDependencies) {
       res.status(409).json({ error: "policy_rejected", message: "reviewed binding is stale or mismatched" });
       return;
     }
-    // LearningTaskContract v1 distinguishes the durable task instance from an
-    // execution attempt. Hugin's current structured result has no
-    // authoritative attempt identity: the per-claim MCP session UUID is not
-    // persisted as attempt evidence, and startup/lease recovery can finalize a
-    // task after that process has disappeared. Native v2 requires the exact
-    // attempt, so using `task_id` here would fabricate provenance. Issue #240
-    // owns creation and persistence of that evidence; until it lands, retain
-    // the schema/storage seam but fail closed before emitting a v2 receipt.
+    let authoritativeAttemptId: string | null = null;
     if (parsed.correction) {
-      res.status(409).json({
-        error: "policy_rejected",
-        message: "native v2 correction requires authoritative execution attempt evidence; this task result does not provide it",
-      });
-      return;
+      // The successful structured-result parse above is the trust boundary:
+      // its nested LearningTask schema cross-validates the task/attempt stamp,
+      // gateway echo, digests, and every durable evidence reference. Never
+      // accept an attempt identity from the request or infer one from task_id.
+      const learning = currentStructuredResult?.runtimeMetadata?.learningTask;
+      if (!currentStructuredResult || !learning) {
+        res.status(409).json({
+          error: "policy_rejected",
+          message: "native v2 correction requires schema-valid authoritative execution attempt evidence",
+        });
+        return;
+      }
+      if (
+        currentStructuredResult.taskId !== parsed.task_id ||
+        currentStructuredResult.taskNamespace !== `tasks/${parsed.task_id}` ||
+        learning.taskId !== parsed.task_id
+      ) {
+        res.status(409).json({
+          error: "policy_rejected",
+          message: "native v2 correction attempt evidence does not match the rated task",
+        });
+        return;
+      }
+      if (learning.state !== "m5-admitted" || learning.evidenceAccepted !== true) {
+        res.status(409).json({
+          error: "policy_rejected",
+          message: "native v2 correction requires an accepted m5-admitted execution attempt",
+        });
+        return;
+      }
+      if (
+        !learning.attemptStartRef ||
+        !learning.preparedDispatchRef ||
+        !learning.replayPayloadRef ||
+        !learning.attemptOutcomeRef
+      ) {
+        res.status(409).json({
+          error: "policy_rejected",
+          message: "native v2 correction requires complete durable execution-attempt references",
+        });
+        return;
+      }
+      authoritativeAttemptId = learning.attemptId;
     }
     const principal = authenticatedPrincipal;
     const brokerOwner = canonical.ok
@@ -574,9 +607,74 @@ export function createRateHandler(deps: BrokerHandlerDependencies) {
       bindingAttestation: expected ? "reviewer-confirmed" as const : "server-bound" as const,
       binding,
     };
-    const receipt = buildQualityReceipt(commonReceipt);
+    const correction = parsed.correction;
+    const correctionReceiptInput = correction
+      ? {
+          ...commonReceipt,
+          attemptId: authoritativeAttemptId!,
+          correctsReceiptId: correction.predecessor_receipt_id,
+          rubric: correction.rubric,
+          verifier: correction.verifier,
+          failure: correction.failure,
+          ...(correction.producing_configuration
+            ? {
+                producingConfiguration: {
+                  ...(correction.producing_configuration.prompt
+                    ? { prompt: correction.producing_configuration.prompt }
+                    : {}),
+                  ...(correction.producing_configuration.harness
+                    ? { harness: correction.producing_configuration.harness }
+                    : {}),
+                  ...(correction.producing_configuration.model
+                    ? {
+                        model: {
+                          id: correction.producing_configuration.model.id,
+                          configurationSha256:
+                            correction.producing_configuration.model.configuration_sha256,
+                        },
+                      }
+                    : {}),
+                  ...(correction.producing_configuration.tool_policy
+                    ? { toolPolicy: correction.producing_configuration.tool_policy }
+                    : {}),
+                },
+              }
+            : {}),
+          ...(correction.references
+            ? {
+                references: {
+                  ...(correction.references.corrected_successor
+                    ? {
+                        correctedSuccessor: {
+                          taskId: correction.references.corrected_successor.task_id,
+                          structuredResultSha256:
+                            correction.references.corrected_successor.structured_result_sha256,
+                        },
+                      }
+                    : {}),
+                  ...(correction.references.follow_up_task_id
+                    ? { followUpTaskId: correction.references.follow_up_task_id }
+                    : {}),
+                  ...(correction.references.pull_request_url
+                    ? { pullRequestUrl: correction.references.pull_request_url }
+                    : {}),
+                  ...(correction.references.replacement_commit
+                    ? { replacementCommit: correction.references.replacement_commit }
+                    : {}),
+                },
+              }
+            : {}),
+        }
+      : null;
     try {
-      await deps.taskStore.writeQualityReceipt(parsed.task_id, receipt);
+      if (correctionReceiptInput) {
+        await deps.taskStore.writeQualityCorrection(parsed.task_id, correctionReceiptInput);
+      } else {
+        await deps.taskStore.writeQualityReceipt(
+          parsed.task_id,
+          buildQualityReceipt(commonReceipt),
+        );
+      }
     } catch (err) {
       res.status(err instanceof QualityReceiptConflictError ? 409 : 500).json({
         error: err instanceof QualityReceiptConflictError ? "policy_rejected" : "internal",

--- a/src/broker/task-store.ts
+++ b/src/broker/task-store.ts
@@ -41,7 +41,10 @@ import {
   sanitiseTaskId,
 } from "../friction/munin-key.js";
 import {
+  advancingQualityCorrectionRatedAt,
+  buildQualityCorrectionReceipt,
   foldQualityReceipt,
+  type BuildQualityCorrectionReceiptInput,
   type NativeQualityReceipt,
 } from "../quality-receipt.js";
 import { buildBrokerTaskTypeTags } from "./task-type-metadata.js";
@@ -321,6 +324,30 @@ export class BrokerTaskStore {
     taskId: string,
     receipt: NativeQualityReceipt,
   ): Promise<{ changed: boolean }> {
+    return this.writeQualityReceiptWithFactory(taskId, () => receipt);
+  }
+
+  async writeQualityCorrection(
+    taskId: string,
+    input: BuildQualityCorrectionReceiptInput,
+  ): Promise<{ changed: boolean }> {
+    return this.writeQualityReceiptWithFactory(taskId, (existing) =>
+      buildQualityCorrectionReceipt({
+        ...input,
+        ratedAt: advancingQualityCorrectionRatedAt(
+          existing,
+          input.correctsReceiptId,
+          input.ratedAt,
+        ),
+      }));
+  }
+
+  private async writeQualityReceiptWithFactory(
+    taskId: string,
+    buildReceipt: (
+      existing: Record<string, unknown> | null,
+    ) => NativeQualityReceipt,
+  ): Promise<{ changed: boolean }> {
     const status = await this.readStatus(taskId);
     const envelope = status ? parseStoredEnvelope(status.content) : null;
     const namespace = namespaceForTaskId(taskId);
@@ -334,6 +361,7 @@ export class BrokerTaskStore {
         }
         existing = parsed as Record<string, unknown>;
       }
+      const receipt = buildReceipt(existing);
       const folded = foldQualityReceipt(existing, receipt);
       if (!folded.changed) return { changed: false };
       const receiptVersionTags = [...new Set(

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -152,7 +152,7 @@ export const rateInputShape = {
   reviewer_role: z.enum(["independent", "self"]).optional()
     .describe("Authenticated reviewer attestation. Same-task owners cannot claim independent."),
   correction: qualityCorrectionRequestSchema.optional().describe(
-    "Append-only native v2 correction shape. Names the predecessor and carries content-blind rubric, failure, configuration, and successor provenance. The Broker currently fails closed until authoritative execution-attempt evidence lands; callers cannot provide or infer it.",
+    "Append-only native v2 correction shape. Names the predecessor and carries content-blind rubric, failure, configuration, and successor provenance. The Broker derives the attempt only from accepted authoritative LearningTask evidence in the exact structured result; callers cannot provide or infer it.",
   ),
   expected_binding: z.object({
     task_document_sha256: z.string().regex(/^[0-9a-f]{64}$/),

--- a/src/quality-receipt.ts
+++ b/src/quality-receipt.ts
@@ -709,6 +709,31 @@ export function buildQualityCorrectionReceipt(
   });
 }
 
+/**
+ * Corrections use a server-owned clock, but the immutable predecessor may have
+ * been rated in the same millisecond. Resolve the candidate clock while the
+ * current CAS snapshot is in hand so the first append is always strictly later.
+ * Missing/invalid predecessors remain the fold's responsibility.
+ */
+export function advancingQualityCorrectionRatedAt(
+  current: QualityReceiptLedger | Record<string, unknown> | null,
+  correctsReceiptId: string,
+  proposedRatedAt: string,
+): string {
+  const ledger = qualityReceiptLedgerSchema.safeParse(current);
+  if (!ledger.success) return proposedRatedAt;
+  const predecessor = ledger.data.receipts.find(
+    (receipt) => receipt.receiptId === correctsReceiptId,
+  );
+  if (!predecessor) return proposedRatedAt;
+  const predecessorMs = Date.parse(predecessor.ratedAt);
+  const proposedMs = Date.parse(proposedRatedAt);
+  if (!Number.isFinite(predecessorMs) || !Number.isFinite(proposedMs) || proposedMs > predecessorMs) {
+    return proposedRatedAt;
+  }
+  return new Date(predecessorMs + 1).toISOString();
+}
+
 export class QualityReceiptConflictError extends Error {
   constructor(message: string) {
     super(message);
@@ -812,11 +837,27 @@ export function foldQualityReceipt(
         "quality correction predecessor must retain task, reviewer, and binding",
       );
     }
-    if (ledger.receipts.some(
+    const existingSuccessor = ledger.receipts.find(
       (receipt) =>
         receipt.schemaVersion === 2 &&
         receipt.correctsReceiptId === next.correctsReceiptId,
-    )) {
+    );
+    if (existingSuccessor) {
+      const {
+        receiptId: _storedReceiptId,
+        ratedAt: _storedRatedAt,
+        ...storedRequest
+      } = existingSuccessor;
+      const {
+        receiptId: _nextReceiptId,
+        ratedAt: _nextRatedAt,
+        ...nextRequest
+      } = next;
+      if (canonicalizeJcs(storedRequest) === canonicalizeJcs(nextRequest)) {
+        // `ratedAt` and its derived receipt id are server-owned. A retry after
+        // a lost success response must preserve the exact first artifact.
+        return { ledger, changed: false };
+      }
       throw new QualityReceiptConflictError(
         `quality correction predecessor ${next.correctsReceiptId} already has a successor`,
       );

--- a/tests/broker/handlers.test.ts
+++ b/tests/broker/handlers.test.ts
@@ -9,7 +9,19 @@ import { DelegationJournal } from "../../src/broker/journal.js";
 import { IdempotencyIndex } from "../../src/broker/idempotency.js";
 import { brokerExecutorCapabilities } from "../../src/broker/executor-capabilities.js";
 import type { MuninClient } from "../../src/munin-client.js";
-import { buildStructuredTaskResult } from "../../src/task-result-schema.js";
+import {
+  buildStructuredTaskResult,
+  type StructuredTaskResult,
+} from "../../src/task-result-schema.js";
+import {
+  gatewayEchoDigest,
+  learningTaskExecutionEvidenceSchema,
+} from "../../src/learning-task-handshake.js";
+import { buildHomeserverRequestBody } from "../../src/homeserver-executor.js";
+import {
+  withLearningTaskContext,
+  withLearningTaskGatewayEcho,
+} from "../helpers/learning-task.js";
 
 const SECRET = "a".repeat(64);
 const OTHER_SECRET = "b".repeat(64);
@@ -62,6 +74,7 @@ interface Harness {
   idempotency: IdempotencyIndex;
   url: string;
   tmpDir: string;
+  clock: { value: Date | null };
 }
 
 let harness: Harness;
@@ -72,6 +85,7 @@ beforeEach(async () => {
   const journal = new DelegationJournal({ path: path.join(tmpDir, "events.jsonl") });
   const idempotency = new IdempotencyIndex();
   const taskStore = new BrokerTaskStore(munin as unknown as MuninClient);
+  const clock = { value: null as Date | null };
   const broker = await startBroker({
     host: "127.0.0.1",
     port: 0,
@@ -86,6 +100,7 @@ beforeEach(async () => {
       journal,
       idempotency,
       executorCapabilities: brokerExecutorCapabilities({ homeserverEnabled: true }),
+      now: () => clock.value ?? new Date(),
     },
   });
   const addr = broker.server.address() as AddressInfo;
@@ -96,6 +111,7 @@ beforeEach(async () => {
     idempotency,
     tmpDir,
     url: `http://127.0.0.1:${addr.port}`,
+    clock,
   };
 });
 
@@ -138,6 +154,141 @@ function structuredTaskResultContent(taskId: string): string {
     bodyText: "ok",
     repositoryOutcome: { state: "not-managed" },
   }));
+}
+
+function authoritativeStructuredTaskResult(taskId: string): {
+  result: StructuredTaskResult;
+  attemptId: string;
+} {
+  const task = withLearningTaskContext({
+    prompt: "Summarize the authoritative learning-task fixture.",
+    gatewayBaseUrl: "https://m5.test",
+    apiKey: "private-owner-key",
+    path: "delegate",
+    taskType: "summarize",
+    timeoutMs: 30_000,
+    maxOutputChars: 4_096,
+  }, taskId);
+  if (task.learningTask?.kind !== "ready") {
+    throw new Error("learning-task fixture was not prepared");
+  }
+  const requestBody = buildHomeserverRequestBody(task, taskId);
+  const gatewayResponse = withLearningTaskGatewayEcho(task, taskId, {}) as {
+    learningTaskGatewayEcho: unknown;
+  };
+  const gatewayEcho = gatewayResponse.learningTaskGatewayEcho;
+  const prepared = task.learningTask.preparedDispatch;
+  const learningTask = learningTaskExecutionEvidenceSchema.parse({
+    schemaVersion: 1,
+    contractVersion: "grimnir.learning-task/v1",
+    state: "m5-admitted",
+    evidenceAccepted: true,
+    taskId,
+    attemptId: prepared.attemptId,
+    attemptStartedAt: prepared.attemptStartedAt,
+    attemptStartRef: prepared.attemptStartRef,
+    preparedDispatchRef: prepared.preparedDispatchRef,
+    replayPayloadRef: prepared.replayPayloadRef,
+    replayPayloadDigest: prepared.replayPayloadDigest,
+    taskOutcomeRef: prepared.taskOutcomeRef,
+    rawFingerprint: prepared.requestStamp.raw_fingerprint,
+    requestStamp: prepared.requestStamp,
+    requestStampDigest: prepared.requestStampDigest,
+    gatewayEcho,
+    gatewayEchoDigest: gatewayEchoDigest(gatewayEcho as Parameters<typeof gatewayEchoDigest>[0]),
+    attemptOutcomeRef: prepared.attemptOutcomeRef,
+  });
+  return {
+    result: buildStructuredTaskResult({
+      schemaVersion: 1,
+      taskId,
+      taskNamespace: `tasks/${taskId}`,
+      lifecycle: "completed",
+      outcome: "completed",
+      runtime: "homeserver",
+      executor: "homeserver-delegate",
+      resultSource: "homeserver-delegate",
+      exitCode: 0,
+      completedAt: "2026-07-19T10:00:10.000Z",
+      bodyKind: "response",
+      bodyText: "ok",
+      repositoryOutcome: { state: "not-managed" },
+      runtimeMetadata: {
+        huginTaskIdentity: requestBody.huginTaskIdentity!,
+        learningTask,
+      },
+    }),
+    attemptId: learningTask.attemptId,
+  };
+}
+
+function qualityCorrection(predecessorReceiptId: string) {
+  return {
+    predecessor_receipt_id: predecessorReceiptId,
+    rubric: {
+      id: "code-review",
+      version: "2.1.0",
+      config_digest: {
+        algorithm: "sha256",
+        canonicalization: "jcs-rfc8785-utf8-v1",
+        source_ref: "source-doc:rubric/code-review-2.1.0",
+        source_type: "rubric-config",
+        source_version: "rubric-source-2.1.0",
+        digest: "d".repeat(64),
+      },
+    },
+    verifier: { id: "claude-opus", version: "2026-07-19" },
+    failure: {
+      taxonomy: { id: "hugin-quality-failure", version: "1" },
+      code: "incorrect-answer",
+    },
+    producing_configuration: {
+      harness: { id: "codex", version: "1", sha256: "e".repeat(64) },
+      model: { id: "gpt-5", configuration_sha256: "f".repeat(64) },
+    },
+    references: {
+      corrected_successor: {
+        task_id: "general-correction-fix",
+        structured_result_sha256: "1".repeat(64),
+      },
+      pull_request_url: "https://github.com/Magnus-Gille/demo/pull/2",
+      replacement_commit: "2".repeat(40),
+    },
+  };
+}
+
+async function prepareAuthoritativeCorrectionTask(taskId: string, ratedAt: string) {
+  harness.clock.value = new Date(ratedAt);
+  const authoritative = authoritativeStructuredTaskResult(taskId);
+  harness.munin.reads[`tasks/${taskId}/status`] = {
+    content: "## Task: correction\n\n### Prompt\nFix it.",
+    tags: ["completed", "runtime:homeserver"],
+    created_at: "ts",
+    updated_at: "ts",
+  };
+  harness.munin.reads[`tasks/${taskId}/result-structured`] = {
+    content: JSON.stringify(authoritative.result),
+    tags: ["type:task-result-structured"],
+    created_at: "ts",
+    updated_at: "ts",
+  };
+  const initialResponse = await fetch(`${harness.url}/v1/delegate/rate`, {
+    method: "POST",
+    headers: authHeader(),
+    body: JSON.stringify({
+      task_id: taskId,
+      rating: "pass",
+      rating_reason: "Initially accepted.",
+      verification_outcome: "accepted_unchanged",
+      reviewer_role: "independent",
+    }),
+  });
+  expect(initialResponse.status).toBe(204);
+  const ledger = JSON.parse(harness.munin.writes.at(-1)!.content);
+  return {
+    authoritative,
+    predecessor: ledger.receipts[0] as { receiptId: string; ratedAt: string },
+  };
 }
 
 function validRequest(overrides: Record<string, unknown> = {}) {
@@ -942,91 +1093,255 @@ describe("POST /v1/delegate/rate", () => {
     expect(harness.munin.writes.filter((write) => write.key === "feedback")).toHaveLength(1);
   });
 
-  it("fails closed instead of fabricating a task id as native-v2 attempt identity", async () => {
-    harness.munin.reads["tasks/general-correction/status"] = {
-      content: "## Task: correction\n\n### Prompt\nFix it.",
-      tags: ["completed", "runtime:codex"],
-      created_at: "ts",
-      updated_at: "ts",
-    };
-    harness.munin.reads["tasks/general-correction/result-structured"] = {
-      content: structuredTaskResultContent("general-correction"),
-      tags: ["type:task-result-structured"],
-      created_at: "ts",
-      updated_at: "ts",
-    };
-    const initial = {
-      task_id: "general-correction",
-      rating: "pass",
-      rating_reason: "Initially accepted.",
-      verification_outcome: "accepted_unchanged",
-      reviewer_role: "independent",
-    };
-    expect((await fetch(`${harness.url}/v1/delegate/rate`, {
-      method: "POST",
-      headers: authHeader(),
-      body: JSON.stringify(initial),
-    })).status).toBe(204);
-    const firstLedger = JSON.parse(harness.munin.writes.at(-1)!.content);
-    const predecessor = firstLedger.receipts[0];
-    // Make the immutable lineage clock deterministic rather than relying on
-    // two loopback HTTP requests landing in different milliseconds.
-    predecessor.ratedAt = "2026-07-18T10:00:00.000Z";
-    (harness.munin.reads["tasks/general-correction/feedback"] as { content: string }).content =
-      JSON.stringify(firstLedger);
+  it("derives the native-v2 attempt from exact admitted learning evidence", async () => {
+    const { authoritative, predecessor } = await prepareAuthoritativeCorrectionTask(
+      "general-correction",
+      "2026-07-19T10:00:00.000Z",
+    );
 
     const correctionPayload = {
-      ...initial,
+      task_id: "general-correction",
       rating: "wrong",
       rating_reason: "Unicode regression remained.",
       verification_outcome: "discarded",
-      correction: {
-        predecessor_receipt_id: predecessor.receiptId,
-        rubric: {
-          id: "code-review",
-          version: "2.1.0",
-          config_digest: {
-            algorithm: "sha256",
-            canonicalization: "jcs-rfc8785-utf8-v1",
-            source_ref: "source-doc:rubric/code-review-2.1.0",
-            source_type: "rubric-config",
-            source_version: "rubric-source-2.1.0",
-            digest: "d".repeat(64),
-          },
-        },
-        verifier: { id: "claude-opus", version: "2026-07-19" },
-        failure: {
-          taxonomy: { id: "hugin-quality-failure", version: "1" },
-          code: "incorrect-answer",
-        },
-        producing_configuration: {
-          harness: { id: "codex", version: "1", sha256: "e".repeat(64) },
-          model: { id: "gpt-5", configuration_sha256: "f".repeat(64) },
-        },
-        references: {
-          corrected_successor: {
-            task_id: "general-correction-fix",
-            structured_result_sha256: "1".repeat(64),
-          },
-          pull_request_url: "https://github.com/Magnus-Gille/demo/pull/2",
-          replacement_commit: "2".repeat(40),
-        },
-      },
+      reviewer_role: "independent",
+      correction: qualityCorrection(predecessor.receiptId),
     };
     const correctionResponse = await fetch(`${harness.url}/v1/delegate/rate`, {
       method: "POST",
       headers: authHeader(),
       body: JSON.stringify(correctionPayload),
     });
-    expect(correctionResponse.status).toBe(409);
-    expect(await correctionResponse.json()).toMatchObject({
-      error: "policy_rejected",
-      message: expect.stringContaining("authoritative execution attempt"),
+    expect(correctionResponse.status).toBe(204);
+    const ledger = JSON.parse(harness.munin.writes.at(-1)!.content);
+    expect(ledger).toMatchObject({
+      schemaVersion: 2,
+      taskId: "general-correction",
+      receipts: [
+        { schemaVersion: 1, receiptId: predecessor.receiptId },
+        {
+          schemaVersion: 2,
+          attemptId: authoritative.attemptId,
+          correctsReceiptId: predecessor.receiptId,
+          ratedAt: "2026-07-19T10:00:00.001Z",
+          rubric: correctionPayload.correction.rubric,
+          verifier: correctionPayload.correction.verifier,
+          failure: correctionPayload.correction.failure,
+          producingConfiguration: {
+            harness: { id: "codex", version: "1", sha256: "e".repeat(64) },
+            model: { id: "gpt-5", configurationSha256: "f".repeat(64) },
+          },
+          references: {
+            correctedSuccessor: {
+              taskId: "general-correction-fix",
+              structuredResultSha256: "1".repeat(64),
+            },
+            pullRequestUrl: "https://github.com/Magnus-Gille/demo/pull/2",
+            replacementCommit: "2".repeat(40),
+          },
+        },
+      ],
     });
-    expect(harness.munin.writes.filter((write) => write.key === "feedback")).toHaveLength(1);
     expect(JSON.parse(
       (harness.munin.reads["tasks/general-correction/feedback"] as { content: string }).content,
-    )).toEqual(firstLedger);
+    )).toEqual(ledger);
+  });
+
+  it("preserves the first native-v2 artifact on an identical retry after a lost response", async () => {
+    const { predecessor } = await prepareAuthoritativeCorrectionTask(
+      "correction-retry",
+      "2026-07-19T10:00:00.000Z",
+    );
+    const payload = {
+      task_id: "correction-retry",
+      rating: "wrong",
+      rating_reason: "Unicode regression remained.",
+      verification_outcome: "discarded",
+      reviewer_role: "independent",
+      correction: qualityCorrection(predecessor.receiptId),
+    };
+    harness.clock.value = new Date("2026-07-19T10:00:01.000Z");
+    expect((await fetch(`${harness.url}/v1/delegate/rate`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify(payload),
+    })).status).toBe(204);
+    const firstStoredBytes = (
+      harness.munin.reads["tasks/correction-retry/feedback"] as { content: string }
+    ).content;
+    const firstLedger = JSON.parse(firstStoredBytes);
+    const firstCorrectionId = firstLedger.receipts[1].receiptId;
+    const writesAfterFirst = harness.munin.writes.filter((write) => write.key === "feedback").length;
+
+    harness.clock.value = new Date("2026-07-19T10:00:02.000Z");
+    const retry = await fetch(`${harness.url}/v1/delegate/rate`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify(payload),
+    });
+
+    expect(retry.status).toBe(204);
+    expect(harness.munin.writes.filter((write) => write.key === "feedback"))
+      .toHaveLength(writesAfterFirst);
+    const retryStoredBytes = (
+      harness.munin.reads["tasks/correction-retry/feedback"] as { content: string }
+    ).content;
+    expect(retryStoredBytes).toBe(firstStoredBytes);
+    expect(JSON.parse(retryStoredBytes).receipts[1].receiptId).toBe(firstCorrectionId);
+  });
+
+  it("rejects a genuinely changed successor as a native-v2 fork", async () => {
+    const { predecessor } = await prepareAuthoritativeCorrectionTask(
+      "correction-fork",
+      "2026-07-19T10:00:00.000Z",
+    );
+    const payload = {
+      task_id: "correction-fork",
+      rating: "wrong",
+      rating_reason: "Unicode regression remained.",
+      verification_outcome: "discarded",
+      reviewer_role: "independent",
+      correction: qualityCorrection(predecessor.receiptId),
+    };
+    harness.clock.value = new Date("2026-07-19T10:00:01.000Z");
+    expect((await fetch(`${harness.url}/v1/delegate/rate`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify(payload),
+    })).status).toBe(204);
+    const firstStoredBytes = (
+      harness.munin.reads["tasks/correction-fork/feedback"] as { content: string }
+    ).content;
+    const changedCorrection = structuredClone(payload.correction);
+    changedCorrection.references.corrected_successor.structured_result_sha256 = "9".repeat(64);
+    harness.clock.value = new Date("2026-07-19T10:00:02.000Z");
+
+    const fork = await fetch(`${harness.url}/v1/delegate/rate`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify({ ...payload, correction: changedCorrection }),
+    });
+
+    expect(fork.status).toBe(409);
+    expect((harness.munin.reads["tasks/correction-fork/feedback"] as { content: string }).content)
+      .toBe(firstStoredBytes);
+  });
+
+  it.each(["top-level", "correction"])(
+    "does not let the caller choose or substitute the native-v2 attempt (%s)",
+    async (location) => {
+      const correction = qualityCorrection("qr-" + "a".repeat(24)) as Record<string, unknown>;
+      const payload: Record<string, unknown> = {
+        task_id: "caller-attempt",
+        rating: "wrong",
+        rating_reason: "Caller must not choose provenance.",
+        verification_outcome: "discarded",
+        correction,
+      };
+      if (location === "top-level") {
+        payload.attempt_id = "hugin-attempt:99999999-9999-4999-8999-999999999999";
+      } else {
+        correction.attempt_id = "hugin-attempt:99999999-9999-4999-8999-999999999999";
+      }
+
+      const response = await fetch(`${harness.url}/v1/delegate/rate`, {
+        method: "POST",
+        headers: authHeader(),
+        body: JSON.stringify(payload),
+      });
+
+      expect(response.status).toBe(400);
+      expect(harness.munin.writes).toHaveLength(0);
+    },
+  );
+
+  it.each([
+    ["legacy", () => JSON.stringify({
+      task_id: "unsafe-correction",
+      result_schema_version: 1,
+      response: "ok",
+    })],
+    ["missing", () => structuredTaskResultContent("unsafe-correction")],
+    ["mismatched attempt-start ref", () => {
+      const current = authoritativeStructuredTaskResult("unsafe-correction").result;
+      current.runtimeMetadata!.learningTask!.attemptStartRef!.key = "learning-attempt-wrong";
+      return JSON.stringify(current);
+    }],
+    ["mismatched prepared-dispatch ref", () => {
+      const current = authoritativeStructuredTaskResult("unsafe-correction").result;
+      current.runtimeMetadata!.learningTask!.preparedDispatchRef!.key = "learning-attempt-wrong-prepared";
+      return JSON.stringify(current);
+    }],
+    ["mismatched replay-payload ref", () => {
+      const current = authoritativeStructuredTaskResult("unsafe-correction").result;
+      current.runtimeMetadata!.learningTask!.replayPayloadRef!.key = "learning-attempt-wrong-replay";
+      return JSON.stringify(current);
+    }],
+    ["mismatched attempt-outcome ref", () => {
+      const current = authoritativeStructuredTaskResult("unsafe-correction").result;
+      current.runtimeMetadata!.learningTask!.attemptOutcomeRef!.key = "learning-attempt-wrong-outcome";
+      return JSON.stringify(current);
+    }],
+    ["mismatched task-outcome ref", () => {
+      const current = authoritativeStructuredTaskResult("unsafe-correction").result;
+      current.runtimeMetadata!.learningTask!.taskOutcomeRef.key = "result";
+      return JSON.stringify(current);
+    }],
+    ["missing durable attempt-outcome ref", () => {
+      const current = authoritativeStructuredTaskResult("unsafe-correction").result;
+      delete current.runtimeMetadata!.learningTask!.attemptOutcomeRef;
+      return JSON.stringify(buildStructuredTaskResult(current));
+    }],
+    ["non-admitted", () => {
+      const current = authoritativeStructuredTaskResult("unsafe-correction").result;
+      const learning = current.runtimeMetadata!.learningTask!;
+      learning.state = "m5-not-admitted";
+      learning.evidenceAccepted = false;
+      delete learning.gatewayEcho;
+      delete learning.gatewayEchoDigest;
+      learning.failureCode = "transport-not-admitted";
+      learning.failureReason = "gateway admission was not proven";
+      return JSON.stringify(buildStructuredTaskResult(current));
+    }],
+    ["unaccepted", () => {
+      const current = authoritativeStructuredTaskResult("unsafe-correction").result;
+      current.runtimeMetadata!.learningTask!.evidenceAccepted = false;
+      return JSON.stringify(current);
+    }],
+    ["mismatched", () => {
+      const current = authoritativeStructuredTaskResult("unsafe-correction").result;
+      current.runtimeMetadata!.learningTask!.taskId = "another-task";
+      return JSON.stringify(current);
+    }],
+  ])("rejects %s attempt evidence without a feedback write", async (_case, content) => {
+    harness.munin.reads["tasks/unsafe-correction/status"] = {
+      content: "## Task: correction\n\n### Prompt\nFix it.",
+      tags: ["completed", "runtime:homeserver"],
+      created_at: "ts",
+      updated_at: "ts",
+    };
+    harness.munin.reads["tasks/unsafe-correction/result-structured"] = {
+      content: content(),
+      tags: ["type:task-result-structured"],
+      created_at: "ts",
+      updated_at: "ts",
+    };
+
+    const response = await fetch(`${harness.url}/v1/delegate/rate`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify({
+        task_id: "unsafe-correction",
+        rating: "wrong",
+        rating_reason: "Invalid attempt evidence must fail closed.",
+        verification_outcome: "discarded",
+        correction: qualityCorrection("qr-" + "a".repeat(24)),
+      }),
+    });
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({ error: "policy_rejected" });
+    expect(harness.munin.writes.some((write) => write.key === "feedback")).toBe(false);
   });
 
   it("enforces failure code none iff a v2 correction is accepted unchanged", async () => {

--- a/tests/broker/task-store.test.ts
+++ b/tests/broker/task-store.test.ts
@@ -15,7 +15,9 @@ import { MuninWriteRejectedError, type MuninClient } from "../../src/munin-clien
 import type { DelegationEnvelope } from "../../src/broker/types.js";
 import {
   buildQualityBinding,
+  buildQualityCorrectionReceipt,
   buildQualityReceipt,
+  foldQualityReceipt,
 } from "../../src/quality-receipt.js";
 
 interface WriteCall {
@@ -640,9 +642,12 @@ describe("BrokerTaskStore.writeQualityReceipt — concurrent append safety (#231
     sensitivity: "internal",
   })}\n\`\`\`\n`;
 
-  function concurrentMunin() {
+  function concurrentMunin(initialFeedback?: string) {
     const entries: Record<string, { content: string; updated_at: string }> = {
       "tasks/t1/status": { content: ENVELOPE_CONTENT, updated_at: "s1" },
+      ...(initialFeedback
+        ? { "tasks/t1/feedback": { content: initialFeedback, updated_at: "v0" } }
+        : {}),
     };
     let feedbackReads = 0;
     let releaseFirstReads!: () => void;
@@ -654,10 +659,11 @@ describe("BrokerTaskStore.writeQualityReceipt — concurrent append safety (#231
       writes,
       read: async (namespace: string, key: string) => {
         if (key === "feedback" && feedbackReads < 2) {
+          const snapshot = entries[`${namespace}/${key}`] ?? null;
           feedbackReads += 1;
           if (feedbackReads === 2) releaseFirstReads();
           await firstReadsReady;
-          return null;
+          return snapshot;
         }
         return entries[`${namespace}/${key}`] ?? null;
       },
@@ -744,6 +750,71 @@ describe("BrokerTaskStore.writeQualityReceipt — concurrent append safety (#231
     expect(results.map((result) => result.changed).sort()).toEqual([false, true]);
     const ledger = JSON.parse(munin.entries["tasks/t1/feedback"]!.content) as { receipts: unknown[] };
     expect(ledger.receipts).toHaveLength(1);
+  });
+
+  it("preserves one native-v2 artifact when different server clocks race", async () => {
+    const predecessor = qualityReceipt("reviewer-a");
+    const initialLedger = foldQualityReceipt(null, predecessor).ledger;
+    const munin = concurrentMunin(JSON.stringify(initialLedger));
+    const store = new BrokerTaskStore(munin as unknown as MuninClient);
+    const correctionInput = {
+      taskId: "t1",
+      attemptId: "hugin-attempt:11111111-1111-4111-8111-111111111111",
+      correctsReceiptId: predecessor.receiptId,
+      reviewerPrincipal: predecessor.reviewer.principal,
+      reviewerIndependence: predecessor.reviewer.independence,
+      rating: "wrong" as const,
+      ratingReason: "The accepted result still fails the Unicode case.",
+      verificationOutcome: "discarded" as const,
+      ratedAt: predecessor.ratedAt,
+      bindingAttestation: predecessor.bindingAttestation,
+      binding: predecessor.binding,
+      rubric: {
+        id: "code-review",
+        version: "2.1.0",
+        config_digest: {
+          algorithm: "sha256" as const,
+          canonicalization: "jcs-rfc8785-utf8-v1" as const,
+          source_ref: "source-doc:rubric/code-review-2.1.0",
+          source_type: "rubric-config" as const,
+          source_version: "rubric-source-2.1.0",
+          digest: "d".repeat(64),
+        },
+      },
+      verifier: { id: "claude-opus", version: "2026-07-19" },
+      failure: {
+        taxonomy: { id: "hugin-quality-failure", version: "1" },
+        code: "incorrect-answer" as const,
+      },
+    };
+
+    const results = await Promise.all([
+      store.writeQualityCorrection("t1", correctionInput),
+      store.writeQualityCorrection("t1", {
+        ...correctionInput,
+        ratedAt: "2026-07-19T10:00:01.000Z",
+      }),
+    ]);
+
+    expect(results.map((result) => result.changed).sort()).toEqual([false, true]);
+    const storedBytes = munin.entries["tasks/t1/feedback"]!.content;
+    const ledger = JSON.parse(storedBytes) as { receipts: Array<{ schemaVersion: number }> };
+    expect(ledger.receipts).toHaveLength(2);
+    expect(ledger.receipts[1]!.schemaVersion).toBe(2);
+    expect(munin.writes.filter((write) => write.key === "feedback")).toHaveLength(1);
+
+    const storedCorrection = (JSON.parse(storedBytes) as { receipts: unknown[] }).receipts[1];
+    const candidates = [
+      buildQualityCorrectionReceipt({
+        ...correctionInput,
+        ratedAt: "2026-07-19T10:00:00.001Z",
+      }),
+      buildQualityCorrectionReceipt({
+        ...correctionInput,
+        ratedAt: "2026-07-19T10:00:01.000Z",
+      }),
+    ];
+    expect(candidates).toContainEqual(storedCorrection);
   });
 
   it("fails closed on a typed conflict that does not match the attempted write mode", async () => {

--- a/tests/quality-receipt.test.ts
+++ b/tests/quality-receipt.test.ts
@@ -331,6 +331,25 @@ describe("quality receipt v2 corrections", () => {
     })).toThrow(/identity collision/);
   });
 
+  it("treats a correction retry with only a new server clock and derived id as unchanged", () => {
+    const original = receipt();
+    const first = correction(original.receiptId);
+    const ledger = foldQualityReceipt(
+      foldQualityReceipt(null, original).ledger,
+      first,
+    ).ledger;
+    const laterRetry = correction(original.receiptId, {
+      ratedAt: "2026-07-15T10:16:00.000Z",
+    });
+
+    expect(laterRetry.receiptId).not.toBe(first.receiptId);
+    expect(foldQualityReceipt(ledger, laterRetry)).toEqual({
+      ledger,
+      changed: false,
+    });
+    expect(ledger.receipts[1]).toEqual(first);
+  });
+
   it("rejects correction forks and changed correction replays", () => {
     const original = receipt();
     const first = correction(original.receiptId);


### PR DESCRIPTION
Refs #231.

## What

Activates native-v2 Quality Receipt correction emission, which PR #244 deliberately left fail-closed pending authoritative attempt identity from #240.

- `POST /v1/delegate/rate` with a `correction` now derives the execution attempt **solely** from accepted authoritative LearningTask evidence inside the schema-validated structured result: `state === "m5-admitted"`, `evidenceAccepted === true`, and all four durable refs (attempt start, prepared dispatch, replay payload, attempt outcome), cross-checked against the rated task id/namespace. Callers cannot provide or infer attempt identity; every missing/mismatched element fail-closes 409 with a specific reason.
- Idempotent retry: an identical correction re-sent after a lost success response returns the first server-owned artifact unchanged (JCS-canonical comparison excluding server-owned `receiptId`/`ratedAt`); genuinely changed successors remain `QualityReceiptConflictError` forks.
- Correction `ratedAt` is server-owned and strictly advances past the predecessor inside the same CAS snapshot (same-millisecond safe).

## Provenance

Carries forward the independently re-reviewed unpushed commit `b32328a` (2026-07-19 session) minus its STATUS.md hunk, per repo convention that STATUS updates ride separate docs PRs. Re-reviewed in full by the grimnir session (Fable) as the PR gate; diff verdict: approve.

## Verification

- `npm run build` (tsc) clean
- `npm test`: 122 files / **1,972 passed**, including 3 new handler tests (derive-from-evidence, lost-response retry preserves first artifact, changed-successor fork rejection), plus new task-store and quality-receipt coverage
- `git diff --check` clean

## Rollout gate

CI is currently **billing-blocked account-wide** (job not started: payment/spending-limit). Do not merge until CI runs green or the owner explicitly waives it. After merge + deploy, the remaining #231 delta is the live dogfood: one real rejection+correction cycle rated end to end against an admitted attempt (gated on the #240 joint smoke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)