### PR TITLE
Propose one-axis experiments from production evidence (read-only)

### DIFF
--- a/src/learning/experiment-proposer-schema.ts
+++ b/src/learning/experiment-proposer-schema.ts
@@ -1,0 +1,191 @@
+/**
+ * Read-only one-axis experiment proposer -- contract (#234).
+ *
+ * Scans already-qualified production evidence (the same qualified-candidate
+ * shape the #233 packager consumes, `PackagerCandidateInput`) and proposes
+ * which one-axis champion/challenger experiments are worth packaging. It
+ * never packages, creates, runs, evaluates, or promotes anything -- see
+ * experiment-proposer.ts's module doc comment for the read-only guarantee.
+ *
+ * Shape alignment with the #233 packager (candidate-packager-schema.ts):
+ *  - `ExperimentProposal.matchedTasks` reuses `packagerMatchedTaskSchema`
+ *    verbatim -- the exact content-blind (taskId/attemptId/arm/taskType/
+ *    qualityReceiptId/qualityRating) reference shape the packager itself
+ *    freezes into a package. A proposal never carries more than the packager
+ *    would keep.
+ *  - `experimentProposerModule.proposalToPackageRequest` (in
+ *    experiment-proposer.ts) maps a proposal onto `PackageRequest` --
+ *    (task-type, axis, champion, challenger, matched set) becomes
+ *    (scope, hypothesis, changeAxis, championFingerprint) directly. The
+ *    caller still resolves each `matchedTasks` entry back into a full
+ *    `PackagerCandidateInput` (configuration + native quality receipt) from
+ *    its own durable stores before calling the packager -- exactly mirroring
+ *    how `packageAndHandOff` re-reads registry timelines from bare task ids
+ *    rather than trusting a caller-supplied cache.
+ *
+ * Content-blindness: like the packager's `ExperimentPackage`, a proposal
+ * carries only opaque identifiers, versions, digests, counts, and rates. It
+ * never copies a quality receipt's free-text `ratingReason`, a task prompt,
+ * or a diff.
+ */
+
+import { z } from "zod";
+import { taskTypeSchema } from "../broker/task-type-metadata.js";
+import {
+  learningChangeAxisSchema,
+  learningConfigurationSchema,
+} from "./experiment-schema.js";
+import {
+  packagerCandidateInputSchema,
+  packagerMatchedTaskSchema,
+  sha256Schema,
+  type CandidateRejectionReason,
+  type PackagerCandidateInput,
+  type PackagerMatchedTask,
+} from "./candidate-packager-schema.js";
+
+export { packagerCandidateInputSchema, sha256Schema };
+export type { CandidateRejectionReason, PackagerCandidateInput, PackagerMatchedTask };
+
+const slugSchema = z.string().regex(/^[a-z0-9][a-z0-9-]{1,79}$/);
+const proposalIdSchema = z.string().regex(/^prop-[a-f0-9]{64}$/);
+
+export const proposalConfidenceSchema = z.enum(["low", "medium", "high"]);
+export type ProposalConfidence = z.infer<typeof proposalConfidenceSchema>;
+
+/**
+ * Aggregate, content-blind evidence backing one proposal. Every field is a
+ * count, rate, timestamp, or derived statistic -- never raw task content.
+ */
+export const proposalEvidenceSchema = z.object({
+  championSamples: z.number().int().positive(),
+  challengerSamples: z.number().int().positive(),
+  championQualityRate: z.number().min(0).max(1),
+  challengerQualityRate: z.number().min(0).max(1),
+  /** challengerQualityRate - championQualityRate. Positive means the challenger looks better. */
+  qualityRateDelta: z.number().min(-1).max(1),
+  mostRecentEvidenceAt: z.string().min(1),
+  /** Exponential recency decay applied to `mostRecentEvidenceAt` at proposal time; see rank.recencyWeight. */
+  recencyWeight: z.number().min(0).max(1),
+  /**
+   * Normal approximation to a two-proportion z-test comparing
+   * championQualityRate and challengerQualityRate. This is a coarse
+   * screening heuristic, not a rigorous significance test: samples are not
+   * guaranteed independent (a task type may share operators, prompts-under-
+   * test, or time windows across arms) and no multiple-comparison
+   * correction is applied across the proposals a single run emits. `null`
+   * when the pooled standard error is degenerate (see computeConfidence).
+   */
+  zScore: z.number().nullable(),
+  confidence: proposalConfidenceSchema,
+}).strict();
+export type ProposalEvidence = z.infer<typeof proposalEvidenceSchema>;
+
+export const proposalRankSchema = z.object({
+  /** effectSize * sampleSize * recencyWeight -- see experiment-proposer.ts's module doc for the rationale. */
+  score: z.number().min(0),
+  effectSize: z.number().min(0).max(1),
+  sampleSize: z.number().int().positive(),
+  recencyWeight: z.number().min(0).max(1),
+}).strict();
+export type ProposalRank = z.infer<typeof proposalRankSchema>;
+
+/**
+ * A read-only, content-blind proposal to run a one-axis experiment. Never
+ * packaged, created, or executed by this module -- a human or the #233
+ * packager decides whether to act on it.
+ */
+export const experimentProposalSchema = z.object({
+  schemaVersion: z.literal(1),
+  proposalId: proposalIdSchema,
+  taskType: taskTypeSchema,
+  changeAxis: learningChangeAxisSchema,
+  championFingerprint: sha256Schema,
+  challengerFingerprint: sha256Schema,
+  champion: learningConfigurationSchema,
+  challenger: learningConfigurationSchema,
+  evidence: proposalEvidenceSchema,
+  matchedTasks: z.array(packagerMatchedTaskSchema).min(2),
+  hypothesis: z.string().min(1).max(2_000),
+  /** A candidate scope slug for `PackageRequest.scope` -- the caller may override it. */
+  suggestedScope: slugSchema,
+  rank: proposalRankSchema,
+  proposedAt: z.string().min(1),
+}).strict().superRefine((value, ctx) => {
+  if (value.championFingerprint === value.challengerFingerprint) {
+    ctx.addIssue({ code: "custom", path: ["challengerFingerprint"], message: "challenger fingerprint must differ from champion" });
+  }
+  if (value.champion.fingerprint !== value.championFingerprint) {
+    ctx.addIssue({ code: "custom", path: ["champion", "fingerprint"], message: "champion configuration fingerprint mismatch" });
+  }
+  if (value.challenger.fingerprint !== value.challengerFingerprint) {
+    ctx.addIssue({ code: "custom", path: ["challenger", "fingerprint"], message: "challenger configuration fingerprint mismatch" });
+  }
+  const champCount = value.matchedTasks.filter((task) => task.arm === "champion").length;
+  const challCount = value.matchedTasks.filter((task) => task.arm === "challenger").length;
+  if (champCount === 0 || challCount === 0) {
+    ctx.addIssue({ code: "custom", path: ["matchedTasks"], message: "a proposal requires at least one matched task per arm" });
+  }
+  if (champCount !== value.evidence.championSamples || challCount !== value.evidence.challengerSamples) {
+    ctx.addIssue({ code: "custom", path: ["matchedTasks"], message: "matched task counts must match the reported evidence sample sizes" });
+  }
+  const seen = new Set<string>();
+  for (const task of value.matchedTasks) {
+    const key = `${task.taskId}/${task.attemptId}`;
+    if (seen.has(key)) {
+      ctx.addIssue({ code: "custom", path: ["matchedTasks"], message: `duplicate matched task ${key}` });
+    }
+    seen.add(key);
+  }
+});
+export type ExperimentProposal = z.infer<typeof experimentProposalSchema>;
+
+// ---------------------------------------------------------------------------
+// Fail-closed reasons -- why a population was never turned into a proposal.
+// ---------------------------------------------------------------------------
+
+export type PopulationDeclineReason =
+  | { code: "no-qualified-evidence" }
+  | { code: "single-configuration"; taskType: string; distinctConfigurations: number }
+  | {
+      code: "insufficient-samples";
+      taskType: string;
+      axis: string;
+      arm: "champion" | "challenger";
+      count: number;
+      required: number;
+      championFingerprint: string;
+      challengerFingerprint: string;
+    }
+  | {
+      code: "multi-axis-delta";
+      taskType: string;
+      championFingerprint: string;
+      challengerFingerprint: string;
+      changedAxes: string[];
+    }
+  | {
+      code: "no-axis-delta";
+      taskType: string;
+      championFingerprint: string;
+      challengerFingerprint: string;
+    }
+  | {
+      code: "no-quality-signal-delta";
+      taskType: string;
+      axis: string;
+      championFingerprint: string;
+      challengerFingerprint: string;
+      qualityRateDelta: number;
+      threshold: number;
+    };
+
+export interface ProposalOutcome {
+  status: "proposed" | "no-proposals";
+  /** Ranked descending by rank.score. */
+  proposals: ExperimentProposal[];
+  /** Candidates dropped before grouping -- same fail-closed reasons the packager uses. */
+  rejectedCandidates: Array<{ taskId: string; attemptId: string; reasons: CandidateRejectionReason[] }>;
+  /** Populations considered but not proposal-worthy, with the concrete reason. */
+  declinedPopulations: PopulationDeclineReason[];
+}

--- a/src/learning/experiment-proposer.ts
+++ b/src/learning/experiment-proposer.ts
@@ -1,0 +1,486 @@
+/**
+ * Read-only one-axis experiment proposer -- logic (#234).
+ *
+ * See experiment-proposer-schema.ts for the full scope-boundary and
+ * content-blindness rationale. In short: this module reads already-qualified
+ * production evidence (candidate/timeline pairs, exactly the shape the #233
+ * packager consumes), groups it into comparable populations, and proposes
+ * ranked one-axis champion/challenger experiments worth packaging. It never
+ * generates evidence, never packages, and never runs, evaluates, or promotes
+ * an experiment -- that stays entirely inside candidate-packager.ts and
+ * experiment-store.ts.
+ *
+ * Read-only guarantee: `proposeExperiments` is a pure function over
+ * caller-supplied candidates and timelines. `proposeExperimentsFromRegistry`
+ * only calls `listEventsForTask` (via `buildTaskLifecycleTimeline`, itself
+ * read-only) before delegating to the pure core -- it never calls a registry
+ * mutation method, an experiment store, or the packager.
+ *
+ * One-axis detection: reuses `configurationChangedAxes` (experiment-schema.ts)
+ * -- the same axis vocabulary and comparison the packager and
+ * `LearningExperimentStore.create` already enforce -- so a proposal's
+ * `changeAxis` can never disagree with what the packager would itself detect
+ * for the same champion/challenger pair.
+ *
+ * Ranking heuristic: `score = effectSize * sampleSize * recencyWeight`.
+ *  - `effectSize` is the absolute pass-rate delta between the two arms
+ *    (0..1) -- a coarse but interpretable proxy for "how much does this axis
+ *    seem to matter", matching the `quality-rate` primary metric the gates
+ *    schema already defines.
+ *  - `sampleSize` is `min(championSamples, challengerSamples)` -- an
+ *    experiment's statistical power is bound by its thinner arm, so the
+ *    weaker side should suppress the score even when the other arm is huge.
+ *  - `recencyWeight` is an exponential half-life decay (default 14 days)
+ *    applied to the most recent evidence timestamp in the pair, so a
+ *    population built entirely from stale evidence is ranked below an
+ *    equally-sized fresh one even with an identical effect size.
+ * This is a deliberately simple, auditable scoring function, not a
+ * statistical model -- `evidence.confidence` (a normal-approximation
+ * two-proportion z-test) is reported alongside it as an explicit caveat
+ * rather than folded into the score, since it is not resistant to
+ * non-independent samples or multiple-comparison inflation across the
+ * several populations one run may propose.
+ */
+
+import { jcsDigestHex } from "../learning-registry-schema.js";
+import { buildTaskLifecycleTimeline, type TaskLifecycleTimeline } from "../learning-registry-view.js";
+import type { LearningRegistryStore } from "../learning-registry-store.js";
+import {
+  configurationChangedAxes,
+  learningExperimentGatesSchema,
+  type LearningExperimentGates,
+} from "./experiment-schema.js";
+import { qualifyCandidate, type PackageRequest } from "./candidate-packager.js";
+import type { PackagerQualityRating } from "./candidate-packager-schema.js";
+import {
+  experimentProposalSchema,
+  type ExperimentProposal,
+  type PackagerCandidateInput,
+  type PackagerMatchedTask,
+  type PopulationDeclineReason,
+  type ProposalOutcome,
+} from "./experiment-proposer-schema.js";
+
+export * from "./experiment-proposer-schema.js";
+
+export interface ProposeRequest {
+  now?: () => string;
+  /** Minimum qualified samples required in EACH arm before a pair is proposal-worthy. Default 3. */
+  minSamplesPerArm?: number;
+  /**
+   * Rating floor passed through to `qualifyCandidate`'s per-candidate
+   * contamination checks. Default "wrong" (the lowest rating -- every rated,
+   * uncontaminated attempt is eligible) so the population reflects the full
+   * outcome spectrum; see DEFAULT_MIN_QUALITY_RATING's comment for why this
+   * differs from the packager's "pass" floor.
+   */
+  minQualityRating?: PackagerQualityRating;
+  /** Minimum |challengerQualityRate - championQualityRate| worth surfacing. Default 0.1 (10 points). */
+  minQualityRateDelta?: number;
+  /** Half-life, in days, of the recency weight applied to a population's most recent evidence. Default 14. */
+  recencyHalfLifeDays?: number;
+  /** Prefix for the generated `suggestedScope` slug. Default "proposed". */
+  scopePrefix?: string;
+}
+
+const DEFAULT_MIN_SAMPLES_PER_ARM = 3;
+/**
+ * Unlike the #233 packager -- which only ever freezes already-winning
+ * candidates and therefore floors at "pass" -- the proposer needs the full
+ * outcome spectrum to detect a quality delta between two configurations at
+ * all. Flooring at "pass" here would mean only already-passing candidates
+ * ever survive qualification, making every surviving population's pass rate
+ * trivially 1.0 and the whole quality-signal comparison vacuous. The lowest
+ * rating floor still leaves every OTHER `qualifyCandidate` contamination
+ * check (timeline completeness, exclusion/erasure, superseded evidence,
+ * receipt binding) fully in force -- only the rating floor itself differs.
+ */
+const DEFAULT_MIN_QUALITY_RATING: PackagerQualityRating = "wrong";
+const DEFAULT_MIN_QUALITY_RATE_DELTA = 0.1;
+const DEFAULT_RECENCY_HALF_LIFE_DAYS = 14;
+const DEFAULT_SCOPE_PREFIX = "proposed";
+const MS_PER_DAY = 86_400_000;
+
+function groupBy<T, K>(items: readonly T[], keyFn: (item: T) => K): Map<K, T[]> {
+  const map = new Map<K, T[]>();
+  for (const item of items) {
+    const key = keyFn(item);
+    const list = map.get(key);
+    if (list) list.push(item); else map.set(key, [item]);
+  }
+  return map;
+}
+
+/** "pass" scores 1, everything else (already floored above `minQualityRating`) scores 0. */
+function qualityScoreOf(candidate: PackagerCandidateInput): number {
+  return candidate.qualityReceipt.rating === "pass" ? 1 : 0;
+}
+
+function meanQualityRate(group: readonly PackagerCandidateInput[]): number {
+  return group.reduce((sum, candidate) => sum + qualityScoreOf(candidate), 0) / group.length;
+}
+
+function ratedTimestamps(group: readonly PackagerCandidateInput[]): string[] {
+  return group.map((candidate) => candidate.qualityReceipt.ratedAt);
+}
+
+function earliestTimestamp(group: readonly PackagerCandidateInput[]): string {
+  return ratedTimestamps(group).reduce((a, b) => (a <= b ? a : b));
+}
+
+function latestTimestamp(group: readonly PackagerCandidateInput[]): string {
+  return ratedTimestamps(group).reduce((a, b) => (a >= b ? a : b));
+}
+
+function computeRecencyWeight(mostRecentIso: string, nowIso: string, halfLifeDays: number): number {
+  const ageMs = Date.parse(nowIso) - Date.parse(mostRecentIso);
+  const ageDays = Math.max(0, ageMs / MS_PER_DAY);
+  const safeHalfLife = Math.max(halfLifeDays, 0.001);
+  return Math.pow(0.5, ageDays / safeHalfLife);
+}
+
+/**
+ * Normal approximation to a two-proportion z-test. See the module doc
+ * comment for its limitations. `null` when the pooled standard error is
+ * degenerate (e.g. one arm is 0% and the other 100%, giving zero pooled
+ * variance) -- confidence then falls back to sample size alone.
+ */
+function computeConfidence(
+  championRate: number,
+  championN: number,
+  challengerRate: number,
+  challengerN: number,
+): { zScore: number | null; confidence: "low" | "medium" | "high" } {
+  const pooled = (championRate * championN + challengerRate * challengerN) / (championN + challengerN);
+  const se = Math.sqrt(pooled * (1 - pooled) * (1 / championN + 1 / challengerN));
+  if (se === 0) {
+    const minN = Math.min(championN, challengerN);
+    return { zScore: null, confidence: minN >= 8 ? "high" : minN >= 4 ? "medium" : "low" };
+  }
+  const z = (challengerRate - championRate) / se;
+  const absZ = Math.abs(z);
+  const confidence = absZ >= 1.96 ? "high" : absZ >= 1 ? "medium" : "low";
+  return { zScore: z, confidence };
+}
+
+function matchedTaskFor(candidate: PackagerCandidateInput, arm: "champion" | "challenger"): PackagerMatchedTask {
+  return {
+    taskId: candidate.taskId,
+    attemptId: candidate.attemptId,
+    arm,
+    taskType: candidate.taskType,
+    qualityReceiptId: candidate.qualityReceipt.receiptId,
+    qualityRating: candidate.qualityReceipt.rating,
+  };
+}
+
+function slugPart(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+function buildSuggestedScope(prefix: string, taskType: string, axis: string): string {
+  const joined = [slugPart(prefix), slugPart(taskType), slugPart(axis)].filter((part) => part.length > 0).join("-");
+  const clipped = joined.slice(0, 79).replace(/-+$/g, "");
+  // slugSchema requires at least 2 characters starting with [a-z0-9]; every real
+  // taskType/axis value is well above that, so this pad is defensive only.
+  return clipped.length >= 2 ? clipped : `${clipped}-x`;
+}
+
+/** Canonical digest input for a proposal -- excludes every wall-clock-dependent field
+ * (`proposedAt`, `evidence.recencyWeight`, `rank.recencyWeight`, `rank.score`) so the
+ * same underlying evidence pool re-analyzed at a later time still yields the same
+ * `proposalId`. This lets a downstream conductor detect "the same proposal, evidence
+ * unchanged" versus "a new/expanded evidence pool" cheaply by comparing ids, though
+ * building that dedup conductor itself is out of this module's scope. */
+function proposalDigestPayload(proposal: Omit<ExperimentProposal, "proposalId" | "proposedAt">): unknown {
+  const { recencyWeight: _evidenceRecencyWeight, ...evidenceForDigest } = proposal.evidence;
+  const { recencyWeight: _rankRecencyWeight, score: _score, ...rankForDigest } = proposal.rank;
+  return {
+    schemaVersion: proposal.schemaVersion,
+    taskType: proposal.taskType,
+    changeAxis: proposal.changeAxis,
+    championFingerprint: proposal.championFingerprint,
+    challengerFingerprint: proposal.challengerFingerprint,
+    champion: proposal.champion,
+    challenger: proposal.challenger,
+    evidence: evidenceForDigest,
+    matchedTasks: [...proposal.matchedTasks].sort((a, b) =>
+      `${a.taskId}/${a.attemptId}`.localeCompare(`${b.taskId}/${b.attemptId}`)),
+    hypothesis: proposal.hypothesis,
+    suggestedScope: proposal.suggestedScope,
+    rank: rankForDigest,
+  };
+}
+
+function computeProposalId(proposal: Omit<ExperimentProposal, "proposalId" | "proposedAt">): string {
+  return `prop-${jcsDigestHex(proposalDigestPayload(proposal))}`;
+}
+
+/**
+ * Scan qualified production evidence and propose ranked one-axis
+ * champion/challenger experiments. Pure and deterministic given its inputs,
+ * aside from `request.now`, which never feeds a proposal's content-addressed
+ * identity (see `proposalDigestPayload`).
+ */
+export function proposeExperiments(
+  candidates: readonly PackagerCandidateInput[],
+  timelines: ReadonlyMap<string, TaskLifecycleTimeline>,
+  request: ProposeRequest = {},
+): ProposalOutcome {
+  const now = request.now ?? (() => new Date().toISOString());
+  const nowIso = now();
+  const minSamplesPerArm = request.minSamplesPerArm ?? DEFAULT_MIN_SAMPLES_PER_ARM;
+  const minQualityRating = request.minQualityRating ?? DEFAULT_MIN_QUALITY_RATING;
+  const minQualityRateDelta = request.minQualityRateDelta ?? DEFAULT_MIN_QUALITY_RATE_DELTA;
+  const recencyHalfLifeDays = request.recencyHalfLifeDays ?? DEFAULT_RECENCY_HALF_LIFE_DAYS;
+  const scopePrefix = request.scopePrefix ?? DEFAULT_SCOPE_PREFIX;
+
+  // Fail closed on the same per-candidate contamination checks the packager
+  // uses (truncated timeline, excluded/superseded evidence, incomplete
+  // attempts, mismatched or sub-floor quality receipts) before any evidence
+  // is grouped into a population.
+  const qualified: PackagerCandidateInput[] = [];
+  const rejectedCandidates: ProposalOutcome["rejectedCandidates"] = [];
+  for (const candidate of candidates) {
+    const timeline = timelines.get(candidate.taskId);
+    if (!timeline) {
+      rejectedCandidates.push({
+        taskId: candidate.taskId,
+        attemptId: candidate.attemptId,
+        reasons: [{ code: "missing-timeline" }],
+      });
+      continue;
+    }
+    const result = qualifyCandidate(candidate, timeline, { minQualityRating });
+    if (result.ok) {
+      qualified.push(candidate);
+    } else {
+      rejectedCandidates.push({ taskId: candidate.taskId, attemptId: candidate.attemptId, reasons: result.reasons });
+    }
+  }
+
+  if (qualified.length === 0) {
+    return {
+      status: "no-proposals",
+      proposals: [],
+      rejectedCandidates,
+      declinedPopulations: [{ code: "no-qualified-evidence" }],
+    };
+  }
+
+  const declinedPopulations: PopulationDeclineReason[] = [];
+  const proposals: ExperimentProposal[] = [];
+
+  const byTaskType = groupBy(qualified, (candidate) => candidate.taskType);
+  for (const [taskType, taskCandidates] of [...byTaskType.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    const byFingerprint = groupBy(taskCandidates, (candidate) => candidate.configuration.fingerprint);
+    const fingerprints = [...byFingerprint.keys()].sort();
+
+    if (fingerprints.length < 2) {
+      declinedPopulations.push({
+        code: "single-configuration",
+        taskType,
+        distinctConfigurations: fingerprints.length,
+      });
+      continue;
+    }
+
+    // Compare every pairwise combination of distinct configurations within
+    // this task type -- a population is not required to reduce to exactly
+    // two configurations the way a frozen package must; the proposer's job
+    // is to surface every proposal-worthy pair, ranked, not to pick one.
+    for (let i = 0; i < fingerprints.length; i += 1) {
+      for (let j = i + 1; j < fingerprints.length; j += 1) {
+        const fingerprintA = fingerprints[i]!;
+        const fingerprintB = fingerprints[j]!;
+        const groupA = byFingerprint.get(fingerprintA)!;
+        const groupB = byFingerprint.get(fingerprintB)!;
+        const configA = groupA[0]!.configuration;
+        const configB = groupB[0]!.configuration;
+
+        const changed = configurationChangedAxes(configA, configB);
+        if (changed.length === 0) {
+          // Defensive only: differing fingerprints already imply differing
+          // canonicalized content barring a SHA-256 collision (identical
+          // reasoning to candidate-packager.ts's own defensive comment).
+          declinedPopulations.push({
+            code: "no-axis-delta",
+            taskType,
+            championFingerprint: fingerprintA,
+            challengerFingerprint: fingerprintB,
+          });
+          continue;
+        }
+        if (changed.length > 1) {
+          declinedPopulations.push({
+            code: "multi-axis-delta",
+            taskType,
+            championFingerprint: fingerprintA,
+            challengerFingerprint: fingerprintB,
+            changedAxes: changed,
+          });
+          continue;
+        }
+        const axis = changed[0]!;
+
+        // Older evidence is treated as the incumbent (champion); the group
+        // that started appearing later is the challenger under test. Ties
+        // fall back to the lexicographically smaller fingerprint so the
+        // assignment is deterministic.
+        const aEarliest = earliestTimestamp(groupA);
+        const bEarliest = earliestTimestamp(groupB);
+        const aIsChampion = aEarliest !== bEarliest ? aEarliest < bEarliest : fingerprintA < fingerprintB;
+        const [champGroup, challGroup, champConfig, challConfig, champFp, challFp] = aIsChampion
+          ? [groupA, groupB, configA, configB, fingerprintA, fingerprintB]
+          : [groupB, groupA, configB, configA, fingerprintB, fingerprintA];
+
+        if (champGroup.length < minSamplesPerArm || challGroup.length < minSamplesPerArm) {
+          const shortArm: "champion" | "challenger" = champGroup.length < minSamplesPerArm ? "champion" : "challenger";
+          declinedPopulations.push({
+            code: "insufficient-samples",
+            taskType,
+            axis,
+            arm: shortArm,
+            count: shortArm === "champion" ? champGroup.length : challGroup.length,
+            required: minSamplesPerArm,
+            championFingerprint: champFp,
+            challengerFingerprint: challFp,
+          });
+          continue;
+        }
+
+        const championQualityRate = meanQualityRate(champGroup);
+        const challengerQualityRate = meanQualityRate(challGroup);
+        const qualityRateDelta = challengerQualityRate - championQualityRate;
+        if (Math.abs(qualityRateDelta) < minQualityRateDelta) {
+          declinedPopulations.push({
+            code: "no-quality-signal-delta",
+            taskType,
+            axis,
+            championFingerprint: champFp,
+            challengerFingerprint: challFp,
+            qualityRateDelta,
+            threshold: minQualityRateDelta,
+          });
+          continue;
+        }
+
+        const mostRecentEvidenceAt = [latestTimestamp(champGroup), latestTimestamp(challGroup)]
+          .reduce((a, b) => (a >= b ? a : b));
+        const recencyWeight = computeRecencyWeight(mostRecentEvidenceAt, nowIso, recencyHalfLifeDays);
+        const sampleSize = Math.min(champGroup.length, challGroup.length);
+        const effectSize = Math.abs(qualityRateDelta);
+        const score = effectSize * sampleSize * recencyWeight;
+        const { zScore, confidence } = computeConfidence(
+          championQualityRate, champGroup.length, challengerQualityRate, challGroup.length,
+        );
+
+        const matchedTasks = [
+          ...champGroup.map((candidate) => matchedTaskFor(candidate, "champion")),
+          ...challGroup.map((candidate) => matchedTaskFor(candidate, "challenger")),
+        ].sort((a, b) => `${a.taskId}/${a.attemptId}`.localeCompare(`${b.taskId}/${b.attemptId}`));
+
+        const deltaPoints = (qualityRateDelta * 100).toFixed(1);
+        const direction = qualityRateDelta > 0 ? "higher" : "lower";
+        const hypothesis =
+          `Varying ${axis} for ${taskType} tasks is associated with a ${Math.abs(Number(deltaPoints))}-point ` +
+          `${direction} pass rate (challenger ${(challengerQualityRate * 100).toFixed(1)}% over ${challGroup.length} ` +
+          `samples vs champion ${(championQualityRate * 100).toFixed(1)}% over ${champGroup.length} samples); ` +
+          `worth a controlled one-axis experiment to confirm.`;
+
+        const unstamped = {
+          schemaVersion: 1 as const,
+          taskType,
+          changeAxis: axis,
+          championFingerprint: champFp,
+          challengerFingerprint: challFp,
+          champion: champConfig,
+          challenger: challConfig,
+          evidence: {
+            championSamples: champGroup.length,
+            challengerSamples: challGroup.length,
+            championQualityRate,
+            challengerQualityRate,
+            qualityRateDelta,
+            mostRecentEvidenceAt,
+            recencyWeight,
+            zScore,
+            confidence,
+          },
+          matchedTasks,
+          hypothesis,
+          suggestedScope: buildSuggestedScope(scopePrefix, taskType, axis),
+          rank: { score, effectSize, sampleSize, recencyWeight },
+        };
+        const proposalId = computeProposalId(unstamped);
+        proposals.push(experimentProposalSchema.parse({ ...unstamped, proposalId, proposedAt: nowIso }));
+      }
+    }
+  }
+
+  proposals.sort((a, b) => b.rank.score - a.rank.score || a.proposalId.localeCompare(b.proposalId));
+
+  return {
+    status: proposals.length > 0 ? "proposed" : "no-proposals",
+    proposals,
+    rejectedCandidates,
+    declinedPopulations,
+  };
+}
+
+/**
+ * Orchestration wrapper: fetch each candidate task's CURRENT registry
+ * timeline (mirroring `packageAndHandOff`'s freeze-time recheck) and hand the
+ * result to the pure `proposeExperiments` core. Never calls a registry
+ * mutation method, an experiment store, or the packager -- this function's
+ * only I/O is `listEventsForTask` reads.
+ */
+export async function proposeExperimentsFromRegistry(
+  registry: Pick<LearningRegistryStore, "listEventsForTask">,
+  candidates: readonly PackagerCandidateInput[],
+  request: ProposeRequest = {},
+): Promise<ProposalOutcome> {
+  const taskIds = [...new Set(candidates.map((candidate) => candidate.taskId))];
+  const timelines = new Map<string, TaskLifecycleTimeline>();
+  for (const taskId of taskIds) {
+    timelines.set(taskId, await buildTaskLifecycleTimeline(registry, taskId));
+  }
+  return proposeExperiments(candidates, timelines, request);
+}
+
+/**
+ * Map a proposal onto the #233 packager's `PackageRequest` shape --
+ * (task-type, axis, champion, challenger, matched set) becomes (scope,
+ * hypothesis, changeAxis, championFingerprint) directly, with `gates`
+ * defaulted to the `quality-rate` primary metric the proposer itself
+ * screened on. Deliberately does NOT return `PackagerCandidateInput[]`: a
+ * proposal only carries content-blind `matchedTasks` references (taskId /
+ * attemptId / arm / taskType / qualityReceiptId / qualityRating), never a
+ * candidate's full configuration or native quality receipt. The caller must
+ * still resolve each `proposal.matchedTasks` entry back into a full
+ * `PackagerCandidateInput` from its own durable stores (the registry and the
+ * quality-receipt ledger) before calling `packageExperimentCandidates` --
+ * exactly the same re-fetch-by-id discipline `packageAndHandOff` already
+ * applies to registry timelines rather than trusting a cached view.
+ */
+export function proposalToPackageRequest(
+  proposal: ExperimentProposal,
+  overrides: {
+    scope?: string;
+    gates?: LearningExperimentGates;
+    minCandidatesPerArm?: number;
+    minQualityRating?: PackagerQualityRating;
+    now?: () => string;
+  } = {},
+): PackageRequest {
+  return {
+    scope: overrides.scope ?? proposal.suggestedScope,
+    hypothesis: proposal.hypothesis,
+    changeAxis: proposal.changeAxis,
+    championFingerprint: proposal.championFingerprint,
+    gates: overrides.gates ?? learningExperimentGatesSchema.parse({ primaryMetric: "quality-rate" }),
+    ...(overrides.minCandidatesPerArm !== undefined ? { minCandidatesPerArm: overrides.minCandidatesPerArm } : {}),
+    ...(overrides.minQualityRating !== undefined ? { minQualityRating: overrides.minQualityRating } : {}),
+    ...(overrides.now !== undefined ? { now: overrides.now } : {}),
+  };
+}

--- a/tests/experiment-proposer.test.ts
+++ b/tests/experiment-proposer.test.ts
@@ -1,0 +1,563 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { MuninWriteRejectedError, type MuninClient, type MuninQueryResult } from "../src/munin-client.js";
+import { LearningRegistryStore } from "../src/learning-registry-store.js";
+import { buildTaskLifecycleTimeline, type TaskLifecycleTimeline } from "../src/learning-registry-view.js";
+import { computeConfigurationFingerprint } from "../src/learning/experiment-schema.js";
+import { packageExperimentCandidates } from "../src/learning/candidate-packager.js";
+import { buildQualityReceipt, type QualityReceipt } from "../src/quality-receipt.js";
+import {
+  proposeExperiments,
+  proposeExperimentsFromRegistry,
+  proposalToPackageRequest,
+  type ProposeRequest,
+} from "../src/learning/experiment-proposer.js";
+import type { PackagerCandidateInput } from "../src/learning/candidate-packager-schema.js";
+import { makeLearningConfig } from "./fixtures/learning.js";
+
+// ---------------------------------------------------------------------------
+// In-memory Munin double -- same create-if-absent / CAS contract as the real
+// service, copied from tests/candidate-packager.test.ts's own copy of the
+// tests/learning-registry-store.test.ts fixture.
+// ---------------------------------------------------------------------------
+
+interface StoredEntry {
+  namespace: string;
+  key: string;
+  content: string;
+  tags: string[];
+  classification?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+class InMemoryMunin {
+  private entries: StoredEntry[] = [];
+  private seq = 0;
+
+  private clock(): string {
+    this.seq += 1;
+    return new Date(Date.UTC(2026, 6, 1, 0, 0, 0, 0) + this.seq).toISOString();
+  }
+
+  private find(namespace: string, key: string): StoredEntry | undefined {
+    return this.entries.find((e) => e.namespace === namespace && e.key === key);
+  }
+
+  async read(namespace: string, key: string) {
+    const entry = this.find(namespace, key);
+    if (!entry) return null;
+    return { ...entry, found: true } as unknown as (MuninQueryResult & { found: true });
+  }
+
+  async write(
+    namespace: string,
+    key: string,
+    content: string,
+    tags?: string[],
+    expectedUpdatedAt?: string,
+    classification?: string,
+    createIfAbsent?: boolean,
+  ) {
+    const existing = this.find(namespace, key);
+    if (createIfAbsent && existing) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        message: "Entry already exists.",
+        conflict_reason: "already_exists",
+        current_updated_at: existing.updated_at,
+      });
+    }
+    if (expectedUpdatedAt !== undefined && (!existing || existing.updated_at !== expectedUpdatedAt)) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        message: "Entry version changed.",
+        conflict_reason: "version_mismatch",
+        current_updated_at: existing?.updated_at,
+      });
+    }
+    const updated_at = this.clock();
+    const created_at = existing?.created_at ?? updated_at;
+    const next: StoredEntry = { namespace, key, content, tags: tags ?? [], classification, created_at, updated_at };
+    if (existing) Object.assign(existing, next); else this.entries.push(next);
+    return { ok: true, status: existing ? "updated" : "created", updated_at };
+  }
+
+  async query(opts: { namespace?: string; tags?: string[]; limit?: number; since?: string; until?: string }) {
+    let rows = this.entries.filter((e) =>
+      (!opts.namespace || e.namespace.startsWith(opts.namespace))
+      && (opts.tags ?? []).every((tag) => e.tags.includes(tag)));
+    if (opts.since) rows = rows.filter((e) => e.updated_at >= opts.since!);
+    if (opts.until) rows = rows.filter((e) => e.updated_at <= opts.until!);
+    rows = [...rows].sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+    const limited = rows.slice(0, opts.limit ?? 50);
+    return {
+      results: limited.map((e) => ({
+        id: `${e.namespace}/${e.key}`,
+        namespace: e.namespace,
+        key: e.key,
+        entry_type: "state",
+        content_preview: e.content.slice(0, 80),
+        tags: e.tags,
+        classification: e.classification,
+        created_at: e.created_at,
+        updated_at: e.updated_at,
+      })),
+      total: rows.length,
+    };
+  }
+}
+
+function munin(): InMemoryMunin & MuninClient {
+  return new InMemoryMunin() as unknown as InMemoryMunin & MuninClient;
+}
+
+const ref = (namespace: string, key: string) => ({ namespace, key });
+const hash = (seed: string) => createHash("sha256").update(seed).digest("hex");
+
+async function registerQualifiedAttempt(
+  store: LearningRegistryStore,
+  input: { taskId: string; attemptId: string; occurredAt: string; outcome?: "completed" | "failed" },
+) {
+  const taskOutcomeRef = ref(`tasks/${input.taskId}`, "result-structured");
+  await store.recordSubmission({ taskId: input.taskId, taskOutcomeRef, occurredAt: input.occurredAt });
+  await store.recordAttemptReference({
+    taskId: input.taskId,
+    attemptId: input.attemptId,
+    attemptStartRef: ref(`tasks/${input.taskId}`, `learning-attempt-${input.attemptId}`),
+    taskOutcomeRef,
+    occurredAt: input.occurredAt,
+  });
+  await store.recordTerminalOutcome({
+    taskId: input.taskId,
+    attemptId: input.attemptId,
+    outcome: input.outcome ?? "completed",
+    taskOutcomeRef,
+    occurredAt: input.occurredAt,
+  });
+}
+
+function receiptFor(
+  taskId: string,
+  rating: "pass" | "partial" | "redo" | "wrong",
+  ratedAt: string,
+  overrides: Partial<Parameters<typeof buildQualityReceipt>[0]> = {},
+): QualityReceipt {
+  return buildQualityReceipt({
+    taskId,
+    reviewerPrincipal: "codex",
+    reviewerIndependence: "independent",
+    rating,
+    ratingReason: `SECRET-RAW-EVIDENCE-TEXT-${taskId}-${rating}`,
+    verificationOutcome: rating === "pass" ? "accepted_unchanged" : "major_rewrite",
+    ratedAt,
+    bindingAttestation: "server-bound",
+    binding: {
+      taskDocumentSha256: hash(`${taskId}-doc`),
+      structuredResultSha256: hash(`${taskId}-result`),
+      repository: { state: "no-changes", baseBranch: "main", baseCommit: hash(`${taskId}-base`).slice(0, 40) },
+    },
+    ...overrides,
+  });
+}
+
+/**
+ * Register `count` qualified attempts of `taskType` for one config arm and
+ * return their proposer candidate inputs. `ratings` (cycled if shorter than
+ * `count`) drives the population's quality signal; `ratedAt` timestamps step
+ * forward one day apart starting at `startIso` so recency ordering is
+ * deterministic and distinct from the other arm's timestamps.
+ */
+async function seedArm(
+  store: LearningRegistryStore,
+  input: {
+    taskType: string;
+    arm: "champion" | "challenger";
+    axis: Parameters<typeof makeLearningConfig>[1];
+    idPrefix: string;
+    count: number;
+    ratings: Array<"pass" | "partial" | "redo" | "wrong">;
+    startIso: string;
+  },
+): Promise<{ candidates: PackagerCandidateInput[]; timelines: Map<string, TaskLifecycleTimeline> }> {
+  const candidates: PackagerCandidateInput[] = [];
+  const timelines = new Map<string, TaskLifecycleTimeline>();
+  const configuration = makeLearningConfig(input.arm, input.axis);
+  for (let i = 0; i < input.count; i += 1) {
+    const taskId = `${input.idPrefix}-${i}`;
+    const attemptId = `${input.idPrefix}-attempt-${i}`;
+    const occurredAt = new Date(Date.parse(input.startIso) + i * 86_400_000).toISOString();
+    await registerQualifiedAttempt(store, { taskId, attemptId, occurredAt });
+    timelines.set(taskId, await buildTaskLifecycleTimeline(store, taskId));
+    const rating = input.ratings[i % input.ratings.length]!;
+    candidates.push({
+      taskId,
+      attemptId,
+      taskType: input.taskType as PackagerCandidateInput["taskType"],
+      configuration,
+      qualityReceipt: receiptFor(taskId, rating, occurredAt),
+    });
+  }
+  return { candidates, timelines };
+}
+
+function mergeSeeds(...seeds: Array<{ candidates: PackagerCandidateInput[]; timelines: Map<string, TaskLifecycleTimeline> }>) {
+  const candidates = seeds.flatMap((seed) => seed.candidates);
+  const timelines = new Map<string, TaskLifecycleTimeline>();
+  for (const seed of seeds) {
+    for (const [taskId, timeline] of seed.timelines) timelines.set(taskId, timeline);
+  }
+  return { candidates, timelines };
+}
+
+describe("proposeExperiments", () => {
+  it("proposes a valid one-axis experiment from a seeded two-config population", async () => {
+    const store = new LearningRegistryStore(munin());
+    const champion = await seedArm(store, {
+      taskType: "code-edit", arm: "champion", axis: "agent-prompt", idPrefix: "champ",
+      count: 4, ratings: ["partial", "redo", "partial", "wrong"], startIso: "2026-07-01T00:00:00.000Z",
+    });
+    const challenger = await seedArm(store, {
+      taskType: "code-edit", arm: "challenger", axis: "agent-prompt", idPrefix: "chall",
+      count: 4, ratings: ["pass", "pass", "pass", "partial"], startIso: "2026-07-05T00:00:00.000Z",
+    });
+    const { candidates, timelines } = mergeSeeds(champion, challenger);
+
+    const outcome = proposeExperiments(candidates, timelines, {
+      now: () => "2026-07-10T00:00:00.000Z",
+    });
+
+    expect(outcome.status).toBe("proposed");
+    expect(outcome.rejectedCandidates).toEqual([]);
+    expect(outcome.proposals).toHaveLength(1);
+    const proposal = outcome.proposals[0]!;
+    expect(proposal.taskType).toBe("code-edit");
+    expect(proposal.changeAxis).toBe("agent-prompt");
+    // Champion evidence started earlier (2026-07-01) than challenger (2026-07-05).
+    expect(proposal.championFingerprint).toBe(makeLearningConfig("champion", "agent-prompt").fingerprint);
+    expect(proposal.challengerFingerprint).toBe(makeLearningConfig("challenger", "agent-prompt").fingerprint);
+    expect(proposal.evidence.championQualityRate).toBe(0);
+    expect(proposal.evidence.challengerQualityRate).toBeCloseTo(0.75, 5);
+    expect(proposal.evidence.qualityRateDelta).toBeCloseTo(0.75, 5);
+    expect(proposal.rank.effectSize).toBeCloseTo(0.75, 5);
+    expect(proposal.rank.sampleSize).toBe(4);
+    expect(proposal.matchedTasks).toHaveLength(8);
+    expect(proposal.matchedTasks.filter((t) => t.arm === "champion")).toHaveLength(4);
+    expect(proposal.matchedTasks.filter((t) => t.arm === "challenger")).toHaveLength(4);
+    expect(proposal.proposalId).toMatch(/^prop-[a-f0-9]{64}$/);
+    expect(proposal.suggestedScope).toBe("proposed-code-edit-agent-prompt");
+  });
+
+  it("refuses (declines) a population whose two configurations differ on more than one axis", async () => {
+    const store = new LearningRegistryStore(munin());
+    const champion = await seedArm(store, {
+      taskType: "code-edit", arm: "champion", axis: "agent-prompt", idPrefix: "champ",
+      count: 3, ratings: ["partial"], startIso: "2026-07-01T00:00:00.000Z",
+    });
+    const challengerBase = await seedArm(store, {
+      taskType: "code-edit", arm: "challenger", axis: "agent-prompt", idPrefix: "chall",
+      count: 3, ratings: ["pass"], startIso: "2026-07-05T00:00:00.000Z",
+    });
+    // Contaminate the challenger arm so its harness ALSO differs, not just the prompt.
+    const contaminatedHarnessDigest = hash("contaminated-harness");
+    const challenger = {
+      ...challengerBase,
+      candidates: challengerBase.candidates.map((c) => {
+        const configuration = {
+          ...c.configuration,
+          harness: { ...c.configuration.harness, version: "9", configSha256: contaminatedHarnessDigest },
+        };
+        configuration.fingerprint = computeConfigurationFingerprint(configuration);
+        return { ...c, configuration };
+      }),
+    };
+    const { candidates, timelines } = mergeSeeds(champion, challenger);
+
+    const outcome = proposeExperiments(candidates, timelines, { now: () => "2026-07-10T00:00:00.000Z" });
+
+    expect(outcome.status).toBe("no-proposals");
+    expect(outcome.proposals).toEqual([]);
+    expect(outcome.declinedPopulations).toContainEqual(
+      expect.objectContaining({
+        code: "multi-axis-delta",
+        taskType: "code-edit",
+        changedAxes: expect.arrayContaining(["agent-prompt", "agent-harness"]),
+      }),
+    );
+  });
+
+  it("refuses (declines) a population with fewer than the required samples in one arm", async () => {
+    const store = new LearningRegistryStore(munin());
+    const champion = await seedArm(store, {
+      taskType: "code-edit", arm: "champion", axis: "agent-prompt", idPrefix: "champ",
+      count: 3, ratings: ["partial"], startIso: "2026-07-01T00:00:00.000Z",
+    });
+    const challenger = await seedArm(store, {
+      taskType: "code-edit", arm: "challenger", axis: "agent-prompt", idPrefix: "chall",
+      count: 2, ratings: ["pass"], startIso: "2026-07-05T00:00:00.000Z",
+    });
+    const { candidates, timelines } = mergeSeeds(champion, challenger);
+
+    const outcome = proposeExperiments(candidates, timelines, {
+      now: () => "2026-07-10T00:00:00.000Z", minSamplesPerArm: 3,
+    });
+
+    expect(outcome.status).toBe("no-proposals");
+    expect(outcome.declinedPopulations).toContainEqual({
+      code: "insufficient-samples",
+      taskType: "code-edit",
+      axis: "agent-prompt",
+      arm: "challenger",
+      count: 2,
+      required: 3,
+      championFingerprint: makeLearningConfig("champion", "agent-prompt").fingerprint,
+      challengerFingerprint: makeLearningConfig("challenger", "agent-prompt").fingerprint,
+    });
+  });
+
+  it("refuses (declines) a task type with only a single observed configuration", async () => {
+    const store = new LearningRegistryStore(munin());
+    const champion = await seedArm(store, {
+      taskType: "code-edit", arm: "champion", axis: "agent-prompt", idPrefix: "champ",
+      count: 5, ratings: ["pass", "partial"], startIso: "2026-07-01T00:00:00.000Z",
+    });
+
+    const outcome = proposeExperiments(champion.candidates, champion.timelines, {
+      now: () => "2026-07-10T00:00:00.000Z",
+    });
+
+    expect(outcome.status).toBe("no-proposals");
+    expect(outcome.declinedPopulations).toContainEqual({
+      code: "single-configuration",
+      taskType: "code-edit",
+      distinctConfigurations: 1,
+    });
+  });
+
+  it("declines a population whose quality-rate delta does not clear the configured threshold", async () => {
+    const store = new LearningRegistryStore(munin());
+    const champion = await seedArm(store, {
+      taskType: "code-edit", arm: "champion", axis: "agent-prompt", idPrefix: "champ",
+      count: 4, ratings: ["pass", "pass", "pass", "partial"], startIso: "2026-07-01T00:00:00.000Z",
+    });
+    const challenger = await seedArm(store, {
+      taskType: "code-edit", arm: "challenger", axis: "agent-prompt", idPrefix: "chall",
+      count: 4, ratings: ["pass", "pass", "pass", "wrong"], startIso: "2026-07-05T00:00:00.000Z",
+    });
+    const { candidates, timelines } = mergeSeeds(champion, challenger);
+
+    const outcome = proposeExperiments(candidates, timelines, {
+      now: () => "2026-07-10T00:00:00.000Z", minQualityRateDelta: 0.5,
+    });
+
+    expect(outcome.status).toBe("no-proposals");
+    expect(outcome.declinedPopulations).toContainEqual(
+      expect.objectContaining({ code: "no-quality-signal-delta", taskType: "code-edit", axis: "agent-prompt" }),
+    );
+  });
+
+  it("fails closed on contaminated evidence exactly like the packager's qualifyCandidate", async () => {
+    const store = new LearningRegistryStore(munin());
+    const champion = await seedArm(store, {
+      taskType: "code-edit", arm: "champion", axis: "agent-prompt", idPrefix: "champ",
+      count: 3, ratings: ["partial"], startIso: "2026-07-01T00:00:00.000Z",
+    });
+    // A failed (never-completed) attempt on the challenger side.
+    await registerQualifiedAttempt(store, {
+      taskId: "chall-broken", attemptId: "chall-broken-attempt", occurredAt: "2026-07-05T00:00:00.000Z", outcome: "failed",
+    });
+    const brokenTimeline = await buildTaskLifecycleTimeline(store, "chall-broken");
+    const brokenCandidate: PackagerCandidateInput = {
+      taskId: "chall-broken",
+      attemptId: "chall-broken-attempt",
+      taskType: "code-edit",
+      configuration: makeLearningConfig("challenger", "agent-prompt"),
+      qualityReceipt: receiptFor("chall-broken", "pass", "2026-07-05T00:00:00.000Z"),
+    };
+
+    const outcome = proposeExperiments(
+      [...champion.candidates, brokenCandidate],
+      new Map([...champion.timelines, ["chall-broken", brokenTimeline]]),
+      { now: () => "2026-07-10T00:00:00.000Z" },
+    );
+
+    expect(outcome.rejectedCandidates).toContainEqual({
+      taskId: "chall-broken",
+      attemptId: "chall-broken-attempt",
+      reasons: [{ code: "outcome-not-completed", outcome: "failed" }],
+    });
+    // Only one configuration (champion's) survived qualification -- nothing to compare.
+    expect(outcome.status).toBe("no-proposals");
+    expect(outcome.declinedPopulations).toContainEqual({
+      code: "single-configuration", taskType: "code-edit", distinctConfigurations: 1,
+    });
+  });
+
+  it("refuses entirely when no candidate survives qualification", async () => {
+    const store = new LearningRegistryStore(munin());
+    await registerQualifiedAttempt(store, {
+      taskId: "t1", attemptId: "a1", occurredAt: "2026-07-01T00:00:00.000Z", outcome: "failed",
+    });
+    const timeline = await buildTaskLifecycleTimeline(store, "t1");
+    const candidate: PackagerCandidateInput = {
+      taskId: "t1", attemptId: "a1", taskType: "code-edit",
+      configuration: makeLearningConfig("champion", "agent-prompt"),
+      qualityReceipt: receiptFor("t1", "pass", "2026-07-01T00:00:00.000Z"),
+    };
+    const outcome = proposeExperiments([candidate], new Map([["t1", timeline]]), {
+      now: () => "2026-07-10T00:00:00.000Z",
+    });
+    expect(outcome.status).toBe("no-proposals");
+    expect(outcome.declinedPopulations).toEqual([{ code: "no-qualified-evidence" }]);
+  });
+
+  it("ranks multiple proposal-worthy populations by effect size x sample size x recency, descending", async () => {
+    const store = new LearningRegistryStore(munin());
+    // code-edit / agent-prompt: large effect (1.0), small samples (3 each), stale (30 days old at "now").
+    const editChamp = await seedArm(store, {
+      taskType: "code-edit", arm: "champion", axis: "agent-prompt", idPrefix: "edit-champ",
+      count: 3, ratings: ["wrong"], startIso: "2026-06-01T00:00:00.000Z",
+    });
+    const editChall = await seedArm(store, {
+      taskType: "code-edit", arm: "challenger", axis: "agent-prompt", idPrefix: "edit-chall",
+      count: 3, ratings: ["pass"], startIso: "2026-06-02T00:00:00.000Z",
+    });
+    // code-review / model: moderate effect (~0.6), large samples (8 each), fresh (recent).
+    const reviewChamp = await seedArm(store, {
+      taskType: "code-review", arm: "champion", axis: "model", idPrefix: "review-champ",
+      count: 8, ratings: ["partial", "partial", "wrong"], startIso: "2026-07-08T00:00:00.000Z",
+    });
+    const reviewChall = await seedArm(store, {
+      taskType: "code-review", arm: "challenger", axis: "model", idPrefix: "review-chall",
+      count: 8, ratings: ["pass", "pass", "partial"], startIso: "2026-07-08T00:00:00.000Z",
+    });
+    const { candidates, timelines } = mergeSeeds(editChamp, editChall, reviewChamp, reviewChall);
+
+    const outcome = proposeExperiments(candidates, timelines, { now: () => "2026-07-10T00:00:00.000Z" });
+
+    expect(outcome.status).toBe("proposed");
+    expect(outcome.proposals).toHaveLength(2);
+    // Fresh, larger, moderate-effect code-review/model population should outrank
+    // the stale, small, large-effect code-edit/agent-prompt population.
+    expect(outcome.proposals[0]!.taskType).toBe("code-review");
+    expect(outcome.proposals[1]!.taskType).toBe("code-edit");
+    expect(outcome.proposals[0]!.rank.score).toBeGreaterThan(outcome.proposals[1]!.rank.score);
+    // The list itself is sorted descending by score.
+    const scores = outcome.proposals.map((p) => p.rank.score);
+    expect(scores).toEqual([...scores].sort((a, b) => b - a));
+  });
+
+  it("never leaks raw rating-reason text or other task content into a proposal (content-blindness)", async () => {
+    const store = new LearningRegistryStore(munin());
+    const champion = await seedArm(store, {
+      taskType: "code-edit", arm: "champion", axis: "agent-prompt", idPrefix: "champ",
+      count: 3, ratings: ["partial"], startIso: "2026-07-01T00:00:00.000Z",
+    });
+    const challenger = await seedArm(store, {
+      taskType: "code-edit", arm: "challenger", axis: "agent-prompt", idPrefix: "chall",
+      count: 3, ratings: ["pass"], startIso: "2026-07-05T00:00:00.000Z",
+    });
+    const { candidates, timelines } = mergeSeeds(champion, challenger);
+
+    const outcome = proposeExperiments(candidates, timelines, { now: () => "2026-07-10T00:00:00.000Z" });
+    expect(outcome.status).toBe("proposed");
+    const serialized = JSON.stringify(outcome.proposals);
+    expect(serialized).not.toContain("SECRET-RAW-EVIDENCE-TEXT");
+    expect(serialized).not.toContain("ratingReason");
+  });
+
+  it("is a pure function of its inputs -- proposalId is stable across reruns at a different wall clock", async () => {
+    const store = new LearningRegistryStore(munin());
+    const champion = await seedArm(store, {
+      taskType: "code-edit", arm: "champion", axis: "agent-prompt", idPrefix: "champ",
+      count: 3, ratings: ["partial"], startIso: "2026-07-01T00:00:00.000Z",
+    });
+    const challenger = await seedArm(store, {
+      taskType: "code-edit", arm: "challenger", axis: "agent-prompt", idPrefix: "chall",
+      count: 3, ratings: ["pass"], startIso: "2026-07-05T00:00:00.000Z",
+    });
+    const { candidates, timelines } = mergeSeeds(champion, challenger);
+
+    const first = proposeExperiments(candidates, timelines, { now: () => "2026-07-10T00:00:00.000Z" });
+    const second = proposeExperiments(candidates, timelines, { now: () => "2026-07-20T00:00:00.000Z" });
+
+    expect(first.proposals[0]!.proposalId).toBe(second.proposals[0]!.proposalId);
+    // Recency weight legitimately differs (evaluated 10 days later) even though identity does not.
+    expect(first.proposals[0]!.evidence.recencyWeight).not.toBe(second.proposals[0]!.evidence.recencyWeight);
+  });
+});
+
+describe("proposeExperimentsFromRegistry", () => {
+  it("is read-only: fetches timelines from the registry and never mutates it", async () => {
+    const store = new LearningRegistryStore(munin());
+    const champion = await seedArm(store, {
+      taskType: "code-edit", arm: "champion", axis: "agent-prompt", idPrefix: "champ",
+      count: 3, ratings: ["partial"], startIso: "2026-07-01T00:00:00.000Z",
+    });
+    const challenger = await seedArm(store, {
+      taskType: "code-edit", arm: "challenger", axis: "agent-prompt", idPrefix: "chall",
+      count: 3, ratings: ["pass"], startIso: "2026-07-05T00:00:00.000Z",
+    });
+    const { candidates } = mergeSeeds(champion, challenger);
+
+    const outcome = await proposeExperimentsFromRegistry(store, candidates, { now: () => "2026-07-10T00:00:00.000Z" });
+
+    expect(outcome.status).toBe("proposed");
+    expect(outcome.proposals).toHaveLength(1);
+    // A second call against the same, unmodified registry is deterministic.
+    const again = await proposeExperimentsFromRegistry(store, candidates, { now: () => "2026-07-10T00:00:00.000Z" });
+    expect(again.proposals[0]!.proposalId).toBe(outcome.proposals[0]!.proposalId);
+  });
+});
+
+describe("proposalToPackageRequest (shape alignment with the #233 packager)", () => {
+  it("maps a proposal onto a PackageRequest the packager accepts, and the resolved candidates package successfully", async () => {
+    const store = new LearningRegistryStore(munin());
+    const champion = await seedArm(store, {
+      taskType: "code-edit", arm: "champion", axis: "agent-prompt", idPrefix: "champ",
+      count: 3, ratings: ["partial"], startIso: "2026-07-01T00:00:00.000Z",
+    });
+    const challenger = await seedArm(store, {
+      taskType: "code-edit", arm: "challenger", axis: "agent-prompt", idPrefix: "chall",
+      count: 3, ratings: ["pass"], startIso: "2026-07-05T00:00:00.000Z",
+    });
+    const { candidates, timelines } = mergeSeeds(champion, challenger);
+
+    const proposeOutcome = proposeExperiments(candidates, timelines, { now: () => "2026-07-10T00:00:00.000Z" });
+    expect(proposeOutcome.status).toBe("proposed");
+    const proposal = proposeOutcome.proposals[0]!;
+
+    // The proposer's own default rating floor ("wrong") is deliberately looser than
+    // the packager's ("pass"), so a proposal built from partial/wrong-rated evidence
+    // must explicitly relax the packager's floor to actually freeze -- exercise that
+    // override here rather than papering over it.
+    const packageRequest = proposalToPackageRequest(proposal, {
+      now: () => "2026-07-11T00:00:00.000Z",
+      minCandidatesPerArm: 3,
+      minQualityRating: "partial",
+    });
+    expect(packageRequest.scope).toBe(proposal.suggestedScope);
+    expect(packageRequest.changeAxis).toBe(proposal.changeAxis);
+    expect(packageRequest.championFingerprint).toBe(proposal.championFingerprint);
+    expect(packageRequest.gates.primaryMetric).toBe("quality-rate");
+    expect(packageRequest.minCandidatesPerArm).toBe(3);
+    expect(packageRequest.minQualityRating).toBe("partial");
+
+    // The proposal's matchedTasks are content-blind references; a caller resolves
+    // each one back into a full PackagerCandidateInput from its own durable stores
+    // (here, simply looking the original seeded candidate back up by taskId) --
+    // exactly the re-fetch-by-id discipline documented on proposalToPackageRequest.
+    const byTaskId = new Map(candidates.map((c) => [c.taskId, c]));
+    const resolvedCandidates: PackagerCandidateInput[] = proposal.matchedTasks.map((matched) => {
+      const resolved = byTaskId.get(matched.taskId);
+      if (!resolved) throw new Error(`test setup error: no candidate for ${matched.taskId}`);
+      return resolved;
+    });
+
+    const packageOutcome = packageExperimentCandidates(resolvedCandidates, timelines, packageRequest);
+    expect(packageOutcome.status).toBe("packaged");
+    expect(packageOutcome.package!.changeAxis).toBe(proposal.changeAxis);
+    expect(packageOutcome.package!.champion.fingerprint).toBe(proposal.championFingerprint);
+    expect(packageOutcome.package!.challenger.fingerprint).toBe(proposal.challengerFingerprint);
+  });
+});


### PR DESCRIPTION
Refs #234

## What

Adds a strictly read-only proposer that scans qualified production evidence and proposes ranked one-axis champion/challenger experiments, precedeing the #233 candidate packager in the pipeline.

- `src/learning/experiment-proposer-schema.ts` -- contract: `ExperimentProposal`, content-blind `matchedTasks` (reuses the packager's own `PackagerMatchedTask` shape), `ProposalOutcome`, and fail-closed `PopulationDeclineReason` codes.
- `src/learning/experiment-proposer.ts` -- logic: `proposeExperiments` (pure), `proposeExperimentsFromRegistry` (read-only registry wrapper), `proposalToPackageRequest` (maps a proposal onto the #233 packager's `PackageRequest`).
- `tests/experiment-proposer.test.ts` -- 12 tests.

It scans `PackagerCandidateInput` rows (the same shape the #233 packager consumes) plus their registry timelines, groups them by task type then by `configuration.fingerprint`, and for every pair of distinct configurations within a task type checks whether they differ on exactly one axis (via the existing `configurationChangedAxes`). When both arms clear a minimum sample size and the quality-rate delta clears a minimum threshold, it emits a ranked proposal; otherwise it records a concrete decline reason instead of a weak proposal.

It never packages, creates, runs, evaluates, or promotes an experiment -- those stay entirely inside `candidate-packager.ts` and `experiment-store.ts`.

## Design decisions

- **Ranking heuristic**: `score = effectSize * sampleSize * recencyWeight`, where `effectSize` is the absolute pass-rate delta, `sampleSize = min(championSamples, challengerSamples)` (an experiment's power is bound by its thinner arm), and `recencyWeight` is an exponential half-life decay (default 14 days) on the population's most recent evidence. A normal-approximation two-proportion z-test is reported alongside as `evidence.confidence`/`evidence.zScore`, deliberately *not* folded into the score, since it isn't robust to non-independent samples or multiple-comparison inflation across the several populations one run may propose. Documented in the module doc comment.
- **Rating floor differs from the packager on purpose**: the packager floors `qualifyCandidate` at `"pass"` (it only ever freezes already-winning candidates). The proposer floors at `"wrong"` (the lowest rating) by default, because it needs the full outcome spectrum to detect a quality delta between two configurations at all -- flooring at `"pass"` here would make every surviving population's pass rate trivially 1.0. Every *other* `qualifyCandidate` contamination check (timeline completeness, exclusion/erasure, superseded evidence, receipt binding) still applies unchanged.
- **Proposer -> packager shape alignment**: `ExperimentProposal.matchedTasks` reuses `packagerMatchedTaskSchema` verbatim -- content-blind (taskId/attemptId/arm/taskType/qualityReceiptId/qualityRating) references only, no free-text `ratingReason`, no raw task content. `proposalToPackageRequest` maps `(taskType, axis, champion, challenger, matchedTasks)` directly onto `(scope, hypothesis, changeAxis, championFingerprint, gates)`. It deliberately does **not** return `PackagerCandidateInput[]` -- the caller must re-resolve each matched task by id from its own durable stores (registry + quality-receipt ledger) before calling the packager, mirroring the same re-fetch-by-id discipline `packageAndHandOff` already applies to registry timelines rather than trusting a cached view. Exercised end-to-end in the last test (proposal -> `proposalToPackageRequest` -> resolved candidates -> `packageExperimentCandidates` -> `"packaged"`).
- **Champion/challenger assignment**: within a one-axis-differing pair, the group whose evidence started appearing earlier is treated as the incumbent (champion); the later group is the challenger under test. Deterministic tie-break on fingerprint string when timestamps coincide.
- **Content-addressed `proposalId`** excludes every wall-clock-dependent field (`recencyWeight`, `rank.score`, `proposedAt`) so the same underlying evidence pool re-analyzed later keeps the same identity -- this doesn't build a dedup conductor (out of scope here) but gives one a cheap identity to compare against.

## Verification

- `npm run build` -- clean (`tsc`, strict mode).
- `npm test` -- **128 test files passed (128), 2068 tests passed (2068)** (baseline before this change: 127 files / 2056 tests; this PR adds 1 file / 12 tests, no regressions).

Tests cover: a valid one-axis proposal from a seeded two-config population; refusal on multi-axis delta; refusal on insufficient samples in either arm; refusal on a single-configuration population; decline when the quality-rate delta doesn't clear the configured threshold; fail-closed behavior on contaminated evidence (identical to the packager's `qualifyCandidate`); refusal when nothing survives qualification; ranking order across multiple populations (effect size x sample size x recency); content-blindness (no raw `ratingReason` text anywhere in a serialized proposal); `proposalId` stability across reruns at a different wall clock; the read-only registry wrapper; and the proposal -> packager end-to-end shape alignment.

### Dogfooding note (M5)

Ran a bounded `mcp__m5__ask` review (qwen3-30b-instruct) against the literal ranking-heuristic/one-axis-detection source, asking specifically for edge cases in the score formula, the pairwise grouping/champion assignment, and the confidence z-test. All three findings it returned were verified against the actual source and **none held up**:
1. Claimed the recency weight could exceed 1 under clock skew -- but the exact code shown to it already clamps `ageDays` via `Math.max(0, ...)`, which its own answer quoted and then ignored.
2. Claimed a tie-break bug when two fingerprints are equal -- structurally impossible, since the compared fingerprints come from distinct keys of a dedup'd `Map`.
3. Restated the already-documented, intentional sample-size fallback for a degenerate standard error as a "flaw" without identifying an actual defect.

Consistent with this program's prior rounds: M5 fabricated a bug against inline source it was directly shown. Net for this round: not useful as a bug-finder, though verifying its claims did force a second confirmation pass over the clamp and the fingerprint-uniqueness invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)