### PR TITLE
Add durable append-only task/outcome learning registry (#232)

### DIFF
--- a/docs/learning-registry.md
+++ b/docs/learning-registry.md
@@ -1,0 +1,188 @@
+# Durable append-only task/outcome learning registry (#232)
+
+**Status:** mechanism implemented; not yet wired into the dispatcher's normal
+task lifecycle. `src/learning-registry-schema.ts`, `src/learning-registry-store.ts`,
+and `src/learning-registry-view.ts` are a self-contained, tested library. Wiring
+calls into `src/index.ts`/`src/broker/handlers.ts` is deliberately left to the
+tickets that actually need it (#233, #237), to avoid broadening this PR's blast
+radius across in-flight sibling work on `src/broker/handlers.ts` (#250/#251).
+
+## Scope boundary vs #241
+
+Per hugin#241's 2026-07-20 "Boundary clarification" comment:
+
+- **#232 (this module) owns the mechanism** — the append-only registry, its
+  natural keys, membership evidence issued at capture, and the
+  partition/high-water proof primitives, including their issuance.
+- **#241 owns consumption** — period closes, monthly statements, and
+  cross-owner accounting that *verify and consume* #232's proofs. It must not
+  re-implement or re-issue them.
+
+Concretely: this module never computes a monthly close, never talks to
+`gille-inference`, never ingests external Codex/Pi receipts (#237), and never
+packages evaluation candidates (#233). It only appends events, resolves
+correction chains, and issues/verifies partition proofs that #241 will later
+consume as its authoritative "is this period complete" input.
+
+## Store choice: Munin envelopes, not SQLite
+
+The task brief's framing ("Munin envelopes like `task-store.ts`, or SQLite
+like `learning-task-store.ts`") does not match this repository: **there is no
+SQLite (or other embedded database) dependency anywhere in Hugin.**
+`src/learning-task-store.ts` — the "immutable artifacts" module the issue
+points at — is itself Munin-backed (`createImmutableLearningArtifact` calls
+`munin.write(..., create_if_absent: true)`), exactly like `src/broker/task-store.ts`.
+
+The registry therefore uses Munin envelopes, for two reasons:
+
+1. **It sits next to the evidence it references.** The existing durable
+   LearningTask attempt rows this registry points at
+   (`tasks/<taskId>/learning-attempt-<uuid>`, `-prepared`, `-replay`,
+   `-outcome`, and `tasks/<taskId>/result-structured` — see
+   `docs/learning-task-handshake.md`) already live in Munin under the task's
+   own namespace. Registry events live at `tasks/<taskId>/reg-<hash>` in that
+   same namespace, so a reader never crosses a storage boundary to join them.
+2. **Munin already provides the two primitives this registry needs.**
+   `create_if_absent` gives atomic idempotent-create; `expected_updated_at`
+   gives compare-and-swap. Both are used throughout the existing codebase
+   (`BrokerTaskStore.recordAwait`, `BrokerTaskStore.writeQualityReceipt`,
+   `createImmutableLearningArtifact`). Introducing SQLite would mean a second
+   persistence technology, a second backup/restore/deploy story, and a second
+   set of failure modes — for no capability this registry actually needs.
+
+## Record model
+
+Six append-only record kinds, each content-blind (ids, digests, refs, closed
+classifications — never prompt/response bytes):
+
+| `recordKind` | Natural key | Purpose |
+|---|---|---|
+| `submission` | `{taskId}` | One per task: the task entered the registry. |
+| `attempt-reference` | `{taskId, attemptId}` | References (never copies) the existing durable LearningTask attempt-start row. |
+| `terminal-outcome` | `{taskId, attemptId}` | The attempt's closed execution outcome (`completed\|failed\|timed_out\|cancelled`) plus optional repository-outcome state. |
+| `publication` | `{taskId, attemptId, publicationRef}` | A publication/label event (PR published, quality receipt, experiment product rating, ...). |
+| `correction` | `{taskId, predecessorEventId}` | A new, distinctly-keyed event chained to an immutable predecessor. |
+| `exclusion-adjustment` | `{taskId, targetEventId}` | Records that a target's referenced content was erased/excluded, without touching the target. |
+
+Every event's Munin key (`eventId`, `reg-<32 hex chars>`) is **content-derived
+from its natural key** (`deriveEventId` = truncated SHA-256 of the JCS
+canonicalization of the natural key). This is what makes idempotency and
+no-fork-on-correction structural rather than merely convention:
+
+- Two calls describing the same natural key always target the same row.
+  `create_if_absent` makes the first writer's create atomic; a racing
+  duplicate gets a typed `already_exists` conflict, reads back the winner's
+  bytes, and — if genuinely identical — returns the same result. A
+  **different** payload at the same natural key is refused
+  (`RegistryNaturalKeyConflictError`); the caller must express the change as
+  a correction instead.
+- A correction's own natural key is `{recordKind: "correction", taskId,
+  predecessorEventId}`. At most one correction can therefore exist per
+  predecessor — a second, different correction targeting the same
+  predecessor collides structurally instead of silently forking the chain.
+  To correct a correction, target the correction's own event id.
+
+`recordedAt` (when the registry durably accepted the event) is intentionally
+excluded from the idempotency/collision comparison: it is store-observed, not
+caller-asserted, so two calls racing to persist the exact same logical fact
+legitimately differ there. `appendRegistryEvent` always returns the
+**actually-persisted** event (the true winner's `recordedAt`), never the
+caller's locally-built candidate, so a reader is never told two different
+truths for one natural key.
+
+## Membership evidence at capture
+
+Every event carries a `membership` object bound at capture time (see the
+2026-07-19 owner-review comment on #232):
+
+```
+membership: {
+  naturalKey,             // the identity above
+  occurrencePeriodUtc,    // half-open UTC month, derived from occurredAt
+  counter,                // == naturalKey.recordKind (Hugin-owned counters only)
+  counterOwner: "hugin",
+  issuedAt,                // == occurredAt — never backdated or re-derived later
+}
+```
+
+`occurredAt` (when the underlying fact happened) and `recordedAt` (when the
+registry accepted it) are separate fields; `occurredAt` must not be after
+`recordedAt`, and `membership.issuedAt` must equal `occurredAt` exactly — a
+correction cannot retroactively move an event's period, counter, or owner.
+
+## Partition / high-water proof primitives
+
+A per-`(counter, occurrencePeriodUtc)` high-water document tracks, as an
+append-ordered list, every member event plus a running SHA-256 hash chain
+over each member's canonical digest. Every `appendRegistryEvent` call updates
+this document through the same bounded CAS-retry idiom already used by
+`BrokerTaskStore.writeQualityReceipt` (re-read, compute next state, write with
+`expected_updated_at`, retry on conflict) — concurrent writers to one
+partition serialize instead of clobbering each other's membership count, and
+a duplicate delivery that already appears in the document's member list is
+skipped rather than double-counted.
+
+`issuePartitionProof(counter, period)` reads that authoritative document and:
+
+- returns `status: "complete"` only after **recomputing** the chain digest
+  from the actual persisted member events (not merely trusting the document's
+  own digest field) and confirming it matches;
+- returns `status: "empty-confirmed"` when no high-water document exists
+  *and* a bounded tag probe finds no tagged events either — a legitimate
+  zero-event partition, distinguished from "haven't checked";
+- returns `status: "partial"` — and therefore `isEligibleForCertification() ===
+  false` — for every inconsistency: a missing document despite tagged events,
+  a member event that cannot be read back, a member belonging to a different
+  partition, or a recomputed digest that disagrees with the stored one.
+
+`verifyPartitionProof` never trusts the proof body alone. It re-derives
+validity from the store's current state: for `"complete"`, it requires the
+proof's `highWaterSeq`/`chainDigest` to match the *current* high-water
+document (this is the "stale" check — a full-period view must use the
+authoritative current mark, not a claim`s frozen at some earlier point) and
+independently recomputes the chain from the proof's own claimed members (this
+is the "forged" check — a fabricated digest cannot borrow another partition's
+real chain). A caller can pass `{ requireCurrent: false }` to ask only "was
+this proof honestly derived as of its own high-water mark", which is what a
+future consumer verifying a historical close would need — but the default is
+`true`, matching the acceptance criterion that a full-period view is only
+ever backed by the authoritative *current* high-water proof.
+
+A `"partial"` proof is never eligible for certification, structurally: there
+is no code path that lets a caller recompute a digest over whatever subset it
+happened to load and have that subset accepted as `"complete"` —
+`issuePartitionProof` is the only way to obtain a non-`"partial"` status, and
+it always reads the authoritative document rather than caller-supplied input.
+
+## Erasure-safe exclusion adjustments
+
+`writeExclusionAdjustment` never deletes, mutates, or re-keys the target
+event. It appends a new, separately-partitioned `exclusion-adjustment` event
+recording that the target's referenced content was erased/excluded. The
+target's own natural key, occurrence period, counter, and owner — and
+therefore its partition membership count — are untouched. Because this
+registry never stored prompt/response bytes to begin with (content-blind by
+design), there is nothing to "resurrect"; the adjustment exists purely so a
+downstream reader honors the upstream erasure when it later dereferences the
+target's evidence refs.
+
+## Lifecycle read view
+
+`src/learning-registry-view.ts`'s `buildTaskLifecycleTimeline(store, taskId)`
+joins one task's primary lifecycle events (submission, attempt-reference,
+terminal-outcome, publication) into one chronologically ordered timeline,
+resolving each to its correction-chain effective leaf and flagging exclusion
+state — without removing superseded or excluded events from the underlying
+audit trail (`timeline.corrections`, `timeline.exclusionAdjustments`). This is
+the query #233's candidate packager and #237's ingest are expected to build
+on.
+
+## What is deliberately out of scope here
+
+- Monthly closes, cross-owner `gille-inference` accounting, and membership
+  tokens for cross-owner erasure — #241.
+- Ingesting external Codex/Pi receipts — #237.
+- Candidate packaging/promotion — #233.
+- Wiring `record*` calls into the live dispatcher lifecycle in
+  `src/index.ts`/`src/broker/handlers.ts` — left to the consuming tickets so
+  this PR stays a self-contained, independently testable library.

--- a/src/learning-registry-schema.ts
+++ b/src/learning-registry-schema.ts
@@ -387,7 +387,13 @@ export const registryHighWaterDocSchema = z.object({
   counterOwner: z.literal(LEARNING_REGISTRY_COUNTER_OWNER),
   occurrencePeriodUtc: occurrencePeriodSchema,
   highWaterSeq: z.number().int().nonnegative(),
-  /** Append-ordered members currently known in this partition. */
+  /**
+   * Append-ordered members currently known in this partition. This array
+   * grows unboundedly for the life of the partition (one UTC month per
+   * counter) — acceptable at current per-period volumes, but revisit (e.g. a
+   * paged or summarized document) if a single period ever approaches a few
+   * thousand events.
+   */
   members: z.array(registryPartitionMemberSchema),
   /** Running hash chain over ordered event digests — tamper-evident. */
   chainDigest: z.string().regex(/^[0-9a-f]{64}$/),

--- a/src/learning-registry-schema.ts
+++ b/src/learning-registry-schema.ts
@@ -1,0 +1,452 @@
+/**
+ * Durable append-only task/outcome learning registry — record model (#232).
+ *
+ * Scope boundary (hugin#241 "Boundary clarification", 2026-07-20): this module
+ * owns the *mechanism* — natural keys, membership evidence issued at capture,
+ * and the partition/high-water proof primitives. Monthly closes, cross-owner
+ * gille accounting, and candidate packaging are explicitly out of scope; #241
+ * and #233 consume what this module issues, they do not re-implement it.
+ *
+ * Every event is content-blind: it carries opaque ids, refs, digests, and
+ * closed classifications only. It never carries prompt or response bytes.
+ * Existing durable evidence (learning-task attempt start/prepared/replay/
+ * outcome rows, `result-structured`) is referenced by namespace/key, never
+ * copied — see docs/learning-task-handshake.md.
+ */
+
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import { jcsCanonicalize } from "./learning-task-handshake.js";
+import { taskExecutionOutcomeSchema } from "./task-result-schema.js";
+
+export const LEARNING_REGISTRY_SCHEMA_VERSION = 1 as const;
+/** Every #232-mechanism event is owned and counted by Hugin itself. Cross-owner
+ * counters (#241) are consumed through this mechanism, not emitted by it. */
+export const LEARNING_REGISTRY_COUNTER_OWNER = "hugin" as const;
+
+const utcTimestampPattern = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?Z$/;
+
+function isExactUtcTimestamp(value: string): boolean {
+  const match = utcTimestampPattern.exec(value);
+  if (!match) return false;
+  const instant = new Date(value);
+  if (Number.isNaN(instant.getTime())) return false;
+  return instant.getUTCFullYear() === Number(match[1])
+    && instant.getUTCMonth() + 1 === Number(match[2])
+    && instant.getUTCDate() === Number(match[3])
+    && instant.getUTCHours() === Number(match[4])
+    && instant.getUTCMinutes() === Number(match[5])
+    && instant.getUTCSeconds() === Number(match[6]);
+}
+
+export const registryTimestampSchema = z.string().refine(isExactUtcTimestamp, {
+  message: "invalid RFC 3339 UTC timestamp",
+});
+
+/** Half-open UTC calendar month, e.g. "2026-07". */
+export const occurrencePeriodSchema = z.string().regex(/^\d{4}-(0[1-9]|1[0-2])$/);
+
+export function occurrencePeriodUtcFromInstant(iso: string): string {
+  if (!isExactUtcTimestamp(iso)) {
+    throw new LearningRegistryError(`cannot derive occurrence period from invalid timestamp ${iso}`);
+  }
+  return iso.slice(0, 7);
+}
+
+export class LearningRegistryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LearningRegistryError";
+  }
+}
+
+export function sha256Hex(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+export function jcsDigestHex(value: unknown): string {
+  return sha256Hex(jcsCanonicalize(value));
+}
+
+export function canonicalEqual(left: unknown, right: unknown): boolean {
+  return jcsCanonicalize(left) === jcsCanonicalize(right);
+}
+
+export const registryEvidenceRefSchema = z.object({
+  namespace: z.string().min(1),
+  key: z.string().min(1),
+}).strict();
+export type RegistryEvidenceRef = z.infer<typeof registryEvidenceRefSchema>;
+
+export const REGISTRY_RECORD_KINDS = [
+  "submission",
+  "attempt-reference",
+  "terminal-outcome",
+  "publication",
+  "correction",
+  "exclusion-adjustment",
+] as const;
+export const registryRecordKindSchema = z.enum(REGISTRY_RECORD_KINDS);
+export type RegistryRecordKind = z.infer<typeof registryRecordKindSchema>;
+
+// ---------------------------------------------------------------------------
+// Natural keys — one discriminated shape per record kind. Denominator
+// membership binds the *natural key*, so two records with the same kind and
+// same identity fields are the same logical fact: a duplicate delivery, never
+// a second independent event.
+// ---------------------------------------------------------------------------
+
+const submissionNaturalKeySchema = z.object({
+  recordKind: z.literal("submission"),
+  taskId: z.string().min(1),
+}).strict();
+
+const attemptReferenceNaturalKeySchema = z.object({
+  recordKind: z.literal("attempt-reference"),
+  taskId: z.string().min(1),
+  attemptId: z.string().min(1),
+}).strict();
+
+const terminalOutcomeNaturalKeySchema = z.object({
+  recordKind: z.literal("terminal-outcome"),
+  taskId: z.string().min(1),
+  attemptId: z.string().min(1),
+}).strict();
+
+const publicationNaturalKeySchema = z.object({
+  recordKind: z.literal("publication"),
+  taskId: z.string().min(1),
+  attemptId: z.string().min(1),
+  publicationRef: z.string().min(1).max(128),
+}).strict();
+
+const correctionNaturalKeySchema = z.object({
+  recordKind: z.literal("correction"),
+  taskId: z.string().min(1),
+  predecessorEventId: z.string().min(1),
+}).strict();
+
+const exclusionAdjustmentNaturalKeySchema = z.object({
+  recordKind: z.literal("exclusion-adjustment"),
+  taskId: z.string().min(1),
+  targetEventId: z.string().min(1),
+}).strict();
+
+export const registryNaturalKeySchema = z.discriminatedUnion("recordKind", [
+  submissionNaturalKeySchema,
+  attemptReferenceNaturalKeySchema,
+  terminalOutcomeNaturalKeySchema,
+  publicationNaturalKeySchema,
+  correctionNaturalKeySchema,
+  exclusionAdjustmentNaturalKeySchema,
+]);
+export type RegistryNaturalKey = z.infer<typeof registryNaturalKeySchema>;
+
+/** Deterministic content-derived id: same natural key -> same event id, always. */
+export function naturalKeyDigest(key: RegistryNaturalKey): string {
+  return jcsDigestHex(registryNaturalKeySchema.parse(key));
+}
+
+export function deriveEventId(key: RegistryNaturalKey): string {
+  return `reg-${naturalKeyDigest(key).slice(0, 32)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Membership evidence — bound at capture time. Owner-review binding (#232,
+// 2026-07-19): "Denominator membership must bind the original natural key,
+// occurrence period, counter, and owner so erasure cannot move July evidence
+// into August or relabel joined/direct traffic."
+// ---------------------------------------------------------------------------
+
+export const registryMembershipSchema = z.object({
+  naturalKey: registryNaturalKeySchema,
+  occurrencePeriodUtc: occurrencePeriodSchema,
+  counter: registryRecordKindSchema,
+  counterOwner: z.literal(LEARNING_REGISTRY_COUNTER_OWNER),
+  /** Issued at original capture time — never re-derived or backdated later. */
+  issuedAt: registryTimestampSchema,
+}).strict().superRefine((value, ctx) => {
+  if (value.naturalKey.recordKind !== value.counter) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["counter"],
+      message: "membership counter must equal the natural key's record kind",
+    });
+  }
+});
+export type RegistryMembership = z.infer<typeof registryMembershipSchema>;
+
+export function buildMembership(input: {
+  naturalKey: RegistryNaturalKey;
+  issuedAt: string;
+}): RegistryMembership {
+  return registryMembershipSchema.parse({
+    naturalKey: input.naturalKey,
+    occurrencePeriodUtc: occurrencePeriodUtcFromInstant(input.issuedAt),
+    counter: input.naturalKey.recordKind,
+    counterOwner: LEARNING_REGISTRY_COUNTER_OWNER,
+    issuedAt: input.issuedAt,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+const registryEventBase = {
+  schemaVersion: z.literal(LEARNING_REGISTRY_SCHEMA_VERSION),
+  eventId: z.string().regex(/^reg-[0-9a-f]{32}$/),
+  taskId: z.string().min(1),
+  membership: registryMembershipSchema,
+  /** When the underlying fact happened. */
+  occurredAt: registryTimestampSchema,
+  /** When the registry durably accepted the event. */
+  recordedAt: registryTimestampSchema,
+};
+
+export const submissionEventSchema = z.object({
+  ...registryEventBase,
+  recordKind: z.literal("submission"),
+  payload: z.object({
+    taskOutcomeRef: registryEvidenceRefSchema,
+    originComponent: z.literal("hugin"),
+  }).strict(),
+}).strict();
+
+export const attemptReferenceEventSchema = z.object({
+  ...registryEventBase,
+  recordKind: z.literal("attempt-reference"),
+  attemptId: z.string().min(1),
+  payload: z.object({
+    /** Reference into the existing durable LearningTask attempt row — never copied. */
+    attemptStartRef: registryEvidenceRefSchema,
+    taskOutcomeRef: registryEvidenceRefSchema,
+  }).strict(),
+}).strict();
+
+export const terminalOutcomeEventSchema = z.object({
+  ...registryEventBase,
+  recordKind: z.literal("terminal-outcome"),
+  attemptId: z.string().min(1),
+  payload: z.object({
+    outcome: taskExecutionOutcomeSchema,
+    repositoryOutcomeState: z.enum([
+      "not-managed",
+      "checkout-failed",
+      "not-finalized",
+      "no-changes",
+      "changes-present",
+      "publication-failed",
+    ]).optional(),
+    taskOutcomeRef: registryEvidenceRefSchema,
+    attemptOutcomeRef: registryEvidenceRefSchema.optional(),
+  }).strict(),
+}).strict();
+
+export const publicationEventSchema = z.object({
+  ...registryEventBase,
+  recordKind: z.literal("publication"),
+  attemptId: z.string().min(1),
+  payload: z.object({
+    publicationRef: z.string().min(1).max(128),
+    label: z.enum([
+      "pr-published",
+      "quality-receipt",
+      "experiment-product-rating",
+      "label-applied",
+    ]),
+    evidenceRef: registryEvidenceRefSchema,
+  }).strict(),
+}).strict();
+
+export const correctionEventSchema = z.object({
+  ...registryEventBase,
+  recordKind: z.literal("correction"),
+  payload: z.object({
+    predecessorEventId: z.string().min(1),
+    /** Must equal the predecessor's own natural key — a correction cannot retarget. */
+    correctedNaturalKey: registryNaturalKeySchema,
+    reason: z.string().min(1).max(512),
+    evidenceRef: registryEvidenceRefSchema.optional(),
+  }).strict(),
+}).strict();
+
+export const exclusionAdjustmentEventSchema = z.object({
+  ...registryEventBase,
+  recordKind: z.literal("exclusion-adjustment"),
+  payload: z.object({
+    targetEventId: z.string().min(1),
+    targetNaturalKey: registryNaturalKeySchema,
+    adjustmentReason: z.enum(["erasure", "exclusion"]),
+    note: z.string().min(1).max(512).optional(),
+  }).strict(),
+}).strict();
+
+export const registryEventSchema = z.discriminatedUnion("recordKind", [
+  submissionEventSchema,
+  attemptReferenceEventSchema,
+  terminalOutcomeEventSchema,
+  publicationEventSchema,
+  correctionEventSchema,
+  exclusionAdjustmentEventSchema,
+]).superRefine((value, ctx) => {
+  if (value.membership.counter !== value.recordKind) {
+    ctx.addIssue({ code: "custom", message: "event record kind does not match its membership counter" });
+  }
+  if (value.membership.naturalKey.recordKind !== value.recordKind
+    || value.membership.naturalKey.taskId !== value.taskId) {
+    ctx.addIssue({ code: "custom", message: "event does not bind its own natural key" });
+  }
+  if (Date.parse(value.occurredAt) > Date.parse(value.recordedAt)) {
+    ctx.addIssue({ code: "custom", message: "occurredAt cannot be after recordedAt" });
+  }
+  if (value.occurredAt !== value.membership.issuedAt) {
+    ctx.addIssue({
+      code: "custom",
+      message: "membership evidence must be issued at original capture time (occurredAt)",
+    });
+  }
+  const expectedEventId = deriveEventId(value.membership.naturalKey);
+  if (value.eventId !== expectedEventId) {
+    ctx.addIssue({ code: "custom", path: ["eventId"], message: "event id is not content-derived from its natural key" });
+  }
+  if (value.recordKind === "attempt-reference" || value.recordKind === "terminal-outcome"
+    || value.recordKind === "publication") {
+    const key = value.membership.naturalKey as { attemptId?: string };
+    if (key.attemptId !== value.attemptId) {
+      ctx.addIssue({ code: "custom", path: ["attemptId"], message: "event attemptId does not match its natural key" });
+    }
+  }
+  if (value.recordKind === "publication"
+    && value.membership.naturalKey.recordKind === "publication"
+    && value.membership.naturalKey.publicationRef !== value.payload.publicationRef) {
+    ctx.addIssue({ code: "custom", path: ["payload", "publicationRef"], message: "publication ref does not match its natural key" });
+  }
+  if (value.recordKind === "correction") {
+    if (value.membership.naturalKey.recordKind === "correction"
+      && value.membership.naturalKey.predecessorEventId !== value.payload.predecessorEventId) {
+      ctx.addIssue({ code: "custom", path: ["payload", "predecessorEventId"], message: "correction natural key does not match its own predecessor" });
+    }
+    if (value.payload.predecessorEventId === value.eventId) {
+      ctx.addIssue({ code: "custom", message: "a correction cannot target itself" });
+    }
+  }
+  if (value.recordKind === "exclusion-adjustment") {
+    if (value.membership.naturalKey.recordKind === "exclusion-adjustment"
+      && value.membership.naturalKey.targetEventId !== value.payload.targetEventId) {
+      ctx.addIssue({ code: "custom", path: ["payload", "targetEventId"], message: "exclusion-adjustment natural key does not match its own target" });
+    }
+    if (value.payload.targetEventId === value.eventId) {
+      ctx.addIssue({ code: "custom", message: "an exclusion-adjustment cannot target itself" });
+    }
+  }
+});
+export type RegistryEvent = z.infer<typeof registryEventSchema>;
+export type SubmissionEvent = z.infer<typeof submissionEventSchema>;
+export type AttemptReferenceEvent = z.infer<typeof attemptReferenceEventSchema>;
+export type TerminalOutcomeEvent = z.infer<typeof terminalOutcomeEventSchema>;
+export type PublicationEvent = z.infer<typeof publicationEventSchema>;
+export type CorrectionEvent = z.infer<typeof correctionEventSchema>;
+export type ExclusionAdjustmentEvent = z.infer<typeof exclusionAdjustmentEventSchema>;
+
+export function registryEventNamespace(taskId: string): string {
+  return `tasks/${taskId}`;
+}
+
+/** Munin key for one event — deterministic, so retries and idempotency checks
+ * never need to search: they read the exact expected key directly. */
+export function registryEventKey(eventId: string): string {
+  if (!/^reg-[0-9a-f]{32}$/.test(eventId)) {
+    throw new LearningRegistryError(`not a valid registry event id: ${eventId}`);
+  }
+  return eventId;
+}
+
+export const REGISTRY_EVENT_TAG = "learning-registry";
+
+export function registryPartitionTag(counter: RegistryRecordKind, occurrencePeriodUtc: string): string {
+  occurrencePeriodSchema.parse(occurrencePeriodUtc);
+  return `learning-registry-partition:${LEARNING_REGISTRY_COUNTER_OWNER}:${counter}:${occurrencePeriodUtc}`;
+}
+
+// ---------------------------------------------------------------------------
+// Partition / high-water proof primitives
+// ---------------------------------------------------------------------------
+
+/** Events live per-task (`tasks/<taskId>/reg-...`), so a partition doc must
+ * carry enough to locate each member without a second global index. */
+export const registryPartitionMemberSchema = z.object({
+  taskId: z.string().min(1),
+  eventId: z.string().min(1),
+}).strict();
+export type RegistryPartitionMember = z.infer<typeof registryPartitionMemberSchema>;
+
+export const registryHighWaterDocSchema = z.object({
+  schemaVersion: z.literal(LEARNING_REGISTRY_SCHEMA_VERSION),
+  counter: registryRecordKindSchema,
+  counterOwner: z.literal(LEARNING_REGISTRY_COUNTER_OWNER),
+  occurrencePeriodUtc: occurrencePeriodSchema,
+  highWaterSeq: z.number().int().nonnegative(),
+  /** Append-ordered members currently known in this partition. */
+  members: z.array(registryPartitionMemberSchema),
+  /** Running hash chain over ordered event digests — tamper-evident. */
+  chainDigest: z.string().regex(/^[0-9a-f]{64}$/),
+  updatedAt: registryTimestampSchema,
+}).strict().superRefine((value, ctx) => {
+  if (value.members.length !== value.highWaterSeq) {
+    ctx.addIssue({ code: "custom", message: "high-water sequence does not match the recorded event count" });
+  }
+  const seen = new Set<string>();
+  for (const member of value.members) {
+    if (seen.has(member.eventId)) {
+      ctx.addIssue({ code: "custom", path: ["members"], message: `duplicate member event id ${member.eventId}` });
+    }
+    seen.add(member.eventId);
+  }
+});
+export type RegistryHighWaterDoc = z.infer<typeof registryHighWaterDocSchema>;
+
+export const EMPTY_CHAIN_DIGEST = sha256Hex("");
+
+export function nextChainDigest(previousChainDigest: string, eventDigest: string): string {
+  return sha256Hex(`${previousChainDigest}\0${eventDigest}`);
+}
+
+export const registryPartitionProofStatusSchema = z.enum(["complete", "empty-confirmed", "partial"]);
+export type RegistryPartitionProofStatus = z.infer<typeof registryPartitionProofStatusSchema>;
+
+export const registryPartitionProofSchema = z.object({
+  schemaVersion: z.literal(LEARNING_REGISTRY_SCHEMA_VERSION),
+  counter: registryRecordKindSchema,
+  counterOwner: z.literal(LEARNING_REGISTRY_COUNTER_OWNER),
+  occurrencePeriodUtc: occurrencePeriodSchema,
+  status: registryPartitionProofStatusSchema,
+  highWaterSeq: z.number().int().nonnegative(),
+  members: z.array(registryPartitionMemberSchema),
+  chainDigest: z.string().regex(/^[0-9a-f]{64}$/),
+  issuedAt: registryTimestampSchema,
+  /** Non-empty only for status "partial" — why certification was refused. */
+  partialReason: z.string().min(1).max(256).optional(),
+}).strict().superRefine((value, ctx) => {
+  if (value.status === "partial" && !value.partialReason) {
+    ctx.addIssue({ code: "custom", path: ["partialReason"], message: "a partial proof must explain why it is not certifiable" });
+  }
+  if (value.status !== "partial" && value.partialReason) {
+    ctx.addIssue({ code: "custom", path: ["partialReason"], message: "only a partial proof carries a partialReason" });
+  }
+  if (value.status === "empty-confirmed" && (value.highWaterSeq !== 0 || value.members.length !== 0)) {
+    ctx.addIssue({ code: "custom", message: "an empty-confirmed proof cannot carry events" });
+  }
+  if (value.members.length !== value.highWaterSeq) {
+    ctx.addIssue({ code: "custom", message: "proof event count does not match its high-water sequence" });
+  }
+});
+export type RegistryPartitionProof = z.infer<typeof registryPartitionProofSchema>;
+
+/** Only a "complete" or an authenticated "empty-confirmed" proof may certify a
+ * full-period view. A "partial" proof — including one a caller derives by
+ * recomputing a digest over whatever subset it happened to load — is always
+ * ineligible, per the #232 owner-review binding criteria. */
+export function isEligibleForCertification(proof: RegistryPartitionProof): boolean {
+  return proof.status === "complete" || proof.status === "empty-confirmed";
+}

--- a/src/learning-registry-store.ts
+++ b/src/learning-registry-store.ts
@@ -1,0 +1,676 @@
+/**
+ * Durable append-only task/outcome learning registry — store (#232).
+ *
+ * Backing store: Munin envelopes, the same idiom as src/broker/task-store.ts
+ * and src/learning-task-store.ts. The registry's own natural-key evidence
+ * (`tasks/<taskId>/reg-<hash>`) sits directly beside the LearningTaskContract
+ * attempt rows it references (`tasks/<taskId>/learning-attempt-<uuid>...`),
+ * so a reader never has to cross a storage boundary to join them. There is no
+ * SQLite (or other embedded-database) dependency anywhere in this repository
+ * to plug into; Munin's create-if-absent / CAS primitives already give us
+ * exactly the idempotent-create and no-lost-update guarantees this registry
+ * needs, and reusing them keeps the registry's failure modes identical to
+ * every other durable Hugin store instead of adding a second persistence
+ * technology and a second backup/restore story.
+ *
+ * Idempotency and concurrency, concretely:
+ *  - Every event's Munin key is content-derived from its natural key
+ *    (`deriveEventId`), so a duplicate delivery targets the exact same row.
+ *    Munin's `create_if_absent` makes the first writer's create atomic; a
+ *    racing duplicate gets a typed `already_exists` conflict, reads back the
+ *    winner's bytes, and returns the same result — never a second event, and
+ *    never a lost one.
+ *  - Genuinely different payloads colliding on one natural key are refused
+ *    (`RegistryNaturalKeyConflictError`) rather than silently overwritten;
+ *    the caller must express the change as a correction, which mints a new,
+ *    distinctly-keyed event chained to the immutable predecessor.
+ *  - The per-partition high-water document is updated through the same
+ *    CAS-retry idiom already used by `BrokerTaskStore.writeQualityReceipt`
+ *    (bounded read-modify-write retries against `expected_updated_at`), so
+ *    concurrent writers to the same partition serialize instead of clobbering
+ *    each other's membership accounting.
+ */
+
+import { MuninWriteRejectedError, type MuninClient } from "./munin-client.js";
+import { queryAllMuninEntries } from "./munin-pagination.js";
+import {
+  buildMembership,
+  canonicalEqual,
+  deriveEventId,
+  EMPTY_CHAIN_DIGEST,
+  isEligibleForCertification,
+  jcsDigestHex,
+  LearningRegistryError,
+  LEARNING_REGISTRY_COUNTER_OWNER,
+  LEARNING_REGISTRY_SCHEMA_VERSION,
+  nextChainDigest,
+  registryEventKey,
+  registryEventNamespace,
+  registryEventSchema,
+  registryHighWaterDocSchema,
+  registryNaturalKeySchema,
+  registryPartitionProofSchema,
+  registryPartitionTag,
+  REGISTRY_EVENT_TAG,
+  submissionEventSchema,
+  attemptReferenceEventSchema,
+  terminalOutcomeEventSchema,
+  publicationEventSchema,
+  correctionEventSchema,
+  exclusionAdjustmentEventSchema,
+  type RegistryEvent,
+  type RegistryEvidenceRef,
+  type RegistryHighWaterDoc,
+  type RegistryNaturalKey,
+  type RegistryPartitionProof,
+  type RegistryRecordKind,
+  type SubmissionEvent,
+  type AttemptReferenceEvent,
+  type TerminalOutcomeEvent,
+  type PublicationEvent,
+  type CorrectionEvent,
+  type ExclusionAdjustmentEvent,
+} from "./learning-registry-schema.js";
+
+export * from "./learning-registry-schema.js";
+
+export class RegistryNaturalKeyConflictError extends Error {
+  constructor(
+    public readonly eventId: string,
+    public readonly namespace: string,
+    public readonly key: string,
+  ) {
+    super(
+      `learning registry natural key collision at ${namespace}/${key}: a different payload ` +
+      `already occupies event id ${eventId}. File a correction instead of retrying the write.`,
+    );
+    this.name = "RegistryNaturalKeyConflictError";
+  }
+}
+
+export interface AppendResult<E extends RegistryEvent = RegistryEvent> {
+  status: "created" | "exact-existing";
+  event: E;
+}
+
+const REGISTRY_PARTITION_NAMESPACE = "learning-registry/partitions";
+const REGISTRY_PARTITION_DOC_TAG = "learning-registry-partition";
+const HIGH_WATER_CAS_ATTEMPTS = 8;
+
+function partitionDocKey(counter: RegistryRecordKind, occurrencePeriodUtc: string): string {
+  return `${counter}-${occurrencePeriodUtc}`;
+}
+
+async function bumpHighWater(
+  munin: MuninClient,
+  event: RegistryEvent,
+  now: string,
+): Promise<RegistryHighWaterDoc> {
+  const { counter, occurrencePeriodUtc } = event.membership;
+  const namespace = REGISTRY_PARTITION_NAMESPACE;
+  const key = partitionDocKey(counter, occurrencePeriodUtc);
+  const eventDigest = jcsDigestHex(event);
+
+  for (let attempt = 0; attempt < HIGH_WATER_CAS_ATTEMPTS; attempt += 1) {
+    const current = await munin.read(namespace, key);
+    const doc = current
+      ? registryHighWaterDocSchema.parse(JSON.parse(current.content))
+      : null;
+    if (doc?.members.some((member) => member.eventId === event.eventId)) {
+      // Already accounted for by an earlier attempt (ours or a racing
+      // duplicate delivery). Bumping again would double-count membership.
+      return doc;
+    }
+    const nextDoc = registryHighWaterDocSchema.parse({
+      schemaVersion: LEARNING_REGISTRY_SCHEMA_VERSION,
+      counter,
+      counterOwner: LEARNING_REGISTRY_COUNTER_OWNER,
+      occurrencePeriodUtc,
+      highWaterSeq: (doc?.highWaterSeq ?? 0) + 1,
+      members: [...(doc?.members ?? []), { taskId: event.taskId, eventId: event.eventId }],
+      chainDigest: nextChainDigest(doc?.chainDigest ?? EMPTY_CHAIN_DIGEST, eventDigest),
+      updatedAt: now,
+    });
+    try {
+      await munin.write(
+        namespace,
+        key,
+        JSON.stringify(nextDoc),
+        [REGISTRY_PARTITION_DOC_TAG, registryPartitionTag(counter, occurrencePeriodUtc)],
+        current?.updated_at,
+        "internal",
+        current === null ? true : undefined,
+      );
+      return nextDoc;
+    } catch (err) {
+      if (err instanceof MuninWriteRejectedError) continue; // lost the CAS race — reread and retry
+      throw err;
+    }
+  }
+  throw new LearningRegistryError(
+    `high-water partition update for ${counter}/${occurrencePeriodUtc} lost ${HIGH_WATER_CAS_ATTEMPTS} repeated CAS races`,
+  );
+}
+
+function withoutRecordedAt(event: RegistryEvent): Record<string, unknown> {
+  const { recordedAt: _recordedAt, ...rest } = event as unknown as Record<string, unknown>;
+  return rest;
+}
+
+async function appendRegistryEvent<E extends RegistryEvent>(
+  munin: MuninClient,
+  event: E,
+  now: string,
+): Promise<AppendResult<E>> {
+  const validated = registryEventSchema.parse(event) as E;
+  const namespace = registryEventNamespace(validated.taskId);
+  const key = registryEventKey(validated.eventId);
+  const content = JSON.stringify(validated);
+  const tags = [
+    REGISTRY_EVENT_TAG,
+    `registry-kind:${validated.recordKind}`,
+    registryPartitionTag(validated.membership.counter, validated.membership.occurrencePeriodUtc),
+  ];
+
+  try {
+    const result = await munin.write(namespace, key, content, tags, undefined, "internal", true);
+    if (result.status !== "created") {
+      throw new LearningRegistryError(
+        `registry event write returned non-created status for ${namespace}/${key}`,
+      );
+    }
+  } catch (err) {
+    if (err instanceof MuninWriteRejectedError && err.conflictReason === "already_exists") {
+      const existing = await munin.read(namespace, key);
+      if (!existing) {
+        throw new LearningRegistryError(
+          `registry event ${namespace}/${key} reported already-existing but could not be read back`,
+        );
+      }
+      let existingEvent: E;
+      try {
+        existingEvent = registryEventSchema.parse(JSON.parse(existing.content)) as E;
+      } catch {
+        throw new LearningRegistryError(`registry event ${namespace}/${key} existing content is not a valid registry event`);
+      }
+      // `recordedAt` is store-observed ("when this was durably accepted"), not
+      // caller-asserted content — two calls racing to persist the exact same
+      // logical fact will legitimately differ there even though they describe
+      // the same natural key. Compare identity on everything else, and always
+      // return the actually-persisted (winning) event rather than the caller's
+      // locally built candidate, so a later read is never inconsistent with
+      // what this call reported.
+      if (!canonicalEqual(withoutRecordedAt(existingEvent), withoutRecordedAt(validated))) {
+        throw new RegistryNaturalKeyConflictError(validated.eventId, namespace, key);
+      }
+      // Identical replay: ensure the partition accounting saw it, then stop.
+      await bumpHighWater(munin, existingEvent, now);
+      return { status: "exact-existing", event: existingEvent };
+    }
+    throw err;
+  }
+
+  await bumpHighWater(munin, validated, now);
+  return { status: "created", event: validated };
+}
+
+export interface LearningRegistryStoreOptions {
+  now?: () => string;
+}
+
+export class LearningRegistryStore {
+  private readonly now: () => string;
+
+  constructor(
+    private readonly munin: MuninClient,
+    options: LearningRegistryStoreOptions = {},
+  ) {
+    this.now = options.now ?? (() => new Date().toISOString());
+  }
+
+  // -- capture-time membership events -------------------------------------
+
+  async recordSubmission(input: {
+    taskId: string;
+    taskOutcomeRef: RegistryEvidenceRef;
+    occurredAt: string;
+  }): Promise<AppendResult<SubmissionEvent>> {
+    const naturalKey: RegistryNaturalKey = { recordKind: "submission", taskId: input.taskId };
+    const recordedAt = this.now();
+    const event = submissionEventSchema.parse({
+      schemaVersion: LEARNING_REGISTRY_SCHEMA_VERSION,
+      eventId: deriveEventId(naturalKey),
+      taskId: input.taskId,
+      recordKind: "submission",
+      membership: buildMembership({ naturalKey, issuedAt: input.occurredAt }),
+      occurredAt: input.occurredAt,
+      recordedAt,
+      payload: { taskOutcomeRef: input.taskOutcomeRef, originComponent: "hugin" },
+    });
+    return appendRegistryEvent(this.munin, event, recordedAt);
+  }
+
+  /** References the existing durable LearningTask attempt row — never copies it. */
+  async recordAttemptReference(input: {
+    taskId: string;
+    attemptId: string;
+    attemptStartRef: RegistryEvidenceRef;
+    taskOutcomeRef: RegistryEvidenceRef;
+    occurredAt: string;
+  }): Promise<AppendResult<AttemptReferenceEvent>> {
+    const naturalKey: RegistryNaturalKey = {
+      recordKind: "attempt-reference",
+      taskId: input.taskId,
+      attemptId: input.attemptId,
+    };
+    const recordedAt = this.now();
+    const event = attemptReferenceEventSchema.parse({
+      schemaVersion: LEARNING_REGISTRY_SCHEMA_VERSION,
+      eventId: deriveEventId(naturalKey),
+      taskId: input.taskId,
+      recordKind: "attempt-reference",
+      attemptId: input.attemptId,
+      membership: buildMembership({ naturalKey, issuedAt: input.occurredAt }),
+      occurredAt: input.occurredAt,
+      recordedAt,
+      payload: { attemptStartRef: input.attemptStartRef, taskOutcomeRef: input.taskOutcomeRef },
+    });
+    return appendRegistryEvent(this.munin, event, recordedAt);
+  }
+
+  async recordTerminalOutcome(input: {
+    taskId: string;
+    attemptId: string;
+    outcome: TerminalOutcomeEvent["payload"]["outcome"];
+    repositoryOutcomeState?: TerminalOutcomeEvent["payload"]["repositoryOutcomeState"];
+    taskOutcomeRef: RegistryEvidenceRef;
+    attemptOutcomeRef?: RegistryEvidenceRef;
+    occurredAt: string;
+  }): Promise<AppendResult<TerminalOutcomeEvent>> {
+    const naturalKey: RegistryNaturalKey = {
+      recordKind: "terminal-outcome",
+      taskId: input.taskId,
+      attemptId: input.attemptId,
+    };
+    const recordedAt = this.now();
+    const event = terminalOutcomeEventSchema.parse({
+      schemaVersion: LEARNING_REGISTRY_SCHEMA_VERSION,
+      eventId: deriveEventId(naturalKey),
+      taskId: input.taskId,
+      recordKind: "terminal-outcome",
+      attemptId: input.attemptId,
+      membership: buildMembership({ naturalKey, issuedAt: input.occurredAt }),
+      occurredAt: input.occurredAt,
+      recordedAt,
+      payload: {
+        outcome: input.outcome,
+        taskOutcomeRef: input.taskOutcomeRef,
+        // JCS canonicalization rejects an explicit `undefined` value, so an
+        // absent optional field must be omitted entirely, never set to
+        // `undefined` — otherwise two logically-identical events (one built
+        // with the field, one without) would digest differently.
+        ...(input.repositoryOutcomeState !== undefined
+          ? { repositoryOutcomeState: input.repositoryOutcomeState } : {}),
+        ...(input.attemptOutcomeRef !== undefined
+          ? { attemptOutcomeRef: input.attemptOutcomeRef } : {}),
+      },
+    });
+    return appendRegistryEvent(this.munin, event, recordedAt);
+  }
+
+  async recordPublication(input: {
+    taskId: string;
+    attemptId: string;
+    publicationRef: string;
+    label: PublicationEvent["payload"]["label"];
+    evidenceRef: RegistryEvidenceRef;
+    occurredAt: string;
+  }): Promise<AppendResult<PublicationEvent>> {
+    const naturalKey: RegistryNaturalKey = {
+      recordKind: "publication",
+      taskId: input.taskId,
+      attemptId: input.attemptId,
+      publicationRef: input.publicationRef,
+    };
+    const recordedAt = this.now();
+    const event = publicationEventSchema.parse({
+      schemaVersion: LEARNING_REGISTRY_SCHEMA_VERSION,
+      eventId: deriveEventId(naturalKey),
+      taskId: input.taskId,
+      recordKind: "publication",
+      attemptId: input.attemptId,
+      membership: buildMembership({ naturalKey, issuedAt: input.occurredAt }),
+      occurredAt: input.occurredAt,
+      recordedAt,
+      payload: {
+        publicationRef: input.publicationRef,
+        label: input.label,
+        evidenceRef: input.evidenceRef,
+      },
+    });
+    return appendRegistryEvent(this.munin, event, recordedAt);
+  }
+
+  // -- corrections and erasure-safe exclusion adjustments ------------------
+
+  /**
+   * Chain a new, distinctly-keyed correction onto an existing event.
+   *
+   * The predecessor is read but never mutated. At most one correction can
+   * exist per predecessor (its natural key is `{correction, predecessorId}`,
+   * so a second *different* correction targeting the same predecessor is a
+   * natural-key collision, not a silent fork) — to correct a correction,
+   * target the correction's own event id instead.
+   */
+  async writeCorrection(input: {
+    taskId: string;
+    predecessorEventId: string;
+    reason: string;
+    evidenceRef?: RegistryEvidenceRef;
+    occurredAt: string;
+  }): Promise<AppendResult<CorrectionEvent>> {
+    const predecessor = await this.getEvent(input.taskId, input.predecessorEventId);
+    if (!predecessor) {
+      throw new LearningRegistryError(
+        `cannot correct unknown predecessor event ${input.predecessorEventId} in task ${input.taskId}`,
+      );
+    }
+    if (Date.parse(input.occurredAt) <= Date.parse(predecessor.occurredAt)) {
+      throw new LearningRegistryError(
+        "a correction must strictly time-advance past its predecessor's occurredAt",
+      );
+    }
+    const naturalKey: RegistryNaturalKey = {
+      recordKind: "correction",
+      taskId: input.taskId,
+      predecessorEventId: input.predecessorEventId,
+    };
+    const recordedAt = this.now();
+    const event = correctionEventSchema.parse({
+      schemaVersion: LEARNING_REGISTRY_SCHEMA_VERSION,
+      eventId: deriveEventId(naturalKey),
+      taskId: input.taskId,
+      recordKind: "correction",
+      membership: buildMembership({ naturalKey, issuedAt: input.occurredAt }),
+      occurredAt: input.occurredAt,
+      recordedAt,
+      payload: {
+        predecessorEventId: input.predecessorEventId,
+        correctedNaturalKey: predecessor.membership.naturalKey,
+        reason: input.reason,
+        ...(input.evidenceRef !== undefined ? { evidenceRef: input.evidenceRef } : {}),
+      },
+    });
+    return appendRegistryEvent(this.munin, event, recordedAt);
+  }
+
+  /**
+   * Record that a target event's referenced content has been erased or
+   * excluded, without deleting, mutating, or moving the target's own natural
+   * key / occurrence period / counter / owner. The target's original
+   * denominator membership is therefore preserved exactly — this registry
+   * never stored prompt/response bytes to begin with, so there is nothing to
+   * "resurrect"; the adjustment exists purely so a reader can honor the
+   * upstream erasure when it later dereferences the target's evidence refs.
+   */
+  async writeExclusionAdjustment(input: {
+    taskId: string;
+    targetEventId: string;
+    adjustmentReason: ExclusionAdjustmentEvent["payload"]["adjustmentReason"];
+    note?: string;
+    occurredAt: string;
+  }): Promise<AppendResult<ExclusionAdjustmentEvent>> {
+    const target = await this.getEvent(input.taskId, input.targetEventId);
+    if (!target) {
+      throw new LearningRegistryError(
+        `cannot adjust unknown target event ${input.targetEventId} in task ${input.taskId}`,
+      );
+    }
+    const naturalKey: RegistryNaturalKey = {
+      recordKind: "exclusion-adjustment",
+      taskId: input.taskId,
+      targetEventId: input.targetEventId,
+    };
+    const recordedAt = this.now();
+    const event = exclusionAdjustmentEventSchema.parse({
+      schemaVersion: LEARNING_REGISTRY_SCHEMA_VERSION,
+      eventId: deriveEventId(naturalKey),
+      taskId: input.taskId,
+      recordKind: "exclusion-adjustment",
+      membership: buildMembership({ naturalKey, issuedAt: input.occurredAt }),
+      occurredAt: input.occurredAt,
+      recordedAt,
+      payload: {
+        targetEventId: input.targetEventId,
+        targetNaturalKey: target.membership.naturalKey,
+        adjustmentReason: input.adjustmentReason,
+        ...(input.note !== undefined ? { note: input.note } : {}),
+      },
+    });
+    return appendRegistryEvent(this.munin, event, recordedAt);
+  }
+
+  // -- reads -----------------------------------------------------------------
+
+  async getEvent(taskId: string, eventId: string): Promise<RegistryEvent | null> {
+    const namespace = registryEventNamespace(taskId);
+    const key = registryEventKey(eventId);
+    const entry = await this.munin.read(namespace, key);
+    if (!entry) return null;
+    return registryEventSchema.parse(JSON.parse(entry.content));
+  }
+
+  /**
+   * Walk the correction chain starting at `rootEventId` and return the id of
+   * its unique unsuperseded leaf. Each hop is a direct key lookup (the
+   * correction natural key is derived from its predecessor id), so this never
+   * needs an index query and cannot silently stop at a stale branch: every
+   * hop either finds the real (immutable, content-derived) next link or
+   * proves none exists yet.
+   *
+   * This reflects the chain as of each hop's read, not a single atomic
+   * snapshot — Munin has no multi-key transaction. A correction concurrently
+   * committed after this walk already passed its hop is invisible to this
+   * call, exactly like reading a ref that moves after you resolved it; a
+   * later call observes it. This never produces a *wrong* leaf, only a
+   * possibly-momentarily-stale one, and corrections themselves cannot fork
+   * (at most one exists per predecessor), so there is no ambiguity to race on.
+   */
+  async findEffectiveLeaf(taskId: string, rootEventId: string, maxHops = 64): Promise<string> {
+    let current = rootEventId;
+    for (let hop = 0; hop < maxHops; hop += 1) {
+      const correctionKey = registryNaturalKeySchema.parse({
+        recordKind: "correction",
+        taskId,
+        predecessorEventId: current,
+      });
+      const correctionEventId = deriveEventId(correctionKey);
+      const existing = await this.munin.read(registryEventNamespace(taskId), registryEventKey(correctionEventId));
+      if (!existing) return current;
+      current = correctionEventId;
+    }
+    throw new LearningRegistryError(
+      `correction chain for ${taskId}/${rootEventId} exceeded ${maxHops} hops — possible cycle`,
+    );
+  }
+
+  async listEventsForTask(taskId: string): Promise<{ events: RegistryEvent[]; truncated: boolean }> {
+    const paged = await queryAllMuninEntries(
+      this.munin,
+      { namespace: registryEventNamespace(taskId), tags: [REGISTRY_EVENT_TAG], entry_type: "state" },
+      { maxPages: 20, maxResults: 1_000 },
+    );
+    const reads = await Promise.all(
+      paged.results
+        .filter((result) => typeof result.key === "string" && result.key.startsWith("reg-"))
+        .map((result) => this.munin.read(registryEventNamespace(taskId), result.key as string)),
+    );
+    const events = reads
+      .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+      .map((entry) => registryEventSchema.parse(JSON.parse(entry.content)))
+      .sort((a, b) => a.occurredAt.localeCompare(b.occurredAt) || a.eventId.localeCompare(b.eventId));
+    return { events, truncated: paged.truncated };
+  }
+
+  // -- partition / high-water proof primitives --------------------------------
+
+  private async readHighWaterDoc(
+    counter: RegistryRecordKind,
+    occurrencePeriodUtc: string,
+  ): Promise<RegistryHighWaterDoc | null> {
+    const entry = await this.munin.read(REGISTRY_PARTITION_NAMESPACE, partitionDocKey(counter, occurrencePeriodUtc));
+    return entry ? registryHighWaterDocSchema.parse(JSON.parse(entry.content)) : null;
+  }
+
+  /**
+   * Recompute the chain digest directly from the persisted events a doc
+   * claims as members, rather than trusting the doc's own digest field. This
+   * is what makes a forged or hand-edited high-water document detectable.
+   */
+  private async recomputeChain(
+    doc: RegistryHighWaterDoc,
+  ): Promise<{ ok: true; chainDigest: string } | { ok: false; reason: string }> {
+    let chain = EMPTY_CHAIN_DIGEST;
+    for (const member of doc.members) {
+      const event = await this.getEvent(member.taskId, member.eventId);
+      if (!event) {
+        return { ok: false, reason: `partition member ${member.taskId}/${member.eventId} is missing from the event store` };
+      }
+      if (event.membership.counter !== doc.counter || event.membership.occurrencePeriodUtc !== doc.occurrencePeriodUtc) {
+        return { ok: false, reason: `partition member ${member.taskId}/${member.eventId} does not belong to ${doc.counter}/${doc.occurrencePeriodUtc}` };
+      }
+      chain = nextChainDigest(chain, jcsDigestHex(event));
+    }
+    return { ok: true, chainDigest: chain };
+  }
+
+  /**
+   * Issue an authoritative statement that partition (counter, period) is
+   * complete up to the registry's own recorded high-water mark — or, when no
+   * events ever occurred, an authenticated confirmation of a legitimate
+   * zero-event partition. Any inconsistency (missing member, cross-partition
+   * member, digest mismatch, truncated cross-check) is reported as `partial`
+   * and is never eligible for certification.
+   */
+  async issuePartitionProof(
+    counter: RegistryRecordKind,
+    occurrencePeriodUtc: string,
+    issuedAt: string = this.now(),
+  ): Promise<RegistryPartitionProof> {
+    const doc = await this.readHighWaterDoc(counter, occurrencePeriodUtc);
+    if (!doc) {
+      const probe = await queryAllMuninEntries(
+        this.munin,
+        { tags: [registryPartitionTag(counter, occurrencePeriodUtc)] },
+        { maxPages: 2, maxResults: 1 },
+      );
+      if (probe.results.length > 0 || probe.truncated) {
+        return registryPartitionProofSchema.parse({
+          schemaVersion: LEARNING_REGISTRY_SCHEMA_VERSION,
+          counter,
+          counterOwner: LEARNING_REGISTRY_COUNTER_OWNER,
+          occurrencePeriodUtc,
+          status: "partial",
+          highWaterSeq: 0,
+          members: [],
+          chainDigest: EMPTY_CHAIN_DIGEST,
+          issuedAt,
+          partialReason: "partition high-water record is missing but tagged events were found",
+        });
+      }
+      return registryPartitionProofSchema.parse({
+        schemaVersion: LEARNING_REGISTRY_SCHEMA_VERSION,
+        counter,
+        counterOwner: LEARNING_REGISTRY_COUNTER_OWNER,
+        occurrencePeriodUtc,
+        status: "empty-confirmed",
+        highWaterSeq: 0,
+        members: [],
+        chainDigest: EMPTY_CHAIN_DIGEST,
+        issuedAt,
+      });
+    }
+    const recompute = await this.recomputeChain(doc);
+    if (!recompute.ok || recompute.chainDigest !== doc.chainDigest) {
+      return registryPartitionProofSchema.parse({
+        schemaVersion: LEARNING_REGISTRY_SCHEMA_VERSION,
+        counter,
+        counterOwner: LEARNING_REGISTRY_COUNTER_OWNER,
+        occurrencePeriodUtc,
+        status: "partial",
+        highWaterSeq: doc.highWaterSeq,
+        members: doc.members,
+        chainDigest: doc.chainDigest,
+        issuedAt,
+        partialReason: recompute.ok
+          ? "recomputed event chain digest does not match the stored high-water record"
+          : recompute.reason,
+      });
+    }
+    return registryPartitionProofSchema.parse({
+      schemaVersion: LEARNING_REGISTRY_SCHEMA_VERSION,
+      counter,
+      counterOwner: LEARNING_REGISTRY_COUNTER_OWNER,
+      occurrencePeriodUtc,
+      status: "complete",
+      highWaterSeq: doc.highWaterSeq,
+      members: doc.members,
+      chainDigest: doc.chainDigest,
+      issuedAt,
+    });
+  }
+
+  /**
+   * Re-derive validity from the store's own current state — never from the
+   * proof body alone. A hand-crafted ("forged") proof whose digest does not
+   * match any real recomputed chain fails. A proof that is no longer current
+   * (the partition has since advanced past it) fails when `requireCurrent`
+   * is set, which is the default: a full-period view must use the
+   * authoritative *current* high-water mark, not a stale earlier one.
+   */
+  async verifyPartitionProof(
+    proof: RegistryPartitionProof,
+    options: { requireCurrent?: boolean } = {},
+  ): Promise<{ valid: boolean; reason?: string }> {
+    const requireCurrent = options.requireCurrent ?? true;
+    const parsed = registryPartitionProofSchema.parse(proof);
+    if (!isEligibleForCertification(parsed)) {
+      return { valid: false, reason: "a partial proof is never certifiable" };
+    }
+    const doc = await this.readHighWaterDoc(parsed.counter, parsed.occurrencePeriodUtc);
+    if (parsed.status === "empty-confirmed") {
+      if (doc) return { valid: false, reason: "partition has recorded events; empty-confirmed proof is forged or stale" };
+      const probe = await queryAllMuninEntries(
+        this.munin,
+        { tags: [registryPartitionTag(parsed.counter, parsed.occurrencePeriodUtc)] },
+        { maxPages: 2, maxResults: 1 },
+      );
+      if (probe.results.length > 0 || probe.truncated) {
+        return { valid: false, reason: "tagged events exist despite no high-water record; cannot confirm empty" };
+      }
+      return { valid: true };
+    }
+    // status === "complete"
+    if (!doc) return { valid: false, reason: "no high-water record exists for this partition; proof is forged" };
+    if (requireCurrent && (doc.highWaterSeq !== parsed.highWaterSeq || doc.chainDigest !== parsed.chainDigest)) {
+      return { valid: false, reason: "proof does not match the partition's current high-water mark; it is stale" };
+    }
+    // Recompute independently from the *proof's own* claimed members — a
+    // forged proof cannot borrow another partition's real chain digest.
+    const asDoc = registryHighWaterDocSchema.parse({
+      schemaVersion: parsed.schemaVersion,
+      counter: parsed.counter,
+      counterOwner: parsed.counterOwner,
+      occurrencePeriodUtc: parsed.occurrencePeriodUtc,
+      highWaterSeq: parsed.highWaterSeq,
+      members: parsed.members,
+      chainDigest: parsed.chainDigest,
+      updatedAt: parsed.issuedAt,
+    });
+    const recompute = await this.recomputeChain(asDoc);
+    if (!recompute.ok || recompute.chainDigest !== parsed.chainDigest) {
+      return { valid: false, reason: recompute.ok ? "proof chain digest does not recompute from its own claimed members" : recompute.reason };
+    }
+    return { valid: true };
+  }
+}

--- a/src/learning-registry-store.ts
+++ b/src/learning-registry-store.ts
@@ -32,7 +32,7 @@
  */
 
 import { MuninWriteRejectedError, type MuninClient } from "./munin-client.js";
-import { queryAllMuninEntries } from "./munin-pagination.js";
+import { queryAllMuninEntries, type MuninPaginationBudget } from "./munin-pagination.js";
 import {
   buildMembership,
   canonicalEqual,
@@ -96,6 +96,15 @@ export interface AppendResult<E extends RegistryEvent = RegistryEvent> {
 const REGISTRY_PARTITION_NAMESPACE = "learning-registry/partitions";
 const REGISTRY_PARTITION_DOC_TAG = "learning-registry-partition";
 const HIGH_WATER_CAS_ATTEMPTS = 8;
+/** Cheap existence probe used only to tell "genuinely zero events" apart from
+ * a missing/corrupt high-water doc — doesn't need to enumerate anything. */
+const PARTITION_EXISTENCE_PROBE_BUDGET: MuninPaginationBudget = { maxPages: 2, maxResults: 1 };
+/** Full enumeration budget for the completeness cross-check below. Proof
+ * issuance is period-close-frequency work (#241 is expected to call this
+ * roughly once per UTC month per counter), not the hot append path, so a
+ * generous page budget is an acceptable cost for actually proving
+ * completeness rather than only self-consistency. */
+const PARTITION_COMPLETENESS_QUERY_BUDGET: MuninPaginationBudget = { maxPages: 200, maxResults: 5_000 };
 
 function partitionDocKey(counter: RegistryRecordKind, occurrencePeriodUtc: string): string {
   return `${counter}-${occurrencePeriodUtc}`;
@@ -216,16 +225,23 @@ async function appendRegistryEvent<E extends RegistryEvent>(
 
 export interface LearningRegistryStoreOptions {
   now?: () => string;
+  /** Override the completeness cross-check's query budget — mainly for
+   * tests that want to force an honest truncation without enumerating
+   * thousands of rows. Defaults to `PARTITION_COMPLETENESS_QUERY_BUDGET`. */
+  partitionCompletenessQueryBudget?: MuninPaginationBudget;
 }
 
 export class LearningRegistryStore {
   private readonly now: () => string;
+  private readonly partitionCompletenessQueryBudget: MuninPaginationBudget;
 
   constructor(
     private readonly munin: MuninClient,
     options: LearningRegistryStoreOptions = {},
   ) {
     this.now = options.now ?? (() => new Date().toISOString());
+    this.partitionCompletenessQueryBudget =
+      options.partitionCompletenessQueryBudget ?? PARTITION_COMPLETENESS_QUERY_BUDGET;
   }
 
   // -- capture-time membership events -------------------------------------
@@ -545,6 +561,52 @@ export class LearningRegistryStore {
   }
 
   /**
+   * `recomputeChain` only proves that every event a high-water document
+   * *claims* as a member actually exists and belongs to this partition — it
+   * cannot see an event that was durably written but never folded in. That
+   * gap is real: `appendRegistryEvent` persists the event first and folds it
+   * into the high-water document second (`bumpHighWater`); a crash between
+   * those two writes leaves a durably-written, correctly-tagged event that
+   * `bumpHighWater`'s idempotent skip-if-already-present check will only
+   * ever fix on a *later redelivery of that same natural key* — which may
+   * never come. Without this reverse check, `issuePartitionProof` could
+   * certify a partition `"complete"` while silently omitting a persisted
+   * event: exactly the "aggregate looks internally consistent but omits an
+   * attempt" failure this registry exists to prevent.
+   *
+   * This queries every event tagged with this partition, cross-repository of
+   * task namespace, and reports any whose id is not already in
+   * `knownMemberIds`. An honest truncation (the tag query's own budget
+   * exhausted before enumerating everything) is reported as its own failure
+   * rather than silently treated as "no orphans found".
+   */
+  private async findPartitionOrphans(
+    counter: RegistryRecordKind,
+    occurrencePeriodUtc: string,
+    knownMemberIds: ReadonlySet<string>,
+  ): Promise<{ ok: true; orphanEventIds: string[] } | { ok: false; reason: string }> {
+    const probe = await queryAllMuninEntries(
+      this.munin,
+      { tags: [registryPartitionTag(counter, occurrencePeriodUtc)] },
+      this.partitionCompletenessQueryBudget,
+    );
+    if (probe.truncated) {
+      return {
+        ok: false,
+        reason: "partition completeness tag query truncated before enumerating every tagged event",
+      };
+    }
+    const orphanEventIds = probe.results
+      // The high-water document itself carries this same partition tag but
+      // lives in a different namespace/key shape (`counter-period`, not
+      // `reg-<hash>`) — exclude it so it never mistakes itself for an orphan.
+      .filter((result) => typeof result.key === "string" && result.key.startsWith("reg-"))
+      .map((result) => result.key as string)
+      .filter((eventId) => !knownMemberIds.has(eventId));
+    return { ok: true, orphanEventIds };
+  }
+
+  /**
    * Issue an authoritative statement that partition (counter, period) is
    * complete up to the registry's own recorded high-water mark — or, when no
    * events ever occurred, an authenticated confirmation of a legitimate
@@ -562,7 +624,7 @@ export class LearningRegistryStore {
       const probe = await queryAllMuninEntries(
         this.munin,
         { tags: [registryPartitionTag(counter, occurrencePeriodUtc)] },
-        { maxPages: 2, maxResults: 1 },
+        PARTITION_EXISTENCE_PROBE_BUDGET,
       );
       if (probe.results.length > 0 || probe.truncated) {
         return registryPartitionProofSchema.parse({
@@ -607,6 +669,45 @@ export class LearningRegistryStore {
           : recompute.reason,
       });
     }
+    // The document is internally consistent — but internal consistency alone
+    // cannot rule out an event that was durably written and correctly tagged
+    // yet never folded into `doc.members` (see `findPartitionOrphans`). Cross
+    // -check the other direction before certifying "complete".
+    const knownMemberIds = new Set(doc.members.map((member) => member.eventId));
+    const orphanCheck = await this.findPartitionOrphans(counter, occurrencePeriodUtc, knownMemberIds);
+    if (!orphanCheck.ok) {
+      return registryPartitionProofSchema.parse({
+        schemaVersion: LEARNING_REGISTRY_SCHEMA_VERSION,
+        counter,
+        counterOwner: LEARNING_REGISTRY_COUNTER_OWNER,
+        occurrencePeriodUtc,
+        status: "partial",
+        highWaterSeq: doc.highWaterSeq,
+        members: doc.members,
+        chainDigest: doc.chainDigest,
+        issuedAt,
+        partialReason: orphanCheck.reason,
+      });
+    }
+    if (orphanCheck.orphanEventIds.length > 0) {
+      // Keep well under the proof's 256-char partialReason cap even when
+      // every event id is a full "reg-<32 hex>" string.
+      const preview = orphanCheck.orphanEventIds.slice(0, 3).join(", ");
+      const suffix = orphanCheck.orphanEventIds.length > 3 ? ", ..." : "";
+      return registryPartitionProofSchema.parse({
+        schemaVersion: LEARNING_REGISTRY_SCHEMA_VERSION,
+        counter,
+        counterOwner: LEARNING_REGISTRY_COUNTER_OWNER,
+        occurrencePeriodUtc,
+        status: "partial",
+        highWaterSeq: doc.highWaterSeq,
+        members: doc.members,
+        chainDigest: doc.chainDigest,
+        issuedAt,
+        partialReason:
+          `${orphanCheck.orphanEventIds.length} tagged event(s) not present in the high-water record: ${preview}${suffix}`,
+      });
+    }
     return registryPartitionProofSchema.parse({
       schemaVersion: LEARNING_REGISTRY_SCHEMA_VERSION,
       counter,
@@ -643,7 +744,7 @@ export class LearningRegistryStore {
       const probe = await queryAllMuninEntries(
         this.munin,
         { tags: [registryPartitionTag(parsed.counter, parsed.occurrencePeriodUtc)] },
-        { maxPages: 2, maxResults: 1 },
+        PARTITION_EXISTENCE_PROBE_BUDGET,
       );
       if (probe.results.length > 0 || probe.truncated) {
         return { valid: false, reason: "tagged events exist despite no high-water record; cannot confirm empty" };

--- a/src/learning-registry-view.ts
+++ b/src/learning-registry-view.ts
@@ -1,0 +1,111 @@
+/**
+ * Read view: join one task's append-only registry events into a single
+ * lifecycle timeline (#232, point 6). This is the query #233's candidate
+ * packager and #237's ingest are expected to build on — it resolves
+ * correction chains to their effective leaf and surfaces exclusion state, but
+ * still exposes the complete raw event list for callers that need full audit
+ * history rather than only the current view.
+ */
+
+import type { LearningRegistryStore } from "./learning-registry-store.js";
+import type {
+  CorrectionEvent,
+  ExclusionAdjustmentEvent,
+  RegistryEvent,
+} from "./learning-registry-schema.js";
+
+export interface RegistryTimelineEntry {
+  event: RegistryEvent;
+  /** True when a correction event supersedes this exact event id. */
+  superseded: boolean;
+  /** This event's own id if unsuperseded, else the chain's unique effective leaf. */
+  effectiveEventId: string;
+  /** True when at least one exclusion-adjustment targets this event directly. */
+  excluded: boolean;
+  excludedReasons: ExclusionAdjustmentEvent["payload"]["adjustmentReason"][];
+}
+
+export interface TaskLifecycleTimeline {
+  taskId: string;
+  /** Primary lifecycle facts (submission/attempt-reference/terminal-outcome/publication),
+   * ordered by occurredAt, each resolved to its effective (unsuperseded) state. */
+  entries: RegistryTimelineEntry[];
+  /** Full correction audit trail, unfiltered. */
+  corrections: CorrectionEvent[];
+  /** Full exclusion/erasure audit trail, unfiltered. */
+  exclusionAdjustments: ExclusionAdjustmentEvent[];
+  /** True when the underlying event listing could not prove completeness
+   * (Munin pagination budget exhausted) — treat the timeline as provisional. */
+  truncated: boolean;
+}
+
+/**
+ * Resolve `eventId` forward through the correction chain to its unique
+ * unsuperseded leaf. Cycles cannot occur through the store's own append path
+ * (a correction's natural key is derived from its predecessor id, so at most
+ * one direct child exists per predecessor), but this stays defensive against
+ * a hand-assembled event list from an untrusted source.
+ */
+function resolveEffectiveLeaf(
+  eventId: string,
+  correctionByPredecessor: Map<string, CorrectionEvent>,
+): string {
+  let current = eventId;
+  const visited = new Set<string>([current]);
+  for (;;) {
+    const correction = correctionByPredecessor.get(current);
+    if (!correction) return current;
+    if (visited.has(correction.eventId)) return current; // defensive cycle guard
+    current = correction.eventId;
+    visited.add(current);
+  }
+}
+
+const PRIMARY_LIFECYCLE_KINDS = new Set<RegistryEvent["recordKind"]>([
+  "submission",
+  "attempt-reference",
+  "terminal-outcome",
+  "publication",
+]);
+
+export async function buildTaskLifecycleTimeline(
+  store: Pick<LearningRegistryStore, "listEventsForTask">,
+  taskId: string,
+): Promise<TaskLifecycleTimeline> {
+  const { events, truncated } = await store.listEventsForTask(taskId);
+
+  const corrections: CorrectionEvent[] = [];
+  const exclusionAdjustments: ExclusionAdjustmentEvent[] = [];
+  const correctionByPredecessor = new Map<string, CorrectionEvent>();
+  const exclusionsByTarget = new Map<string, ExclusionAdjustmentEvent[]>();
+
+  for (const event of events) {
+    if (event.recordKind === "correction") {
+      corrections.push(event);
+      correctionByPredecessor.set(event.payload.predecessorEventId, event);
+    } else if (event.recordKind === "exclusion-adjustment") {
+      exclusionAdjustments.push(event);
+      const list = exclusionsByTarget.get(event.payload.targetEventId) ?? [];
+      list.push(event);
+      exclusionsByTarget.set(event.payload.targetEventId, list);
+    }
+  }
+
+  const entries: RegistryTimelineEntry[] = events
+    .filter((event) => PRIMARY_LIFECYCLE_KINDS.has(event.recordKind))
+    .map((event) => {
+      const exclusions = exclusionsByTarget.get(event.eventId) ?? [];
+      return {
+        event,
+        superseded: correctionByPredecessor.has(event.eventId),
+        effectiveEventId: resolveEffectiveLeaf(event.eventId, correctionByPredecessor),
+        excluded: exclusions.length > 0,
+        excludedReasons: exclusions.map((adjustment) => adjustment.payload.adjustmentReason),
+      };
+    })
+    .sort((a, b) =>
+      a.event.occurredAt.localeCompare(b.event.occurredAt)
+      || a.event.eventId.localeCompare(b.event.eventId));
+
+  return { taskId, entries, corrections, exclusionAdjustments, truncated };
+}

--- a/tests/learning-registry-store.test.ts
+++ b/tests/learning-registry-store.test.ts
@@ -1,0 +1,547 @@
+import { describe, expect, it } from "vitest";
+import { MuninWriteRejectedError, type MuninClient, type MuninQueryResult } from "../src/munin-client.js";
+import {
+  LearningRegistryStore,
+  RegistryNaturalKeyConflictError,
+  isEligibleForCertification,
+} from "../src/learning-registry-store.js";
+
+interface StoredEntry {
+  namespace: string;
+  key: string;
+  content: string;
+  tags: string[];
+  classification?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * In-memory Munin double with the same create-if-absent / CAS contract as the
+ * real service: `create_if_absent` atomically fails when a row exists, and an
+ * `expected_updated_at` mismatch atomically fails. `beforeWrite` lets a test
+ * interleave two logically concurrent callers around that atomic boundary.
+ */
+class InMemoryMunin {
+  private entries: StoredEntry[] = [];
+  private seq = 0;
+  public writeCount = 0;
+  public beforeWrite?: (namespace: string, key: string) => Promise<void> | void;
+
+  private clock(): string {
+    this.seq += 1;
+    return new Date(Date.UTC(2026, 6, 1, 0, 0, 0, 0) + this.seq).toISOString();
+  }
+
+  private find(namespace: string, key: string): StoredEntry | undefined {
+    return this.entries.find((e) => e.namespace === namespace && e.key === key);
+  }
+
+  /** Test-only: simulate a lost/corrupted high-water document. */
+  remove(namespace: string, key: string): void {
+    this.entries = this.entries.filter((e) => !(e.namespace === namespace && e.key === key));
+  }
+
+  async read(namespace: string, key: string) {
+    const entry = this.find(namespace, key);
+    if (!entry) return null;
+    return { ...entry, found: true } as unknown as (MuninQueryResult & { found: true });
+  }
+
+  async write(
+    namespace: string,
+    key: string,
+    content: string,
+    tags?: string[],
+    expectedUpdatedAt?: string,
+    classification?: string,
+    createIfAbsent?: boolean,
+  ) {
+    if (this.beforeWrite) await this.beforeWrite(namespace, key);
+    this.writeCount += 1;
+    const existing = this.find(namespace, key);
+    if (createIfAbsent && existing) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        message: "Entry already exists.",
+        conflict_reason: "already_exists",
+        current_updated_at: existing.updated_at,
+      });
+    }
+    if (expectedUpdatedAt !== undefined && (!existing || existing.updated_at !== expectedUpdatedAt)) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        message: "Entry version changed.",
+        conflict_reason: "version_mismatch",
+        current_updated_at: existing?.updated_at,
+      });
+    }
+    const updated_at = this.clock();
+    const created_at = existing?.created_at ?? updated_at;
+    const next: StoredEntry = { namespace, key, content, tags: tags ?? [], classification, created_at, updated_at };
+    if (existing) {
+      Object.assign(existing, next);
+    } else {
+      this.entries.push(next);
+    }
+    return { ok: true, status: existing ? "updated" : "created", updated_at };
+  }
+
+  async query(opts: { namespace?: string; tags?: string[]; limit?: number; since?: string; until?: string }) {
+    let rows = this.entries.filter((e) =>
+      (!opts.namespace || e.namespace.startsWith(opts.namespace))
+      && (opts.tags ?? []).every((tag) => e.tags.includes(tag)));
+    if (opts.since) rows = rows.filter((e) => e.updated_at >= opts.since!);
+    if (opts.until) rows = rows.filter((e) => e.updated_at <= opts.until!);
+    rows = [...rows].sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+    const limited = rows.slice(0, opts.limit ?? 50);
+    return {
+      results: limited.map((e) => ({
+        id: `${e.namespace}/${e.key}`,
+        namespace: e.namespace,
+        key: e.key,
+        entry_type: "state",
+        content_preview: e.content.slice(0, 80),
+        tags: e.tags,
+        classification: e.classification,
+        created_at: e.created_at,
+        updated_at: e.updated_at,
+      })),
+      total: rows.length,
+    };
+  }
+}
+
+function munin(): InMemoryMunin & MuninClient {
+  return new InMemoryMunin() as unknown as InMemoryMunin & MuninClient;
+}
+
+function ref(namespace: string, key: string) {
+  return { namespace, key };
+}
+
+describe("LearningRegistryStore — natural-key idempotency", () => {
+  it("treats a duplicate submission delivery as a no-op, not a second event", async () => {
+    const store = new LearningRegistryStore(munin());
+    const occurredAt = "2024-03-10T08:00:00.000Z";
+    const a = await store.recordSubmission({
+      taskId: "task-1",
+      taskOutcomeRef: ref("tasks/task-1", "result-structured"),
+      occurredAt,
+    });
+    const b = await store.recordSubmission({
+      taskId: "task-1",
+      taskOutcomeRef: ref("tasks/task-1", "result-structured"),
+      occurredAt,
+    });
+    expect(a.status).toBe("created");
+    expect(b.status).toBe("exact-existing");
+    expect(a.event.eventId).toBe(b.event.eventId);
+
+    const { events } = await store.listEventsForTask("task-1");
+    expect(events).toHaveLength(1);
+  });
+
+  it("rejects a divergent payload colliding on the same natural key", async () => {
+    const store = new LearningRegistryStore(munin());
+    await store.recordTerminalOutcome({
+      taskId: "task-1",
+      attemptId: "hugin-attempt:1",
+      outcome: "completed",
+      taskOutcomeRef: ref("tasks/task-1", "result-structured"),
+      occurredAt: "2024-03-10T08:00:00.000Z",
+    });
+    await expect(store.recordTerminalOutcome({
+      taskId: "task-1",
+      attemptId: "hugin-attempt:1",
+      outcome: "failed", // different terminal fact, same natural key
+      taskOutcomeRef: ref("tasks/task-1", "result-structured"),
+      occurredAt: "2024-03-10T08:00:00.000Z",
+    })).rejects.toThrow(RegistryNaturalKeyConflictError);
+  });
+
+  it("is idempotent even though recordedAt differs between the retry and the original", async () => {
+    let tick = 0;
+    const clockValues = ["2024-03-10T09:00:00.000Z", "2024-03-10T09:05:00.000Z"];
+    const store = new LearningRegistryStore(munin(), { now: () => clockValues[tick++] });
+    const occurredAt = "2024-03-10T08:00:00.000Z";
+    const first = await store.recordSubmission({
+      taskId: "task-1",
+      taskOutcomeRef: ref("tasks/task-1", "result-structured"),
+      occurredAt,
+    });
+    const second = await store.recordSubmission({
+      taskId: "task-1",
+      taskOutcomeRef: ref("tasks/task-1", "result-structured"),
+      occurredAt,
+    });
+    // Sanity: the two calls really did observe different wall-clock times.
+    expect(first.event.recordedAt).toBe(clockValues[0]);
+    // The retry must report the *actually persisted* (first) recordedAt, not
+    // fabricate its own — a reader must never see two different truths for
+    // the same natural key.
+    expect(second.event.recordedAt).toBe(first.event.recordedAt);
+    expect(second.event.recordedAt).not.toBe(clockValues[1]);
+  });
+});
+
+describe("LearningRegistryStore — concurrent-writer safety", () => {
+  it("cannot lose either of two attempt-reference events racing in the same partition", async () => {
+    const client = munin();
+    const store = new LearningRegistryStore(client);
+    const occurredAt = "2024-03-10T08:00:00.000Z";
+
+    const results = await Promise.all([
+      store.recordAttemptReference({
+        taskId: "task-1",
+        attemptId: "hugin-attempt:aaaa",
+        attemptStartRef: ref("tasks/task-1", "learning-attempt-aaaa"),
+        taskOutcomeRef: ref("tasks/task-1", "result-structured"),
+        occurredAt,
+      }),
+      store.recordAttemptReference({
+        taskId: "task-1",
+        attemptId: "hugin-attempt:bbbb",
+        attemptStartRef: ref("tasks/task-1", "learning-attempt-bbbb"),
+        taskOutcomeRef: ref("tasks/task-1", "result-structured"),
+        occurredAt,
+      }),
+    ]);
+    expect(results.every((r) => r.status === "created")).toBe(true);
+
+    const { events } = await store.listEventsForTask("task-1");
+    expect(events).toHaveLength(2);
+
+    const proof = await store.issuePartitionProof("attempt-reference", "2024-03");
+    expect(proof.status).toBe("complete");
+    expect(proof.highWaterSeq).toBe(2);
+    expect(new Set(proof.members.map((m) => m.eventId)).size).toBe(2);
+  });
+
+  it("resolves a true duplicate-delivery race to exactly one winner with no data loss", async () => {
+    const client = munin();
+    const store = new LearningRegistryStore(client);
+    const occurredAt = "2024-03-10T08:00:00.000Z";
+
+    // Force both writers to observe "does not exist yet" before either
+    // commits, then let both attempt the atomic create — this is the
+    // adversarial ordering a real network race can produce.
+    let inFlight = 0;
+    let release: (() => void) | undefined;
+    const bothArrived = new Promise<void>((resolve) => { release = resolve; });
+    client.beforeWrite = async (namespace, key) => {
+      if (!key.startsWith("reg-")) return;
+      inFlight += 1;
+      if (inFlight === 2) release?.();
+      await bothArrived;
+    };
+
+    const results = await Promise.all([
+      store.recordSubmission({ taskId: "task-1", taskOutcomeRef: ref("tasks/task-1", "result-structured"), occurredAt }),
+      store.recordSubmission({ taskId: "task-1", taskOutcomeRef: ref("tasks/task-1", "result-structured"), occurredAt }),
+    ]);
+    const statuses = results.map((r) => r.status).sort();
+    expect(statuses).toEqual(["created", "exact-existing"]);
+    expect(results[0].event.eventId).toBe(results[1].event.eventId);
+
+    const { events } = await store.listEventsForTask("task-1");
+    expect(events).toHaveLength(1);
+    const proof = await store.issuePartitionProof("submission", "2024-03");
+    expect(proof.highWaterSeq).toBe(1); // never double-counted despite the race
+  });
+
+  it("serializes concurrent high-water updates across different partitions members without loss", async () => {
+    const client = munin();
+    const store = new LearningRegistryStore(client);
+    const occurredAt = "2024-03-10T08:00:00.000Z";
+    const attempts = Array.from({ length: 6 }, (_, i) => `hugin-attempt:${i}`);
+
+    await Promise.all(attempts.map((attemptId) => store.recordAttemptReference({
+      taskId: "task-1",
+      attemptId,
+      attemptStartRef: ref("tasks/task-1", `learning-attempt-${attemptId}`),
+      taskOutcomeRef: ref("tasks/task-1", "result-structured"),
+      occurredAt,
+    })));
+
+    const proof = await store.issuePartitionProof("attempt-reference", "2024-03");
+    expect(proof.status).toBe("complete");
+    expect(proof.highWaterSeq).toBe(6);
+    expect(new Set(proof.members.map((m) => m.eventId)).size).toBe(6);
+  });
+});
+
+describe("LearningRegistryStore — correction chains", () => {
+  it("chains a new immutable identity to the predecessor without rewriting it", async () => {
+    const store = new LearningRegistryStore(munin());
+    const created = await store.recordTerminalOutcome({
+      taskId: "task-1",
+      attemptId: "hugin-attempt:1",
+      outcome: "failed",
+      taskOutcomeRef: ref("tasks/task-1", "result-structured"),
+      occurredAt: "2024-03-10T08:00:00.000Z",
+    });
+    const before = await store.getEvent("task-1", created.event.eventId);
+
+    const correction = await store.writeCorrection({
+      taskId: "task-1",
+      predecessorEventId: created.event.eventId,
+      reason: "late receipt reclassified the outcome as completed",
+      occurredAt: "2024-03-11T08:00:00.000Z",
+    });
+
+    expect(correction.event.eventId).not.toBe(created.event.eventId);
+    expect(correction.event.payload.predecessorEventId).toBe(created.event.eventId);
+
+    const after = await store.getEvent("task-1", created.event.eventId);
+    expect(after).toEqual(before); // predecessor is byte-for-byte unchanged
+
+    const leaf = await store.findEffectiveLeaf("task-1", created.event.eventId);
+    expect(leaf).toBe(correction.event.eventId);
+  });
+
+  it("refuses a fork: a second different correction on the same predecessor collides", async () => {
+    const store = new LearningRegistryStore(munin());
+    const created = await store.recordTerminalOutcome({
+      taskId: "task-1",
+      attemptId: "hugin-attempt:1",
+      outcome: "failed",
+      taskOutcomeRef: ref("tasks/task-1", "result-structured"),
+      occurredAt: "2024-03-10T08:00:00.000Z",
+    });
+    await store.writeCorrection({
+      taskId: "task-1",
+      predecessorEventId: created.event.eventId,
+      reason: "first correction",
+      occurredAt: "2024-03-11T08:00:00.000Z",
+    });
+    await expect(store.writeCorrection({
+      taskId: "task-1",
+      predecessorEventId: created.event.eventId,
+      reason: "a different, conflicting correction",
+      occurredAt: "2024-03-12T08:00:00.000Z",
+    })).rejects.toThrow(RegistryNaturalKeyConflictError);
+  });
+
+  it("supports chaining a correction onto a correction (multi-hop leaf resolution)", async () => {
+    const store = new LearningRegistryStore(munin());
+    const created = await store.recordTerminalOutcome({
+      taskId: "task-1",
+      attemptId: "hugin-attempt:1",
+      outcome: "failed",
+      taskOutcomeRef: ref("tasks/task-1", "result-structured"),
+      occurredAt: "2024-03-10T08:00:00.000Z",
+    });
+    const first = await store.writeCorrection({
+      taskId: "task-1",
+      predecessorEventId: created.event.eventId,
+      reason: "first correction",
+      occurredAt: "2024-03-11T08:00:00.000Z",
+    });
+    const second = await store.writeCorrection({
+      taskId: "task-1",
+      predecessorEventId: first.event.eventId,
+      reason: "second correction, correcting the first",
+      occurredAt: "2024-03-12T08:00:00.000Z",
+    });
+    const leaf = await store.findEffectiveLeaf("task-1", created.event.eventId);
+    expect(leaf).toBe(second.event.eventId);
+  });
+
+  it("rejects a correction that does not strictly time-advance past its predecessor", async () => {
+    const store = new LearningRegistryStore(munin());
+    const created = await store.recordTerminalOutcome({
+      taskId: "task-1",
+      attemptId: "hugin-attempt:1",
+      outcome: "failed",
+      taskOutcomeRef: ref("tasks/task-1", "result-structured"),
+      occurredAt: "2024-03-10T08:00:00.000Z",
+    });
+    await expect(store.writeCorrection({
+      taskId: "task-1",
+      predecessorEventId: created.event.eventId,
+      reason: "back-dated correction",
+      occurredAt: "2024-03-09T08:00:00.000Z",
+    })).rejects.toThrow(/strictly time-advance/);
+  });
+
+  it("rejects correcting an unknown predecessor", async () => {
+    const store = new LearningRegistryStore(munin());
+    await expect(store.writeCorrection({
+      taskId: "task-1",
+      predecessorEventId: "reg-00000000000000000000000000000000",
+      reason: "no such event",
+      occurredAt: "2024-03-11T08:00:00.000Z",
+    })).rejects.toThrow(/unknown predecessor/);
+  });
+});
+
+describe("LearningRegistryStore — exclusion/erasure adjustments", () => {
+  it("preserves the target's counter membership without resurrecting content", async () => {
+    const store = new LearningRegistryStore(munin());
+    const created = await store.recordAttemptReference({
+      taskId: "task-1",
+      attemptId: "hugin-attempt:1",
+      attemptStartRef: ref("tasks/task-1", "learning-attempt-1"),
+      taskOutcomeRef: ref("tasks/task-1", "result-structured"),
+      occurredAt: "2024-03-10T08:00:00.000Z",
+    });
+    const beforeProof = await store.issuePartitionProof("attempt-reference", "2024-03");
+    expect(beforeProof.highWaterSeq).toBe(1);
+
+    const before = await store.getEvent("task-1", created.event.eventId);
+    const adjustment = await store.writeExclusionAdjustment({
+      taskId: "task-1",
+      targetEventId: created.event.eventId,
+      adjustmentReason: "erasure",
+      note: "upstream replay payload erased on request",
+      occurredAt: "2024-03-15T08:00:00.000Z",
+    });
+    const after = await store.getEvent("task-1", created.event.eventId);
+
+    // The original event's natural key / period / counter / owner is untouched.
+    expect(after).toEqual(before);
+    expect(after?.membership.occurrencePeriodUtc).toBe("2024-03");
+    expect(after?.membership.counter).toBe("attempt-reference");
+
+    // The target's own partition membership count never shrinks.
+    const afterProof = await store.issuePartitionProof("attempt-reference", "2024-03");
+    expect(afterProof.highWaterSeq).toBe(1);
+    expect(afterProof.chainDigest).toBe(beforeProof.chainDigest);
+
+    // The adjustment itself is separately, honestly counted in its own partition.
+    const adjustmentProof = await store.issuePartitionProof("exclusion-adjustment", "2024-03");
+    expect(adjustmentProof.highWaterSeq).toBe(1);
+    expect(adjustment.event.payload.adjustmentReason).toBe("erasure");
+  });
+
+  it("rejects adjusting an unknown target", async () => {
+    const store = new LearningRegistryStore(munin());
+    await expect(store.writeExclusionAdjustment({
+      taskId: "task-1",
+      targetEventId: "reg-00000000000000000000000000000000",
+      adjustmentReason: "erasure",
+      occurredAt: "2024-03-11T08:00:00.000Z",
+    })).rejects.toThrow(/unknown target/);
+  });
+});
+
+describe("LearningRegistryStore — partition/high-water proofs", () => {
+  it("confirms a legitimate zero-event partition as empty-confirmed, not partial", async () => {
+    const store = new LearningRegistryStore(munin());
+    const proof = await store.issuePartitionProof("submission", "2024-03");
+    expect(proof.status).toBe("empty-confirmed");
+    expect(isEligibleForCertification(proof)).toBe(true);
+    const verdict = await store.verifyPartitionProof(proof);
+    expect(verdict.valid).toBe(true);
+  });
+
+  it("issues a complete proof that verifies against the authoritative store state", async () => {
+    const store = new LearningRegistryStore(munin());
+    await store.recordSubmission({ taskId: "task-1", taskOutcomeRef: ref("tasks/task-1", "result-structured"), occurredAt: "2024-03-01T00:00:00.000Z" });
+    await store.recordSubmission({ taskId: "task-2", taskOutcomeRef: ref("tasks/task-2", "result-structured"), occurredAt: "2024-03-02T00:00:00.000Z" });
+
+    const proof = await store.issuePartitionProof("submission", "2024-03");
+    expect(proof.status).toBe("complete");
+    expect(proof.highWaterSeq).toBe(2);
+    expect(isEligibleForCertification(proof)).toBe(true);
+
+    const verdict = await store.verifyPartitionProof(proof);
+    expect(verdict.valid).toBe(true);
+  });
+
+  it("rejects a forged proof whose chain digest does not match any real state", async () => {
+    const store = new LearningRegistryStore(munin());
+    await store.recordSubmission({ taskId: "task-1", taskOutcomeRef: ref("tasks/task-1", "result-structured"), occurredAt: "2024-03-01T00:00:00.000Z" });
+    const real = await store.issuePartitionProof("submission", "2024-03");
+
+    const forged = {
+      ...real,
+      chainDigest: "f".repeat(64),
+    };
+    const verdict = await store.verifyPartitionProof(forged);
+    expect(verdict.valid).toBe(false);
+    expect(verdict.reason).toMatch(/does not recompute|stale|forged/);
+  });
+
+  it("rejects a forged empty-confirmed proof once real events exist", async () => {
+    const store = new LearningRegistryStore(munin());
+    const fabricatedEmpty = await store.issuePartitionProof("submission", "2024-04"); // legitimately empty first
+    expect(fabricatedEmpty.status).toBe("empty-confirmed");
+
+    await store.recordSubmission({ taskId: "task-1", taskOutcomeRef: ref("tasks/task-1", "result-structured"), occurredAt: "2024-04-01T00:00:00.000Z" });
+
+    const verdict = await store.verifyPartitionProof(fabricatedEmpty);
+    expect(verdict.valid).toBe(false);
+  });
+
+  it("rejects a stale proof once the partition has advanced, when requireCurrent is set", async () => {
+    const store = new LearningRegistryStore(munin());
+    await store.recordSubmission({ taskId: "task-1", taskOutcomeRef: ref("tasks/task-1", "result-structured"), occurredAt: "2024-03-01T00:00:00.000Z" });
+    const stale = await store.issuePartitionProof("submission", "2024-03");
+
+    await store.recordSubmission({ taskId: "task-2", taskOutcomeRef: ref("tasks/task-2", "result-structured"), occurredAt: "2024-03-02T00:00:00.000Z" });
+
+    const verdict = await store.verifyPartitionProof(stale, { requireCurrent: true });
+    expect(verdict.valid).toBe(false);
+    expect(verdict.reason).toMatch(/stale/);
+
+    // The same proof was honestly complete "as of" its own high-water mark.
+    const verdictAsOf = await store.verifyPartitionProof(stale, { requireCurrent: false });
+    expect(verdictAsOf.valid).toBe(true);
+  });
+
+  it("marks a proof partial, and ineligible for certification, when the high-water doc is missing but tagged events exist", async () => {
+    const client = munin();
+    const store = new LearningRegistryStore(client);
+    await store.recordSubmission({ taskId: "task-1", taskOutcomeRef: ref("tasks/task-1", "result-structured"), occurredAt: "2024-03-01T00:00:00.000Z" });
+
+    // Simulate a corrupted/lost high-water document despite a real tagged
+    // event still existing — exactly the situation the acceptance criteria
+    // call out: recomputing a digest over whatever subset happens to be
+    // visible must never silently certify as complete.
+    client.remove("learning-registry/partitions", "submission-2024-03");
+
+    const proof = await store.issuePartitionProof("submission", "2024-03");
+    expect(proof.status).toBe("partial");
+    expect(proof.partialReason).toMatch(/missing/);
+    expect(isEligibleForCertification(proof)).toBe(false);
+  });
+
+  it("marks a proof partial when a recorded member cannot be read back (missing event)", async () => {
+    const client = munin();
+    const store = new LearningRegistryStore(client);
+    const created = await store.recordSubmission({
+      taskId: "task-1",
+      taskOutcomeRef: ref("tasks/task-1", "result-structured"),
+      occurredAt: "2024-03-01T00:00:00.000Z",
+    });
+
+    // The high-water doc still claims this member, but its event row is gone.
+    client.remove("tasks/task-1", created.event.eventId);
+
+    const proof = await store.issuePartitionProof("submission", "2024-03");
+    expect(proof.status).toBe("partial");
+    expect(proof.partialReason).toMatch(/missing from the event store/);
+    expect(isEligibleForCertification(proof)).toBe(false);
+  });
+
+  it("never lets a caller self-certify a subset as complete: a hand-built partial proof is always ineligible", async () => {
+    const store = new LearningRegistryStore(munin());
+    await store.recordSubmission({ taskId: "task-1", taskOutcomeRef: ref("tasks/task-1", "result-structured"), occurredAt: "2024-03-01T00:00:00.000Z" });
+    await store.recordSubmission({ taskId: "task-2", taskOutcomeRef: ref("tasks/task-2", "result-structured"), occurredAt: "2024-03-02T00:00:00.000Z" });
+    const real = await store.issuePartitionProof("submission", "2024-03");
+
+    const selfAssembledSubset = {
+      ...real,
+      status: "partial" as const,
+      highWaterSeq: 1,
+      members: real.members.slice(0, 1),
+      partialReason: "caller only loaded one of the two events",
+    };
+    expect(isEligibleForCertification(selfAssembledSubset)).toBe(false);
+    const verdict = await store.verifyPartitionProof(selfAssembledSubset);
+    expect(verdict.valid).toBe(false);
+    expect(verdict.reason).toMatch(/partial/);
+  });
+});

--- a/tests/learning-registry-store.test.ts
+++ b/tests/learning-registry-store.test.ts
@@ -4,6 +4,15 @@ import {
   LearningRegistryStore,
   RegistryNaturalKeyConflictError,
   isEligibleForCertification,
+  submissionEventSchema,
+  buildMembership,
+  deriveEventId,
+  registryEventNamespace,
+  registryEventKey,
+  registryPartitionTag,
+  REGISTRY_EVENT_TAG,
+  LEARNING_REGISTRY_SCHEMA_VERSION,
+  type RegistryNaturalKey,
 } from "../src/learning-registry-store.js";
 
 interface StoredEntry {
@@ -543,5 +552,81 @@ describe("LearningRegistryStore — partition/high-water proofs", () => {
     const verdict = await store.verifyPartitionProof(selfAssembledSubset);
     expect(verdict.valid).toBe(false);
     expect(verdict.reason).toMatch(/partial/);
+  });
+
+  it("degrades to partial when a persisted event never reached the high-water document (crash before bumpHighWater)", async () => {
+    const client = munin();
+    const store = new LearningRegistryStore(client);
+
+    // A normal, healthy event first, so the partition has a real high-water doc.
+    await store.recordSubmission({
+      taskId: "task-1",
+      taskOutcomeRef: ref("tasks/task-1", "result-structured"),
+      occurredAt: "2024-03-01T00:00:00.000Z",
+    });
+
+    // Simulate the crash window `appendRegistryEvent` cannot fully close: its
+    // `munin.write` for the event succeeded, but the process died before
+    // `bumpHighWater` folded it into the high-water document, and it was
+    // never redelivered (so the idempotent skip-if-already-present path in
+    // `bumpHighWater` never got a chance to heal it). We reproduce that exact
+    // persisted state directly against the fake store, bypassing the
+    // LearningRegistryStore API entirely — the store itself never leaves this
+    // window open on a call that runs to completion.
+    const orphanNaturalKey: RegistryNaturalKey = { recordKind: "submission", taskId: "task-2" };
+    const orphanEvent = submissionEventSchema.parse({
+      schemaVersion: LEARNING_REGISTRY_SCHEMA_VERSION,
+      eventId: deriveEventId(orphanNaturalKey),
+      taskId: "task-2",
+      recordKind: "submission",
+      membership: buildMembership({ naturalKey: orphanNaturalKey, issuedAt: "2024-03-01T00:00:00.000Z" }),
+      occurredAt: "2024-03-01T00:00:00.000Z",
+      recordedAt: "2024-03-01T00:00:00.000Z",
+      payload: { taskOutcomeRef: ref("tasks/task-2", "result-structured"), originComponent: "hugin" },
+    });
+    await client.write(
+      registryEventNamespace("task-2"),
+      registryEventKey(orphanEvent.eventId),
+      JSON.stringify(orphanEvent),
+      [REGISTRY_EVENT_TAG, "registry-kind:submission", registryPartitionTag("submission", "2024-03")],
+      undefined,
+      "internal",
+      true,
+    );
+
+    const proof = await store.issuePartitionProof("submission", "2024-03");
+    expect(proof.status).toBe("partial");
+    expect(proof.partialReason).toMatch(/not present in the high-water record/);
+    expect(proof.partialReason).toContain(orphanEvent.eventId);
+    expect(isEligibleForCertification(proof)).toBe(false);
+
+    // The pre-existing per-member existence check alone would have missed
+    // this — every doc-claimed member (task-1's submission) genuinely exists
+    // and recomputes correctly. Only the reverse (tag-query) direction catches it.
+  });
+
+  it("degrades to partial, rather than silently certifying, when the completeness tag query truncates", async () => {
+    const client = munin();
+    // Force the completeness cross-check's own query budget down to something
+    // two real members will overflow, without needing thousands of rows.
+    const store = new LearningRegistryStore(client, {
+      partitionCompletenessQueryBudget: { maxPages: 1, maxResults: 1 },
+    });
+
+    await store.recordSubmission({
+      taskId: "task-1",
+      taskOutcomeRef: ref("tasks/task-1", "result-structured"),
+      occurredAt: "2024-03-01T00:00:00.000Z",
+    });
+    await store.recordSubmission({
+      taskId: "task-2",
+      taskOutcomeRef: ref("tasks/task-2", "result-structured"),
+      occurredAt: "2024-03-02T00:00:00.000Z",
+    });
+
+    const proof = await store.issuePartitionProof("submission", "2024-03");
+    expect(proof.status).toBe("partial");
+    expect(proof.partialReason).toMatch(/truncat/i);
+    expect(isEligibleForCertification(proof)).toBe(false);
   });
 });

--- a/tests/learning-registry-view.test.ts
+++ b/tests/learning-registry-view.test.ts
@@ -1,0 +1,212 @@
+import { describe, expect, it } from "vitest";
+import { MuninWriteRejectedError, type MuninClient } from "../src/munin-client.js";
+import { LearningRegistryStore } from "../src/learning-registry-store.js";
+import { buildTaskLifecycleTimeline } from "../src/learning-registry-view.js";
+
+interface StoredEntry {
+  namespace: string;
+  key: string;
+  content: string;
+  tags: string[];
+  classification?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+class InMemoryMunin {
+  private entries: StoredEntry[] = [];
+  private seq = 0;
+
+  private clock(): string {
+    this.seq += 1;
+    return new Date(Date.UTC(2024, 2, 1, 0, 0, 0, 0) + this.seq).toISOString();
+  }
+
+  private find(namespace: string, key: string): StoredEntry | undefined {
+    return this.entries.find((e) => e.namespace === namespace && e.key === key);
+  }
+
+  async read(namespace: string, key: string) {
+    const entry = this.find(namespace, key);
+    return entry ? ({ ...entry, found: true } as unknown as Record<string, unknown>) : null;
+  }
+
+  async write(
+    namespace: string,
+    key: string,
+    content: string,
+    tags?: string[],
+    expectedUpdatedAt?: string,
+    classification?: string,
+    createIfAbsent?: boolean,
+  ) {
+    const existing = this.find(namespace, key);
+    if (createIfAbsent && existing) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        conflict_reason: "already_exists",
+        current_updated_at: existing.updated_at,
+      });
+    }
+    if (expectedUpdatedAt !== undefined && (!existing || existing.updated_at !== expectedUpdatedAt)) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        conflict_reason: "version_mismatch",
+        current_updated_at: existing?.updated_at,
+      });
+    }
+    const updated_at = this.clock();
+    const created_at = existing?.created_at ?? updated_at;
+    const next: StoredEntry = { namespace, key, content, tags: tags ?? [], classification, created_at, updated_at };
+    if (existing) Object.assign(existing, next); else this.entries.push(next);
+    return { ok: true, status: existing ? "updated" : "created", updated_at };
+  }
+
+  async query(opts: { namespace?: string; tags?: string[]; limit?: number; since?: string; until?: string }) {
+    let rows = this.entries.filter((e) =>
+      (!opts.namespace || e.namespace.startsWith(opts.namespace))
+      && (opts.tags ?? []).every((tag) => e.tags.includes(tag)));
+    if (opts.since) rows = rows.filter((e) => e.updated_at >= opts.since!);
+    if (opts.until) rows = rows.filter((e) => e.updated_at <= opts.until!);
+    rows = [...rows].sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+    const limited = rows.slice(0, opts.limit ?? 50);
+    return {
+      results: limited.map((e) => ({
+        id: `${e.namespace}/${e.key}`,
+        namespace: e.namespace,
+        key: e.key,
+        entry_type: "state",
+        content_preview: e.content.slice(0, 80),
+        tags: e.tags,
+        classification: e.classification,
+        created_at: e.created_at,
+        updated_at: e.updated_at,
+      })),
+      total: rows.length,
+    };
+  }
+}
+
+function munin(): InMemoryMunin & MuninClient {
+  return new InMemoryMunin() as unknown as InMemoryMunin & MuninClient;
+}
+
+function ref(namespace: string, key: string) {
+  return { namespace, key };
+}
+
+describe("buildTaskLifecycleTimeline", () => {
+  it("joins submission, attempt-reference, terminal-outcome and publication into one ordered timeline referencing the real attempt-evidence rows", async () => {
+    const store = new LearningRegistryStore(munin());
+    const taskId = "task-1";
+    const attemptId = "hugin-attempt:11111111-1111-4111-8111-111111111111";
+    // These are exactly the durable LearningTask rows the handshake module
+    // (src/learning-task-handshake.ts) writes — the registry only points at
+    // them, per docs/learning-task-handshake.md's key list.
+    const attemptStartRef = ref("tasks/task-1", "learning-attempt-11111111-1111-4111-8111-111111111111");
+    const taskOutcomeRef = ref("tasks/task-1", "result-structured");
+
+    await store.recordSubmission({ taskId, taskOutcomeRef, occurredAt: "2024-03-01T00:00:00.000Z" });
+    await store.recordAttemptReference({
+      taskId, attemptId, attemptStartRef, taskOutcomeRef, occurredAt: "2024-03-01T00:01:00.000Z",
+    });
+    await store.recordTerminalOutcome({
+      taskId, attemptId, outcome: "completed", taskOutcomeRef, occurredAt: "2024-03-01T00:05:00.000Z",
+    });
+    await store.recordPublication({
+      taskId, attemptId, publicationRef: "pr-742", label: "pr-published",
+      evidenceRef: ref("tasks/task-1", "result-structured"), occurredAt: "2024-03-01T00:06:00.000Z",
+    });
+
+    const timeline = await buildTaskLifecycleTimeline(store, taskId);
+    expect(timeline.truncated).toBe(false);
+    expect(timeline.entries.map((e) => e.event.recordKind)).toEqual([
+      "submission", "attempt-reference", "terminal-outcome", "publication",
+    ]);
+    expect(timeline.entries.every((e) => !e.superseded && !e.excluded)).toBe(true);
+
+    const attemptEntry = timeline.entries.find((e) => e.event.recordKind === "attempt-reference");
+    expect(attemptEntry?.event.recordKind === "attempt-reference"
+      && attemptEntry.event.payload.attemptStartRef).toEqual(attemptStartRef);
+  });
+
+  it("resolves a corrected terminal outcome to its effective leaf and marks the predecessor superseded", async () => {
+    const store = new LearningRegistryStore(munin());
+    const taskId = "task-1";
+    const attemptId = "hugin-attempt:1";
+    const taskOutcomeRef = ref("tasks/task-1", "result-structured");
+
+    const created = await store.recordTerminalOutcome({
+      taskId, attemptId, outcome: "failed", taskOutcomeRef, occurredAt: "2024-03-01T00:00:00.000Z",
+    });
+    const correction = await store.writeCorrection({
+      taskId, predecessorEventId: created.event.eventId,
+      reason: "late receipt reclassified as completed", occurredAt: "2024-03-02T00:00:00.000Z",
+    });
+
+    const timeline = await buildTaskLifecycleTimeline(store, taskId);
+    const outcomeEntry = timeline.entries.find((e) => e.event.recordKind === "terminal-outcome");
+    expect(outcomeEntry?.superseded).toBe(true);
+    expect(outcomeEntry?.effectiveEventId).toBe(correction.event.eventId);
+    expect(timeline.corrections.map((c) => c.eventId)).toEqual([correction.event.eventId]);
+  });
+
+  it("surfaces exclusion state on the affected entry without removing it from the timeline", async () => {
+    const store = new LearningRegistryStore(munin());
+    const taskId = "task-1";
+    const attemptId = "hugin-attempt:1";
+    const attemptStartRef = ref("tasks/task-1", "learning-attempt-1");
+    const taskOutcomeRef = ref("tasks/task-1", "result-structured");
+
+    const attempt = await store.recordAttemptReference({
+      taskId, attemptId, attemptStartRef, taskOutcomeRef, occurredAt: "2024-03-01T00:00:00.000Z",
+    });
+    await store.writeExclusionAdjustment({
+      taskId, targetEventId: attempt.event.eventId, adjustmentReason: "erasure",
+      note: "upstream replay payload erased", occurredAt: "2024-03-05T00:00:00.000Z",
+    });
+
+    const timeline = await buildTaskLifecycleTimeline(store, taskId);
+    const entry = timeline.entries.find((e) => e.event.recordKind === "attempt-reference");
+    expect(entry?.excluded).toBe(true);
+    expect(entry?.excludedReasons).toEqual(["erasure"]);
+    // The event itself is still present and unmutated in the timeline.
+    expect(entry?.event.eventId).toBe(attempt.event.eventId);
+    expect(timeline.exclusionAdjustments).toHaveLength(1);
+  });
+
+  it("orders a multi-attempt task's events chronologically across attempts", async () => {
+    const store = new LearningRegistryStore(munin());
+    const taskId = "task-1";
+    const taskOutcomeRef = ref("tasks/task-1", "result-structured");
+
+    await store.recordSubmission({ taskId, taskOutcomeRef, occurredAt: "2024-03-01T00:00:00.000Z" });
+    await store.recordAttemptReference({
+      taskId, attemptId: "hugin-attempt:1",
+      attemptStartRef: ref("tasks/task-1", "learning-attempt-1"), taskOutcomeRef,
+      occurredAt: "2024-03-01T00:01:00.000Z",
+    });
+    await store.recordTerminalOutcome({
+      taskId, attemptId: "hugin-attempt:1", outcome: "failed", taskOutcomeRef,
+      occurredAt: "2024-03-01T00:02:00.000Z",
+    });
+    await store.recordAttemptReference({
+      taskId, attemptId: "hugin-attempt:2",
+      attemptStartRef: ref("tasks/task-1", "learning-attempt-2"), taskOutcomeRef,
+      occurredAt: "2024-03-01T00:03:00.000Z",
+    });
+    await store.recordTerminalOutcome({
+      taskId, attemptId: "hugin-attempt:2", outcome: "completed", taskOutcomeRef,
+      occurredAt: "2024-03-01T00:04:00.000Z",
+    });
+
+    const timeline = await buildTaskLifecycleTimeline(store, taskId);
+    expect(timeline.entries.map((e) => e.event.occurredAt)).toEqual([
+      "2024-03-01T00:00:00.000Z",
+      "2024-03-01T00:01:00.000Z",
+      "2024-03-01T00:02:00.000Z",
+      "2024-03-01T00:03:00.000Z",
+      "2024-03-01T00:04:00.000Z",
+    ]);
+  });
+});


### PR DESCRIPTION
Refs #232

## What

Implements the append-only, idempotent task/outcome learning registry (the mechanism, not the accounting) required by hugin#232 and bound by its 2026-07-19 owner-review comment:

- **`src/learning-registry-schema.ts`** — six content-blind record kinds (`submission`, `attempt-reference`, `terminal-outcome`, `publication`, `correction`, `exclusion-adjustment`), each with a discriminated natural key and a content-derived event id (`reg-<hash>`).
- **`src/learning-registry-store.ts`** — Munin-backed store: idempotent natural-key append (duplicate delivery is a no-op; a genuinely different payload at the same natural key is rejected, never overwritten), correction chains (new immutable identity, predecessor never rewritten, forks structurally impossible), erasure-safe exclusion adjustments (target's counter membership preserved, nothing to "resurrect" since content was never stored), and per-partition high-water hash-chain proof issuance/verification.
- **`src/learning-registry-view.ts`** — `buildTaskLifecycleTimeline` joins one task's registry events into a single ordered timeline, resolving corrections to their effective leaf and surfacing exclusion state, while keeping the full audit trail available.
- **`docs/learning-registry.md`** — design decisions, the store-choice justification, and the #232-mechanism vs #241-consumption boundary.

## Design decisions

**Store choice.** The task brief suggested "Munin envelopes like `task-store.ts`, or SQLite like `learning-task-store.ts`" — but there is no SQLite (or any embedded database) anywhere in this repository. `src/learning-task-store.ts` is itself Munin-backed (`createImmutableLearningArtifact` uses `munin.write(..., create_if_absent: true)`), exactly like `src/broker/task-store.ts`. The registry therefore uses Munin envelopes: it sits next to the existing durable LearningTask attempt rows it references (`tasks/<taskId>/learning-attempt-<uuid>...`, `result-structured`), reuses Munin's existing `create_if_absent`/`expected_updated_at` primitives (already used by `BrokerTaskStore.recordAwait` and `writeQualityReceipt`), and avoids adding a second persistence technology with its own backup/restore story. Full rationale in `docs/learning-registry.md`.

**#232-mechanism vs #241-consumption boundary.** Per hugin#241's 2026-07-20 "Boundary clarification" comment: this PR owns the registry's natural keys, membership evidence issued at capture, and the partition/high-water proof primitives (issuance *and* verification). It does not compute monthly closes, does not talk to `gille-inference`, does not ingest external Codex/Pi receipts (#237), and does not package evaluation candidates (#233) — those stay #241/#237/#233's job, consuming what this module issues rather than re-implementing it.

**Idempotency identity excludes `recordedAt`.** `recordedAt` (when the registry durably accepted an event) is store-observed, not caller-asserted — two calls racing to persist the same logical fact legitimately differ there. The natural-key collision check compares everything *except* `recordedAt`, and always returns the actually-persisted (winning) event rather than the caller's locally-built candidate, so a reader is never told two different truths for one natural key. (Caught by a first draft that would have spuriously rejected legitimate retries — see commit message.)

**Partition proofs are never self-certifiable from a subset.** `issuePartitionProof` is the only path to a `"complete"`/`"empty-confirmed"` status, and it always recomputes the chain digest from the authoritative high-water document's actual persisted members — never from whatever subset a caller happened to load. `verifyPartitionProof` re-derives from current store state (rejecting forged digests and, by default, stale high-water marks) rather than trusting the proof body.

**Not wired into the dispatcher yet.** This is a self-contained, independently tested library. Wiring `record*` calls into `src/index.ts`/`src/broker/handlers.ts` is left to #233/#237, which actually need it — this keeps the PR's blast radius off `src/broker/handlers.ts` while #250/#251 are in flight.

## Verification

- `npm run build` — clean, no errors.
- `npm test` — **124 test files / 1980 tests passed** (2 new files, 25 new tests: 21 in `tests/learning-registry-store.test.ts`, 4 in `tests/learning-registry-view.test.ts`). No pre-existing test touched or modified.

Tests cover: duplicate-delivery idempotency (including `recordedAt` divergence across a retry); concurrent-writer safety for both a true duplicate-delivery race and distinct events racing in one partition; correction chains (new identity, immutable predecessor, fork rejection, multi-hop leaf resolution, strict time-advance requirement, unknown-predecessor rejection); erasure adjustments (counter membership preserved, target byte-for-byte unchanged); partial-partition ineligibility (missing high-water doc, missing member event); high-water proof issuance and verification (valid, forged digest, forged empty-confirmed, stale); and the lifecycle view joining real attempt-evidence refs across corrections and exclusions.

**M5 dogfood:** ran a concurrency/edge-case review via `mcp__m5__ask` (qwen3-30b-instruct, `delegator_model_id: anthropic/claude-sonnet-5`) against the store implementation. Verified every finding against the actual code: 3 of 4 flagged "bugs" were false alarms — the "fixes" it proposed were already present verbatim (the CAS loop already re-reads before each retry attempt; `bumpHighWater` already skips an already-counted member; `verifyPartitionProof` already recomputes from the current high-water document). The 4th (a claimed TOCTOU in the correction-chain walk) was a mischaracterization of an inherent, harmless eventual-consistency property rather than a bug, so I added a clarifying doc comment instead of a functional change. Noting this plainly since the review's practical yield was low this time — worth knowing for future dogfooding.

CI is billing-blocked account-wide; this merges after green CI or an owner waiver, and after #250/#251 land first per the task brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)