### PR TITLE
fix: carry cross-host skew tolerance into the stamp-context clock ordering

### DIFF
--- a/src/learning-task-handshake.ts
+++ b/src/learning-task-handshake.ts
@@ -915,9 +915,14 @@ export function buildLearningTaskRequestStamp(input: {
     // A previously authenticated request/advertisement pair may be cached
     // before this attempt. Its own request must still precede advertisement,
     // and the advertisement must remain fresh at this attempt's stamp time.
-    && requested <= advertised
-    && advertised <= stamped
-    && stamped < expires)) {
+    // `requested`/`stamped` are Hugin-host clocks; `advertised`/`expires` are
+    // gateway-host clocks, so those orderings carry the bounded cross-host
+    // skew tolerance (#253, same as fetchLearningTaskPreflight and the
+    // gateway-echo check) — with the expiry edge tightened, never extended.
+    // The same-host chain above stays exact.
+    && requested - LEARNING_TASK_CLOCK_SKEW_TOLERANCE_MS <= advertised
+    && advertised <= stamped + LEARNING_TASK_CLOCK_SKEW_TOLERANCE_MS
+    && stamped < expires - LEARNING_TASK_CLOCK_SKEW_TOLERANCE_MS)) {
     throw new LearningTaskHandshakeError("LearningTaskContract attempt/preflight/stamp clocks are out of order");
   }
   if (expires - advertised > LEARNING_TASK_PREFLIGHT_TTL_MS

--- a/tests/learning-task-handshake.test.ts
+++ b/tests/learning-task-handshake.test.ts
@@ -825,5 +825,42 @@ describe("LearningTaskContract v1 producer handshake", () => {
       expect(() => validateLearningTaskGatewayEcho(echo, stamp, new Date("2026-07-19T10:00:04Z")))
         .toThrow(/admission clock/);
     });
+
+    // The stamp-context ordering (attempt/preflight/stamp) repeats the same
+    // cross-host comparisons and must carry the same tolerance — caught live
+    // by joint-smoke r6 after the fetch-time check was fixed (#253).
+    const stampWith = (advertisedAtOverride: string, expiresAtOverride?: string) => {
+      const ctx = context();
+      ctx.preflight.response.advertised_at = advertisedAtOverride;
+      ctx.preflight.response.expires_at = expiresAtOverride
+        ?? new Date(Date.parse(advertisedAtOverride) + 15 * 60 * 1_000).toISOString();
+      return () => buildLearningTaskRequestStamp({
+        context: ctx,
+        taskType: "summarize",
+        rawTaskText: "  Summarize the fixture incident report.\n",
+        renderedPrompt: ctx.attempt.renderedPrompt,
+      });
+    };
+
+    it("stamp context accepts a gateway advertisement clock ahead of the stamp within tolerance", () => {
+      // stampedAt fixture is 10:00:02.250; advertisement 1.25s later on the gateway clock.
+      expect(stampWith("2026-07-19T10:00:03.500Z")).not.toThrow();
+    });
+
+    it("stamp context accepts a gateway advertisement clock behind the request within tolerance", () => {
+      // requested_at fixture is 10:00:01.500; advertisement 1.3s earlier on the gateway clock.
+      expect(stampWith("2026-07-19T10:00:00.200Z")).not.toThrow();
+    });
+
+    it("stamp context rejects a gateway advertisement clock beyond the tolerance", () => {
+      expect(stampWith("2026-07-19T10:00:05.000Z")).toThrow(/clocks are out of order/);
+    });
+
+    it("stamp context tightens the expiry edge instead of extending it", () => {
+      // stamped (10:00:02.250) is before expires (10:00:03.000) but NOT before
+      // expires minus tolerance — the window must shrink, never grow.
+      expect(stampWith("2026-07-19T10:00:02.000Z", "2026-07-19T10:00:03.000Z"))
+        .toThrow(/clocks are out of order/);
+    });
   });
 });


### PR DESCRIPTION
Refs #253. Second member of the same defect class #254 fixed: the stamp-context ordering (`requested <= advertised <= stamped < expires`) at learning-task-handshake.ts:918-920 had zero cross-host tolerance — found live by joint-smoke r6 on the deployed stack, one check past the previous fix. Same pattern applied (tolerance on cross-host only, expiry tightened); a full-file sweep confirms these were the last untoleranced cross-host comparisons. Verification: build clean, **126 files / 2,034 tests** (2,030 baseline + 4 regression). Merging under the standing owner option-2 waiver; deploy + smoke rerun immediately after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)