### PR TITLE
fix: tolerantly parse M5 exposure lookup responses (Closes #258)

### DIFF
--- a/src/learning/daily-task-exam-factory.ts
+++ b/src/learning/daily-task-exam-factory.ts
@@ -532,6 +532,15 @@ function applySnapshot(candidate: DailyExamCandidate, snapshot: TaskExposureSnap
     return;
   }
 
+  // #27's fail-closed signal: when the gateway itself cannot vouch for its
+  // own negative match, that match must never be treated as a fresh/eligible
+  // holdout. Quarantine before evaluating coverage completeness/window/lanes.
+  if (snapshot.result.unseen_claim_supported === false) {
+    candidate.crossClientExposure.evidence = ["m5-unseen-claim-unsupported"];
+    quarantine(candidate, "cross-client-unseen-claim-unsupported");
+    return;
+  }
+
   const createdAtIsIso = isoTimestampSchema.safeParse(candidate.source.taskCreatedAt).success;
   const createdMs = Date.parse(candidate.source.taskCreatedAt);
   const fromMs = Date.parse(snapshot.coverage.from);

--- a/src/learning/m5-task-exposure.ts
+++ b/src/learning/m5-task-exposure.ts
@@ -25,6 +25,11 @@ const sha256Schema = z.string().regex(/^[0-9a-f]{64}$/);
 const isoTimestampSchema = z.string().datetime({ offset: true });
 const metadataIdSchema = z.string().min(1).max(160);
 
+// `.passthrough()` (not `.strict()`): the gateway owns this contract and may
+// add fields under the same `schema_version` (gille-inference#27 added six
+// coverage keys the same day it shipped). A client must not hard-fail on
+// unknown-but-additive fields it does not yet understand (hugin#258); every
+// field the client actually depends on remains required and validated below.
 export const taskExposureCoverageSchema = z.object({
   coverage_complete: z.boolean(),
   from: isoTimestampSchema,
@@ -37,8 +42,12 @@ export const taskExposureCoverageSchema = z.object({
   historical_rows_skipped_inexact: z.number().int().nonnegative(),
   incomplete_before: isoTimestampSchema,
   incomplete_reasons: z.array(z.string().min(1).max(500)).max(64),
-}).strict();
+}).passthrough();
 
+// `identity_kind` and `unseen_claim_supported` are #27's fail-closed holdout
+// signal: they are recognized (typed) optional fields, not merely passed
+// through, so `daily-task-exam-factory.ts` can read them. Any other unknown
+// key (e.g. `includes_legacy_inexact`) is tolerated via `.passthrough()`.
 export const taskExposureLookupResultSchema = z.object({
   fingerprint_sha256: sha256Schema,
   seen: z.boolean(),
@@ -47,14 +56,21 @@ export const taskExposureLookupResultSchema = z.object({
   lanes: z.array(z.string().min(1).max(80)).max(64),
   model_ids: z.array(metadataIdSchema).max(256),
   harness_ids: z.array(metadataIdSchema).max(256),
-}).strict();
+  identity_kind: z.string().min(1).max(160).optional(),
+  unseen_claim_supported: z.boolean().optional(),
+}).passthrough();
 
+// Tolerant at the top level too, for consistency: the observed #27 payload
+// only added nested coverage/result keys plus the already-modeled
+// `fingerprint_version`, but a client that will not `.strict()`-parse a
+// response it does not own should apply that rule uniformly rather than
+// re-litigate it the next time the gateway adds a top-level field.
 const taskExposureLookupResponseSchema = z.object({
   schema_version: z.literal(1),
   fingerprint_version: z.literal(TASK_EXPOSURE_FINGERPRINT_VERSION),
   coverage: taskExposureCoverageSchema,
   results: z.array(taskExposureLookupResultSchema).min(1).max(TASK_EXPOSURE_LOOKUP_MAX),
-}).strict();
+}).passthrough();
 
 export type TaskExposureCoverage = z.infer<typeof taskExposureCoverageSchema>;
 export type TaskExposureLookupResult = z.infer<typeof taskExposureLookupResultSchema>;

--- a/tests/daily-task-exam-factory.test.ts
+++ b/tests/daily-task-exam-factory.test.ts
@@ -143,6 +143,7 @@ function snapshot(fingerprint: string, input: {
   from?: string;
   through?: string;
   lanes?: string[];
+  unseenClaimSupported?: boolean;
 } = {}): TaskExposureSnapshot {
   const seen = input.seen ?? false;
   return {
@@ -168,6 +169,7 @@ function snapshot(fingerprint: string, input: {
       lanes: seen ? ["chat"] : [],
       model_ids: seen ? ["mellum"] : [],
       harness_ids: seen ? ["openai-chat"] : [],
+      ...(input.unseenClaimSupported === undefined ? {} : { unseen_claim_supported: input.unseenClaimSupported }),
     },
   };
 }
@@ -475,6 +477,27 @@ describe("daily task exam factory", () => {
     expect(candidate.crossClientExposure.coverage?.through).toBe("2026-07-14T12:00:00.000Z");
     expect(candidate.reasons).not.toContain("requires-cross-client-exposure-check-before-holdout-seal");
     expect(candidate.reasons).toContain("independent-verifier-required");
+  });
+
+  it("never clears an unseen result as fresh when the gateway cannot vouch for the claim (unseen_claim_supported: false)", () => {
+    const manifest = buildDailyExamManifest({
+      generatedAt: "2026-07-14T12:00:00.000Z",
+      historyComplete: true,
+      sources: [source("claude")],
+    });
+    const digest = manifest.candidates[0]!.source.promptSha256!;
+    const finalized = applyCrossClientExposure(manifest, {
+      snapshots: new Map([[digest, snapshot(digest, { unseenClaimSupported: false })]]),
+    });
+    const candidate = finalized.candidates[0]!;
+
+    // Otherwise this exact snapshot (complete coverage, task inside the
+    // window, all required lanes present) would clear to unseen-covered.
+    expect(candidate.lane).toBe("quarantine");
+    expect(candidate.readiness).toBe("quarantined");
+    expect(candidate.crossClientExposure.state).not.toBe("unseen-covered");
+    expect(candidate.reasons).toContain("cross-client-unseen-claim-unsupported");
+    expect(candidate.reasons).not.toContain("independent-verifier-required");
   });
 
   it("routes seen=true to regression even when coverage is incomplete", () => {

--- a/tests/m5-task-exposure.test.ts
+++ b/tests/m5-task-exposure.test.ts
@@ -135,6 +135,55 @@ describe("M5 task exposure lookup", () => {
     expect(snapshots.get(A)?.result.seen).toBe(true);
   });
 
+  it("tolerates #27's additive coverage/result fields under the same schema_version (regression for hugin#258)", async () => {
+    const body = responseFor([A], { seen: new Set([A]) });
+    const withAdditiveFields = {
+      ...body,
+      coverage: {
+        ...body.coverage,
+        coverage_epoch_id: "epoch-9",
+        restart_count: 2,
+        total_restart_gap_ms: 4500,
+        canonical_identity_capture_started_at: "2026-07-14T20:00:00.000Z",
+        direct_loopback_traffic: true,
+        exact_match_semantics: "trim-utf8-sha256-v1",
+      },
+      results: body.results.map((result) => ({
+        ...result,
+        identity_kind: "canonical",
+        unseen_claim_supported: true,
+        includes_legacy_inexact: false,
+      })),
+    };
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify(withAdditiveFields), { status: 200 }));
+
+    const snapshots = await lookupTaskExposureSnapshots({
+      gatewayBaseUrl: "https://host",
+      apiKey: "owner-token",
+      fingerprints: [A],
+      fetchImpl,
+    });
+
+    const snapshot = snapshots.get(A);
+    expect(snapshot?.result.seen).toBe(true);
+    // Recognized as typed optional fields, not merely passed through.
+    expect(snapshot?.result.identity_kind).toBe("canonical");
+    expect(snapshot?.result.unseen_claim_supported).toBe(true);
+  });
+
+  it("still rejects a response missing a required field (does not over-loosen)", async () => {
+    const body = responseFor([A], { seen: new Set([A]) }) as { coverage: Record<string, unknown> };
+    delete body.coverage.coverage_complete;
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify(body), { status: 200 }));
+
+    await expect(lookupTaskExposureSnapshots({
+      gatewayBaseUrl: "https://host",
+      apiKey: "owner-token",
+      fingerprints: [A],
+      fetchImpl,
+    })).rejects.toMatchObject({ code: "invalid-response" });
+  });
+
   it("fails closed on auth, version, schema, cardinality, or result-order ambiguity", async () => {
     const base = {
       gatewayBaseUrl: "https://host",


### PR DESCRIPTION
Closes #258

## What

Production regression: `hugin-daily-exam-factory.service` failed every nightly run starting 2026-07-20 12:05 CEST with `M5 task exposure lookup failed (invalid-response)`. Root cause: `src/learning/m5-task-exposure.ts` parsed the gateway `POST /admin/task-exposures/lookup` response with `.strict()` Zod schemas. `gille-inference` PR #27 (canonical exposure identity + coverage epochs) added 6 coverage keys and 3 result keys under the *same* `schema_version: 1` the same day it deployed — an additive, normally backward-compatible change that `.strict()` rejected outright.

Both fix tiers from the ticket are delivered:

**Tier 1 — forward-compatible parsing**
- `taskExposureCoverageSchema`, `taskExposureLookupResultSchema`, and the top-level `taskExposureLookupResponseSchema` changed from `.strict()` to `.passthrough()`. Additive gateway fields under the same `schema_version` no longer break the client.
- The top-level schema was made tolerant too for consistency, even though the observed incident only added nested fields — documented inline as a deliberate, uniform application of "don't `.strict()`-parse a response you don't own," so the next additive top-level field doesn't cause a repeat incident.
- Every existing required field is still validated exactly as before; `.passthrough()` only relaxes handling of unrecognized keys, it does not touch known-field validation.

**Tier 2 — consume the fail-closed signal**
- `identity_kind` (string) and `unseen_claim_supported` (boolean) are now typed, recognized optional fields on `taskExposureLookupResultSchema` (not just passed through).
- `applySnapshot()` in `src/learning/daily-task-exam-factory.ts` now quarantines a candidate — rather than clearing it to `unseen-covered`/provisional-holdout — whenever `unseen_claim_supported === false`, i.e. a negative match the gateway itself cannot vouch for is never treated as fresh.

**Residual follow-up (documented, not implemented here, per the ticket's "keep it minimal" guidance):** `identity_kind`/`unseen_claim_supported` are used only for the eligibility gate; they are not yet propagated into the persisted `crossClientExposure.match` manifest shape. Separately, grimnir#88 / the LearningTaskContract doc should record that admin lookup responses may add fields within a `schema_version` and consumers must ignore unknown ones (called out in the ticket as a cross-repo note).

## Verification

- `npm run build` — clean, no errors.
- `npm test` — **126 test files, 2037 tests, all passing** (includes 2 new tests in `tests/m5-task-exposure.test.ts` and 1 new test in `tests/daily-task-exam-factory.test.ts`).
- New/updated tests:
  - `tolerates #27's additive coverage/result fields under the same schema_version (regression for hugin#258)` — a response with all 9 documented extra keys parses successfully and `identity_kind`/`unseen_claim_supported` come through typed.
  - `still rejects a response missing a required field (does not over-loosen)` — deleting an existing required field (`coverage_complete`) still fails with `invalid-response`.
  - `never clears an unseen result as fresh when the gateway cannot vouch for the claim (unseen_claim_supported: false)` — an otherwise-clean unseen snapshot (complete coverage, in-window, all required lanes) is quarantined instead of sealed as `unseen-covered`, and does **not** pick up `independent-verifier-required`.
- This fix would have prevented the observed 2026-07-20 12:05 failure: the live gateway response (6 extra coverage keys + 3 extra result keys, same `schema_version: 1`) is exactly the shape exercised by the new regression test, and it now parses successfully instead of throwing `invalid-response`.

## Dogfood note

Used `mcp__m5__ask` (qwen3-30b-instruct, `delegator_model_id: anthropic/claude-sonnet-5`) for a bounded independent check that `.passthrough()` doesn't weaken existing required-field validation and that the `unseen_claim_supported` guard placement in `applySnapshot` is correct/sufficient (no downstream path can re-promote a quarantined candidate back to provisional-holdout). Its answers matched independent manual tracing of `applyCrossClientExposure`/`applySnapshot`/`quarantine`; both points verified rather than taken on faith.

🤖 Generated with [Claude Code](https://claude.com/claude-code)