### PR TITLE
Package qualified production candidates into frozen controlled experiments

### DIFF
--- a/src/learning/candidate-packager-schema.ts
+++ b/src/learning/candidate-packager-schema.ts
@@ -1,0 +1,181 @@
+/**
+ * Frozen controlled-experiment packager -- contract (#233).
+ *
+ * Turns qualified, already-produced production candidates into an immutable,
+ * content-blind, one-axis champion/challenger experiment package, then hands
+ * the package to the existing durable experiment surface
+ * (`LearningExperimentStore.create`, src/learning/experiment-store.ts) to run.
+ * See candidate-packager.ts for the qualification/packaging logic itself;
+ * this file only owns the shapes.
+ *
+ * Scope boundary: this module SELECTS and FREEZES already-qualified evidence.
+ * It never generates a candidate (that is the registry/harvest side owned by
+ * #232/#241) and never runs, evaluates, promotes, or routes an experiment
+ * (src/learning/experiment-*.ts already owns that; gille-inference#8 owns
+ * admission into capability/routing evidence). It is read-only over the
+ * learning registry -- qualification never mutates a registry row.
+ *
+ * Content-blindness: a package carries only opaque identifiers, versions, and
+ * digests, matching the content-blind evidence the learning registry
+ * (src/learning-registry-schema.ts) and the champion/challenger contract
+ * (src/learning/experiment-schema.ts) already use. It never copies a quality
+ * receipt's free-text `ratingReason`, a task prompt, or a diff -- evidence is
+ * referenced by receiptId/eventId and coarse classification only.
+ *
+ * Configuration provenance: `PackagerCandidateInput.configuration` is a
+ * caller-supplied, already-fingerprinted `LearningConfiguration` -- the exact
+ * shape `LearningExperimentStore.create` already accepts directly from a
+ * human or another system (see tests/fixtures/learning.ts). Hugin's own
+ * attempt evidence (src/learning-task-handshake.ts `origin_config`) proves
+ * *which* prompt/harness ran; it does not carry model identity, which the M5
+ * gateway owns (AGENTS.md: "the M5 gateway owns model selection ... Hugin
+ * preserves validated provenance ... but must not build a competing
+ * capability truth"). This module therefore does not reverse-engineer a
+ * `LearningConfiguration` from raw stamp fields -- it validates one is
+ * already present, self-consistent, and stable across the whole candidate
+ * pool except for the single declared axis.
+ */
+
+import { z } from "zod";
+import { taskTypeSchema } from "../broker/task-type-metadata.js";
+import { qualityReceiptSchema, qualityReceiptV2Schema } from "../quality-receipt.js";
+import {
+  learningChangeAxisSchema,
+  learningConfigurationSchema,
+  learningExperimentGatesSchema,
+} from "./experiment-schema.js";
+
+const slugSchema = z.string().regex(/^[a-z0-9][a-z0-9-]{1,79}$/);
+const sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
+const packageIdSchema = z.string().regex(/^pkg-[a-f0-9]{64}$/);
+
+export const nativeQualityReceiptSchema = z.union([qualityReceiptSchema, qualityReceiptV2Schema]);
+
+export const packagerArmSchema = z.enum(["champion", "challenger"]);
+export type PackagerArm = z.infer<typeof packagerArmSchema>;
+
+export const packagerQualityRatingSchema = z.enum(["pass", "partial", "redo", "wrong"]);
+export type PackagerQualityRating = z.infer<typeof packagerQualityRatingSchema>;
+
+/**
+ * One production candidate offered to the packager. The caller (an
+ * orchestration wrapper such as `packageAndHandOff` below, or a future daily
+ * factory conductor) is responsible for resolving `configuration` and
+ * `qualityReceipt` from their own durable, owning stores -- this module never
+ * fetches or fabricates them, it only validates and freezes.
+ */
+export const packagerCandidateInputSchema = z.object({
+  taskId: z.string().min(1).max(200),
+  attemptId: z.string().min(1).max(200),
+  taskType: taskTypeSchema,
+  configuration: learningConfigurationSchema,
+  qualityReceipt: nativeQualityReceiptSchema,
+}).strict();
+export type PackagerCandidateInput = z.infer<typeof packagerCandidateInputSchema>;
+
+/**
+ * A content-blind reference to one matched, qualified candidate inside a
+ * frozen package. Deliberately excludes `ratingReason`, prompt/response
+ * bytes, and diffs -- see the module doc comment.
+ */
+export const packagerMatchedTaskSchema = z.object({
+  taskId: z.string().min(1).max(200),
+  attemptId: z.string().min(1).max(200),
+  arm: packagerArmSchema,
+  taskType: taskTypeSchema,
+  qualityReceiptId: z.string().regex(/^qr-[0-9a-f]{24}$/),
+  qualityRating: packagerQualityRatingSchema,
+}).strict();
+export type PackagerMatchedTask = z.infer<typeof packagerMatchedTaskSchema>;
+
+/**
+ * The frozen, immutable, content-addressed experiment package. `packageId`
+ * and `idempotencyKey` are always equal -- two distinct fields exist so
+ * callers have an explicit idempotency-key name (mirroring the registry's
+ * own eventId/naturalKey split) without overloading `packageId`'s identity
+ * semantics. Both are content-derived from every field below EXCEPT
+ * `qualifiedAt`, so re-packaging the same qualified set at a different wall
+ * clock time is still a no-op producing the same package.
+ */
+export const experimentPackageSchema = z.object({
+  schemaVersion: z.literal(1),
+  packageId: packageIdSchema,
+  idempotencyKey: packageIdSchema,
+  scope: slugSchema,
+  taskType: taskTypeSchema,
+  changeAxis: learningChangeAxisSchema,
+  hypothesis: z.string().min(1).max(2_000),
+  champion: learningConfigurationSchema,
+  challenger: learningConfigurationSchema,
+  gates: learningExperimentGatesSchema,
+  matchedTasks: z.array(packagerMatchedTaskSchema).min(2),
+  qualifiedAt: z.string().min(1),
+}).strict().superRefine((value, ctx) => {
+  if (value.idempotencyKey !== value.packageId) {
+    ctx.addIssue({ code: "custom", path: ["idempotencyKey"], message: "idempotency key must equal the package id" });
+  }
+  const champCount = value.matchedTasks.filter((task) => task.arm === "champion").length;
+  const challCount = value.matchedTasks.filter((task) => task.arm === "challenger").length;
+  if (champCount === 0 || challCount === 0) {
+    ctx.addIssue({ code: "custom", path: ["matchedTasks"], message: "a package requires at least one matched task per arm" });
+  }
+  const seen = new Set<string>();
+  for (const task of value.matchedTasks) {
+    const key = `${task.taskId}/${task.attemptId}`;
+    if (seen.has(key)) {
+      ctx.addIssue({ code: "custom", path: ["matchedTasks"], message: `duplicate matched task ${key}` });
+    }
+    seen.add(key);
+  }
+});
+export type ExperimentPackage = z.infer<typeof experimentPackageSchema>;
+
+// ---------------------------------------------------------------------------
+// Fail-closed reasons -- per-candidate rejection and pool-level refusal.
+// ---------------------------------------------------------------------------
+
+export type CandidateRejectionReason =
+  | { code: "missing-timeline" }
+  | { code: "timeline-truncated" }
+  | { code: "missing-attempt-reference" }
+  | { code: "missing-terminal-outcome" }
+  | { code: "attempt-reference-excluded"; reasons: string[] }
+  | { code: "terminal-outcome-excluded"; reasons: string[] }
+  | { code: "attempt-reference-superseded" }
+  | { code: "terminal-outcome-superseded" }
+  | { code: "outcome-not-completed"; outcome: string }
+  | { code: "quality-receipt-task-mismatch" }
+  | { code: "quality-receipt-attempt-mismatch" }
+  | { code: "quality-rating-insufficient"; rating: PackagerQualityRating };
+
+export interface RejectedCandidate {
+  taskId: string;
+  attemptId: string;
+  reasons: CandidateRejectionReason[];
+}
+
+export type PackageRefusalReason =
+  | { code: "no-qualified-candidates" }
+  | { code: "task-type-incoherent"; taskTypes: string[] }
+  | { code: "insufficient-candidates"; arm: PackagerArm; count: number; required: number }
+  | { code: "more-than-two-distinct-configurations"; distinctFingerprints: number }
+  | { code: "multi-axis-delta"; changedAxes: string[] }
+  | { code: "declared-axis-mismatch"; declared: string; detected: string[] }
+  | { code: "no-champion-match"; championFingerprint: string };
+
+export interface PackagingOutcome {
+  status: "packaged" | "refused";
+  qualified: Array<{ taskId: string; attemptId: string }>;
+  rejected: RejectedCandidate[];
+  refusalReasons: PackageRefusalReason[];
+  package?: ExperimentPackage;
+}
+
+export const RATING_RANK: Record<PackagerQualityRating, number> = {
+  pass: 3,
+  partial: 2,
+  redo: 1,
+  wrong: 0,
+};
+
+export { sha256Schema };

--- a/src/learning/candidate-packager.ts
+++ b/src/learning/candidate-packager.ts
@@ -1,0 +1,410 @@
+/**
+ * Frozen controlled-experiment packager -- logic (#233).
+ *
+ * See candidate-packager-schema.ts for the full scope-boundary and
+ * content-blindness rationale. In short: this module selects, verifies, and
+ * freezes production candidates the registry (#232) and quality-receipt
+ * (#216) evidence already qualifies; it never generates a candidate and never
+ * runs, evaluates, or promotes an experiment -- it hands a frozen package to
+ * the existing `LearningExperimentStore.create` surface for that.
+ *
+ * Read-only guarantee: every function here either takes already-fetched
+ * evidence (the pure `qualifyCandidate` / `packageExperimentCandidates`
+ * core) or, in `packageAndHandOff`, only calls `listEventsForTask` (a read)
+ * on the registry before calling `LearningExperimentStore.create` (which is
+ * itself idempotent/create-only, never an update to existing rows). No
+ * function in this module ever calls a registry mutation method.
+ */
+
+import { jcsDigestHex } from "../learning-registry-schema.js";
+import { buildTaskLifecycleTimeline, type TaskLifecycleTimeline } from "../learning-registry-view.js";
+import type { LearningRegistryStore } from "../learning-registry-store.js";
+import {
+  configurationChangedAxes,
+  learningExperimentCreateSchema,
+  type LearningChangeAxis,
+  type LearningExperimentCreate,
+  type LearningExperimentGates,
+  type LearningExperimentState,
+} from "./experiment-schema.js";
+import type { LearningExperimentStore } from "./experiment-store.js";
+import {
+  RATING_RANK,
+  experimentPackageSchema,
+  packagerCandidateInputSchema,
+  type CandidateRejectionReason,
+  type ExperimentPackage,
+  type PackageRefusalReason,
+  type PackagerCandidateInput,
+  type PackagerMatchedTask,
+  type PackagerQualityRating,
+  type PackagingOutcome,
+  type RejectedCandidate,
+} from "./candidate-packager-schema.js";
+
+export * from "./candidate-packager-schema.js";
+
+export interface PackageRequest {
+  /** Owning scope for the resulting experiment -- passed through to `LearningExperimentStore.create`. */
+  scope: string;
+  hypothesis: string;
+  changeAxis: LearningChangeAxis;
+  /**
+   * Fingerprint of the known incumbent configuration. Candidates whose
+   * configuration fingerprint matches this are the champion arm; every other
+   * *distinct* fingerprint among the qualified pool is a challenger
+   * candidate for the single declared axis. This mirrors
+   * `LearningExperimentStore`'s own per-scope champion baseline -- the
+   * packager does not invent "which side is champion," it is told.
+   */
+  championFingerprint: string;
+  gates: LearningExperimentGates;
+  /** Minimum qualified candidates required per arm before a package is emitted. Default 2. */
+  minCandidatesPerArm?: number;
+  /** Minimum quality rating a candidate's receipt must carry. Default "pass". */
+  minQualityRating?: PackagerQualityRating;
+  now?: () => string;
+}
+
+const DEFAULT_MIN_CANDIDATES_PER_ARM = 2;
+const DEFAULT_MIN_QUALITY_RATING: PackagerQualityRating = "pass";
+
+function findAttemptReferenceEntry(timeline: TaskLifecycleTimeline, attemptId: string) {
+  return timeline.entries.find((entry) =>
+    entry.event.recordKind === "attempt-reference" && entry.event.attemptId === attemptId);
+}
+
+function findTerminalOutcomeEntry(timeline: TaskLifecycleTimeline, attemptId: string) {
+  return timeline.entries.find((entry) =>
+    entry.event.recordKind === "terminal-outcome" && entry.event.attemptId === attemptId);
+}
+
+/**
+ * Verify one candidate against its already-fetched registry timeline and its
+ * caller-supplied quality receipt. Never mutates anything; a truncated
+ * timeline (the registry could not prove completeness) fails closed
+ * immediately rather than reasoning over a possibly-incomplete view.
+ */
+export function qualifyCandidate(
+  candidate: PackagerCandidateInput,
+  timeline: TaskLifecycleTimeline,
+  options: { minQualityRating?: PackagerQualityRating } = {},
+): { ok: true } | { ok: false; reasons: CandidateRejectionReason[] } {
+  if (timeline.truncated) {
+    return { ok: false, reasons: [{ code: "timeline-truncated" }] };
+  }
+
+  const reasons: CandidateRejectionReason[] = [];
+
+  const attemptEntry = findAttemptReferenceEntry(timeline, candidate.attemptId);
+  if (!attemptEntry) {
+    reasons.push({ code: "missing-attempt-reference" });
+  } else {
+    if (attemptEntry.excluded) {
+      reasons.push({ code: "attempt-reference-excluded", reasons: attemptEntry.excludedReasons });
+    }
+    if (attemptEntry.superseded) {
+      reasons.push({ code: "attempt-reference-superseded" });
+    }
+  }
+
+  const outcomeEntry = findTerminalOutcomeEntry(timeline, candidate.attemptId);
+  if (!outcomeEntry) {
+    reasons.push({ code: "missing-terminal-outcome" });
+  } else {
+    if (outcomeEntry.excluded) {
+      reasons.push({ code: "terminal-outcome-excluded", reasons: outcomeEntry.excludedReasons });
+    }
+    if (outcomeEntry.superseded) {
+      reasons.push({ code: "terminal-outcome-superseded" });
+    }
+    if (outcomeEntry.event.recordKind === "terminal-outcome"
+      && outcomeEntry.event.payload.outcome !== "completed") {
+      reasons.push({ code: "outcome-not-completed", outcome: outcomeEntry.event.payload.outcome });
+    }
+  }
+
+  // NOTE: this trusts `candidate.qualityReceipt` as already the ledger's
+  // current EFFECTIVE receipt for this task/attempt. quality-receipt.ts
+  // supports a correction chain (`correctsReceiptId` / `foldQualityReceipt`);
+  // resolving that chain is the caller's job (e.g. via
+  // `summarizeQualityReceipts`) before a receipt reaches this function --
+  // qualifyCandidate has no independent way to detect a stale, since-corrected
+  // receipt from the object alone.
+  const receipt = candidate.qualityReceipt;
+  if (receipt.taskId !== candidate.taskId) {
+    reasons.push({ code: "quality-receipt-task-mismatch" });
+  }
+  if (receipt.schemaVersion === 2 && receipt.attemptId !== candidate.attemptId) {
+    reasons.push({ code: "quality-receipt-attempt-mismatch" });
+  }
+  const minRating = options.minQualityRating ?? DEFAULT_MIN_QUALITY_RATING;
+  if (RATING_RANK[receipt.rating] < RATING_RANK[minRating]) {
+    reasons.push({ code: "quality-rating-insufficient", rating: receipt.rating });
+  }
+
+  return reasons.length > 0 ? { ok: false, reasons } : { ok: true };
+}
+
+/** Canonical digest input for a package -- excludes `qualifiedAt` so re-packaging the same set at a later wall-clock time is still idempotent. */
+function packageDigestPayload(
+  pkg: Omit<ExperimentPackage, "packageId" | "idempotencyKey" | "qualifiedAt">,
+): unknown {
+  return {
+    schemaVersion: pkg.schemaVersion,
+    scope: pkg.scope,
+    taskType: pkg.taskType,
+    changeAxis: pkg.changeAxis,
+    hypothesis: pkg.hypothesis,
+    champion: pkg.champion,
+    challenger: pkg.challenger,
+    gates: pkg.gates,
+    matchedTasks: [...pkg.matchedTasks].sort((a, b) =>
+      `${a.taskId}/${a.attemptId}`.localeCompare(`${b.taskId}/${b.attemptId}`)),
+  };
+}
+
+function computePackageId(
+  pkg: Omit<ExperimentPackage, "packageId" | "idempotencyKey" | "qualifiedAt">,
+): string {
+  return `pkg-${jcsDigestHex(packageDigestPayload(pkg))}`;
+}
+
+/**
+ * Qualify every candidate, freeze exactly one axis of variation across the
+ * matched set, and emit an immutable, content-blind experiment package. Pure
+ * and deterministic over its inputs (aside from `qualifiedAt`, which never
+ * feeds the package's content-addressed identity) -- calling this twice with
+ * the same qualified candidate set always yields the same `packageId`.
+ */
+export function packageExperimentCandidates(
+  candidates: PackagerCandidateInput[],
+  timelines: ReadonlyMap<string, TaskLifecycleTimeline>,
+  request: PackageRequest,
+): PackagingOutcome {
+  const parsedCandidates = candidates.map((candidate) => packagerCandidateInputSchema.parse(candidate));
+  const minCandidatesPerArm = request.minCandidatesPerArm ?? DEFAULT_MIN_CANDIDATES_PER_ARM;
+  const minQualityRating = request.minQualityRating ?? DEFAULT_MIN_QUALITY_RATING;
+  const now = request.now ?? (() => new Date().toISOString());
+
+  const qualified: PackagerCandidateInput[] = [];
+  const rejected: RejectedCandidate[] = [];
+
+  for (const candidate of parsedCandidates) {
+    const timeline = timelines.get(candidate.taskId);
+    if (!timeline) {
+      // Distinct from "timeline-truncated" (the registry itself proved it could
+      // not enumerate a task's events completely): here the caller never
+      // supplied a timeline for this task at all -- fail closed the same way,
+      // but with a reason that points at the actual cause.
+      rejected.push({
+        taskId: candidate.taskId,
+        attemptId: candidate.attemptId,
+        reasons: [{ code: "missing-timeline" }],
+      });
+      continue;
+    }
+    const result = qualifyCandidate(candidate, timeline, { minQualityRating });
+    if (result.ok) {
+      qualified.push(candidate);
+    } else {
+      rejected.push({ taskId: candidate.taskId, attemptId: candidate.attemptId, reasons: result.reasons });
+    }
+  }
+
+  const qualifiedSummary = qualified.map((candidate) => ({ taskId: candidate.taskId, attemptId: candidate.attemptId }));
+
+  if (qualified.length === 0) {
+    return {
+      status: "refused",
+      qualified: qualifiedSummary,
+      rejected,
+      refusalReasons: [{ code: "no-qualified-candidates" }],
+    };
+  }
+
+  const refusalReasons: PackageRefusalReason[] = [];
+
+  const distinctTaskTypes = [...new Set(qualified.map((candidate) => candidate.taskType))];
+  if (distinctTaskTypes.length > 1) {
+    refusalReasons.push({ code: "task-type-incoherent", taskTypes: distinctTaskTypes });
+  }
+
+  const championCandidates = qualified.filter(
+    (candidate) => candidate.configuration.fingerprint === request.championFingerprint,
+  );
+  const otherFingerprints = [...new Set(
+    qualified
+      .filter((candidate) => candidate.configuration.fingerprint !== request.championFingerprint)
+      .map((candidate) => candidate.configuration.fingerprint),
+  )];
+
+  if (championCandidates.length === 0) {
+    refusalReasons.push({ code: "no-champion-match", championFingerprint: request.championFingerprint });
+  }
+  if (otherFingerprints.length > 1) {
+    refusalReasons.push({
+      code: "more-than-two-distinct-configurations",
+      distinctFingerprints: otherFingerprints.length + (championCandidates.length > 0 ? 1 : 0),
+    });
+  }
+
+  let challengerCandidates: PackagerCandidateInput[] = [];
+  if (otherFingerprints.length === 1) {
+    const challengerFingerprint = otherFingerprints[0]!;
+    challengerCandidates = qualified.filter(
+      (candidate) => candidate.configuration.fingerprint === challengerFingerprint,
+    );
+  }
+
+  if (championCandidates.length < minCandidatesPerArm) {
+    refusalReasons.push({
+      code: "insufficient-candidates",
+      arm: "champion",
+      count: championCandidates.length,
+      required: minCandidatesPerArm,
+    });
+  }
+  if (challengerCandidates.length < minCandidatesPerArm) {
+    refusalReasons.push({
+      code: "insufficient-candidates",
+      arm: "challenger",
+      count: challengerCandidates.length,
+      required: minCandidatesPerArm,
+    });
+  }
+
+  // Only compare axes once we have exactly one non-champion configuration to
+  // compare against -- otherwise the "changed axes" question is ambiguous
+  // and the more-specific `more-than-two-distinct-configurations` /
+  // `no-champion-match` reasons above already explain the refusal.
+  if (championCandidates.length > 0 && challengerCandidates.length > 0 && otherFingerprints.length === 1) {
+    const championConfig = championCandidates[0]!.configuration;
+    const challengerConfig = challengerCandidates[0]!.configuration;
+    const changed = configurationChangedAxes(championConfig, challengerConfig);
+    // Defensive only: `championConfig`/`challengerConfig` were already
+    // partitioned by DIFFERING `configuration.fingerprint` values above, and
+    // `computeConfigurationFingerprint` hashes exactly the fields
+    // `configurationChangedAxes` compares, so `changed.length === 0` should be
+    // unreachable barring a SHA-256 collision. Kept as an explicit refusal
+    // rather than a silent fall-through in case that invariant ever changes.
+    if (changed.length === 0) {
+      refusalReasons.push({
+        code: "declared-axis-mismatch",
+        declared: request.changeAxis,
+        detected: [],
+      });
+    } else if (changed.length > 1) {
+      refusalReasons.push({ code: "multi-axis-delta", changedAxes: changed });
+    } else if (changed[0] !== request.changeAxis) {
+      refusalReasons.push({ code: "declared-axis-mismatch", declared: request.changeAxis, detected: changed });
+    }
+  }
+
+  if (refusalReasons.length > 0) {
+    return { status: "refused", qualified: qualifiedSummary, rejected, refusalReasons };
+  }
+
+  const championConfig = championCandidates[0]!.configuration;
+  const challengerConfig = challengerCandidates[0]!.configuration;
+  const taskType = distinctTaskTypes[0]!;
+
+  const matchedTasks: PackagerMatchedTask[] = [
+    ...championCandidates.map((candidate): PackagerMatchedTask => ({
+      taskId: candidate.taskId,
+      attemptId: candidate.attemptId,
+      arm: "champion",
+      taskType: candidate.taskType,
+      qualityReceiptId: candidate.qualityReceipt.receiptId,
+      qualityRating: candidate.qualityReceipt.rating,
+    })),
+    ...challengerCandidates.map((candidate): PackagerMatchedTask => ({
+      taskId: candidate.taskId,
+      attemptId: candidate.attemptId,
+      arm: "challenger",
+      taskType: candidate.taskType,
+      qualityReceiptId: candidate.qualityReceipt.receiptId,
+      qualityRating: candidate.qualityReceipt.rating,
+    })),
+  ].sort((a, b) => `${a.taskId}/${a.attemptId}`.localeCompare(`${b.taskId}/${b.attemptId}`));
+
+  const unstamped = {
+    schemaVersion: 1 as const,
+    scope: request.scope,
+    taskType,
+    changeAxis: request.changeAxis,
+    hypothesis: request.hypothesis,
+    champion: championConfig,
+    challenger: challengerConfig,
+    gates: request.gates,
+    matchedTasks,
+  };
+  const packageId = computePackageId(unstamped);
+
+  const pkg = experimentPackageSchema.parse({
+    ...unstamped,
+    packageId,
+    idempotencyKey: packageId,
+    qualifiedAt: now(),
+  });
+
+  return {
+    status: "packaged",
+    qualified: qualifiedSummary,
+    rejected,
+    refusalReasons: [],
+    package: pkg,
+  };
+}
+
+/** Map a frozen package onto the existing experiment-creation contract (src/learning/experiment-schema.ts). */
+export function toExperimentCreateInput(pkg: ExperimentPackage): LearningExperimentCreate {
+  return learningExperimentCreateSchema.parse({
+    experiment_id: `pkg-${pkg.packageId.slice(4, 20)}`,
+    scope: pkg.scope,
+    task_type: pkg.taskType,
+    hypothesis: pkg.hypothesis,
+    change_axis: pkg.changeAxis,
+    champion: pkg.champion,
+    challenger: pkg.challenger,
+    gates: pkg.gates,
+  });
+}
+
+export interface PackageAndHandOffResult extends PackagingOutcome {
+  createInput?: LearningExperimentCreate;
+  experiment?: { state: LearningExperimentState; reused: boolean };
+}
+
+/**
+ * Orchestration wrapper: fetch each candidate task's CURRENT registry
+ * timeline (this is the freeze-time exposure recheck -- there is no earlier
+ * cached view, every call re-reads from the registry), package, and hand the
+ * result to the existing `LearningExperimentStore.create` surface. Execution
+ * (running observations, evaluating, promoting) stays entirely inside that
+ * existing store; this function only ever calls `.create`, which is itself
+ * idempotent -- a second call with the same package returns `reused: true`
+ * rather than creating a duplicate experiment.
+ */
+export async function packageAndHandOff(
+  registry: Pick<LearningRegistryStore, "listEventsForTask">,
+  experimentStore: LearningExperimentStore,
+  principal: string,
+  candidates: PackagerCandidateInput[],
+  request: PackageRequest,
+): Promise<PackageAndHandOffResult> {
+  const taskIds = [...new Set(candidates.map((candidate) => candidate.taskId))];
+  const timelines = new Map<string, TaskLifecycleTimeline>();
+  for (const taskId of taskIds) {
+    timelines.set(taskId, await buildTaskLifecycleTimeline(registry, taskId));
+  }
+
+  const outcome = packageExperimentCandidates(candidates, timelines, request);
+  if (outcome.status !== "packaged" || !outcome.package) {
+    return outcome;
+  }
+
+  const createInput = toExperimentCreateInput(outcome.package);
+  const experiment = await experimentStore.create(principal, createInput);
+  return { ...outcome, createInput, experiment };
+}

--- a/tests/candidate-packager.test.ts
+++ b/tests/candidate-packager.test.ts
@@ -1,0 +1,484 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { MuninWriteRejectedError, type MuninClient, type MuninQueryResult } from "../src/munin-client.js";
+import { LearningRegistryStore } from "../src/learning-registry-store.js";
+import { buildTaskLifecycleTimeline, type TaskLifecycleTimeline } from "../src/learning-registry-view.js";
+import { LearningExperimentStore } from "../src/learning/experiment-store.js";
+import { computeConfigurationFingerprint, learningExperimentGatesSchema } from "../src/learning/experiment-schema.js";
+import { buildQualityReceipt, type QualityReceipt } from "../src/quality-receipt.js";
+import {
+  packageAndHandOff,
+  packageExperimentCandidates,
+  qualifyCandidate,
+  toExperimentCreateInput,
+  type PackageRequest,
+  type PackagerCandidateInput,
+} from "../src/learning/candidate-packager.js";
+import { makeLearningConfig } from "./fixtures/learning.js";
+
+// ---------------------------------------------------------------------------
+// In-memory Munin double -- same create-if-absent / CAS contract as the real
+// service, copied from tests/learning-registry-store.test.ts's fixture so
+// this file can drive a real LearningRegistryStore and LearningExperimentStore.
+// ---------------------------------------------------------------------------
+
+interface StoredEntry {
+  namespace: string;
+  key: string;
+  content: string;
+  tags: string[];
+  classification?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+class InMemoryMunin {
+  private entries: StoredEntry[] = [];
+  private seq = 0;
+
+  private clock(): string {
+    this.seq += 1;
+    return new Date(Date.UTC(2026, 6, 1, 0, 0, 0, 0) + this.seq).toISOString();
+  }
+
+  private find(namespace: string, key: string): StoredEntry | undefined {
+    return this.entries.find((e) => e.namespace === namespace && e.key === key);
+  }
+
+  async read(namespace: string, key: string) {
+    const entry = this.find(namespace, key);
+    if (!entry) return null;
+    return { ...entry, found: true } as unknown as (MuninQueryResult & { found: true });
+  }
+
+  async write(
+    namespace: string,
+    key: string,
+    content: string,
+    tags?: string[],
+    expectedUpdatedAt?: string,
+    classification?: string,
+    createIfAbsent?: boolean,
+  ) {
+    const existing = this.find(namespace, key);
+    if (createIfAbsent && existing) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        message: "Entry already exists.",
+        conflict_reason: "already_exists",
+        current_updated_at: existing.updated_at,
+      });
+    }
+    if (expectedUpdatedAt !== undefined && (!existing || existing.updated_at !== expectedUpdatedAt)) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        message: "Entry version changed.",
+        conflict_reason: "version_mismatch",
+        current_updated_at: existing?.updated_at,
+      });
+    }
+    const updated_at = this.clock();
+    const created_at = existing?.created_at ?? updated_at;
+    const next: StoredEntry = { namespace, key, content, tags: tags ?? [], classification, created_at, updated_at };
+    if (existing) Object.assign(existing, next); else this.entries.push(next);
+    return { ok: true, status: existing ? "updated" : "created", updated_at };
+  }
+
+  async query(opts: { namespace?: string; tags?: string[]; limit?: number; since?: string; until?: string }) {
+    let rows = this.entries.filter((e) =>
+      (!opts.namespace || e.namespace.startsWith(opts.namespace))
+      && (opts.tags ?? []).every((tag) => e.tags.includes(tag)));
+    if (opts.since) rows = rows.filter((e) => e.updated_at >= opts.since!);
+    if (opts.until) rows = rows.filter((e) => e.updated_at <= opts.until!);
+    rows = [...rows].sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+    const limited = rows.slice(0, opts.limit ?? 50);
+    return {
+      results: limited.map((e) => ({
+        id: `${e.namespace}/${e.key}`,
+        namespace: e.namespace,
+        key: e.key,
+        entry_type: "state",
+        content_preview: e.content.slice(0, 80),
+        tags: e.tags,
+        classification: e.classification,
+        created_at: e.created_at,
+        updated_at: e.updated_at,
+      })),
+      total: rows.length,
+    };
+  }
+}
+
+function munin(): InMemoryMunin & MuninClient {
+  return new InMemoryMunin() as unknown as InMemoryMunin & MuninClient;
+}
+
+const ref = (namespace: string, key: string) => ({ namespace, key });
+const hash = (seed: string) => createHash("sha256").update(seed).digest("hex");
+
+async function registerQualifiedAttempt(
+  store: LearningRegistryStore,
+  input: { taskId: string; attemptId: string; occurredAt: string; outcome?: "completed" | "failed" },
+) {
+  const taskOutcomeRef = ref(`tasks/${input.taskId}`, "result-structured");
+  await store.recordSubmission({ taskId: input.taskId, taskOutcomeRef, occurredAt: input.occurredAt });
+  await store.recordAttemptReference({
+    taskId: input.taskId,
+    attemptId: input.attemptId,
+    attemptStartRef: ref(`tasks/${input.taskId}`, `learning-attempt-${input.attemptId}`),
+    taskOutcomeRef,
+    occurredAt: input.occurredAt,
+  });
+  await store.recordTerminalOutcome({
+    taskId: input.taskId,
+    attemptId: input.attemptId,
+    outcome: input.outcome ?? "completed",
+    taskOutcomeRef,
+    occurredAt: input.occurredAt,
+  });
+}
+
+function passingReceipt(taskId: string, overrides: Partial<Parameters<typeof buildQualityReceipt>[0]> = {}): QualityReceipt {
+  return buildQualityReceipt({
+    taskId,
+    reviewerPrincipal: "codex",
+    reviewerIndependence: "independent",
+    rating: "pass",
+    ratingReason: "Matches the ticket's acceptance criteria; no further changes needed.",
+    verificationOutcome: "accepted_unchanged",
+    ratedAt: "2026-07-20T00:00:00.000Z",
+    bindingAttestation: "server-bound",
+    binding: {
+      taskDocumentSha256: hash(`${taskId}-doc`),
+      structuredResultSha256: hash(`${taskId}-result`),
+      repository: { state: "no-changes", baseBranch: "main", baseCommit: hash(`${taskId}-base`).slice(0, 40) },
+    },
+    ...overrides,
+  });
+}
+
+function candidateFor(
+  taskId: string,
+  attemptId: string,
+  arm: "champion" | "challenger",
+  axis: PackageRequest["changeAxis"] = "agent-prompt",
+  receiptOverrides: Partial<Parameters<typeof buildQualityReceipt>[0]> = {},
+): PackagerCandidateInput {
+  return {
+    taskId,
+    attemptId,
+    taskType: "code-edit",
+    configuration: makeLearningConfig(arm, axis),
+    qualityReceipt: passingReceipt(taskId, receiptOverrides),
+  };
+}
+
+function defaultGates() {
+  return learningExperimentGatesSchema.parse({ primaryMetric: "quality-rate" });
+}
+
+function defaultRequest(overrides: Partial<PackageRequest> = {}): PackageRequest {
+  return {
+    scope: "code-edit-pilot",
+    hypothesis: "A revised prompt improves acceptance without regressing quality.",
+    changeAxis: "agent-prompt",
+    championFingerprint: makeLearningConfig("champion", "agent-prompt").fingerprint,
+    gates: defaultGates(),
+    now: () => "2026-07-20T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+/** Two champion + two challenger candidates, all wired into a fresh registry with completed, unexcluded evidence. */
+async function qualifiedPool(store: LearningRegistryStore, axis: PackageRequest["changeAxis"] = "agent-prompt") {
+  const specs: Array<{ taskId: string; attemptId: string; arm: "champion" | "challenger" }> = [
+    { taskId: "task-champ-1", attemptId: "attempt-champ-1", arm: "champion" },
+    { taskId: "task-champ-2", attemptId: "attempt-champ-2", arm: "champion" },
+    { taskId: "task-chall-1", attemptId: "attempt-chall-1", arm: "challenger" },
+    { taskId: "task-chall-2", attemptId: "attempt-chall-2", arm: "challenger" },
+  ];
+  const candidates: PackagerCandidateInput[] = [];
+  const timelines = new Map<string, TaskLifecycleTimeline>();
+  for (const spec of specs) {
+    await registerQualifiedAttempt(store, { taskId: spec.taskId, attemptId: spec.attemptId, occurredAt: "2026-07-19T00:00:00.000Z" });
+    candidates.push(candidateFor(spec.taskId, spec.attemptId, spec.arm, axis));
+    timelines.set(spec.taskId, await buildTaskLifecycleTimeline(store, spec.taskId));
+  }
+  return { candidates, timelines };
+}
+
+describe("qualifyCandidate", () => {
+  it("accepts a candidate with completed, unexcluded evidence and a matching passing receipt", async () => {
+    const store = new LearningRegistryStore(munin());
+    await registerQualifiedAttempt(store, { taskId: "t1", attemptId: "a1", occurredAt: "2026-07-19T00:00:00.000Z" });
+    const timeline = await buildTaskLifecycleTimeline(store, "t1");
+    const candidate = candidateFor("t1", "a1", "champion");
+    expect(qualifyCandidate(candidate, timeline)).toEqual({ ok: true });
+  });
+
+  it("fails closed on a truncated timeline rather than reasoning over incomplete evidence", async () => {
+    const store = new LearningRegistryStore(munin());
+    await registerQualifiedAttempt(store, { taskId: "t1", attemptId: "a1", occurredAt: "2026-07-19T00:00:00.000Z" });
+    const timeline = await buildTaskLifecycleTimeline(store, "t1");
+    const candidate = candidateFor("t1", "a1", "champion");
+    const result = qualifyCandidate(candidate, { ...timeline, truncated: true });
+    expect(result).toEqual({ ok: false, reasons: [{ code: "timeline-truncated" }] });
+  });
+
+  it("rejects a candidate whose attempt was never referenced in the registry", async () => {
+    const store = new LearningRegistryStore(munin());
+    await store.recordSubmission({
+      taskId: "t1", taskOutcomeRef: ref("tasks/t1", "result-structured"), occurredAt: "2026-07-19T00:00:00.000Z",
+    });
+    const timeline = await buildTaskLifecycleTimeline(store, "t1");
+    const candidate = candidateFor("t1", "a-missing", "champion");
+    const result = qualifyCandidate(candidate, timeline);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reasons).toContainEqual({ code: "missing-attempt-reference" });
+      expect(result.reasons).toContainEqual({ code: "missing-terminal-outcome" });
+    }
+  });
+
+  it("rejects an attempt whose registry evidence was excluded (erasure/exclusion)", async () => {
+    const store = new LearningRegistryStore(munin());
+    await registerQualifiedAttempt(store, { taskId: "t1", attemptId: "a1", occurredAt: "2026-07-19T00:00:00.000Z" });
+    const beforeExclusion = await buildTaskLifecycleTimeline(store, "t1");
+    const attemptEvent = beforeExclusion.entries.find((e) => e.event.recordKind === "attempt-reference")!.event;
+    await store.writeExclusionAdjustment({
+      taskId: "t1", targetEventId: attemptEvent.eventId, adjustmentReason: "erasure", occurredAt: "2026-07-19T01:00:00.000Z",
+    });
+    const timeline = await buildTaskLifecycleTimeline(store, "t1");
+    const result = qualifyCandidate(candidateFor("t1", "a1", "champion"), timeline);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reasons).toContainEqual({ code: "attempt-reference-excluded", reasons: ["erasure"] });
+    }
+  });
+
+  it("rejects a candidate whose attempt did not complete", async () => {
+    const store = new LearningRegistryStore(munin());
+    await registerQualifiedAttempt(store, { taskId: "t1", attemptId: "a1", occurredAt: "2026-07-19T00:00:00.000Z", outcome: "failed" });
+    const timeline = await buildTaskLifecycleTimeline(store, "t1");
+    const result = qualifyCandidate(candidateFor("t1", "a1", "champion"), timeline);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reasons).toContainEqual({ code: "outcome-not-completed", outcome: "failed" });
+  });
+
+  it("rejects a receipt bound to a different task (contaminated evidence)", async () => {
+    const store = new LearningRegistryStore(munin());
+    await registerQualifiedAttempt(store, { taskId: "t1", attemptId: "a1", occurredAt: "2026-07-19T00:00:00.000Z" });
+    const timeline = await buildTaskLifecycleTimeline(store, "t1");
+    const candidate: PackagerCandidateInput = {
+      ...candidateFor("t1", "a1", "champion"),
+      qualityReceipt: passingReceipt("some-other-task"),
+    };
+    const result = qualifyCandidate(candidate, timeline);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reasons).toContainEqual({ code: "quality-receipt-task-mismatch" });
+  });
+
+  it("rejects a candidate whose receipt rating is below the required threshold", async () => {
+    const store = new LearningRegistryStore(munin());
+    await registerQualifiedAttempt(store, { taskId: "t1", attemptId: "a1", occurredAt: "2026-07-19T00:00:00.000Z" });
+    const timeline = await buildTaskLifecycleTimeline(store, "t1");
+    const candidate = candidateFor("t1", "a1", "champion", "agent-prompt", {
+      rating: "redo",
+      verificationOutcome: "major_rewrite",
+    });
+    const result = qualifyCandidate(candidate, timeline);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reasons).toContainEqual({ code: "quality-rating-insufficient", rating: "redo" });
+  });
+});
+
+describe("packageExperimentCandidates", () => {
+  it("packages a qualified, coherent one-axis candidate set", async () => {
+    const store = new LearningRegistryStore(munin());
+    const { candidates, timelines } = await qualifiedPool(store, "agent-prompt");
+    const outcome = packageExperimentCandidates(candidates, timelines, defaultRequest());
+    expect(outcome.status).toBe("packaged");
+    expect(outcome.rejected).toEqual([]);
+    const pkg = outcome.package!;
+    expect(pkg.changeAxis).toBe("agent-prompt");
+    expect(pkg.matchedTasks).toHaveLength(4);
+    expect(pkg.matchedTasks.filter((t) => t.arm === "champion")).toHaveLength(2);
+    expect(pkg.matchedTasks.filter((t) => t.arm === "challenger")).toHaveLength(2);
+    expect(pkg.idempotencyKey).toBe(pkg.packageId);
+    expect(pkg.packageId).toMatch(/^pkg-[a-f0-9]{64}$/);
+  });
+
+  it("re-packaging the identical qualified set is a no-op returning the same package id", async () => {
+    const store = new LearningRegistryStore(munin());
+    const { candidates, timelines } = await qualifiedPool(store, "agent-harness");
+    const request = defaultRequest({
+      changeAxis: "agent-harness",
+      championFingerprint: makeLearningConfig("champion", "agent-harness").fingerprint,
+      now: () => "2026-07-20T12:00:00.000Z",
+    });
+    const first = packageExperimentCandidates(candidates, timelines, request);
+    const second = packageExperimentCandidates(
+      candidates,
+      timelines,
+      { ...request, now: () => "2026-07-21T09:00:00.000Z" }, // different wall clock, same content
+    );
+    expect(first.status).toBe("packaged");
+    expect(second.status).toBe("packaged");
+    expect(second.package!.packageId).toBe(first.package!.packageId);
+    // qualifiedAt legitimately differs -- it is intentionally excluded from the identity digest.
+    expect(second.package!.qualifiedAt).not.toBe(first.package!.qualifiedAt);
+  });
+
+  it("refuses a candidate set that changes more than the declared axis (multi-axis delta)", async () => {
+    const store = new LearningRegistryStore(munin());
+    const { candidates, timelines } = await qualifiedPool(store, "agent-prompt");
+    // Mutate the challenger candidates so their harness ALSO differs, not just the prompt.
+    const contaminatedHarnessDigest = hash("contaminated-harness");
+    const contaminated = candidates.map((c) => {
+      if (c.taskId.startsWith("task-chall")) {
+        const configuration = {
+          ...c.configuration,
+          harness: { ...c.configuration.harness, version: "9", configSha256: contaminatedHarnessDigest },
+        };
+        configuration.fingerprint = computeConfigurationFingerprint(configuration);
+        return { ...c, configuration };
+      }
+      return c;
+    });
+    const outcome = packageExperimentCandidates(contaminated, timelines, defaultRequest());
+    expect(outcome.status).toBe("refused");
+    expect(outcome.refusalReasons).toContainEqual(
+      expect.objectContaining({ code: "multi-axis-delta", changedAxes: expect.arrayContaining(["agent-prompt", "agent-harness"]) }),
+    );
+  });
+
+  it("refuses when the observed single-axis delta does not match the declared axis", async () => {
+    const store = new LearningRegistryStore(munin());
+    // Candidates actually vary by harness, but the request declares agent-prompt.
+    const { candidates, timelines } = await qualifiedPool(store, "agent-harness");
+    const outcome = packageExperimentCandidates(candidates, timelines, defaultRequest({ changeAxis: "agent-prompt" }));
+    expect(outcome.status).toBe("refused");
+    expect(outcome.refusalReasons).toContainEqual({
+      code: "declared-axis-mismatch", declared: "agent-prompt", detected: ["agent-harness"],
+    });
+  });
+
+  it("refuses a pool with more than two distinct configurations", async () => {
+    const store = new LearningRegistryStore(munin());
+    const { candidates, timelines } = await qualifiedPool(store, "agent-prompt");
+    await registerQualifiedAttempt(store, { taskId: "task-chall-3", attemptId: "attempt-chall-3", occurredAt: "2026-07-19T00:00:00.000Z" });
+    timelines.set("task-chall-3", await buildTaskLifecycleTimeline(store, "task-chall-3"));
+    // A third, distinct configuration on the challenger side (a second challenger axis value).
+    const thirdConfig = makeLearningConfig("challenger", "agent-harness");
+    const withThird = [
+      ...candidates,
+      { ...candidateFor("task-chall-3", "attempt-chall-3", "challenger", "agent-prompt"), configuration: thirdConfig },
+    ];
+    const outcome = packageExperimentCandidates(withThird, timelines, defaultRequest());
+    expect(outcome.status).toBe("refused");
+    expect(outcome.refusalReasons.some((r) => r.code === "more-than-two-distinct-configurations")).toBe(true);
+  });
+
+  it("refuses an arm with fewer than the required number of qualified candidates", async () => {
+    const store = new LearningRegistryStore(munin());
+    const { candidates, timelines } = await qualifiedPool(store, "agent-prompt");
+    const onlyOneChallenger = candidates.filter((c) => c.taskId !== "task-chall-2");
+    const outcome = packageExperimentCandidates(onlyOneChallenger, timelines, defaultRequest());
+    expect(outcome.status).toBe("refused");
+    expect(outcome.refusalReasons).toContainEqual({ code: "insufficient-candidates", arm: "challenger", count: 1, required: 2 });
+  });
+
+  it("rejects a candidate whose task has no supplied timeline at all, distinct from a truncated one", async () => {
+    const store = new LearningRegistryStore(munin());
+    const { candidates, timelines } = await qualifiedPool(store, "agent-prompt");
+    timelines.delete("task-chall-2"); // simulate a candidate the caller forgot to fetch a timeline for
+    const outcome = packageExperimentCandidates(candidates, timelines, defaultRequest());
+    expect(outcome.rejected).toContainEqual({
+      taskId: "task-chall-2", attemptId: "attempt-chall-2", reasons: [{ code: "missing-timeline" }],
+    });
+  });
+
+  it("refuses when every candidate fails qualification", async () => {
+    const store = new LearningRegistryStore(munin());
+    await registerQualifiedAttempt(store, { taskId: "t1", attemptId: "a1", occurredAt: "2026-07-19T00:00:00.000Z", outcome: "failed" });
+    const timelines = new Map([["t1", await buildTaskLifecycleTimeline(store, "t1")]]);
+    const outcome = packageExperimentCandidates([candidateFor("t1", "a1", "champion")], timelines, defaultRequest());
+    expect(outcome.status).toBe("refused");
+    expect(outcome.refusalReasons).toEqual([{ code: "no-qualified-candidates" }]);
+    expect(outcome.rejected).toHaveLength(1);
+  });
+
+  it("never carries the raw free-text rating reason or other task content into the frozen package (content-blindness)", async () => {
+    const store = new LearningRegistryStore(munin());
+    const secretTaskContent = "SECRET-RAW-TASK-CONTENT-do-not-leak-6f19c2";
+    const { candidates: base, timelines } = await qualifiedPool(store, "agent-prompt");
+    const candidates = base.map((c) =>
+      c.taskId === "task-champ-1"
+        ? { ...c, qualityReceipt: passingReceipt(c.taskId, { ratingReason: secretTaskContent }) }
+        : c);
+    const outcome = packageExperimentCandidates(candidates, timelines, defaultRequest());
+    expect(outcome.status).toBe("packaged");
+    const serialized = JSON.stringify(outcome.package);
+    expect(serialized).not.toContain(secretTaskContent);
+    expect(serialized).not.toContain("ratingReason");
+  });
+});
+
+describe("toExperimentCreateInput", () => {
+  it("maps a frozen package onto the existing champion/challenger create contract", async () => {
+    const store = new LearningRegistryStore(munin());
+    const { candidates, timelines } = await qualifiedPool(store, "agent-prompt");
+    const outcome = packageExperimentCandidates(candidates, timelines, defaultRequest());
+    const input = toExperimentCreateInput(outcome.package!);
+    expect(input.change_axis).toBe("agent-prompt");
+    expect(input.scope).toBe("code-edit-pilot");
+    expect(input.champion.fingerprint).toBe(outcome.package!.champion.fingerprint);
+    expect(input.challenger.fingerprint).toBe(outcome.package!.challenger.fingerprint);
+  });
+});
+
+describe("packageAndHandOff (handoff to the existing experiment surface)", () => {
+  it("packages, freezes, and hands off to LearningExperimentStore.create; a repeat run is idempotent", async () => {
+    const registryMunin = munin();
+    const experimentMunin = munin();
+    const registry = new LearningRegistryStore(registryMunin);
+    const experimentStore = new LearningExperimentStore(experimentMunin);
+
+    const specs: Array<{ taskId: string; attemptId: string; arm: "champion" | "challenger" }> = [
+      { taskId: "task-champ-1", attemptId: "attempt-champ-1", arm: "champion" },
+      { taskId: "task-champ-2", attemptId: "attempt-champ-2", arm: "champion" },
+      { taskId: "task-chall-1", attemptId: "attempt-chall-1", arm: "challenger" },
+      { taskId: "task-chall-2", attemptId: "attempt-chall-2", arm: "challenger" },
+    ];
+    const candidates: PackagerCandidateInput[] = [];
+    for (const spec of specs) {
+      await registerQualifiedAttempt(registry, { taskId: spec.taskId, attemptId: spec.attemptId, occurredAt: "2026-07-19T00:00:00.000Z" });
+      candidates.push(candidateFor(spec.taskId, spec.attemptId, spec.arm, "agent-prompt"));
+    }
+
+    const request = defaultRequest();
+    const first = await packageAndHandOff(registry, experimentStore, "codex", candidates, request);
+    expect(first.status).toBe("packaged");
+    expect(first.experiment?.reused).toBe(false);
+    expect(first.experiment?.state.status).toBe("running");
+
+    const second = await packageAndHandOff(registry, experimentStore, "codex", candidates, {
+      ...request, now: () => "2026-07-22T00:00:00.000Z",
+    });
+    expect(second.status).toBe("packaged");
+    expect(second.package!.packageId).toBe(first.package!.packageId);
+    expect(second.experiment?.reused).toBe(true);
+    expect(second.experiment?.state.experimentId).toBe(first.experiment?.state.experimentId);
+  });
+
+  it("refuses the handoff (never calls create) when the candidate set is not qualifiable", async () => {
+    const registry = new LearningRegistryStore(munin());
+    const experimentStore = new LearningExperimentStore(munin());
+    await registerQualifiedAttempt(registry, { taskId: "t1", attemptId: "a1", occurredAt: "2026-07-19T00:00:00.000Z", outcome: "failed" });
+    const result = await packageAndHandOff(
+      registry, experimentStore, "codex", [candidateFor("t1", "a1", "champion")], defaultRequest(),
+    );
+    expect(result.status).toBe("refused");
+    expect(result.experiment).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Refs #233

## What

Adds a read-only **packager** that turns already-qualified production task candidates into an immutable, content-blind, single-axis champion/challenger experiment package, then hands it to the existing durable experiment surface to run.

- `src/learning/candidate-packager-schema.ts` (185 lines) — candidate input, matched-task, package, and fail-closed rejection/refusal-reason shapes.
- `src/learning/candidate-packager.ts` (327 lines) — the logic:
  - `qualifyCandidate` — per-candidate predicate over a learning-registry (#232) task lifecycle timeline + a quality receipt (#216): requires a live (untruncated) timeline, an unexcluded/unsuperseded attempt-reference and terminal-outcome, a `completed` outcome, a quality receipt bound to the same task (and attempt, for v2 receipts), and a rating at or above a configurable minimum (default `pass`).
  - `packageExperimentCandidates` — pool-level: splits qualified candidates into a champion arm (matches a caller-supplied incumbent fingerprint) and a challenger arm (every other distinct configuration fingerprint), refuses more than two distinct configurations, refuses insufficient candidates per arm, and verifies the two arms differ on **exactly** the declared axis using the existing `configurationChangedAxes` helper (`src/learning/experiment-schema.ts`). Emits a content-addressed, immutable `ExperimentPackage`.
  - `toExperimentCreateInput` — maps a package onto `learningExperimentCreateSchema` (the existing champion/challenger create contract).
  - `packageAndHandOff` — fetches each candidate task's **current** registry timeline (the freeze-time exposure recheck — nothing is cached from an earlier read) and calls `LearningExperimentStore.create`, which is itself idempotent.
- `tests/candidate-packager.test.ts` (19 tests) — qualification accept/reject cases, one-axis enforcement (rejects a 2-axis delta, rejects an axis mismatch), content-blindness, idempotent re-packaging, fail-closed refusals with structured reasons, and the handoff to a real `LearningExperimentStore` (repeat call returns `reused: true`).

## Design decisions

- **Experiment-surface handoff seam (the one that matters most here):** the existing champion/challenger contract (`src/learning/experiment-schema.ts` + `experiment-store.ts`, from the earlier learning-loop work) already enforces one-axis validation itself (`learningExperimentCreateSchema`'s `superRefine`) and already accepts a fully-formed `LearningConfiguration` supplied by a caller (see `tests/fixtures/learning.ts` — that's exactly how the existing test suite builds configurations today). So the packager **wires directly into `LearningExperimentStore.create`** rather than emitting a package for a future importer to consume — the shapes were compatible, per the ticket's stated preference. `packageAndHandOff` is the seam: it is the only place this module talks to Munin-backed stores, and it never calls anything but `.create()` (a read-then-idempotent-create), never an execution/evaluation/promotion method.
- **Configuration provenance is caller-supplied, not reverse-engineered.** Hugin's own attempt evidence (`origin_config` in `learning-task-handshake.ts`) proves *which* prompt/harness ran, but never carries model identity — the M5 gateway owns that capability truth (AGENTS.md: "Hugin ... must not build a competing capability truth"). Rather than fabricate a `model` identity Hugin can't actually evidence, `PackagerCandidateInput.configuration` accepts an already-fingerprinted `LearningConfiguration` the same way `LearningExperimentStore.create` already does, and the packager's job is to verify the *pool's* coherence (task-type match, exactly-one-axis delta, no more than two distinct configurations) rather than construct configuration identity itself.
- **Content-blindness by construction, not by scrubbing.** A package's `matchedTasks` entries carry only `taskId`/`attemptId`/`arm`/`taskType`/`qualityReceiptId`/coarse `qualityRating` — never a receipt's free-text `ratingReason`, a prompt, or a diff. Verified by a dedicated test that injects a marker string into a receipt's `ratingReason` and asserts it never appears in the serialized package.
- **Idempotency key excludes `qualifiedAt`.** `packageId`/`idempotencyKey` are a JCS-canonical SHA-256 digest over everything except the wall-clock freeze timestamp, so re-packaging the identical qualified set later returns the same `packageId`, and the second `LearningExperimentStore.create` call returns `reused: true` instead of a duplicate experiment.
- **Freeze-time exposure recheck, execution-time recheck out of scope.** `packageAndHandOff` always re-fetches each task's registry timeline live before packaging (there is no earlier cached view to go stale) — that satisfies the freeze-time recheck. Re-checking exposure again at *execution* time is the execution engine's responsibility (explicit non-goal here).
- **Quality-receipt correction chains are the caller's responsibility.** `qualifyCandidate` trusts the receipt it's handed as the ledger's current effective receipt; it does not itself walk `quality-receipt.ts`'s correction chain (`correctsReceiptId` / `foldQualityReceipt`). Documented inline as a known scope boundary — resolving a receipt's correction chain belongs to whoever assembles `PackagerCandidateInput` before calling this module.

## Non-goals preserved

No experiment execution/evaluation engine changes (wires to the existing store instead of reimplementing it), no promotion/routing decisions (gille-inference#8's territory), no candidate generation (registry/harvest side, #232/#241's territory).

## Verification

- `npm run build` — clean, no errors.
- `npm test` — **127 files / 2053 tests passing** (baseline on `origin/main`: 126 files / 2034 tests; this PR adds 1 file / 19 tests).

## Dogfooding note

Used `mcp__m5__ask` (qwen3-30b-instruct) for a bounded adversarial review of the qualification predicate and one-axis detection logic. The review's three "critical bugs" all cited code that does not exist in this module (e.g. `task.attempt.supersededBy`, `task.receipt.taskAttemptId`, an `!== [axis]` array-reference check) — a clean instance of the documented confident-false-positive failure mode. I verified each claim against the actual source and found none applicable. My own re-read did surface one real, minor improvement (a missing-timeline case was mislabeled with the same reason code as a genuinely truncated registry read) which is fixed and covered by a new test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)