### PR TITLE
fix: bounded cross-host clock skew tolerance in learning-task handshake

### DIFF
--- a/src/learning-task-handshake.ts
+++ b/src/learning-task-handshake.ts
@@ -19,6 +19,16 @@ export const LEARNING_TASK_PREFLIGHT_ENDPOINT = "/v1/capabilities/learning-task"
 export const LEARNING_TASK_PREFLIGHT_PROTOCOL = "learning-task-preflight/v1" as const;
 export const LEARNING_TASK_GATEWAY_PRINCIPAL = "service:gille-inference" as const;
 export const LEARNING_TASK_PREFLIGHT_TTL_MS = 15 * 60 * 1_000;
+/**
+ * Bounded allowance for clock disagreement between Hugin's host and the M5 gateway host when
+ * ordering timestamps that were stamped on DIFFERENT hosts (issue #253). Without it, the
+ * preflight freshness check requires the gateway's `advertised_at` to land inside the
+ * milliseconds-wide request/observe bracket measured on Hugin's clock — tighter agreement than
+ * NTP delivers between two hosts, so the joint handshake fails on ordinary tens-of-ms offsets.
+ * The tolerance is applied ONLY to cross-host orderings; same-host orderings stay exact, and the
+ * advertisement expiry edge is TIGHTENED by the same amount (the acceptance window never grows).
+ */
+export const LEARNING_TASK_CLOCK_SKEW_TOLERANCE_MS = 2_000;
 export const LEARNING_TASK_FEATURES = [
   "hugin-request-stamp-v1",
   "gateway-echo-v1",
@@ -690,7 +700,14 @@ export async function fetchLearningTaskPreflight(
   const requestedMs = Date.parse(request.requested_at);
   const advertisedMs = Date.parse(response.advertised_at);
   const expiresMs = Date.parse(response.expires_at);
-  if (!(requestedMs <= advertisedMs && advertisedMs <= observedAt && observedAt < expiresMs)) {
+  // `requested_at`/`observedAt` are Hugin-host clocks; `advertised_at`/`expires_at` are
+  // gateway-host clocks. Cross-host orderings carry the bounded skew tolerance (#253); the
+  // expiry edge is tightened by the same amount so tolerance can never extend the window.
+  if (!(
+    requestedMs - LEARNING_TASK_CLOCK_SKEW_TOLERANCE_MS <= advertisedMs
+    && advertisedMs <= observedAt + LEARNING_TASK_CLOCK_SKEW_TOLERANCE_MS
+    && observedAt < expiresMs - LEARNING_TASK_CLOCK_SKEW_TOLERANCE_MS
+  )) {
     throw new LearningTaskHandshakeError("learning-task preflight freshness does not cover observation time");
   }
   if (expiresMs - advertisedMs > LEARNING_TASK_PREFLIGHT_TTL_MS) {
@@ -1244,7 +1261,12 @@ export function validateLearningTaskGatewayEcho(
     throw new LearningTaskHandshakeError("gateway echo authenticated principal substitution");
   }
   const admitted = Date.parse(echo.admitted_at);
-  if (!(Date.parse(stamp.stamped_at) <= admitted && admitted <= observedAt.getTime())) {
+  // `stamped_at`/`observedAt` are Hugin-host clocks; `admitted_at` is a gateway-host clock.
+  // Same bounded cross-host skew tolerance as the preflight freshness check (#253).
+  if (!(
+    Date.parse(stamp.stamped_at) - LEARNING_TASK_CLOCK_SKEW_TOLERANCE_MS <= admitted
+    && admitted <= observedAt.getTime() + LEARNING_TASK_CLOCK_SKEW_TOLERANCE_MS
+  )) {
     throw new LearningTaskHandshakeError("gateway admission clock is outside the request/observation interval");
   }
   const expectedBinding = jcsDigest({

--- a/tests/learning-task-handshake.test.ts
+++ b/tests/learning-task-handshake.test.ts
@@ -727,4 +727,103 @@ describe("LearningTaskContract v1 producer handshake", () => {
     substituted.authenticated_principal_id = "service:other";
     expect(() => validateLearningTaskGatewayEcho(substituted, stamp)).toThrow(/principal/i);
   });
+
+  describe("cross-host clock skew tolerance (#253)", () => {
+    const preflightWith = async (advertised: string, expires: string) => {
+      const fetchImpl = vi.fn(async (url: string) => {
+        if (url.endsWith("/portal/me")) return response({ alias: "service:hugin", tier: "owner" });
+        return response({
+          advertisement_id: `opaque:${randomUUID()}`,
+          endpoint: "/v1/capabilities/learning-task",
+          protocol_version: "learning-task-preflight/v1",
+          advertised_at: advertised,
+          expires_at: expires,
+          authenticated_principal_id: "service:gille-inference",
+          authentication: "service-auth",
+          capabilities: structuredClone(LEARNING_TASK_CAPABILITIES),
+        });
+      });
+      const clock = [
+        new Date("2026-07-19T10:00:01.500Z"),
+        new Date("2026-07-19T10:00:02.250Z"),
+      ];
+      return fetchLearningTaskPreflight({
+        gatewayBaseUrl: "https://m5.test",
+        apiKey: "key",
+        attemptStartedAt: startedAt,
+        now: () => clock.shift() ?? new Date("2026-07-19T10:00:02.250Z"),
+        fetchImpl: fetchImpl as typeof fetch,
+      });
+    };
+
+    it("accepts a gateway clock ahead of the local bracket within tolerance", async () => {
+      await expect(preflightWith("2026-07-19T10:00:03.500Z", "2026-07-19T10:15:03.500Z"))
+        .resolves.toBeDefined();
+    });
+
+    it("accepts a gateway clock behind the local bracket within tolerance", async () => {
+      await expect(preflightWith("2026-07-19T10:00:00.000Z", "2026-07-19T10:15:00.000Z"))
+        .resolves.toBeDefined();
+    });
+
+    it("rejects a gateway clock beyond the tolerance", async () => {
+      await expect(preflightWith("2026-07-19T10:00:05.000Z", "2026-07-19T10:15:05.000Z"))
+        .rejects.toThrow(/does not cover observation time/);
+    });
+
+    it("tightens the expiry edge instead of extending it", async () => {
+      // Observation (10:00:02.250) is before expires (10:00:04.000) but NOT before
+      // expires minus tolerance — the window must shrink, never grow.
+      await expect(preflightWith("2026-07-19T10:00:02.000Z", "2026-07-19T10:00:04.000Z"))
+        .rejects.toThrow(/does not cover observation time/);
+    });
+
+    const echoWith = (admittedAt: string) => {
+      const ctx = context();
+      const stamp = buildLearningTaskRequestStamp({
+        context: ctx,
+        taskType: "summarize",
+        rawTaskText: "  Summarize the fixture incident report.\n",
+        renderedPrompt: ctx.attempt.renderedPrompt,
+      });
+      const binding = {
+        authenticated_principal_id: "service:hugin",
+        request_stamp: stamp,
+      };
+      const echo = {
+        echoed_request: structuredClone(stamp),
+        gateway_request_id: "opaque:e3e3e3e3-e3e3-4e3e-8e3e-e3e3e3e3e3e3",
+        admission_id: "opaque:e4e4e4e4-e4e4-4e4e-8e4e-e4e4e4e4e4e4",
+        admitted_at: admittedAt,
+        authenticated_principal_id: "service:hugin",
+        authentication: "gateway-owner-auth",
+        principal_binding_digest: {
+          algorithm: "sha256",
+          version: "gateway-principal-request-binding-jcs-v1",
+          digest: createHash("sha256").update(jcsCanonicalize(binding), "utf8").digest("hex"),
+        },
+        capabilities: structuredClone(LEARNING_TASK_CAPABILITIES),
+      };
+      return { echo, stamp };
+    };
+
+    it("accepts an admission clock slightly behind the stamp clock", () => {
+      // stampedAt fixture is 10:00:02.250; admission 1.75s earlier on the gateway clock.
+      const { echo, stamp } = echoWith("2026-07-19T10:00:00.500Z");
+      expect(validateLearningTaskGatewayEcho(echo, stamp, new Date("2026-07-19T10:00:04Z")))
+        .toEqual(echo);
+    });
+
+    it("accepts an admission clock slightly ahead of the observation clock", () => {
+      const { echo, stamp } = echoWith("2026-07-19T10:00:05.500Z");
+      expect(validateLearningTaskGatewayEcho(echo, stamp, new Date("2026-07-19T10:00:04Z")))
+        .toEqual(echo);
+    });
+
+    it("rejects an admission clock beyond the tolerance", () => {
+      const { echo, stamp } = echoWith("2026-07-19T10:00:07.000Z");
+      expect(() => validateLearningTaskGatewayEcho(echo, stamp, new Date("2026-07-19T10:00:04Z")))
+        .toThrow(/admission clock/);
+    });
+  });
 });


### PR DESCRIPTION
Refs #253.

## What

The joint live smoke (issue #240 gate) failed deterministically: the preflight freshness check demanded the M5-stamped `advertised_at` land inside the ~25ms Pi-clock bracket between `requested_at` and `observedAt` — cross-host clock agreement tighter than one-way network latency. The gateway-echo admission ordering had the same zero-tolerance class.

Fix: `LEARNING_TASK_CLOCK_SKEW_TOLERANCE_MS = 2_000` applied ONLY to cross-host orderings (requested→advertised, advertised→observed, stamped→admitted, admitted→observed). Same-host orderings stay exact. The expiry edge is **tightened** by the tolerance (`observedAt < expires - tolerance`) so tolerance can never extend the 15-minute advertisement window.

## Verification

- `npm run build` clean; **122 files / 1,962 tests passed** (1,955 baseline + 7 new regression tests: both skew directions accepted within tolerance, both rejected beyond it, expiry edge proven to shrink).
- Live evidence of the defect: tasks `mcp-m5-51cae3477734c6133e095021` and `mcp-m5-2b530a96f822458a518950ab` (both preflight-failed with correct negative attempt evidence — the fail-closed path worked; the margin was structurally zero).

## Review note

Implemented and self-reviewed by the grimnir session (Fable) — the usual reviewer separation is reduced tonight (Codex unavailable); flagged for owner eyes on merge. Contract question routed in #253: if bounded skew needs LearningTaskContract blessing, it goes through the grimnir contract owner as a v1.x clarification.

CI is billing-blocked account-wide; merge after CI runs green or owner waiver. The joint smoke rerun tonight uses this branch client-side on the Pi (no production deploy before merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)