### PR TITLE
Refs #241: authoritative period closes over #232 registry proofs

### DIFF
--- a/src/learning-period-close.ts
+++ b/src/learning-period-close.ts
@@ -1,0 +1,539 @@
+/**
+ * Authoritative monthly (period) close — LearningTaskContract consumption
+ * layer (hugin#241).
+ *
+ * Scope boundary (2026-07-20 "Boundary clarification" on hugin#241, echoed in
+ * the header of src/learning-registry-schema.ts): hugin#232 owns the
+ * *mechanism* — the append-only registry's natural keys, membership evidence
+ * issued at capture, and the partition/high-water proof primitives
+ * (`issuePartitionProof` / `verifyPartitionProof`). This module owns the
+ * *consumption* — period closes, monthly statements, and cross-owner
+ * accounting that VERIFY and CONSUME #232's proofs. It does not:
+ *   - add a new registry record kind or counter,
+ *   - re-issue or re-derive a partition/high-water proof (it always asks
+ *     `LearningRegistryStore` for one and then independently verifies it), or
+ *   - change #232's natural keys.
+ * Correction/exclusion resolution reuses `buildTaskLifecycleTimeline`
+ * (#232's own read view) rather than re-walking correction chains here.
+ *
+ * A period statement is content-addressed and append-only: the same
+ * registry state for a period always produces the same `statementId`, so
+ * re-closing is a no-op. A later correction or erasure changes the derived
+ * corrected/excluded counts (never the underlying partition's own
+ * `highWaterSeq` — see #232's "target's own partition membership count never
+ * shrinks" invariant), which changes the digest and therefore produces a
+ * *new*, distinct statement. The old statement is retained untouched; only a
+ * separate, explicitly mutable "latest" pointer moves.
+ *
+ * Certification is fail-closed: a full-period statement is `"certified"`
+ * only when every constituent counter's partition proof is eligible for
+ * certification (#232's `isEligibleForCertification`) AND independently
+ * re-verifies (`verifyPartitionProof` with `requireCurrent: true`) AND its
+ * derived corrected/excluded counts could be computed without a truncated
+ * read. Any single failure degrades the *whole* statement to `"partial"` and
+ * names exactly which counter/partition blocked certification — never a
+ * silent full-period claim over a subset.
+ */
+
+import { MuninWriteRejectedError, type MuninClient } from "./munin-client.js";
+import { buildTaskLifecycleTimeline } from "./learning-registry-view.js";
+import {
+  canonicalEqual,
+  isEligibleForCertification,
+  jcsDigestHex,
+  LearningRegistryError,
+  LEARNING_REGISTRY_COUNTER_OWNER,
+  occurrencePeriodSchema,
+  registryEvidenceRefSchema,
+  registryPartitionProofSchema,
+  type LearningRegistryStore,
+  type RegistryEvidenceRef,
+  type RegistryPartitionProof,
+  type RegistryRecordKind,
+} from "./learning-registry-store.js";
+import { z } from "zod";
+
+export const PERIOD_CLOSE_SCHEMA_VERSION = 1 as const;
+
+export class PeriodCloseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PeriodCloseError";
+  }
+}
+
+/**
+ * The counters whose partitions constitute the Hugin-owned attempt/outcome
+ * denominators a period statement certifies. `correction` and
+ * `exclusion-adjustment` are not closed as their own partitions here — they
+ * are consumed per-member through `buildTaskLifecycleTimeline` to compute
+ * `correctedEvents` / `excludedEvents` against *these* counters' events,
+ * which is the erasure-safe membership question #241 exists to answer.
+ */
+export const PRIMARY_ACCOUNTING_COUNTERS = [
+  "submission",
+  "attempt-reference",
+  "terminal-outcome",
+  "publication",
+] as const satisfies readonly RegistryRecordKind[];
+export type AccountingCounter = (typeof PRIMARY_ACCOUNTING_COUNTERS)[number];
+
+const periodCounterStatementSchema = z.object({
+  counter: z.enum(PRIMARY_ACCOUNTING_COUNTERS),
+  /** The exact #232 partition/high-water proof this count is bound to. */
+  proof: registryPartitionProofSchema,
+  totalEvents: z.number().int().nonnegative(),
+  /** Members whose correction chain resolves to a leaf other than themselves. */
+  correctedEvents: z.number().int().nonnegative(),
+  /** Members with at least one exclusion-adjustment directly targeting them. */
+  excludedEvents: z.number().int().nonnegative(),
+  erasureAdjustments: z.number().int().nonnegative(),
+  exclusionAdjustments: z.number().int().nonnegative(),
+  /** `totalEvents - excludedEvents` — informational only. `totalEvents` (the
+   * partition's own high-water count) remains the contract-authoritative
+   * denominator; erasure never shrinks it. */
+  effectiveCount: z.number().int().nonnegative(),
+}).strict();
+export type PeriodCounterStatement = z.infer<typeof periodCounterStatementSchema>;
+
+const blockedCounterSchema = z.object({
+  counter: z.enum(PRIMARY_ACCOUNTING_COUNTERS),
+  reason: z.string().min(1),
+}).strict();
+export type BlockedCounter = z.infer<typeof blockedCounterSchema>;
+
+/**
+ * Cross-owner (gille-inference) basis reference. Hugin owns Hugin counters;
+ * gille owns gille counters. This is a *reference* to gille's own
+ * owner-issued basis evidence for the same period — never a value Hugin
+ * computes or fabricates on gille's behalf.
+ */
+export const gilleBasisReferenceSchema = z.object({
+  ownerComponent: z.literal("gille-inference"),
+  period: occurrencePeriodSchema,
+  status: z.enum(["referenced", "unavailable"]),
+  basisRef: registryEvidenceRefSchema.optional(),
+  reason: z.string().min(1).max(512).optional(),
+}).strict().superRefine((value, ctx) => {
+  if (value.status === "referenced" && !value.basisRef) {
+    ctx.addIssue({ code: "custom", path: ["basisRef"], message: "a referenced basis must carry gille's evidence ref" });
+  }
+  if (value.status === "unavailable" && !value.reason) {
+    ctx.addIssue({ code: "custom", path: ["reason"], message: "an unavailable basis must explain why" });
+  }
+  if (value.status === "unavailable" && value.basisRef) {
+    ctx.addIssue({ code: "custom", path: ["basisRef"], message: "an unavailable basis cannot carry a ref" });
+  }
+});
+export type GilleBasisReference = z.infer<typeof gilleBasisReferenceSchema>;
+
+/** Injected port to gille-inference's own authoritative period accounting
+ * (gille-inference#3, not yet implemented at time of writing). Consumed,
+ * never re-implemented: Hugin only ever stores whatever this returns. */
+export interface GilleBasisSource {
+  fetchBasis(period: string): Promise<GilleBasisReference>;
+}
+
+export const periodStatementSchema = z.object({
+  schemaVersion: z.literal(PERIOD_CLOSE_SCHEMA_VERSION),
+  /** Content-derived: `close-<32 hex>`, digested over every field below
+   * except `closedAt` and `supersedes` (call-observed metadata) and each
+   * counter proof's own `issuedAt` (re-issued fresh on every call). */
+  statementId: z.string().regex(/^close-[0-9a-f]{32}$/),
+  counterOwner: z.literal(LEARNING_REGISTRY_COUNTER_OWNER),
+  period: occurrencePeriodSchema,
+  status: z.enum(["certified", "partial"]),
+  counters: z.array(periodCounterStatementSchema),
+  blockedCounters: z.array(blockedCounterSchema),
+  crossOwner: gilleBasisReferenceSchema.nullable(),
+  /** When this exact statement row was durably persisted. Not part of the
+   * content digest — a later idempotent re-close legitimately observes a
+   * different wall-clock time for the same logical statement. */
+  closedAt: z.string(),
+  /** The prior latest statement id for this period at the moment this
+   * statement was first created, or null for the first close. Lineage
+   * metadata only; not part of the content digest. */
+  supersedes: z.string().nullable(),
+}).strict().superRefine((value, ctx) => {
+  if (value.status === "certified" && value.blockedCounters.length > 0) {
+    ctx.addIssue({ code: "custom", path: ["status"], message: "a statement with any blocked counter cannot be certified" });
+  }
+  if (value.status === "certified" && value.counters.length !== PRIMARY_ACCOUNTING_COUNTERS.length) {
+    ctx.addIssue({ code: "custom", path: ["counters"], message: "a certified statement must bind every accounting counter" });
+  }
+  if (value.status === "partial" && value.blockedCounters.length === 0) {
+    ctx.addIssue({ code: "custom", path: ["blockedCounters"], message: "a partial statement must name at least one blocking counter" });
+  }
+});
+export type PeriodStatement = z.infer<typeof periodStatementSchema>;
+
+// ---------------------------------------------------------------------------
+// Content addressing
+// ---------------------------------------------------------------------------
+
+function proofWithoutIssuedAt(proof: RegistryPartitionProof): Omit<RegistryPartitionProof, "issuedAt"> {
+  const { issuedAt: _issuedAt, ...rest } = proof;
+  return rest;
+}
+
+/** Everything that makes a statement *this* statement, excluding
+ * call-observed metadata (`closedAt`, `supersedes`, each proof's `issuedAt`). */
+function digestInput(draft: Omit<PeriodStatement, "statementId" | "closedAt" | "supersedes">): unknown {
+  return {
+    schemaVersion: draft.schemaVersion,
+    counterOwner: draft.counterOwner,
+    period: draft.period,
+    status: draft.status,
+    counters: draft.counters.map((c) => ({ ...c, proof: proofWithoutIssuedAt(c.proof) })),
+    blockedCounters: draft.blockedCounters,
+    crossOwner: draft.crossOwner,
+  };
+}
+
+export function deriveStatementId(
+  draft: Omit<PeriodStatement, "statementId" | "closedAt" | "supersedes">,
+): string {
+  return `close-${jcsDigestHex(digestInput(draft)).slice(0, 32)}`;
+}
+
+function withoutVolatile(statement: PeriodStatement): unknown {
+  const { closedAt: _closedAt, supersedes: _supersedes, statementId: _statementId, ...rest } = statement;
+  return digestInput(rest);
+}
+
+// ---------------------------------------------------------------------------
+// Per-counter accounting
+// ---------------------------------------------------------------------------
+
+interface CounterOutcome {
+  kind: "ok";
+  statement: PeriodCounterStatement;
+}
+interface CounterBlocked {
+  kind: "blocked";
+  reason: string;
+}
+
+async function statsForCounter(
+  registryStore: Pick<LearningRegistryStore, "listEventsForTask">,
+  counter: AccountingCounter,
+  proof: RegistryPartitionProof,
+): Promise<CounterOutcome | CounterBlocked> {
+  const eventIdsByTask = new Map<string, string[]>();
+  for (const member of proof.members) {
+    const list = eventIdsByTask.get(member.taskId) ?? [];
+    list.push(member.eventId);
+    eventIdsByTask.set(member.taskId, list);
+  }
+
+  let correctedEvents = 0;
+  let excludedEvents = 0;
+  let erasureAdjustments = 0;
+  let exclusionAdjustments = 0;
+
+  for (const [taskId, eventIds] of eventIdsByTask) {
+    const timeline = await buildTaskLifecycleTimeline(registryStore, taskId);
+    if (timeline.truncated) {
+      return {
+        kind: "blocked",
+        reason: `task ${taskId}'s lifecycle timeline could not be enumerated completely (Munin pagination budget exhausted); corrected/excluded counts for counter ${counter} cannot be certified`,
+      };
+    }
+    const byEventId = new Map(timeline.entries.map((entry) => [entry.event.eventId, entry] as const));
+    for (const eventId of eventIds) {
+      const entry = byEventId.get(eventId);
+      if (!entry) {
+        return {
+          kind: "blocked",
+          reason: `partition member ${taskId}/${eventId} for counter ${counter} was not found in its task's lifecycle timeline`,
+        };
+      }
+      if (entry.event.recordKind !== counter) {
+        return {
+          kind: "blocked",
+          reason: `partition member ${taskId}/${eventId} tagged for counter ${counter} is actually recordKind ${entry.event.recordKind}`,
+        };
+      }
+      if (entry.superseded) correctedEvents += 1;
+      if (entry.excluded) {
+        excludedEvents += 1;
+        if (entry.excludedReasons.includes("erasure")) erasureAdjustments += 1;
+        if (entry.excludedReasons.includes("exclusion")) exclusionAdjustments += 1;
+      }
+    }
+  }
+
+  return {
+    kind: "ok",
+    statement: periodCounterStatementSchema.parse({
+      counter,
+      proof,
+      totalEvents: proof.highWaterSeq,
+      correctedEvents,
+      excludedEvents,
+      erasureAdjustments,
+      exclusionAdjustments,
+      effectiveCount: proof.highWaterSeq - excludedEvents,
+    }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Persistence
+// ---------------------------------------------------------------------------
+
+const STATEMENT_NAMESPACE = "learning-period-close/statements";
+const STATEMENT_TAG = "learning-period-close-statement";
+const LATEST_NAMESPACE = "learning-period-close/latest";
+const LATEST_CAS_ATTEMPTS = 8;
+
+const latestPointerSchema = z.object({
+  schemaVersion: z.literal(PERIOD_CLOSE_SCHEMA_VERSION),
+  counterOwner: z.literal(LEARNING_REGISTRY_COUNTER_OWNER),
+  period: occurrencePeriodSchema,
+  latestStatementId: z.string().regex(/^close-[0-9a-f]{32}$/),
+  updatedAt: z.string(),
+}).strict();
+type LatestPointer = z.infer<typeof latestPointerSchema>;
+
+function latestPointerKey(period: string): string {
+  return `${LEARNING_REGISTRY_COUNTER_OWNER}-${period}`;
+}
+
+export interface PeriodCloseOptions {
+  /** Which counters to actually evaluate. Defaults to every
+   * `PRIMARY_ACCOUNTING_COUNTERS` entry — mainly useful for focused tests. A
+   * strict subset can never yield `"certified"`: every counter outside the
+   * requested set is added to `blockedCounters` as its own named blocker, so
+   * the statement always honestly degrades to `"partial"` instead of
+   * silently claiming a full period over an evaluated subset. */
+  counters?: readonly AccountingCounter[];
+  gilleBasisSource?: GilleBasisSource;
+  closedAt?: string;
+}
+
+export interface PeriodCloseResult {
+  statement: PeriodStatement;
+  /** True only when this call durably created a new statement row. False
+   * both for "exact idempotent replay" and for "content matched an older
+   * already-persisted statement". */
+  created: boolean;
+}
+
+/**
+ * Authoritative monthly close store (hugin#241). Wraps a `LearningRegistryStore`
+ * (hugin#232) — it never talks to Munin about registry events directly, only
+ * about its own statement/pointer documents.
+ */
+export class LearningPeriodCloseStore {
+  private readonly now: () => string;
+
+  constructor(
+    private readonly munin: MuninClient,
+    private readonly registryStore: LearningRegistryStore,
+    options: { now?: () => string } = {},
+  ) {
+    this.now = options.now ?? (() => new Date().toISOString());
+  }
+
+  private async readLatestPointer(period: string): Promise<LatestPointer | null> {
+    const entry = await this.munin.read(LATEST_NAMESPACE, latestPointerKey(period));
+    return entry ? latestPointerSchema.parse(JSON.parse(entry.content)) : null;
+  }
+
+  private async readStatement(statementId: string): Promise<PeriodStatement | null> {
+    const entry = await this.munin.read(STATEMENT_NAMESPACE, statementId);
+    return entry ? periodStatementSchema.parse(JSON.parse(entry.content)) : null;
+  }
+
+  async getStatement(statementId: string): Promise<PeriodStatement | null> {
+    return this.readStatement(statementId);
+  }
+
+  /** The current effective statement for a period, or null if it has never
+   * been closed. A later correction/erasure moves this pointer to a new,
+   * distinct statement; the statement it superseded remains readable by id. */
+  async getLatest(period: string): Promise<PeriodStatement | null> {
+    occurrencePeriodSchema.parse(period);
+    const pointer = await this.readLatestPointer(period);
+    if (!pointer) return null;
+    const statement = await this.readStatement(pointer.latestStatementId);
+    if (!statement) {
+      throw new LearningRegistryError(
+        `period close latest pointer for ${period} names statement ${pointer.latestStatementId}, which could not be read back`,
+      );
+    }
+    return statement;
+  }
+
+  private async persistStatement(
+    statement: PeriodStatement,
+  ): Promise<{ statement: PeriodStatement; created: boolean }> {
+    const key = statement.statementId;
+    try {
+      const result = await this.munin.write(
+        STATEMENT_NAMESPACE,
+        key,
+        JSON.stringify(statement),
+        [STATEMENT_TAG, `learning-period-close-status:${statement.status}`],
+        undefined,
+        "internal",
+        true,
+      );
+      if (result.status !== "created") {
+        throw new LearningRegistryError(`period statement write returned non-created status for ${STATEMENT_NAMESPACE}/${key}`);
+      }
+      return { statement, created: true };
+    } catch (err) {
+      if (err instanceof MuninWriteRejectedError && err.conflictReason === "already_exists") {
+        const existing = await this.readStatement(key);
+        if (!existing) {
+          throw new LearningRegistryError(
+            `period statement ${STATEMENT_NAMESPACE}/${key} reported already-existing but could not be read back`,
+          );
+        }
+        if (!canonicalEqual(withoutVolatile(existing), withoutVolatile(statement))) {
+          throw new PeriodCloseError(
+            `period statement content-address collision at ${key}: a differently-contented statement already occupies this id`,
+          );
+        }
+        return { statement: existing, created: false };
+      }
+      throw err;
+    }
+  }
+
+  private async advanceLatestPointer(period: string, statementId: string, updatedAt: string): Promise<void> {
+    for (let attempt = 0; attempt < LATEST_CAS_ATTEMPTS; attempt += 1) {
+      const current = await this.munin.read(LATEST_NAMESPACE, latestPointerKey(period));
+      const currentPointer = current ? latestPointerSchema.parse(JSON.parse(current.content)) : null;
+      if (currentPointer?.latestStatementId === statementId) return; // already the latest
+      const nextPointer = latestPointerSchema.parse({
+        schemaVersion: PERIOD_CLOSE_SCHEMA_VERSION,
+        counterOwner: LEARNING_REGISTRY_COUNTER_OWNER,
+        period,
+        latestStatementId: statementId,
+        updatedAt,
+      });
+      try {
+        await this.munin.write(
+          LATEST_NAMESPACE,
+          latestPointerKey(period),
+          JSON.stringify(nextPointer),
+          ["learning-period-close-latest"],
+          current?.updated_at,
+          "internal",
+          current === null ? true : undefined,
+        );
+        return;
+      } catch (err) {
+        if (err instanceof MuninWriteRejectedError) continue; // lost the CAS race — reread and retry
+        throw err;
+      }
+    }
+    throw new LearningRegistryError(
+      `latest-statement pointer update for period ${period} lost ${LATEST_CAS_ATTEMPTS} repeated CAS races`,
+    );
+  }
+
+  /**
+   * Close `period`: gather and independently verify #232's partition proof
+   * for every accounting counter, derive corrected/excluded counts from the
+   * registry's own lifecycle view, optionally join gille's owner-issued
+   * cross-owner basis, and persist the resulting content-addressed statement.
+   *
+   * Fail-closed: any counter whose proof is not eligible for certification,
+   * fails independent re-verification, or whose corrected/excluded counts
+   * cannot be proven complete blocks that counter — the whole statement
+   * degrades to `"partial"` and names exactly which counter(s) blocked it.
+   * A `"certified"` statement only ever comes from every counter succeeding.
+   */
+  async close(period: string, options: PeriodCloseOptions = {}): Promise<PeriodCloseResult> {
+    occurrencePeriodSchema.parse(period);
+    const closedAt = options.closedAt ?? this.now();
+    const counters = options.counters ?? PRIMARY_ACCOUNTING_COUNTERS;
+
+    const previousLatest = await this.readLatestPointer(period);
+
+    const counterStatements: PeriodCounterStatement[] = [];
+    const blockedCounters: BlockedCounter[] = [];
+
+    for (const counter of counters) {
+      const proof = await this.registryStore.issuePartitionProof(counter, period, closedAt);
+      const verdict = await this.registryStore.verifyPartitionProof(proof, { requireCurrent: true });
+      if (!isEligibleForCertification(proof)) {
+        blockedCounters.push({ counter, reason: proof.partialReason ?? "partition proof is not eligible for certification" });
+        continue;
+      }
+      if (!verdict.valid) {
+        blockedCounters.push({ counter, reason: verdict.reason ?? "partition proof failed independent verification" });
+        continue;
+      }
+      const outcome = await statsForCounter(this.registryStore, counter, proof);
+      if (outcome.kind === "blocked") {
+        blockedCounters.push({ counter, reason: outcome.reason });
+        continue;
+      }
+      counterStatements.push(outcome.statement);
+    }
+
+    // A caller-supplied `counters` subset must never be able to earn a
+    // "certified" full-period statement over counters it never evaluated —
+    // that would be exactly the silent full-period claim over a subset this
+    // module exists to prevent. Any counter outside the requested set is
+    // itself a named blocker.
+    for (const counter of PRIMARY_ACCOUNTING_COUNTERS) {
+      if (!counters.includes(counter)) {
+        blockedCounters.push({
+          counter,
+          reason: "excluded from this close by the caller's counters option; a subset cannot be certified as a full period",
+        });
+      }
+    }
+
+    counterStatements.sort((a, b) => a.counter.localeCompare(b.counter));
+    blockedCounters.sort((a, b) => a.counter.localeCompare(b.counter));
+
+    const crossOwner = options.gilleBasisSource
+      ? await options.gilleBasisSource.fetchBasis(period)
+      : null;
+
+    const status: PeriodStatement["status"] = blockedCounters.length === 0 ? "certified" : "partial";
+
+    const draft = {
+      schemaVersion: PERIOD_CLOSE_SCHEMA_VERSION,
+      counterOwner: LEARNING_REGISTRY_COUNTER_OWNER,
+      period,
+      status,
+      counters: counterStatements,
+      blockedCounters,
+      crossOwner,
+    } satisfies Omit<PeriodStatement, "statementId" | "closedAt" | "supersedes">;
+
+    const statementId = deriveStatementId(draft);
+
+    if (previousLatest?.latestStatementId === statementId) {
+      // Exact idempotent replay of the current latest — nothing changed.
+      const existing = await this.readStatement(statementId);
+      if (!existing) {
+        throw new LearningRegistryError(
+          `latest pointer for period ${period} names statement ${statementId}, which could not be read back`,
+        );
+      }
+      return { statement: existing, created: false };
+    }
+
+    const statement = periodStatementSchema.parse({
+      ...draft,
+      statementId,
+      closedAt,
+      supersedes: previousLatest?.latestStatementId ?? null,
+    });
+
+    const persisted = await this.persistStatement(statement);
+    await this.advanceLatestPointer(period, persisted.statement.statementId, closedAt);
+    return persisted;
+  }
+}
+
+export type { RegistryEvidenceRef };

--- a/tests/learning-period-close.test.ts
+++ b/tests/learning-period-close.test.ts
@@ -1,0 +1,427 @@
+import { describe, expect, it } from "vitest";
+import { MuninWriteRejectedError, type MuninClient } from "../src/munin-client.js";
+import { LearningRegistryStore } from "../src/learning-registry-store.js";
+import {
+  LearningPeriodCloseStore,
+  PRIMARY_ACCOUNTING_COUNTERS,
+  type GilleBasisSource,
+  type GilleBasisReference,
+} from "../src/learning-period-close.js";
+
+interface StoredEntry {
+  namespace: string;
+  key: string;
+  content: string;
+  tags: string[];
+  classification?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Same in-memory Munin double idiom as tests/learning-registry-store.test.ts:
+ * atomic create-if-absent and CAS-by-expected-updated_at, so the store's real
+ * concurrency contract is exercised rather than a stub. */
+class InMemoryMunin {
+  private entries: StoredEntry[] = [];
+  private seq = 0;
+
+  private clock(): string {
+    this.seq += 1;
+    return new Date(Date.UTC(2026, 6, 1, 0, 0, 0, 0) + this.seq).toISOString();
+  }
+
+  private find(namespace: string, key: string): StoredEntry | undefined {
+    return this.entries.find((e) => e.namespace === namespace && e.key === key);
+  }
+
+  async read(namespace: string, key: string) {
+    const entry = this.find(namespace, key);
+    return entry ? ({ ...entry, found: true } as unknown as Record<string, unknown>) : null;
+  }
+
+  async write(
+    namespace: string,
+    key: string,
+    content: string,
+    tags?: string[],
+    expectedUpdatedAt?: string,
+    classification?: string,
+    createIfAbsent?: boolean,
+  ) {
+    const existing = this.find(namespace, key);
+    if (createIfAbsent && existing) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        conflict_reason: "already_exists",
+        current_updated_at: existing.updated_at,
+      });
+    }
+    if (expectedUpdatedAt !== undefined && (!existing || existing.updated_at !== expectedUpdatedAt)) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        conflict_reason: "version_mismatch",
+        current_updated_at: existing?.updated_at,
+      });
+    }
+    const updated_at = this.clock();
+    const created_at = existing?.created_at ?? updated_at;
+    const next: StoredEntry = { namespace, key, content, tags: tags ?? [], classification, created_at, updated_at };
+    if (existing) Object.assign(existing, next); else this.entries.push(next);
+    return { ok: true, status: existing ? "updated" : "created", updated_at };
+  }
+
+  async query(opts: { namespace?: string; tags?: string[]; limit?: number; since?: string; until?: string }) {
+    let rows = this.entries.filter((e) =>
+      (!opts.namespace || e.namespace.startsWith(opts.namespace))
+      && (opts.tags ?? []).every((tag) => e.tags.includes(tag)));
+    if (opts.since) rows = rows.filter((e) => e.updated_at >= opts.since!);
+    if (opts.until) rows = rows.filter((e) => e.updated_at <= opts.until!);
+    rows = [...rows].sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+    const limited = rows.slice(0, opts.limit ?? 50);
+    return {
+      results: limited.map((e) => ({
+        id: `${e.namespace}/${e.key}`,
+        namespace: e.namespace,
+        key: e.key,
+        entry_type: "state",
+        content_preview: e.content.slice(0, 80),
+        tags: e.tags,
+        classification: e.classification,
+        created_at: e.created_at,
+        updated_at: e.updated_at,
+      })),
+      total: rows.length,
+    };
+  }
+
+  /** Test-only: simulate a lost/corrupted high-water document, exactly the
+   * fixture the #232 suite uses to force a "partial" proof. */
+  remove(namespace: string, key: string): void {
+    this.entries = this.entries.filter((e) => !(e.namespace === namespace && e.key === key));
+  }
+}
+
+function munin(): InMemoryMunin & MuninClient {
+  return new InMemoryMunin() as unknown as InMemoryMunin & MuninClient;
+}
+
+function ref(namespace: string, key: string) {
+  return { namespace, key };
+}
+
+/** Seed one full lifecycle (submission/attempt-reference/terminal-outcome/
+ * publication) for a task inside the given occurrence month, so all four
+ * accounting counters have exactly one member each. */
+async function seedFullLifecycle(
+  store: LearningRegistryStore,
+  taskId: string,
+  monthPrefix: string,
+): Promise<void> {
+  const attemptId = `hugin-attempt:${taskId}`;
+  const taskOutcomeRef = ref(`tasks/${taskId}`, "result-structured");
+  await store.recordSubmission({ taskId, taskOutcomeRef, occurredAt: `${monthPrefix}-01T00:00:00.000Z` });
+  await store.recordAttemptReference({
+    taskId, attemptId,
+    attemptStartRef: ref(`tasks/${taskId}`, `learning-attempt-${taskId}`),
+    taskOutcomeRef, occurredAt: `${monthPrefix}-01T00:01:00.000Z`,
+  });
+  await store.recordTerminalOutcome({
+    taskId, attemptId, outcome: "completed", taskOutcomeRef, occurredAt: `${monthPrefix}-01T00:02:00.000Z`,
+  });
+  await store.recordPublication({
+    taskId, attemptId, publicationRef: `pr-${taskId}`, label: "pr-published",
+    evidenceRef: taskOutcomeRef, occurredAt: `${monthPrefix}-01T00:03:00.000Z`,
+  });
+}
+
+describe("LearningPeriodCloseStore — full certification", () => {
+  it("certifies a full-period close over all-verified partitions with denominators bound to their exact partition proof", async () => {
+    const client = munin();
+    const registry = new LearningRegistryStore(client);
+    await seedFullLifecycle(registry, "task-1", "2026-07");
+    await seedFullLifecycle(registry, "task-2", "2026-07");
+
+    const closes = new LearningPeriodCloseStore(client, registry);
+    const { statement, created } = await closes.close("2026-07", { closedAt: "2026-08-01T00:10:00.000Z" });
+
+    expect(created).toBe(true);
+    expect(statement.status).toBe("certified");
+    expect(statement.blockedCounters).toEqual([]);
+    expect(statement.counters.map((c) => c.counter).sort()).toEqual([...PRIMARY_ACCOUNTING_COUNTERS].sort());
+
+    for (const counter of statement.counters) {
+      expect(counter.totalEvents).toBe(2);
+      expect(counter.correctedEvents).toBe(0);
+      expect(counter.excludedEvents).toBe(0);
+      expect(counter.effectiveCount).toBe(2);
+      // The denominator is bound to the exact partition/high-water proof it came from.
+      expect(counter.proof.counter).toBe(counter.counter);
+      expect(counter.proof.occurrencePeriodUtc).toBe("2026-07");
+      expect(counter.proof.status).toBe("complete");
+      expect(counter.proof.highWaterSeq).toBe(2);
+    }
+  });
+
+  it("certifies a legitimate zero-event month as a true empty period, not a missing one", async () => {
+    const client = munin();
+    const registry = new LearningRegistryStore(client);
+    const closes = new LearningPeriodCloseStore(client, registry);
+
+    const { statement } = await closes.close("2026-07", { closedAt: "2026-08-01T00:10:00.000Z" });
+    expect(statement.status).toBe("certified");
+    for (const counter of statement.counters) {
+      expect(counter.proof.status).toBe("empty-confirmed");
+      expect(counter.totalEvents).toBe(0);
+    }
+  });
+});
+
+describe("LearningPeriodCloseStore — fail-closed partial statements", () => {
+  it("never certifies over a caller-supplied counters subset, even when every requested counter succeeds", async () => {
+    const client = munin();
+    const registry = new LearningRegistryStore(client);
+    await seedFullLifecycle(registry, "task-1", "2026-07");
+    const closes = new LearningPeriodCloseStore(client, registry);
+
+    const { statement } = await closes.close("2026-07", {
+      counters: ["submission"],
+      closedAt: "2026-08-01T00:10:00.000Z",
+    });
+
+    expect(statement.status).toBe("partial");
+    expect(statement.counters.map((c) => c.counter)).toEqual(["submission"]);
+    expect(statement.blockedCounters.map((b) => b.counter).sort()).toEqual(
+      ["attempt-reference", "publication", "terminal-outcome"],
+    );
+    for (const blocked of statement.blockedCounters) {
+      expect(blocked.reason).toMatch(/excluded from this close by the caller's counters option/);
+    }
+  });
+
+  it("degrades to a PARTIAL statement naming exactly the blocked counter when one partition's high-water record is corrupted", async () => {
+    const client = munin();
+    const registry = new LearningRegistryStore(client);
+    await seedFullLifecycle(registry, "task-1", "2026-07");
+
+    // Corrupt only the terminal-outcome partition's high-water doc, exactly
+    // like the #232 suite's "missing high-water doc" fixture.
+    client.remove("learning-registry/partitions", "terminal-outcome-2026-07");
+
+    const closes = new LearningPeriodCloseStore(client, registry);
+    const { statement } = await closes.close("2026-07", { closedAt: "2026-08-01T00:10:00.000Z" });
+
+    expect(statement.status).toBe("partial");
+    expect(statement.blockedCounters).toHaveLength(1);
+    expect(statement.blockedCounters[0].counter).toBe("terminal-outcome");
+    expect(statement.blockedCounters[0].reason).toMatch(/missing/);
+    // The three healthy counters still certify individually and are still reported.
+    expect(statement.counters.map((c) => c.counter).sort()).toEqual(
+      ["attempt-reference", "publication", "submission"],
+    );
+  });
+
+  it("degrades to PARTIAL and names the blocker when a partition has a durably-written event never folded into its high-water record", async () => {
+    const client = munin();
+    const registry = new LearningRegistryStore(client);
+    await seedFullLifecycle(registry, "task-1", "2026-07");
+
+    // Reproduce the exact "crash between event write and bumpHighWater" gap
+    // covered in tests/learning-registry-store.test.ts: a durably-tagged
+    // event exists but was never folded into the partition's own high-water
+    // document. `issuePartitionProof`'s reverse orphan check is what turns
+    // this into "partial" rather than a silently short "complete" proof, and
+    // close() must propagate that as a named blocker rather than certifying.
+    const naturalKey = {
+      recordKind: "publication" as const,
+      taskId: "task-2",
+      attemptId: "hugin-attempt:task-2",
+      publicationRef: "pr-task-2",
+    };
+    const { deriveEventId, buildMembership, publicationEventSchema, LEARNING_REGISTRY_SCHEMA_VERSION } =
+      await import("../src/learning-registry-schema.js");
+    const orphanEventId = deriveEventId(naturalKey);
+    const orphanEvent = publicationEventSchema.parse({
+      schemaVersion: LEARNING_REGISTRY_SCHEMA_VERSION,
+      eventId: orphanEventId,
+      taskId: "task-2",
+      recordKind: "publication",
+      attemptId: "hugin-attempt:task-2",
+      membership: buildMembership({ naturalKey, issuedAt: "2026-07-02T00:00:00.000Z" }),
+      occurredAt: "2026-07-02T00:00:00.000Z",
+      recordedAt: "2026-07-02T00:00:00.000Z",
+      payload: { publicationRef: "pr-task-2", label: "pr-published", evidenceRef: ref("tasks/task-2", "result-structured") },
+    });
+    await client.write(
+      "tasks/task-2",
+      orphanEventId,
+      JSON.stringify(orphanEvent),
+      ["learning-registry", "registry-kind:publication", "learning-registry-partition:hugin:publication:2026-07"],
+      undefined,
+      "internal",
+      true,
+    );
+
+    const closes = new LearningPeriodCloseStore(client, registry);
+    const { statement } = await closes.close("2026-07", { closedAt: "2026-08-01T00:10:00.000Z" });
+
+    expect(statement.status).toBe("partial");
+    const blocked = statement.blockedCounters.find((b) => b.counter === "publication");
+    expect(blocked).toBeDefined();
+    expect(blocked?.reason).toMatch(/not present in the high-water record|truncat|missing/);
+  });
+});
+
+describe("LearningPeriodCloseStore — idempotency and supersession", () => {
+  it("re-closing the same period with unchanged registry state is a no-op returning the identical statement", async () => {
+    const client = munin();
+    const registry = new LearningRegistryStore(client);
+    await seedFullLifecycle(registry, "task-1", "2026-07");
+    const closes = new LearningPeriodCloseStore(client, registry);
+
+    const first = await closes.close("2026-07", { closedAt: "2026-08-01T00:10:00.000Z" });
+    expect(first.created).toBe(true);
+
+    const second = await closes.close("2026-07", { closedAt: "2026-08-01T09:00:00.000Z" }); // different wall clock
+    expect(second.created).toBe(false);
+    expect(second.statement.statementId).toBe(first.statement.statementId);
+    // closedAt is call-observed metadata; the persisted (first-writer) value wins.
+    expect(second.statement.closedAt).toBe(first.statement.closedAt);
+
+    const latest = await closes.getLatest("2026-07");
+    expect(latest?.statementId).toBe(first.statement.statementId);
+  });
+
+  it("a correction recorded after the first close produces a NEW superseding statement, retaining the old one", async () => {
+    const client = munin();
+    const registry = new LearningRegistryStore(client);
+    await seedFullLifecycle(registry, "task-1", "2026-07");
+    const closes = new LearningPeriodCloseStore(client, registry);
+
+    const first = await closes.close("2026-07", { closedAt: "2026-08-01T00:10:00.000Z" });
+    expect(first.statement.counters.find((c) => c.counter === "terminal-outcome")?.correctedEvents).toBe(0);
+
+    const timeline = await registry.listEventsForTask("task-1");
+    const terminalOutcomeEvent = timeline.events.find((e) => e.recordKind === "terminal-outcome");
+    if (!terminalOutcomeEvent) throw new Error("test fixture missing terminal-outcome event");
+    await registry.writeCorrection({
+      taskId: "task-1",
+      predecessorEventId: terminalOutcomeEvent.eventId,
+      reason: "late receipt reclassified the outcome",
+      occurredAt: "2026-07-15T00:00:00.000Z",
+    });
+
+    const second = await closes.close("2026-07", { closedAt: "2026-08-02T00:00:00.000Z" });
+    expect(second.created).toBe(true);
+    expect(second.statement.statementId).not.toBe(first.statement.statementId);
+    expect(second.statement.supersedes).toBe(first.statement.statementId);
+    expect(second.statement.status).toBe("certified");
+    expect(second.statement.counters.find((c) => c.counter === "terminal-outcome")?.correctedEvents).toBe(1);
+    // The partition's own denominator (highWaterSeq) never shrinks from a correction.
+    expect(second.statement.counters.find((c) => c.counter === "terminal-outcome")?.totalEvents).toBe(1);
+
+    // The old statement is retained byte-for-byte, not rewritten.
+    const oldStatement = await closes.getStatement(first.statement.statementId);
+    expect(oldStatement).toEqual(first.statement);
+
+    const latest = await closes.getLatest("2026-07");
+    expect(latest?.statementId).toBe(second.statement.statementId);
+  });
+
+  it("an erasure adjustment recorded after the first close likewise produces a superseding statement", async () => {
+    const client = munin();
+    const registry = new LearningRegistryStore(client);
+    await seedFullLifecycle(registry, "task-1", "2026-07");
+    const closes = new LearningPeriodCloseStore(client, registry);
+
+    const first = await closes.close("2026-07", { closedAt: "2026-08-01T00:10:00.000Z" });
+
+    const timeline = await registry.listEventsForTask("task-1");
+    const attemptReferenceEvent = timeline.events.find((e) => e.recordKind === "attempt-reference");
+    if (!attemptReferenceEvent) throw new Error("test fixture missing attempt-reference event");
+    await registry.writeExclusionAdjustment({
+      taskId: "task-1",
+      targetEventId: attemptReferenceEvent.eventId,
+      adjustmentReason: "erasure",
+      note: "upstream content erased on request",
+      occurredAt: "2026-07-20T00:00:00.000Z",
+    });
+
+    const second = await closes.close("2026-07", { closedAt: "2026-08-03T00:00:00.000Z" });
+    expect(second.statement.statementId).not.toBe(first.statement.statementId);
+    expect(second.statement.supersedes).toBe(first.statement.statementId);
+    const attemptCounter = second.statement.counters.find((c) => c.counter === "attempt-reference");
+    expect(attemptCounter?.excludedEvents).toBe(1);
+    expect(attemptCounter?.erasureAdjustments).toBe(1);
+    // The denominator itself is untouched by erasure.
+    expect(attemptCounter?.totalEvents).toBe(1);
+    expect(attemptCounter?.effectiveCount).toBe(0);
+  });
+});
+
+describe("LearningPeriodCloseStore — cross-owner accounting", () => {
+  it("references gille's owner-issued basis when a source is supplied, without fabricating it", async () => {
+    const client = munin();
+    const registry = new LearningRegistryStore(client);
+    await seedFullLifecycle(registry, "task-1", "2026-07");
+    const closes = new LearningPeriodCloseStore(client, registry);
+
+    const gilleBasisRef = ref("gille-inference/accounting", "period-close-2026-07");
+    const mockGille: GilleBasisSource = {
+      fetchBasis: async (period): Promise<GilleBasisReference> => ({
+        ownerComponent: "gille-inference",
+        period,
+        status: "referenced",
+        basisRef: gilleBasisRef,
+      }),
+    };
+
+    const { statement } = await closes.close("2026-07", {
+      closedAt: "2026-08-01T00:10:00.000Z",
+      gilleBasisSource: mockGille,
+    });
+
+    expect(statement.crossOwner).toEqual({
+      ownerComponent: "gille-inference",
+      period: "2026-07",
+      status: "referenced",
+      basisRef: gilleBasisRef,
+    });
+    // Hugin's own certification is unaffected by the presence of a cross-owner reference.
+    expect(statement.status).toBe("certified");
+  });
+
+  it("honestly records gille basis unavailability instead of inventing a number, without blocking Hugin's own counters", async () => {
+    const client = munin();
+    const registry = new LearningRegistryStore(client);
+    await seedFullLifecycle(registry, "task-1", "2026-07");
+    const closes = new LearningPeriodCloseStore(client, registry);
+
+    const unavailableGille: GilleBasisSource = {
+      fetchBasis: async (period): Promise<GilleBasisReference> => ({
+        ownerComponent: "gille-inference",
+        period,
+        status: "unavailable",
+        reason: "gille-inference#3 period close not yet implemented",
+      }),
+    };
+
+    const { statement } = await closes.close("2026-07", {
+      closedAt: "2026-08-01T00:10:00.000Z",
+      gilleBasisSource: unavailableGille,
+    });
+
+    expect(statement.crossOwner?.status).toBe("unavailable");
+    expect(statement.crossOwner?.basisRef).toBeUndefined();
+    expect(statement.status).toBe("certified"); // Hugin owns Hugin counters independently
+  });
+
+  it("leaves crossOwner null (never a fabricated default) when no gille source is configured", async () => {
+    const client = munin();
+    const registry = new LearningRegistryStore(client);
+    await seedFullLifecycle(registry, "task-1", "2026-07");
+    const closes = new LearningPeriodCloseStore(client, registry);
+
+    const { statement } = await closes.close("2026-07", { closedAt: "2026-08-01T00:10:00.000Z" });
+    expect(statement.crossOwner).toBeNull();
+  });
+});


### PR DESCRIPTION
Refs #241

## What

Adds the LearningTaskContract **consumption** layer for Hugin-owned monthly
accounting: `LearningPeriodCloseStore` (`src/learning-period-close.ts`).

`close(period)`:
1. For each accounting counter (`submission`, `attempt-reference`,
   `terminal-outcome`, `publication`), asks #232's `LearningRegistryStore` for
   its partition/high-water proof (`issuePartitionProof`) and independently
   re-verifies it (`verifyPartitionProof({ requireCurrent: true })`).
2. For every counter whose proof certifies, derives `correctedEvents` /
   `excludedEvents` / `erasureAdjustments` / `exclusionAdjustments` by
   resolving each partition member through #232's own
   `buildTaskLifecycleTimeline` — never by re-walking correction/exclusion
   chains itself.
3. Any counter whose proof is ineligible, fails re-verification, or whose
   lifecycle timeline can't be proven complete (truncated pagination, missing
   member) blocks that counter by name. The whole statement then degrades to
   `"partial"` — never a silent full-period claim over a subset.
4. Persists a content-addressed, append-only `PeriodStatement`
   (`close-<32 hex>`) plus a separately CAS-updated "latest" pointer per
   period, so re-closing unchanged state is a no-op and a later
   correction/erasure produces a new, distinct, superseding statement while
   the old one is retained untouched.
5. Optionally joins gille-inference's own owner-issued cross-owner basis via
   an injected `GilleBasisSource` port — referenced or honestly
   `"unavailable"`, never fabricated, and never blocking Hugin's own
   independently-certified counters.

## Design decisions

- **#232-mechanism vs #241-consumption boundary** (per the 2026-07-20
  boundary-clarification comment on #241): this module adds **no new
  registry record kind**, **never re-issues or re-derives** a
  partition/high-water proof (it always asks `LearningRegistryStore` for one,
  then independently re-verifies it), and **never changes #232's natural
  keys**. Correction/exclusion resolution is entirely delegated to #232's own
  `buildTaskLifecycleTimeline` read view rather than reimplemented here.
- **The partial-vs-certified rule**: `status` is `"certified"` iff
  `blockedCounters` is empty, which requires *every* `PRIMARY_ACCOUNTING_COUNTERS`
  entry to have (a) an eligible proof, (b) a passing independent
  re-verification, and (c) a fully provable corrected/excluded count. A
  caller-supplied `counters` subset (mainly useful for focused tests) can
  never reach `"certified"` either — every counter outside the requested set
  is added to `blockedCounters` by name, so the statement always honestly
  degrades to `"partial"` instead of risking a schema-validation crash or a
  silent full claim over an evaluated subset (an edge case a bounded M5
  review pass on the certification predicate prompted me to check directly
  against the code, and it reproduced as a real crash before the fix below).
- **Content addressing excludes call-observed fields**: `closedAt`,
  `supersedes`, and each proof's own `issuedAt` are stripped before hashing,
  so two closes of identical registry state at different wall-clock times
  produce the identical `statementId`.
- **Erasure never shrinks the denominator**: `totalEvents` is always the
  partition's own `highWaterSeq`; `excludedEvents`/`effectiveCount` are
  reported separately and informationally, matching #232's "target's own
  partition membership count never shrinks" invariant.

## Verification

- `npm run build` — clean.
- `npm test` — full suite: **129 files / 2079 tests passing** (baseline was
  128 files / 2068 tests; this PR adds 1 file / 11 tests).
- Dogfooded `mcp__m5__ask` (qwen3-30b-instruct) for a bounded review of the
  certification predicate and partial-statement completeness. It confirmed
  no gap in the four checked properties (no path to a "certified" status
  with an unverified/ineligible/unprovable counter; blocked-handling is
  exhaustive; idempotency/content-addressing has no collision hole) — a
  useful confirmatory pass, though its scope was limited to the pasted
  module and it did not itself catch the `counters`-subset schema-crash edge
  case above, which I found by writing a targeted repro test against the
  actual code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>