### PR TITLE
Refs #225: durable recovery for managed-repo publication failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "smoke:learning-task:negative": "tsx scripts/learning-task-joint-smoke.ts --mode=negative",
     "smoke:learning-task:live": "tsx scripts/learning-task-joint-smoke.ts --mode=live",
     "harvest:daily-exams": "node dist/daily-exam-harvest-cli.js",
+    "recover:publication": "node dist/publication-recovery-cli.js",
     "pilot:harbor": "tsx scripts/harbor_pilot/run-pilot.ts",
     "pilot:harbor:import": "tsx scripts/harbor_pilot/import-learning-report.ts",
     "test": "vitest run",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,8 @@ import {
   type MuninClientConfig,
   type MuninReadResult,
 } from "./munin-client.js";
-import { getFoundBatchEntry, extractTaskId, pickEarliestTask, selectNextTask, checkoutTaskBranch, finalizeTaskBranch, deriveRepositoryOutcome, shouldReapExpiredLease, decideStartupRecovery, decideDeliveryRetry, finalizeTaskCompletion, resolveTaskWorkingDirectory, normalizeRoot, parseBaseBranchOverride, DEFAULT_REPOS_ROOT, MAX_TASK_OUTPUT_TOKENS, MAX_TASK_TIMEOUT_MS, parseBoundedPositiveInt } from "./task-helpers.js";
+import { getFoundBatchEntry, extractTaskId, pickEarliestTask, selectNextTask, checkoutTaskBranch, finalizeTaskBranch, deriveRepositoryOutcome, shouldReapExpiredLease, decideStartupRecovery, decideDeliveryRetry, finalizeTaskCompletion, resolveTaskWorkingDirectory, normalizeRoot, parseBaseBranchOverride, DEFAULT_REPOS_ROOT, MAX_TASK_OUTPUT_TOKENS, MAX_TASK_TIMEOUT_MS, parseBoundedPositiveInt, PUBLICATION_FAILED_TAG } from "./task-helpers.js";
+import { persistPublicationFailure } from "./publication-recovery.js";
 import { queryAllMuninEntries } from "./munin-pagination.js";
 import { executeSdkTask, type SdkExecutorResult, type SdkExecutorOptions, type SdkTaskConfig, type TaskPermissionProfile } from "./sdk-executor.js";
 import {
@@ -5341,6 +5342,11 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     // Post-task: finalize branch — auto-commit leftovers, push, open PR (#47)
     let prUrl: string | undefined;
     let repositoryChange: StructuredTaskResult["repositoryChange"];
+    // Issue #225: a publication (push/PR) failure AFTER the paid model work
+    // completed must never strand the exact commit as invisible service-log
+    // noise. This tag survives the terminal status write below so an
+    // operator can discover and retry it without a rerun.
+    let publicationFailureTag: string | undefined;
     if (ok && !isCancelled && branchResult.action === "created" && branchResult.branchName) {
       const prBody = [
         `Automated changes from Hugin task \`${taskId}\`.`,
@@ -5369,6 +5375,28 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         await munin.log(taskNs, `PR created: ${prUrl}`);
       } else if (finalizeResult.action === "push-failed") {
         console.warn(`Post-task branch finalization failed for ${taskNs}: ${finalizeResult.error}`);
+        publicationFailureTag = PUBLICATION_FAILED_TAG;
+        try {
+          await persistPublicationFailure(munin, {
+            taskId,
+            taskNamespace: taskNs,
+            workingDir: task.workingDir,
+            branchName: finalizeResult.branchName ?? branchResult.branchName,
+            baseBranch: branchResult.baseBranch ?? "main",
+            baseCommit: repositoryChange?.baseCommit ?? branchResult.baseCommit ?? "",
+            headCommit: repositoryChange?.headCommit,
+            prBody,
+            allowedEgressHosts: egressPolicy.allowedHosts,
+            failureReason: finalizeResult.error ?? "publication failed",
+            classification: taskClassification,
+          });
+        } catch (err) {
+          // The durable record is best-effort UX for recovery, not the
+          // source of truth — result-structured's `publication-failed`
+          // repositoryOutcome (written below) is. Never let this throw
+          // strand the task off its terminal write.
+          console.error(`[publication-recovery] failed to persist durable record for ${taskNs}:`, err);
+        }
       }
     }
 
@@ -5898,17 +5926,23 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         return { hadTask: true, queueDepth };
       }
     } else {
-      // Append the distinct failure tag (issue #129) AFTER buildTerminalStatusTags,
-      // whose persistent-tag filter would otherwise drop a `failure:*` tag.
+      // Append the distinct failure tag (issue #129) and the publication
+      // failure tag (issue #225) AFTER buildTerminalStatusTags, whose
+      // persistent-tag filter would otherwise drop tags not already present
+      // on the pre-task entry.
       const terminalTags = buildTerminalStatusTags(
         ok ? "completed" : "failed",
         finalizeBaseTags,
         `runtime:${task.runtime}`,
       );
+      const extraTerminalTags = [
+        ...(failureClassification ? [failureClassification.tag] : []),
+        ...(publicationFailureTag ? [publicationFailureTag] : []),
+      ];
       const finalizeOutcome = await finalizeTaskCompletion(munin, taskNs, {
         statusContent: entry.content,
-        terminalTags: failureClassification
-          ? [...terminalTags, failureClassification.tag]
+        terminalTags: extraTerminalTags.length > 0
+          ? [...terminalTags, ...extraTerminalTags]
           : terminalTags,
         classification: taskClassification,
         // Single-owner CAS for runtime-owned delivery (#68): if a startup

--- a/src/learning/daily-task-exam-factory.ts
+++ b/src/learning/daily-task-exam-factory.ts
@@ -29,6 +29,29 @@ const sha256Schema = z.string().regex(/^[0-9a-f]{64}$/);
 const gitCommitSchema = z.string().regex(/^[0-9a-f]{40,64}$/);
 const isoTimestampSchema = z.string().datetime({ offset: true });
 
+// The frozen schema-v2 candidate manifest vocabulary. Issue #225 added
+// `publication-recovered` / `publication-abandoned` to the dispatcher's
+// repositoryOutcome for the durable publication-recovery seam, but ingesting
+// recovery outcomes into the exam factory's reproducible-candidate contract
+// is explicitly owned by #232 (see grimnir#88), not this issue. A task whose
+// outcome is one of those two states simply omits `repositoryOutcome` below
+// rather than widening this manifest's pinned vocabulary out from under it.
+const dailyExamRepositoryOutcomeSchema = z.enum([
+  "not-managed",
+  "checkout-failed",
+  "not-finalized",
+  "no-changes",
+  "changes-present",
+  "publication-failed",
+]);
+type DailyExamRepositoryOutcome = z.infer<typeof dailyExamRepositoryOutcomeSchema>;
+
+function knownDailyExamRepositoryOutcome(
+  state: string | undefined,
+): state is DailyExamRepositoryOutcome {
+  return dailyExamRepositoryOutcomeSchema.safeParse(state).success;
+}
+
 export const dailyExamCandidateSchema = z.object({
   schemaVersion: z.literal(2),
   candidateId: z.string().regex(/^daily-[0-9a-f]{24}$/),
@@ -57,14 +80,7 @@ export const dailyExamCandidateSchema = z.object({
       "legacy-type-tag",
     ]).optional(),
     sensitivity: z.enum(["public", "internal", "private"]).optional(),
-    repositoryOutcome: z.enum([
-      "not-managed",
-      "checkout-failed",
-      "not-finalized",
-      "no-changes",
-      "changes-present",
-      "publication-failed",
-    ]).optional(),
+    repositoryOutcome: dailyExamRepositoryOutcomeSchema.optional(),
   }).strict().superRefine((value, ctx) => {
     const taskTypeFields = [
       value.taskType,
@@ -414,7 +430,9 @@ export function buildDailyExamCandidate(source: DailyTaskHarvestSource): DailyEx
           }
         : {}),
       ...(sensitivity ? { sensitivity } : {}),
-      ...(result?.repositoryOutcome ? { repositoryOutcome: result.repositoryOutcome.state } : {}),
+      ...(knownDailyExamRepositoryOutcome(result?.repositoryOutcome?.state)
+        ? { repositoryOutcome: result!.repositoryOutcome!.state as DailyExamRepositoryOutcome }
+        : {}),
     },
     repository,
     exposure,

--- a/src/publication-recovery-cli.ts
+++ b/src/publication-recovery-cli.ts
@@ -1,0 +1,144 @@
+#!/usr/bin/env tsx
+
+/**
+ * Operator CLI for issue #225: retry ONLY the publication (push/PR) step of a
+ * managed-repository task whose model work already completed. Never invokes
+ * an executor or the model — it exists specifically so the paid work is not
+ * repeated merely to recover from a `git push`/`gh pr create` failure.
+ *
+ * Requires operator credentials (MUNIN_API_KEY) and local `git`/`gh` access
+ * to the same repository checkout the original task used — the same trust
+ * boundary the manual recovery described in issue #225 already required.
+ */
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { MuninClient } from "./munin-client.js";
+import { queryAllMuninEntries } from "./munin-pagination.js";
+import { PUBLICATION_FAILED_TAG } from "./task-helpers.js";
+import { recoverPublicationForTask, type RecoverPublicationOutcome } from "./publication-recovery.js";
+
+interface CliOptions {
+  taskId?: string;
+  all: boolean;
+  limit: number;
+}
+
+function usage(): string {
+  return [
+    "Usage: npm run recover:publication -- [options]",
+    "",
+    "Retry ONLY the repository-publication (push/PR) step for a managed task",
+    "whose model work already completed but whose push/PR failed (tagged",
+    "publication:failed). Never re-runs the executor. Idempotent: a task",
+    "already tagged publication:recovered or publication:abandoned is a no-op.",
+    "",
+    "Options:",
+    "  --task <taskId>   Recover exactly one task (namespace tasks/<taskId>)",
+    "  --all             Sweep every task currently tagged publication:failed",
+    "  --limit <N>       Max tasks to inspect with --all (default 100)",
+    "  --help            Show this help",
+  ].join("\n");
+}
+
+export function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = { all: false, limit: 100 };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]!;
+    if (arg === "--help") {
+      process.stdout.write(`${usage()}\n`);
+      process.exit(0);
+    } else if (arg === "--all") {
+      options.all = true;
+    } else if (arg === "--task") {
+      const value = argv[index + 1];
+      if (!value) throw new Error("--task requires a value");
+      options.taskId = value;
+      index += 1;
+    } else if (arg === "--limit") {
+      const value = argv[index + 1];
+      if (!value) throw new Error("--limit requires a value");
+      const limit = Number(value);
+      if (!Number.isInteger(limit) || limit < 1 || limit > 10_000) {
+        throw new Error("--limit must be an integer from 1 to 10000");
+      }
+      options.limit = limit;
+      index += 1;
+    } else {
+      throw new Error(`unknown option: ${arg}`);
+    }
+  }
+  if (!options.taskId && !options.all) {
+    throw new Error("one of --task <taskId> or --all is required");
+  }
+  if (options.taskId && options.all) {
+    throw new Error("--task and --all are mutually exclusive");
+  }
+  return options;
+}
+
+function formatOutcome(outcome: RecoverPublicationOutcome): string {
+  const detail = outcome.prUrl ?? outcome.reason ?? outcome.error ?? "";
+  return `${outcome.taskNamespace}: ${outcome.status}${detail ? ` — ${detail}` : ""}`;
+}
+
+async function listPublicationFailedNamespaces(
+  munin: MuninClient,
+  limit: number,
+): Promise<string[]> {
+  const queried = await queryAllMuninEntries(
+    munin,
+    { tags: [PUBLICATION_FAILED_TAG], namespace: "tasks/", entry_type: "state" },
+    { maxResults: limit },
+  );
+  if (queried.truncated) {
+    process.stderr.write(
+      `Warning: publication:failed sweep may be incomplete (budget exhausted at ${queried.results.length} rows)\n`,
+    );
+  }
+  return [...new Set(queried.results.map((r) => r.namespace))];
+}
+
+export async function main(argv = process.argv.slice(2)): Promise<void> {
+  const options = parseArgs(argv);
+  const apiKey = process.env.MUNIN_API_KEY?.trim();
+  if (!apiKey) throw new Error("MUNIN_API_KEY is required");
+  const munin = new MuninClient({
+    baseUrl: process.env.MUNIN_URL?.trim() || "http://localhost:3030",
+    apiKey,
+  });
+
+  const namespaces = options.taskId
+    ? [`tasks/${options.taskId}`]
+    : await listPublicationFailedNamespaces(munin, options.limit);
+
+  if (namespaces.length === 0) {
+    process.stdout.write("No publication:failed tasks found.\n");
+    return;
+  }
+
+  let failures = 0;
+  for (const namespace of namespaces) {
+    try {
+      const outcome = await recoverPublicationForTask(munin, namespace);
+      process.stdout.write(`${formatOutcome(outcome)}\n`);
+      if (outcome.status === "failed") failures += 1;
+    } catch (error) {
+      failures += 1;
+      process.stderr.write(
+        `${namespace}: error — ${error instanceof Error ? error.message : String(error)}\n`,
+      );
+    }
+  }
+
+  if (failures > 0) {
+    process.exitCode = 1;
+  }
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : "";
+if (import.meta.url === invokedPath) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/src/publication-recovery.ts
+++ b/src/publication-recovery.ts
@@ -1,0 +1,314 @@
+/**
+ * Munin-backed durability and recovery for managed-repository publication
+ * failures (issue #225).
+ *
+ * `task-helpers.ts` owns the pure git/gh mechanics (`recoverPublication`,
+ * `buildPublicationRecoveryRecord`). This module owns the Munin I/O: writing
+ * the durable record when publication fails, and the idempotent,
+ * operator-triggered recovery orchestration that reads it back, retries ONLY
+ * the publication step, and reconciles the task's terminal state. It never
+ * imports or calls anything from the executor/runtime path — recovery cannot
+ * re-run paid model work even by accident, because this module has no way to
+ * invoke one.
+ */
+import type { MuninEntry } from "./munin-client.js";
+import {
+  PUBLICATION_ABANDONED_TAG,
+  PUBLICATION_FAILED_TAG,
+  PUBLICATION_RECOVERED_TAG,
+  buildPublicationRecoveryRecord,
+  recoverPublication,
+  type BuildPublicationRecoveryRecordInput,
+  type PublicationRecoveryAttemptResult,
+  type PublicationRecoveryOutcome,
+  type PublicationRecoveryRecord,
+} from "./task-helpers.js";
+import { buildTerminalStatusTags } from "./task-status-tags.js";
+import {
+  buildStructuredTaskResult,
+  structuredTaskResultSchema,
+  type StructuredTaskResult,
+} from "./task-result-schema.js";
+
+export const PUBLICATION_RECOVERY_KEY = "publication-recovery";
+
+/** Minimal Munin surface this module needs. A real `MuninClient` satisfies it. */
+export interface PublicationRecoveryMuninClient {
+  read(namespace: string, key: string): Promise<(MuninEntry & { found: true }) | null>;
+  write(
+    namespace: string,
+    key: string,
+    content: string,
+    tags?: string[],
+    expectedUpdatedAt?: string,
+    classification?: string,
+  ): Promise<unknown>;
+  log(namespace: string, content: string): Promise<unknown>;
+}
+
+export type PersistPublicationFailureParams = BuildPublicationRecoveryRecordInput & {
+  classification?: string;
+};
+
+/** Persist the durable recovery record the moment publication fails. */
+export async function persistPublicationFailure(
+  client: PublicationRecoveryMuninClient,
+  params: PersistPublicationFailureParams,
+): Promise<PublicationRecoveryRecord> {
+  const record = buildPublicationRecoveryRecord(params);
+  await client.write(
+    params.taskNamespace,
+    PUBLICATION_RECOVERY_KEY,
+    JSON.stringify(record, null, 2),
+    undefined,
+    undefined,
+    params.classification,
+  );
+  return record;
+}
+
+/** Read back a previously persisted record. Malformed/missing content -> null. */
+export async function readPublicationRecoveryRecord(
+  client: PublicationRecoveryMuninClient,
+  taskNamespace: string,
+): Promise<PublicationRecoveryRecord | null> {
+  const entry = await client.read(taskNamespace, PUBLICATION_RECOVERY_KEY);
+  if (!entry?.content) return null;
+  try {
+    const parsed = JSON.parse(entry.content) as Partial<PublicationRecoveryRecord>;
+    if (
+      parsed.schemaVersion === 1 &&
+      typeof parsed.taskId === "string" &&
+      typeof parsed.taskNamespace === "string" &&
+      typeof parsed.workingDir === "string" &&
+      typeof parsed.branchName === "string" &&
+      typeof parsed.baseBranch === "string" &&
+      typeof parsed.baseCommit === "string" &&
+      typeof parsed.prBody === "string" &&
+      Array.isArray(parsed.allowedEgressHosts) &&
+      typeof parsed.failureReason === "string" &&
+      typeof parsed.attempts === "number" &&
+      typeof parsed.firstFailedAt === "string" &&
+      typeof parsed.lastAttemptAt === "string"
+    ) {
+      return parsed as PublicationRecoveryRecord;
+    }
+  } catch {
+    /* malformed -> treated as no durable record below */
+  }
+  return null;
+}
+
+export interface RecoverPublicationOutcome {
+  /**
+   * `noop`: nothing to do (already recovered/abandoned, or never failed).
+   * `no-record`: tagged `publication:failed` but the durable record is
+   * missing or malformed — surfaced so an operator can investigate rather
+   * than being silently skipped.
+   * Otherwise mirrors {@link PublicationRecoveryOutcome}.
+   */
+  status: "noop" | "no-record" | PublicationRecoveryOutcome;
+  taskNamespace: string;
+  prUrl?: string;
+  reason?: string;
+  error?: string;
+}
+
+function currentLifecycle(tags: string[]): "completed" | "failed" | "cancelled" {
+  if (tags.includes("cancelled")) return "cancelled";
+  if (tags.includes("failed")) return "failed";
+  return "completed";
+}
+
+async function patchStructuredResultForRecovery(
+  client: PublicationRecoveryMuninClient,
+  taskNamespace: string,
+  attemptResult: PublicationRecoveryAttemptResult,
+  classification: string | undefined,
+): Promise<void> {
+  const entry = await client.read(taskNamespace, "result-structured");
+  if (!entry?.content) return;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(entry.content);
+  } catch {
+    return;
+  }
+  const existingResult = structuredTaskResultSchema.safeParse(parsed);
+  if (!existingResult.success) return;
+  const existing = existingResult.data;
+  const baseBranch = existing.repositoryOutcome?.baseBranch ?? existing.repositoryChange?.baseBranch;
+  const baseCommit = existing.repositoryOutcome?.baseCommit ?? existing.repositoryChange?.baseCommit;
+  if (!baseBranch || !baseCommit) return;
+
+  let patched: StructuredTaskResult;
+  try {
+    patched = buildStructuredTaskResult({
+      ...existing,
+      prUrl: attemptResult.prUrl ?? existing.prUrl,
+      repositoryOutcome: {
+        state: attemptResult.outcome === "abandoned" ? "publication-abandoned" : "publication-recovered",
+        baseBranch,
+        baseCommit,
+      },
+    });
+  } catch {
+    // A patch that fails re-validation must never corrupt the durable
+    // result — leave the prior (still-honest "publication-failed") record.
+    return;
+  }
+
+  await client.write(
+    taskNamespace,
+    "result-structured",
+    JSON.stringify(patched, null, 2),
+    ["type:task-result", "type:task-result-structured"],
+    undefined,
+    classification,
+  );
+}
+
+async function appendRecoveryNoteToResult(
+  client: PublicationRecoveryMuninClient,
+  taskNamespace: string,
+  attemptResult: PublicationRecoveryAttemptResult,
+  classification: string | undefined,
+): Promise<void> {
+  const entry = await client.read(taskNamespace, "result");
+  const baseDoc = entry?.content ?? "## Result\n";
+  const note = attemptResult.outcome === "abandoned"
+    ? [
+      "",
+      "### Publication Recovery",
+      "",
+      "- **Outcome:** abandoned",
+      `- **Reason:** ${attemptResult.reason ?? "unrecoverable"}`,
+      "- **Action required:** the completed work is preserved (see repository evidence above); publish it manually.",
+      "",
+    ].join("\n")
+    : [
+      "",
+      "### Publication Recovery",
+      "",
+      `- **Outcome:** ${attemptResult.outcome}`,
+      `- **PR:** ${attemptResult.prUrl}`,
+      "",
+    ].join("\n");
+  await client.write(
+    taskNamespace,
+    "result",
+    `${baseDoc}${note}`,
+    undefined,
+    undefined,
+    classification,
+  );
+}
+
+/**
+ * The single operator-triggered recovery entrypoint. Idempotent: calling it
+ * again after a terminal recovery outcome (`published`/`reconciled`/
+ * `abandoned`) is a no-op that never touches git/gh again. Calling it after a
+ * `failed` attempt retries — still publication-only, still no executor.
+ */
+export async function recoverPublicationForTask(
+  client: PublicationRecoveryMuninClient,
+  taskNamespace: string,
+  options: { now?: () => Date } = {},
+): Promise<RecoverPublicationOutcome> {
+  const now = options.now ?? (() => new Date());
+
+  const statusEntry = await client.read(taskNamespace, "status");
+  if (!statusEntry) {
+    return { status: "noop", taskNamespace, reason: "no status entry for task" };
+  }
+  if (
+    statusEntry.tags.includes(PUBLICATION_RECOVERED_TAG) ||
+    statusEntry.tags.includes(PUBLICATION_ABANDONED_TAG)
+  ) {
+    return { status: "noop", taskNamespace, reason: "publication recovery already reached a terminal outcome" };
+  }
+  if (!statusEntry.tags.includes(PUBLICATION_FAILED_TAG)) {
+    return { status: "noop", taskNamespace, reason: "task is not in a publication:failed state" };
+  }
+
+  const record = await readPublicationRecoveryRecord(client, taskNamespace);
+  if (!record) {
+    return { status: "no-record", taskNamespace, reason: "no durable publication-recovery record found" };
+  }
+
+  const attemptResult = await recoverPublication(record);
+
+  const updatedRecord: PublicationRecoveryRecord = {
+    ...record,
+    attempts: record.attempts + 1,
+    lastAttemptAt: now().toISOString(),
+    lastError:
+      attemptResult.outcome === "failed" || attemptResult.outcome === "abandoned"
+        ? attemptResult.error ?? attemptResult.reason
+        : undefined,
+  };
+  await client.write(
+    taskNamespace,
+    PUBLICATION_RECOVERY_KEY,
+    JSON.stringify(updatedRecord, null, 2),
+    undefined,
+    undefined,
+    statusEntry.classification,
+  );
+
+  if (attemptResult.outcome === "failed") {
+    await client.log(
+      taskNamespace,
+      `Publication recovery attempt ${updatedRecord.attempts} failed: ${attemptResult.error ?? "unknown error"} — retryable`,
+    );
+    return { status: "failed", taskNamespace, error: attemptResult.error };
+  }
+
+  // published / reconciled / abandoned are all TERMINAL recovery outcomes.
+  const newTag = attemptResult.outcome === "abandoned" ? PUBLICATION_ABANDONED_TAG : PUBLICATION_RECOVERED_TAG;
+  const runtimeTag = statusEntry.tags.find((t) => t.startsWith("runtime:"));
+  const newTags = buildTerminalStatusTags(
+    currentLifecycle(statusEntry.tags),
+    [...statusEntry.tags.filter((t) => !t.startsWith("publication:")), newTag],
+    runtimeTag,
+  );
+
+  try {
+    await client.write(
+      taskNamespace,
+      "status",
+      statusEntry.content,
+      newTags,
+      statusEntry.updated_at,
+      statusEntry.classification,
+    );
+  } catch (err) {
+    // Someone else touched the status entry between our read and this write
+    // (CAS conflict). The recovery record above already reflects the
+    // attempt; leave the tag alone so a subsequent recovery run reconciles
+    // it instead of masking the conflict.
+    return {
+      status: "failed",
+      taskNamespace,
+      error: `status update lost a concurrent write: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  await patchStructuredResultForRecovery(client, taskNamespace, attemptResult, statusEntry.classification);
+  await appendRecoveryNoteToResult(client, taskNamespace, attemptResult, statusEntry.classification);
+
+  await client.log(
+    taskNamespace,
+    attemptResult.outcome === "abandoned"
+      ? `Publication recovery abandoned: ${attemptResult.reason ?? "unrecoverable"}`
+      : `Publication recovered (${attemptResult.outcome}): ${attemptResult.prUrl ?? ""}`,
+  );
+
+  return {
+    status: attemptResult.outcome,
+    taskNamespace,
+    prUrl: attemptResult.prUrl,
+    reason: attemptResult.reason,
+    error: attemptResult.error,
+  };
+}

--- a/src/task-helpers.ts
+++ b/src/task-helpers.ts
@@ -1202,6 +1202,265 @@ async function createPullRequest(
   });
 }
 
+// --- Publication failure recovery (#225) ---
+//
+// A managed task's paid model work and its repository publication (push +
+// PR) are separate facts. `finalizeTaskBranch` above can return `push-failed`
+// AFTER an exact commit already exists on the task branch — e.g. GitHub
+// denies the configured identity write access, or `gh pr create` fails
+// transiently. The model work must never be re-run just to retry that last
+// step. The functions below give an authorized operator (never the primary
+// execution loop) an idempotent, git/gh-only path back to a durable
+// publication outcome, driven entirely by a `PublicationRecoveryRecord`
+// persisted at push-failed time — never by re-invoking any executor.
+
+export const PUBLICATION_FAILED_TAG = "publication:failed";
+export const PUBLICATION_RECOVERED_TAG = "publication:recovered";
+export const PUBLICATION_ABANDONED_TAG = "publication:abandoned";
+
+/**
+ * Durable, content-blind record of a publication failure: enough to retry
+ * ONLY the push/PR step, never the model. `headCommit` is only present when
+ * repository-change evidence was captured before the failure (it never is,
+ * for example, when the pre-push branch-vs-base comparison itself failed) —
+ * without it, {@link recoverPublication} cannot safely verify partial success
+ * and refuses to touch git.
+ */
+export interface PublicationRecoveryRecord {
+  schemaVersion: 1;
+  taskId: string;
+  taskNamespace: string;
+  workingDir: string;
+  branchName: string;
+  baseBranch: string;
+  baseCommit: string;
+  headCommit?: string;
+  prBody: string;
+  allowedEgressHosts: string[];
+  failureReason: string;
+  attempts: number;
+  firstFailedAt: string;
+  lastAttemptAt: string;
+  lastError?: string;
+}
+
+export interface BuildPublicationRecoveryRecordInput {
+  taskId: string;
+  taskNamespace: string;
+  workingDir: string;
+  branchName: string;
+  baseBranch: string;
+  baseCommit: string;
+  headCommit?: string;
+  prBody: string;
+  allowedEgressHosts: string[];
+  failureReason: string;
+  now?: Date;
+}
+
+/** Construct the initial durable record at the moment publication fails. */
+export function buildPublicationRecoveryRecord(
+  input: BuildPublicationRecoveryRecordInput,
+): PublicationRecoveryRecord {
+  const nowIso = (input.now ?? new Date()).toISOString();
+  return {
+    schemaVersion: 1,
+    taskId: input.taskId,
+    taskNamespace: input.taskNamespace,
+    workingDir: input.workingDir,
+    branchName: input.branchName,
+    baseBranch: input.baseBranch,
+    baseCommit: input.baseCommit,
+    headCommit: input.headCommit,
+    prBody: input.prBody,
+    allowedEgressHosts: input.allowedEgressHosts,
+    failureReason: input.failureReason,
+    attempts: 0,
+    firstFailedAt: nowIso,
+    lastAttemptAt: nowIso,
+  };
+}
+
+export type PublicationRecoveryOutcome =
+  | "published"
+  | "reconciled"
+  | "failed"
+  | "abandoned";
+
+export interface PublicationRecoveryAttemptResult {
+  outcome: PublicationRecoveryOutcome;
+  /** Set for `published` (freshly created) and `reconciled` (found existing). */
+  prUrl?: string;
+  /** The verified exact head commit the outcome refers to. */
+  headCommit?: string;
+  /** Present for `failed`: a retryable git/gh error. */
+  error?: string;
+  /** Present for `abandoned`: why recovery refused to touch git at all. */
+  reason?: string;
+}
+
+async function findExistingPullRequest(
+  workingDir: string,
+  branchName: string,
+): Promise<string | null> {
+  return new Promise((resolve) => {
+    const child = spawn(
+      "gh",
+      ["pr", "list", "--head", branchName, "--state", "all", "--json", "url", "--limit", "1"],
+      {
+        cwd: workingDir,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: { ...process.env, HOME: "/home/magnus" },
+      },
+    );
+    let out = "";
+    child.stdout?.on("data", (d: Buffer) => (out += d.toString()));
+    child.stderr?.on("data", (d: Buffer) => (out += d.toString()));
+    child.on("close", (code) => {
+      if (code !== 0) {
+        resolve(null);
+        return;
+      }
+      try {
+        const parsed = JSON.parse(out.trim() || "[]") as Array<{ url?: unknown }>;
+        const url = parsed[0]?.url;
+        resolve(typeof url === "string" && url.startsWith("https://") ? url : null);
+      } catch {
+        resolve(null);
+      }
+    });
+    child.on("error", () => resolve(null));
+  });
+}
+
+/**
+ * Retry ONLY the publication step for a previously failed managed-repository
+ * task, from a durable {@link PublicationRecoveryRecord}. Never runs an
+ * executor and never re-derives the diff — it only inspects and, if safe,
+ * advances the exact branch/commit that already exists.
+ *
+ * Reconciliation-first: before pushing or creating anything, it checks
+ * whether the remote already has the recorded exact commit and whether a PR
+ * already exists for the branch. This makes repeated recovery attempts
+ * (including a second call after a first `published`/`reconciled` result)
+ * idempotent at the git/gh level — a retry can never open a second PR for a
+ * publication that already succeeded.
+ *
+ * Refuses to touch git (returns `abandoned`) whenever it cannot verify the
+ * local branch still points at the exact recorded head — the safest failure
+ * mode when a checkout was reused by a later task or evidence was never
+ * captured.
+ */
+export async function recoverPublication(
+  record: PublicationRecoveryRecord,
+): Promise<PublicationRecoveryAttemptResult> {
+  if (!isValidBaseBranchName(record.baseBranch)) {
+    return { outcome: "abandoned", reason: `invalid recorded base branch ${JSON.stringify(record.baseBranch)}` };
+  }
+  if (!record.branchName.startsWith("hugin/") || !GIT_COMMIT_ID.test(record.baseCommit)) {
+    return { outcome: "abandoned", reason: "recovery record is missing a valid branch name or base commit" };
+  }
+  if (!record.headCommit) {
+    return {
+      outcome: "abandoned",
+      reason:
+        "no repository-change evidence was captured before the failure — the exact head commit is " +
+        "unknown, so recovery cannot safely verify what would be published",
+    };
+  }
+
+  // Verify the local branch still exists and points at the exact recorded
+  // head. A mismatch means the working directory was reused by a later task
+  // (or the branch was deleted) — the completed commit is no longer safely
+  // reachable from this checkout, so recovery must not guess.
+  const localHead = await runGitCapture(record.workingDir, [
+    "rev-parse", "--verify", `refs/heads/${record.branchName}^{commit}`,
+  ]);
+  const localHeadCommit = localHead.stdout.toString("utf8").trim().toLowerCase();
+  if (!localHead.ok || !GIT_COMMIT_ID.test(localHeadCommit)) {
+    return {
+      outcome: "abandoned",
+      reason: `local branch ${record.branchName} no longer exists in ${record.workingDir}`,
+    };
+  }
+  if (localHeadCommit !== record.headCommit) {
+    return {
+      outcome: "abandoned",
+      reason:
+        `local branch ${record.branchName} now points at ${localHeadCommit}, not the recorded ` +
+        `head ${record.headCommit} — the checkout was reused; publication cannot be safely recovered`,
+    };
+  }
+
+  // Reconciliation first (Codex-reviewed, #225): an existing PR for this
+  // branch — in ANY state — means a prior attempt already published, so a
+  // retry must never call `gh pr create` again. No base/body cross-check is
+  // needed: `branchName` is always `hugin/<taskId>`, unique per task
+  // throughout this codebase, so any PR found here can only be this task's.
+  // A residual check-then-create race (a PR appearing between this check and
+  // `createPullRequest` below) is not a duplicate-publish risk either — GitHub
+  // rejects a second open PR for the same head branch, so `createPullRequest`
+  // returns null and this attempt reports `failed` (retryable); it never
+  // reports a false `published`, and the next recovery attempt reconciles
+  // against the PR that actually exists.
+  const existingPr = await findExistingPullRequest(record.workingDir, record.branchName);
+  if (existingPr) {
+    return { outcome: "reconciled", prUrl: existingPr, headCommit: record.headCommit };
+  }
+
+  const remoteUrl = await new Promise<string | null>((resolve) => {
+    const child = spawn("git", ["remote", "get-url", "--push", "origin"], {
+      cwd: record.workingDir,
+      stdio: ["ignore", "pipe", "ignore"],
+      env: { ...process.env, HOME: "/home/magnus" },
+    });
+    let out = "";
+    child.stdout?.on("data", (d: Buffer) => (out += d.toString()));
+    child.on("close", (code) => resolve(code === 0 ? out.trim() : null));
+    child.on("error", () => resolve(null));
+  });
+  if (!remoteUrl || !isRemoteHostAllowed(remoteUrl, record.allowedEgressHosts)) {
+    return { outcome: "failed", headCommit: record.headCommit, error: "Remote not allowed by egress policy" };
+  }
+
+  // Push only if the remote doesn't already have the exact recorded commit —
+  // the other half of partial-success reconciliation (branch pushed, PR
+  // creation failed).
+  const remoteBranch = await runGitCapture(record.workingDir, [
+    "ls-remote", "origin", `refs/heads/${record.branchName}`,
+  ]);
+  const remoteHeadCommit = remoteBranch.ok
+    ? remoteBranch.stdout.toString("utf8").trim().split(/\s+/)[0]?.toLowerCase()
+    : undefined;
+  if (remoteHeadCommit !== record.headCommit) {
+    const pushOk = await new Promise<boolean>((resolve) => {
+      const child = spawn("git", ["push", "-u", "origin", record.branchName], {
+        cwd: record.workingDir,
+        stdio: ["ignore", "pipe", "pipe"],
+        env: { ...process.env, HOME: "/home/magnus" },
+      });
+      child.on("close", (code) => resolve(code === 0));
+      child.on("error", () => resolve(false));
+    });
+    if (!pushOk) {
+      return { outcome: "failed", headCommit: record.headCommit, error: "git push failed" };
+    }
+  }
+
+  const prUrl = await createPullRequest(
+    record.workingDir,
+    record.branchName,
+    record.baseBranch,
+    record.taskId,
+    record.prBody,
+  );
+  if (!prUrl) {
+    return { outcome: "failed", headCommit: record.headCommit, error: "gh pr create failed" };
+  }
+
+  return { outcome: "published", prUrl, headCommit: record.headCommit };
+}
+
 // --- Atomic task completion (#57) ---
 
 // Minimal interface needed — avoids importing MuninClient which would create circular deps

--- a/src/task-result-schema.ts
+++ b/src/task-result-schema.ts
@@ -358,11 +358,26 @@ export const repositoryOutcomeSchema = z.object({
     "no-changes",
     "changes-present",
     "publication-failed",
+    // Issue #225: reached only via the durable publication-recovery seam,
+    // never by the primary execution path. "publication-recovered" means an
+    // authorized operator retried a prior "publication-failed" outcome and
+    // the push/PR was confirmed complete (freshly published or reconciled
+    // against a partial success). "publication-abandoned" means recovery
+    // could not safely proceed (e.g. the local task branch no longer matches
+    // the recorded exact head) and the failure is terminal without a rerun.
+    "publication-recovered",
+    "publication-abandoned",
   ]),
   baseBranch: repositoryChangeEvidenceSchema.shape.baseBranch,
   baseCommit: z.string().regex(/^[0-9a-f]{40,64}$/).optional(),
 }).strict().superRefine((value, ctx) => {
-  if (["no-changes", "changes-present", "publication-failed"].includes(value.state)) {
+  if ([
+    "no-changes",
+    "changes-present",
+    "publication-failed",
+    "publication-recovered",
+    "publication-abandoned",
+  ].includes(value.state)) {
     if (!value.baseBranch) {
       ctx.addIssue({ code: "custom", path: ["baseBranch"], message: "managed outcome requires baseBranch" });
     }

--- a/src/task-status-tags.ts
+++ b/src/task-status-tags.ts
@@ -19,6 +19,13 @@ const IDEMPOTENCY_PREFIX = "idempotency:";
 // checkpoint and the terminal `delivery:verified`/`delivery:failed` markers are
 // the source of truth for downstream consumers and for startup reconciliation.
 const DELIVERY_PREFIX = "delivery:";
+// Durable managed-repository publication recovery (issue #225). `publication:*`
+// marks a completed task whose repository publication (push/PR) failed after
+// the paid model work finished. It must survive the terminal status flip so
+// operators can discover it, and it must survive the later recovery rewrite
+// (`publication:failed` -> `publication:recovered`/`publication:abandoned`)
+// so `buildTerminalStatusTags` does not silently drop it mid-transition.
+const PUBLICATION_PREFIX = "publication:";
 
 function dedupeTags(tags: string[]): string[] {
   const seen = new Set<string>();
@@ -48,6 +55,7 @@ export function getPersistentStatusTags(
   const sensitivityTags = tags.filter((tag) => tag.startsWith(SENSITIVITY_PREFIX));
   const routingTags = tags.filter((tag) => tag.startsWith(ROUTING_PREFIX));
   const deliveryTags = tags.filter((tag) => tag.startsWith(DELIVERY_PREFIX));
+  const publicationTags = tags.filter((tag) => tag.startsWith(PUBLICATION_PREFIX));
   const brokerTags = tags.filter((tag) => tag.startsWith(BROKER_PREFIX));
   const aliasTags = tags.filter((tag) => tag.startsWith(ALIAS_PREFIX));
   const taskTypeTags = tags.filter((tag) => tag.startsWith(TASK_TYPE_PREFIX));
@@ -63,6 +71,7 @@ export function getPersistentStatusTags(
     ...sensitivityTags,
     ...routingTags,
     ...deliveryTags,
+    ...publicationTags,
     ...brokerTags,
     ...aliasTags,
     ...taskTypeTags,

--- a/tests/publication-recovery-cli.test.ts
+++ b/tests/publication-recovery-cli.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { parseArgs } from "../src/publication-recovery-cli.js";
+
+describe("publication recovery CLI arg parsing", () => {
+  it("requires either --task or --all", () => {
+    expect(() => parseArgs([])).toThrow("--task <taskId> or --all is required");
+  });
+
+  it("parses --task", () => {
+    expect(parseArgs(["--task", "20260715t093850z-dogfood-cassette4"])).toEqual({
+      all: false,
+      taskId: "20260715t093850z-dogfood-cassette4",
+      limit: 100,
+    });
+  });
+
+  it("parses --all with a default limit", () => {
+    expect(parseArgs(["--all"])).toEqual({ all: true, limit: 100 });
+  });
+
+  it("parses a custom --limit with --all", () => {
+    expect(parseArgs(["--all", "--limit", "5"])).toEqual({ all: true, limit: 5 });
+  });
+
+  it("rejects --task and --all together", () => {
+    expect(() => parseArgs(["--task", "t1", "--all"])).toThrow("mutually exclusive");
+  });
+
+  it("rejects an out-of-range limit", () => {
+    expect(() => parseArgs(["--all", "--limit", "0"])).toThrow("--limit must be an integer");
+    expect(() => parseArgs(["--all", "--limit", "10001"])).toThrow("--limit must be an integer");
+  });
+
+  it("rejects unknown options", () => {
+    expect(() => parseArgs(["--bogus"])).toThrow("unknown option");
+  });
+});

--- a/tests/publication-recovery-no-rerun.test.ts
+++ b/tests/publication-recovery-no-rerun.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+import type { MuninEntry } from "../src/munin-client.js";
+
+// End-to-end guarantee for issue #225's core acceptance criterion: recovering
+// a publication failure must NEVER re-run the paid model work. This test
+// exercises the REAL recoverPublication (no task-helpers mocking) through
+// recoverPublicationForTask, with only `child_process.spawn` intercepted, and
+// asserts every spawned command is git/gh plumbing — nothing that could be an
+// executor (codex, claude, an SDK runtime, a shell wrapping either).
+const spawnCalls: Array<{ cmd: string; args: string[] }> = [];
+
+class MockChildProcess extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+}
+
+vi.mock("node:child_process", () => ({
+  spawn: (cmd: string, args: string[]) => {
+    spawnCalls.push({ cmd, args });
+    const child = new MockChildProcess();
+    setImmediate(() => {
+      if (cmd === "git" && args[0] === "rev-parse" && args[1] === "--verify") {
+        child.stdout.emit("data", Buffer.from(`${"b".repeat(40)}\n`));
+        child.emit("close", 0);
+      } else if (cmd === "gh" && args[0] === "pr" && args[1] === "list") {
+        child.stdout.emit("data", Buffer.from("[]\n"));
+        child.emit("close", 0);
+      } else if (cmd === "git" && args[0] === "remote") {
+        child.stdout.emit("data", Buffer.from("git@github.com:Magnus-Gille/cassette.git\n"));
+        child.emit("close", 0);
+      } else if (cmd === "git" && args[0] === "ls-remote") {
+        child.stdout.emit("data", Buffer.from("\n"));
+        child.emit("close", 0);
+      } else if (cmd === "git" && args[0] === "push") {
+        child.emit("close", 0);
+      } else if (cmd === "gh" && args[0] === "pr" && args[1] === "create") {
+        child.stdout.emit("data", Buffer.from("https://github.com/Magnus-Gille/cassette/pull/28\n"));
+        child.emit("close", 0);
+      } else {
+        child.emit("close", 1);
+      }
+    });
+    return child;
+  },
+}));
+
+const { recoverPublicationForTask } = await import("../src/publication-recovery.js");
+const { PUBLICATION_FAILED_TAG, PUBLICATION_RECOVERY_KEY } = await import("../src/task-helpers.js");
+void PUBLICATION_RECOVERY_KEY; // referenced for readability of the seeded namespace map below
+
+const NS = "tasks/20260715t093850z-dogfood-cassette4";
+const RECOVERY_KEY = "publication-recovery";
+
+interface FakeEntry {
+  content: string;
+  tags: string[];
+  updated_at: string;
+}
+
+function makeClient(seed: Record<string, FakeEntry>) {
+  const store = new Map<string, FakeEntry>(Object.entries(seed));
+  return {
+    async read(_ns: string, key: string): Promise<(MuninEntry & { found: true }) | null> {
+      const entry = store.get(key);
+      if (!entry) return null;
+      return {
+        id: key,
+        namespace: NS,
+        key,
+        content: entry.content,
+        tags: entry.tags,
+        created_at: entry.updated_at,
+        updated_at: entry.updated_at,
+        found: true as const,
+      };
+    },
+    async write(_ns: string, key: string, content: string, tags?: string[]): Promise<unknown> {
+      const existing = store.get(key);
+      store.set(key, { content, tags: tags ?? existing?.tags ?? [], updated_at: new Date().toISOString() });
+      return {};
+    },
+    async log(): Promise<void> {},
+  };
+}
+
+beforeEach(() => {
+  spawnCalls.length = 0;
+});
+
+describe("recoverPublicationForTask — no re-execution guarantee (#225)", () => {
+  it("recovers publication using only git/gh plumbing, never an executor", async () => {
+    const client = makeClient({
+      status: { content: "## Task", tags: ["completed", "runtime:codex", PUBLICATION_FAILED_TAG], updated_at: "t0" },
+      [RECOVERY_KEY]: {
+        content: JSON.stringify({
+          schemaVersion: 1,
+          taskId: "20260715t093850z-dogfood-cassette4",
+          taskNamespace: NS,
+          workingDir: "/home/magnus/repos/cassette",
+          branchName: "hugin/20260715t093850z-dogfood-cassette4",
+          baseBranch: "master",
+          baseCommit: "a".repeat(40),
+          headCommit: "b".repeat(40),
+          prBody: "pr body",
+          allowedEgressHosts: ["github.com"],
+          failureReason: "GitHub denied grimnir-bot write access",
+          attempts: 0,
+          firstFailedAt: "t0",
+          lastAttemptAt: "t0",
+        }),
+        tags: [],
+        updated_at: "t0",
+      },
+    });
+
+    const result = await recoverPublicationForTask(client, NS);
+
+    expect(result.status).toBe("published");
+    expect(result.prUrl).toBe("https://github.com/Magnus-Gille/cassette/pull/28");
+    expect(spawnCalls.length).toBeGreaterThan(0);
+    // The whole point of durable publication recovery: only git/gh commands
+    // ever run. No codex/claude/npx/tsx/sdk process — i.e. no re-invocation
+    // of anything that could re-run the paid model work.
+    for (const call of spawnCalls) {
+      expect(["git", "gh"]).toContain(call.cmd);
+    }
+  });
+});

--- a/tests/publication-recovery.test.ts
+++ b/tests/publication-recovery.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { MuninEntry } from "../src/munin-client.js";
+
+// The git/gh mechanics of recoverPublication are covered end-to-end in
+// repo-sync.test.ts and publication-recovery-no-rerun.test.ts. Here we mock
+// it so the orchestration layer (Munin reads/writes, tag transitions,
+// idempotency, result patching) can be tested against controlled outcomes
+// without spawning anything.
+const recoverPublicationMock = vi.fn();
+
+vi.mock("../src/task-helpers.js", async () => {
+  const actual = await vi.importActual<typeof import("../src/task-helpers.js")>(
+    "../src/task-helpers.js",
+  );
+  return {
+    ...actual,
+    recoverPublication: (...args: unknown[]) => recoverPublicationMock(...args),
+  };
+});
+
+const {
+  persistPublicationFailure,
+  readPublicationRecoveryRecord,
+  recoverPublicationForTask,
+  PUBLICATION_RECOVERY_KEY,
+} = await import("../src/publication-recovery.js");
+const {
+  PUBLICATION_FAILED_TAG,
+  PUBLICATION_RECOVERED_TAG,
+  PUBLICATION_ABANDONED_TAG,
+} = await import("../src/task-helpers.js");
+
+interface FakeEntry {
+  content: string;
+  tags: string[];
+  updated_at: string;
+  classification?: string;
+}
+
+function makeClient(initial: Record<string, Record<string, FakeEntry>> = {}) {
+  const store = new Map<string, Map<string, FakeEntry>>();
+  for (const [ns, keys] of Object.entries(initial)) {
+    store.set(ns, new Map(Object.entries(keys)));
+  }
+  const writeCalls: Array<{ namespace: string; key: string; content: string; tags?: string[] }> = [];
+  const logs: string[] = [];
+  let writeSeq = 0;
+
+  const client = {
+    async read(namespace: string, key: string): Promise<(MuninEntry & { found: true }) | null> {
+      const entry = store.get(namespace)?.get(key);
+      if (!entry) return null;
+      return {
+        id: `${namespace}/${key}`,
+        namespace,
+        key,
+        content: entry.content,
+        tags: entry.tags,
+        classification: entry.classification,
+        created_at: entry.updated_at,
+        updated_at: entry.updated_at,
+        found: true as const,
+      };
+    },
+    async write(
+      namespace: string,
+      key: string,
+      content: string,
+      tags?: string[],
+      expectedUpdatedAt?: string,
+      classification?: string,
+    ): Promise<unknown> {
+      writeCalls.push({ namespace, key, content, tags });
+      const nsMap = store.get(namespace) ?? new Map<string, FakeEntry>();
+      const existing = nsMap.get(key);
+      if (expectedUpdatedAt !== undefined && existing?.updated_at !== expectedUpdatedAt) {
+        throw new Error("expected_updated_at mismatch");
+      }
+      writeSeq += 1;
+      nsMap.set(key, {
+        content,
+        tags: tags ?? existing?.tags ?? [],
+        updated_at: `2026-07-15T09:00:${String(writeSeq).padStart(2, "0")}.000Z`,
+        classification: classification ?? existing?.classification,
+      });
+      store.set(namespace, nsMap);
+      return {};
+    },
+    async log(_namespace: string, content: string): Promise<void> {
+      logs.push(content);
+    },
+  };
+
+  return { client, store, writeCalls, logs };
+}
+
+const NS = "tasks/20260715t093850z-dogfood-cassette4";
+
+beforeEach(() => {
+  recoverPublicationMock.mockReset();
+});
+
+describe("persistPublicationFailure / readPublicationRecoveryRecord", () => {
+  it("round-trips a durable record", async () => {
+    const { client } = makeClient();
+    const now = new Date("2026-07-15T09:38:50.000Z");
+    const written = await persistPublicationFailure(client, {
+      taskId: "20260715t093850z-dogfood-cassette4",
+      taskNamespace: NS,
+      workingDir: "/home/magnus/repos/cassette",
+      branchName: "hugin/20260715t093850z-dogfood-cassette4",
+      baseBranch: "master",
+      baseCommit: "a".repeat(40),
+      headCommit: "b".repeat(40),
+      prBody: "pr body",
+      allowedEgressHosts: ["github.com"],
+      failureReason: "GitHub denied grimnir-bot write access",
+      classification: "internal",
+      now,
+    });
+    expect(written.attempts).toBe(0);
+
+    const read = await readPublicationRecoveryRecord(client, NS);
+    expect(read).toEqual(written);
+  });
+
+  it("returns null for malformed content instead of throwing", async () => {
+    const { client } = makeClient({
+      [NS]: { [PUBLICATION_RECOVERY_KEY]: { content: "not json", tags: [], updated_at: "x" } },
+    });
+    const read = await readPublicationRecoveryRecord(client, NS);
+    expect(read).toBeNull();
+  });
+
+  it("returns null when the record is absent", async () => {
+    const { client } = makeClient();
+    const read = await readPublicationRecoveryRecord(client, NS);
+    expect(read).toBeNull();
+  });
+});
+
+function seededStatus(tags: string[]): Record<string, Record<string, FakeEntry>> {
+  return {
+    [NS]: {
+      status: { content: "## Task", tags, updated_at: "2026-07-15T09:39:00.000Z" },
+      "result-structured": {
+        content: JSON.stringify({
+          schemaVersion: 1,
+          taskId: "20260715t093850z-dogfood-cassette4",
+          taskNamespace: NS,
+          lifecycle: "completed",
+          outcome: "completed",
+          runtime: "codex",
+          executor: "codex",
+          resultSource: "codex",
+          exitCode: 0,
+          completedAt: "2026-07-15T09:40:00.000Z",
+          bodyKind: "response",
+          bodyText: "done",
+          repositoryOutcome: { state: "publication-failed", baseBranch: "master", baseCommit: "a".repeat(40) },
+          repositoryChange: {
+            baseBranch: "master",
+            baseCommit: "a".repeat(40),
+            headCommit: "b".repeat(40),
+            changedFiles: ["src/index.ts"],
+            diffSha256: "c".repeat(64),
+          },
+        }),
+        tags: ["type:task-result", "type:task-result-structured"],
+        updated_at: "2026-07-15T09:40:00.000Z",
+      },
+      result: { content: "## Result\n\n- **Exit code:** 0\n", tags: [], updated_at: "2026-07-15T09:40:00.000Z" },
+      [PUBLICATION_RECOVERY_KEY]: {
+        content: JSON.stringify({
+          schemaVersion: 1,
+          taskId: "20260715t093850z-dogfood-cassette4",
+          taskNamespace: NS,
+          workingDir: "/home/magnus/repos/cassette",
+          branchName: "hugin/20260715t093850z-dogfood-cassette4",
+          baseBranch: "master",
+          baseCommit: "a".repeat(40),
+          headCommit: "b".repeat(40),
+          prBody: "pr body",
+          allowedEgressHosts: ["github.com"],
+          failureReason: "GitHub denied grimnir-bot write access",
+          attempts: 0,
+          firstFailedAt: "2026-07-15T09:39:00.000Z",
+          lastAttemptAt: "2026-07-15T09:39:00.000Z",
+        }),
+        tags: [],
+        updated_at: "2026-07-15T09:39:00.000Z",
+      },
+    },
+  };
+}
+
+describe("recoverPublicationForTask", () => {
+  it("is a no-op when the task has no status entry", async () => {
+    const { client } = makeClient();
+    const result = await recoverPublicationForTask(client, NS);
+    expect(result.status).toBe("noop");
+    expect(recoverPublicationMock).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when the task was never tagged publication:failed", async () => {
+    const { client } = makeClient(seededStatus(["completed", "runtime:codex"]));
+    const result = await recoverPublicationForTask(client, NS);
+    expect(result.status).toBe("noop");
+    expect(recoverPublicationMock).not.toHaveBeenCalled();
+  });
+
+  it("returns no-record when tagged failed but the durable record is missing", async () => {
+    const seeded = seededStatus(["completed", "runtime:codex", PUBLICATION_FAILED_TAG]);
+    delete seeded[NS]![PUBLICATION_RECOVERY_KEY];
+    const { client } = makeClient(seeded);
+    const result = await recoverPublicationForTask(client, NS);
+    expect(result.status).toBe("no-record");
+    expect(recoverPublicationMock).not.toHaveBeenCalled();
+  });
+
+  it("reconciles a partial success, flips tags, and patches the durable results", async () => {
+    recoverPublicationMock.mockResolvedValueOnce({
+      outcome: "reconciled",
+      prUrl: "https://github.com/Magnus-Gille/cassette/pull/28",
+      headCommit: "b".repeat(40),
+    });
+    const { client, store } = makeClient(
+      seededStatus(["completed", "runtime:codex", PUBLICATION_FAILED_TAG]),
+    );
+
+    const result = await recoverPublicationForTask(client, NS);
+
+    expect(result).toMatchObject({
+      status: "reconciled",
+      taskNamespace: NS,
+      prUrl: "https://github.com/Magnus-Gille/cassette/pull/28",
+    });
+    // Executor is never re-invoked — recoverPublication (the only thing that
+    // touches git/gh) was called exactly once with the durable record, and
+    // nothing else in this module can start a task.
+    expect(recoverPublicationMock).toHaveBeenCalledTimes(1);
+
+    const status = store.get(NS)!.get("status")!;
+    expect(status.tags).toContain(PUBLICATION_RECOVERED_TAG);
+    expect(status.tags).not.toContain(PUBLICATION_FAILED_TAG);
+    expect(status.tags).toContain("completed");
+    expect(status.tags).toContain("runtime:codex");
+
+    const resultStructured = JSON.parse(store.get(NS)!.get("result-structured")!.content);
+    expect(resultStructured.repositoryOutcome.state).toBe("publication-recovered");
+    expect(resultStructured.prUrl).toBe("https://github.com/Magnus-Gille/cassette/pull/28");
+
+    const resultDoc = store.get(NS)!.get("result")!.content;
+    expect(resultDoc).toContain("### Publication Recovery");
+    expect(resultDoc).toContain("https://github.com/Magnus-Gille/cassette/pull/28");
+
+    const record = await readPublicationRecoveryRecord(client, NS);
+    expect(record?.attempts).toBe(1);
+  });
+
+  it("double-recovery after a terminal outcome is a no-op (idempotent)", async () => {
+    recoverPublicationMock.mockResolvedValueOnce({
+      outcome: "published",
+      prUrl: "https://github.com/Magnus-Gille/cassette/pull/29",
+      headCommit: "b".repeat(40),
+    });
+    const { client } = makeClient(
+      seededStatus(["completed", "runtime:codex", PUBLICATION_FAILED_TAG]),
+    );
+
+    const first = await recoverPublicationForTask(client, NS);
+    expect(first.status).toBe("published");
+    expect(recoverPublicationMock).toHaveBeenCalledTimes(1);
+
+    const second = await recoverPublicationForTask(client, NS);
+    expect(second.status).toBe("noop");
+    // The second call must not touch git/gh again.
+    expect(recoverPublicationMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the failed tag and preserves work when recovery fails again (retryable)", async () => {
+    recoverPublicationMock.mockResolvedValueOnce({
+      outcome: "failed",
+      error: "git push failed",
+      headCommit: "b".repeat(40),
+    });
+    const { client, store, logs } = makeClient(
+      seededStatus(["completed", "runtime:codex", PUBLICATION_FAILED_TAG]),
+    );
+
+    const result = await recoverPublicationForTask(client, NS);
+
+    expect(result.status).toBe("failed");
+    const status = store.get(NS)!.get("status")!;
+    expect(status.tags).toContain(PUBLICATION_FAILED_TAG);
+    expect(status.tags).not.toContain(PUBLICATION_RECOVERED_TAG);
+    expect(logs.some((l) => l.includes("retryable"))).toBe(true);
+
+    const record = await readPublicationRecoveryRecord(client, NS);
+    expect(record?.attempts).toBe(1);
+    expect(record?.lastError).toBe("git push failed");
+
+    // A subsequent call retries (not a no-op) because the tag is unchanged.
+    recoverPublicationMock.mockResolvedValueOnce({
+      outcome: "published",
+      prUrl: "https://github.com/Magnus-Gille/cassette/pull/30",
+      headCommit: "b".repeat(40),
+    });
+    const retried = await recoverPublicationForTask(client, NS);
+    expect(retried.status).toBe("published");
+    expect(recoverPublicationMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("surfaces an unrecoverable failure durably and preserves the completed work", async () => {
+    recoverPublicationMock.mockResolvedValueOnce({
+      outcome: "abandoned",
+      reason: "local branch no longer exists — checkout was reused",
+    });
+    const { client, store } = makeClient(
+      seededStatus(["completed", "runtime:codex", PUBLICATION_FAILED_TAG]),
+    );
+
+    const result = await recoverPublicationForTask(client, NS);
+
+    expect(result.status).toBe("abandoned");
+    const status = store.get(NS)!.get("status")!;
+    expect(status.tags).toContain(PUBLICATION_ABANDONED_TAG);
+    expect(status.tags).not.toContain(PUBLICATION_FAILED_TAG);
+
+    const resultStructured = JSON.parse(store.get(NS)!.get("result-structured")!.content);
+    expect(resultStructured.repositoryOutcome.state).toBe("publication-abandoned");
+    // repositoryChange evidence (the completed, exact commit reference) is
+    // never dropped by an abandoned recovery.
+    expect(resultStructured.repositoryChange.headCommit).toBe("b".repeat(40));
+
+    const resultDoc = store.get(NS)!.get("result")!.content;
+    expect(resultDoc).toContain("Action required");
+
+    // Abandoned is terminal too — a further call is a no-op.
+    const again = await recoverPublicationForTask(client, NS);
+    expect(again.status).toBe("noop");
+    expect(recoverPublicationMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/repo-sync.test.ts
+++ b/tests/repo-sync.test.ts
@@ -55,7 +55,10 @@ const {
   finalizeTaskBranch,
   isValidBaseBranchName,
   parseBaseBranchOverride,
+  buildPublicationRecoveryRecord,
+  recoverPublication,
 } = await import("../src/task-helpers.js");
+type PublicationRecoveryRecord = Awaited<ReturnType<typeof buildPublicationRecoveryRecord>>;
 
 beforeEach(() => {
   spawnCalls.length = 0;
@@ -638,5 +641,182 @@ describe("finalizeTaskBranch", () => {
     expect(ghCall?.args).toContain("hugin: 20260416-120000-a1b2");
     expect(ghCall?.args).toContain("--body");
     expect(ghCall?.args).toContain("the body");
+  });
+});
+
+describe("buildPublicationRecoveryRecord", () => {
+  it("captures a durable, resumable snapshot at the moment publication fails", () => {
+    const now = new Date("2026-07-15T09:38:50.000Z");
+    const record = buildPublicationRecoveryRecord({
+      taskId: "t-1",
+      taskNamespace: "tasks/t-1",
+      workingDir: "/home/magnus/repos/cassette",
+      branchName: "hugin/t-1",
+      baseBranch: "master",
+      baseCommit: "a".repeat(40),
+      headCommit: "b".repeat(40),
+      prBody: "pr body",
+      allowedEgressHosts: ["github.com"],
+      failureReason: "git push failed",
+      now,
+    });
+    expect(record).toEqual({
+      schemaVersion: 1,
+      taskId: "t-1",
+      taskNamespace: "tasks/t-1",
+      workingDir: "/home/magnus/repos/cassette",
+      branchName: "hugin/t-1",
+      baseBranch: "master",
+      baseCommit: "a".repeat(40),
+      headCommit: "b".repeat(40),
+      prBody: "pr body",
+      allowedEgressHosts: ["github.com"],
+      failureReason: "git push failed",
+      attempts: 0,
+      firstFailedAt: now.toISOString(),
+      lastAttemptAt: now.toISOString(),
+    });
+  });
+});
+
+describe("recoverPublication", () => {
+  const allowedHosts = ["github.com"];
+  const head = "b".repeat(40);
+  const base = "a".repeat(40);
+
+  function record(overrides: Partial<PublicationRecoveryRecord> = {}): PublicationRecoveryRecord {
+    return {
+      schemaVersion: 1,
+      taskId: "t-1",
+      taskNamespace: "tasks/t-1",
+      workingDir: "/home/magnus/repos/cassette",
+      branchName: "hugin/t-1",
+      baseBranch: "master",
+      baseCommit: base,
+      headCommit: head,
+      prBody: "pr body",
+      allowedEgressHosts: allowedHosts,
+      failureReason: "git push failed",
+      attempts: 0,
+      firstFailedAt: "2026-07-15T09:38:50.000Z",
+      lastAttemptAt: "2026-07-15T09:38:50.000Z",
+      ...overrides,
+    };
+  }
+
+  it("abandons without touching git when the base branch is invalid", async () => {
+    const result = await recoverPublication(record({ baseBranch: "origin/master" }));
+    expect(result.outcome).toBe("abandoned");
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  it("abandons without touching git when no head commit was ever captured", async () => {
+    const result = await recoverPublication(record({ headCommit: undefined }));
+    expect(result.outcome).toBe("abandoned");
+    expect(result.reason).toContain("no repository-change evidence");
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  it("abandons when the local task branch no longer exists", async () => {
+    spawnBehaviors = [
+      { exitCode: 128, stderr: "unknown revision" }, // rev-parse --verify
+    ];
+    const result = await recoverPublication(record());
+    expect(result.outcome).toBe("abandoned");
+    expect(result.reason).toContain("no longer exists");
+    expect(spawnCalls).toHaveLength(1);
+  });
+
+  it("abandons when the checkout was reused and no longer points at the recorded head", async () => {
+    spawnBehaviors = [
+      { exitCode: 0, stdout: `${"c".repeat(40)}\n` }, // rev-parse --verify: different commit
+    ];
+    const result = await recoverPublication(record());
+    expect(result.outcome).toBe("abandoned");
+    expect(result.reason).toContain("checkout was reused");
+    expect(spawnCalls).toHaveLength(1);
+  });
+
+  it("reconciles instead of duplicating when a PR already exists (partial success)", async () => {
+    spawnBehaviors = [
+      { exitCode: 0, stdout: `${head}\n` }, // rev-parse --verify: matches
+      { exitCode: 0, stdout: `[{"url":"https://github.com/Magnus-Gille/cassette/pull/28"}]\n` }, // gh pr list
+    ];
+    const result = await recoverPublication(record());
+    expect(result.outcome).toBe("reconciled");
+    expect(result.prUrl).toBe("https://github.com/Magnus-Gille/cassette/pull/28");
+    expect(result.headCommit).toBe(head);
+    // Must not push or attempt to create a second PR.
+    expect(spawnCalls).toHaveLength(2);
+    expect(spawnCalls.some((c) => c.args.includes("push"))).toBe(false);
+    expect(spawnCalls.some((c) => c.args.includes("create"))).toBe(false);
+  });
+
+  it("publishes fresh (push + PR) when nothing was published yet", async () => {
+    spawnBehaviors = [
+      { exitCode: 0, stdout: `${head}\n` },       // rev-parse --verify
+      { exitCode: 0, stdout: "[]\n" },              // gh pr list: none
+      { exitCode: 0, stdout: "git@github.com:Magnus-Gille/cassette.git\n" }, // remote get-url
+      { exitCode: 0, stdout: "\n" },                // ls-remote: branch not on remote yet
+      { exitCode: 0 },                              // git push
+      { exitCode: 0, stdout: "https://github.com/Magnus-Gille/cassette/pull/29\n" }, // gh pr create
+    ];
+    const result = await recoverPublication(record());
+    expect(result.outcome).toBe("published");
+    expect(result.prUrl).toBe("https://github.com/Magnus-Gille/cassette/pull/29");
+    const pushCall = spawnCalls.find((c) => c.args.includes("push"));
+    expect(pushCall).toBeDefined();
+    expect(pushCall?.args).toContain("hugin/t-1");
+  });
+
+  it("skips the redundant push when the remote already has the exact recorded commit", async () => {
+    spawnBehaviors = [
+      { exitCode: 0, stdout: `${head}\n` },
+      { exitCode: 0, stdout: "[]\n" },
+      { exitCode: 0, stdout: "git@github.com:Magnus-Gille/cassette.git\n" },
+      { exitCode: 0, stdout: `${head}\trefs/heads/hugin/t-1\n` }, // ls-remote: already has exact head
+      { exitCode: 0, stdout: "https://github.com/Magnus-Gille/cassette/pull/30\n" }, // gh pr create
+    ];
+    const result = await recoverPublication(record());
+    expect(result.outcome).toBe("published");
+    expect(spawnCalls.some((c) => c.args.includes("push"))).toBe(false);
+  });
+
+  it("returns a retryable failure when the remote is not in the egress allowlist", async () => {
+    spawnBehaviors = [
+      { exitCode: 0, stdout: `${head}\n` },
+      { exitCode: 0, stdout: "[]\n" },
+      { exitCode: 0, stdout: "https://gitlab.com/user/repo.git\n" },
+    ];
+    const result = await recoverPublication(record());
+    expect(result.outcome).toBe("failed");
+    expect(result.error).toContain("egress");
+  });
+
+  it("returns a retryable failure when git push fails again", async () => {
+    spawnBehaviors = [
+      { exitCode: 0, stdout: `${head}\n` },
+      { exitCode: 0, stdout: "[]\n" },
+      { exitCode: 0, stdout: "git@github.com:Magnus-Gille/cassette.git\n" },
+      { exitCode: 0, stdout: "\n" },
+      { exitCode: 1, stderr: "permission denied" },
+    ];
+    const result = await recoverPublication(record());
+    expect(result.outcome).toBe("failed");
+    expect(result.error).toContain("push failed");
+  });
+
+  it("returns a retryable failure when gh pr create fails again", async () => {
+    spawnBehaviors = [
+      { exitCode: 0, stdout: `${head}\n` },
+      { exitCode: 0, stdout: "[]\n" },
+      { exitCode: 0, stdout: "git@github.com:Magnus-Gille/cassette.git\n" },
+      { exitCode: 0, stdout: "\n" },
+      { exitCode: 0 },
+      { exitCode: 1, stderr: "GraphQL error" },
+    ];
+    const result = await recoverPublication(record());
+    expect(result.outcome).toBe("failed");
+    expect(result.error).toContain("gh pr create");
   });
 });

--- a/tests/task-result-schema.test.ts
+++ b/tests/task-result-schema.test.ts
@@ -58,6 +58,55 @@ describe("structured task result schema", () => {
     expect(result.repositoryChange).toBeUndefined();
   });
 
+  it.each(["publication-recovered", "publication-abandoned"] as const)(
+    "accepts the durable publication-recovery outcome %s with its required base evidence (#225)",
+    (state) => {
+      const result = buildStructuredTaskResult({
+        schemaVersion: 1,
+        taskId: "recovered-1",
+        taskNamespace: "tasks/recovered-1",
+        lifecycle: "completed",
+        outcome: "completed",
+        runtime: "codex",
+        executor: "codex-spawn",
+        resultSource: "stdout",
+        exitCode: 0,
+        completedAt: "2026-07-16T12:00:00Z",
+        bodyKind: "response",
+        bodyText: "ok",
+        ...(state === "publication-recovered"
+          ? { prUrl: "https://github.com/Magnus-Gille/cassette/pull/28" }
+          : {}),
+        repositoryOutcome: {
+          state,
+          baseBranch: "master",
+          baseCommit: "a".repeat(40),
+        },
+      });
+      expect(result.repositoryOutcome?.state).toBe(state);
+    },
+  );
+
+  it("rejects a publication-recovery outcome missing its base evidence (#225)", () => {
+    expect(() =>
+      buildStructuredTaskResult({
+        schemaVersion: 1,
+        taskId: "recovered-2",
+        taskNamespace: "tasks/recovered-2",
+        lifecycle: "completed",
+        outcome: "completed",
+        runtime: "codex",
+        executor: "codex-spawn",
+        resultSource: "stdout",
+        exitCode: 0,
+        completedAt: "2026-07-16T12:00:00Z",
+        bodyKind: "response",
+        bodyText: "ok",
+        repositoryOutcome: { state: "publication-recovered" } as never,
+      }),
+    ).toThrow();
+  });
+
   it("preserves M5 delegation provenance on canonical homeserver results", () => {
     const result = buildStructuredTaskResult({
       schemaVersion: 1, taskId: "mcp-m5-abc", taskNamespace: "tasks/mcp-m5-abc",

--- a/tests/task-status-tags.test.ts
+++ b/tests/task-status-tags.test.ts
@@ -35,6 +35,28 @@ describe("task status tag helpers", () => {
     expect(buildTerminalStatusTags("completed", input)).toEqual(persistent);
   });
 
+  it("preserves publication recovery tags (#225) across a terminal status rewrite", () => {
+    // The publication-recovery orchestration rewrites a task's terminal tags
+    // to swap `publication:failed` for `publication:recovered`/`publication:abandoned`
+    // via buildTerminalStatusTags — this must survive that pass exactly like
+    // `delivery:*` does for artifact delivery.
+    expect(
+      buildTerminalStatusTags("completed", [
+        "completed",
+        "runtime:codex",
+        "publication:failed",
+      ]),
+    ).toEqual(["completed", "runtime:codex", "publication:failed"]);
+
+    expect(
+      buildTerminalStatusTags("completed", [
+        "completed",
+        "runtime:codex",
+        "publication:recovered",
+      ]),
+    ).toEqual(["completed", "runtime:codex", "publication:recovered"]);
+  });
+
   it.each(["draft", "conversation"])(
     "preserves the additive M5 task type %s through terminalization",
     (taskType) => {


### PR DESCRIPTION
Refs #225

## What

A managed task's paid model work and its repository publication (`git push` + `gh pr create`) are separate facts. Before this change, a post-run publication failure was invisible outside service logs: the task still finalized `completed` with `repositoryOutcome.state = "publication-failed"`, but nothing durable existed for an operator to discover or retry the publication step — the exact commit was recoverable only by manually digging it out of the Pi's filesystem (as happened for `tasks/20260715t093850z-dogfood-cassette4`, the live evidence in the issue).

This adds durability + an idempotent recovery path around that seam only. It does not touch the model-execution path.

- On a post-run `push-failed`, persist a durable `PublicationRecoveryRecord` (exact branch/base/head commit, PR body, egress allowlist, failure reason) to `<taskNs>/publication-recovery`, and tag the task `publication:failed` so it survives the terminal status write and is discoverable/queryable.
- `recoverPublication` (`src/task-helpers.ts`) retries **only** the push/PR step from that record — it never touches an executor. It reconciles partial success first (an already-pushed exact commit, an already-created PR) before doing anything, and refuses to touch git at all (`abandoned`) whenever it can't verify the local branch still points at the exact recorded head.
- `recoverPublicationForTask` (new `src/publication-recovery.ts`) is the idempotent, operator-triggered orchestration: a task already tagged `publication:recovered`/`publication:abandoned` is a no-op (zero git/gh calls); a `publication:failed` task is retried; a terminal outcome patches `result-structured`'s `repositoryOutcome` (two new states: `publication-recovered` / `publication-abandoned`) and appends a human-readable note to `result` — preserving the completed work either way.
- New operator CLI, `src/publication-recovery-cli.ts` (`npm run recover:publication -- --task <id>` or `--all`).

## Design decisions

- **The durable publication record** lives at `<taskNs>/publication-recovery`, separate from `result-structured`, so it can be updated independently (attempts, last error) without touching the authoritative result document until a recovery attempt actually reaches a terminal outcome. It is content-blind — exact refs/digests only (branch name, base/head commit SHAs, PR body text which is Hugin's own boilerplate, never repository content).
- **Partial-success reconciliation is reconciliation-first**: before pushing or calling `gh pr create`, `recoverPublication` checks (a) whether a PR already exists for the branch (any state) and (b) whether the remote already has the exact recorded head commit. This means a retry can never open a second PR for a publication that already succeeded, and never re-pushes a commit that's already there. Branch names are `hugin/<taskId>`, unique per task throughout the codebase, so any PR found for that branch can only be this task's — no additional cross-check needed.
- **The no-re-execution guarantee is structural, not just a runtime check**: `publication-recovery.ts` never imports anything from the executor/runtime path (no `sdk-executor`, `codex-sandbox`, `spawnRuntime`, etc.) — it has no way to invoke a model even by accident. `tests/publication-recovery-no-rerun.test.ts` proves this end-to-end with a real `recoverPublication` and a `child_process.spawn` spy asserting every spawned command is `git` or `gh`.
- **Fail-closed by default**: if repository-change evidence was never captured (e.g. the pre-push branch-vs-base comparison itself failed), the record has no `headCommit`, and `recoverPublication` refuses to touch git at all rather than guess. Same for a local branch that no longer matches the recorded head (checkout reused by a later task) — both surface as `abandoned`, a terminal, durably recorded state with the completed work preserved for manual publication, not silently dropped.
- **Idempotency is enforced at two layers**: `recoverPublication` itself is git/gh-idempotent (existing-PR/existing-commit checks), and `recoverPublicationForTask` additionally short-circuits to a true no-op (zero git/gh calls) once a terminal recovery outcome (`published`/`reconciled`/`abandoned`) is already tagged.
- **Out of scope, left to #232 / grimnir#88**: ingesting recovery outcomes into the daily-exam-factory's learning registry. The frozen schema-v2 candidate manifest (`src/learning/daily-task-exam-factory.ts`) explicitly omits the two new `repositoryOutcome` states rather than widening that pinned vocabulary.
- **Not implemented** (adjacent AC in the issue, deliberately deferred to keep this PR to the publication seam): the claim-time repository write-capability preflight check. Happy to file that as a follow-up ticket if wanted.

## Verification

- `npm run build` — clean.
- `npm test` — full suite: **132 files / 2112 tests passing** (baseline before this change: 129 files / 2079 tests; +3 files / +33 tests, no regressions).
- M5 (qwen3-30b-instruct via the local homeserver) reviewed the reconciliation/idempotency logic in `recoverPublication` + `recoverPublicationForTask`. 2 of 3 claimed "critical bugs" were noise on inspection — one directly contradicted by the actual `catch` block already handling the case it claimed was missing, one already safely handled by GitHub itself rejecting a duplicate open PR (so the worst case is a retryable `failed`, never a false `published`). The third (verify PR body/base branch before reconciling) was a reasonable but non-critical hardening idea, addressed with a clarifying comment rather than a behavior change since branch-name uniqueness already makes it redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)