### PR TITLE
Refs #236: fail closed or isolate execution after managed checkout failure

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import {
   type MuninClientConfig,
   type MuninReadResult,
 } from "./munin-client.js";
-import { getFoundBatchEntry, extractTaskId, pickEarliestTask, selectNextTask, checkoutTaskBranch, finalizeTaskBranch, deriveRepositoryOutcome, shouldReapExpiredLease, decideStartupRecovery, decideDeliveryRetry, finalizeTaskCompletion, resolveTaskWorkingDirectory, normalizeRoot, parseBaseBranchOverride, DEFAULT_REPOS_ROOT, MAX_TASK_OUTPUT_TOKENS, MAX_TASK_TIMEOUT_MS, parseBoundedPositiveInt, PUBLICATION_FAILED_TAG } from "./task-helpers.js";
+import { getFoundBatchEntry, extractTaskId, pickEarliestTask, selectNextTask, checkoutTaskBranch, finalizeTaskBranch, deriveRepositoryOutcome, prepareManagedCheckout, shouldReapExpiredLease, decideStartupRecovery, decideDeliveryRetry, finalizeTaskCompletion, resolveTaskWorkingDirectory, normalizeRoot, parseBaseBranchOverride, DEFAULT_REPOS_ROOT, MAX_TASK_OUTPUT_TOKENS, MAX_TASK_TIMEOUT_MS, parseBoundedPositiveInt, PUBLICATION_FAILED_TAG } from "./task-helpers.js";
 import { persistPublicationFailure } from "./publication-recovery.js";
 import { queryAllMuninEntries } from "./munin-pagination.js";
 import { executeSdkTask, type SdkExecutorResult, type SdkExecutorOptions, type SdkTaskConfig, type TaskPermissionProfile } from "./sdk-executor.js";
@@ -4592,23 +4592,63 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
       throw new Error(`Internal dispatcher error: parsed task missing for ${taskNs}`);
     }
 
+    const isOllama = task.runtime === "ollama";
+    const isClaude = task.runtime === "claude";
+    const isCodex = task.runtime === "codex";
+    const isOpencode = task.runtime === "opencode";
+    const isHomeserver = task.runtime === "homeserver";
+    const isOrchestrator = task.runtime === "orchestrator";
+
+    // Mutation-capable per issue #236: whether THIS runtime/permission
+    // profile can itself write to the managed working directory, regardless
+    // of what the task's prompt asks for. Codex spawns `--full-auto` (always
+    // write-capable). Claude SDK and OpenCode gate writes behind
+    // `permissionProfile === "trusted-code"` (sdk-executor.ts,
+    // opencode-executor.ts). Ollama has no file-write tool at all. Orchestrator
+    // fans out to a `pi`-harness worker whose write capability this dispatcher
+    // cannot cheaply prove either way, so it is treated as mutation-capable —
+    // the safe default is to fail closed, not to assume read-only.
+    const mutationCapable =
+      isCodex ||
+      isOrchestrator ||
+      ((isClaude || isOpencode) && task.permissionProfile === "trusted-code");
+
     // Pre-task: checkout a fresh hugin/<taskId> branch from the repository's
-    // resolved default branch (or validated explicit override, #217).
+    // resolved default branch (or validated explicit override, #217), then
+    // durably verify it is actually clean at that exact commit before trusting
+    // it (#236) — `checkoutTaskBranch` succeeding does not by itself prove the
+    // tree is clean, since `git checkout -b` can carry over an earlier task's
+    // uncommitted leftovers instead of conflicting.
     let branchResult: Awaited<ReturnType<typeof checkoutTaskBranch>> = { action: "skipped" };
+    let checkoutGateRefusalReason: string | undefined;
+    let checkoutGateDegraded = false;
     if (task.runtime !== "homeserver") {
-      branchResult = await checkoutTaskBranch(task.workingDir, taskId, {
+      const gate = await prepareManagedCheckout(task.workingDir, taskId, {
         reposRoot: config.reposRoot,
         baseBranchOverride: task.baseBranch,
-        captureBaseCommit: true,
+        mutationCapable,
       });
-      if (branchResult.action === "fetch-failed") {
-        console.warn(`Pre-task branch checkout failed for ${taskNs} (non-fatal, proceeding without branch): ${branchResult.error}`);
+      branchResult = gate.branch;
+      checkoutGateRefusalReason = gate.refusalReason;
+      checkoutGateDegraded = Boolean(gate.degraded);
+      if (gate.refusalReason) {
+        console.error(
+          `Managed checkout refused for ${taskNs} (mutation-capable, contaminated/unverified working directory): ${gate.refusalReason}`,
+        );
+      } else if (gate.degraded) {
+        console.warn(
+          `Managed checkout degraded for ${taskNs} (read-only, proceeding against unverified working directory): ${gate.degradedReason}`,
+        );
+      } else if (gate.recovered) {
+        console.warn(
+          `Managed checkout recovered for ${taskNs}: an earlier contaminated/unverified working directory was reset and re-verified clean before this task ran.`,
+        );
       } else if (branchResult.action === "created") {
         console.log(`Pre-task: branch ${branchResult.branchName} ready in ${task.workingDir}`);
       }
     }
     let repositoryOutcome: StructuredTaskResult["repositoryOutcome"] =
-      deriveRepositoryOutcome(branchResult);
+      deriveRepositoryOutcome(branchResult, undefined, Boolean(checkoutGateRefusalReason));
 
     currentTaskConfig = task;
     const taskClassification = getTaskArtifactClassification(task);
@@ -4642,12 +4682,6 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     }
     startCancellationWatch();
 
-    const isOllama = task.runtime === "ollama";
-    const isClaude = task.runtime === "claude";
-    const isCodex = task.runtime === "codex";
-    const isOpencode = task.runtime === "opencode";
-    const isHomeserver = task.runtime === "homeserver";
-    const isOrchestrator = task.runtime === "orchestrator";
     const executorLabel = isOllama
       ? "ollama"
       : isClaude
@@ -4699,7 +4733,37 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     let fallbackTriggered = false;
     let fallbackReason: string | null = null;
 
-    if (isOllama) {
+    if (checkoutGateRefusalReason) {
+      // Issue #236: the pre-execution clean-verification gate refused this
+      // mutation-capable task before any executor ran — the managed checkout
+      // could not be proven clean at the intended commit even after an
+      // explicit recovery attempt. This must never fall through to any
+      // runtime branch below; the model-execution path itself is untouched.
+      exitCode = 1;
+      output = checkoutGateRefusalReason;
+      logFile = path.join(LOG_DIR, `${taskId}.log`);
+      try {
+        fs.writeFileSync(
+          logFile,
+          [
+            "=== Hugin Task Log ===",
+            `Task: ${taskId}`,
+            `Runtime: ${task.runtime}`,
+            "===",
+            "Managed checkout refused by the pre-execution clean-verification gate (#236):",
+            checkoutGateRefusalReason,
+            "",
+            "===",
+            "Exit code: 1",
+            "===",
+            "",
+          ].join("\n"),
+          { encoding: "utf-8" },
+        );
+      } catch {
+        /* log is best-effort — never fail the task on a log write */
+      }
+    } else if (isOllama) {
     // --- Ollama execution path ---
     const ollamaModel = task.model || config.ollamaDefaultModel;
     const freeMemBeforeMb = Math.round(os.freemem() / 1024 / 1024);
@@ -5347,7 +5411,11 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     // noise. This tag survives the terminal status write below so an
     // operator can discover and retry it without a rerun.
     let publicationFailureTag: string | undefined;
-    if (ok && !isCancelled && branchResult.action === "created" && branchResult.branchName) {
+    // Issue #236: a task that ran in explicit degraded mode against an
+    // unverified/contaminated checkout must never have finalizeTaskBranch
+    // auto-commit and publish whatever was ALREADY on disk — that state may
+    // belong to an earlier task entirely, not to this one's output.
+    if (ok && !isCancelled && !checkoutGateDegraded && branchResult.action === "created" && branchResult.branchName) {
       const prBody = [
         `Automated changes from Hugin task \`${taskId}\`.`,
         "",

--- a/src/task-helpers.ts
+++ b/src/task-helpers.ts
@@ -468,7 +468,13 @@ export interface RepositoryOutcomeEvidence {
     | "not-finalized"
     | "no-changes"
     | "changes-present"
-    | "publication-failed";
+    | "publication-failed"
+    // Issue #236: the pre-execution clean-verification gate refused to run a
+    // mutation-capable task against this checkout — either the managed
+    // checkout itself could not be prepared, or it was prepared but found
+    // dirty/unverified even after an explicit recovery attempt. Reached only
+    // via {@link prepareManagedCheckout}, never by a bare checkout-failed.
+    | "checkout-contaminated";
   baseBranch?: string;
   baseCommit?: string;
 }
@@ -477,13 +483,15 @@ export interface RepositoryOutcomeEvidence {
 export function deriveRepositoryOutcome(
   branch: TaskBranchResult,
   finalizeAction?: BranchFinalizeResult["action"],
+  gateRefused?: boolean,
 ): RepositoryOutcomeEvidence {
-  if (branch.action === "skipped") return { state: "not-managed" };
-  if (branch.action === "fetch-failed") return { state: "checkout-failed" };
   const base = {
     ...(branch.baseBranch ? { baseBranch: branch.baseBranch } : {}),
     ...(branch.baseCommit ? { baseCommit: branch.baseCommit } : {}),
   };
+  if (gateRefused) return { state: "checkout-contaminated", ...base };
+  if (branch.action === "skipped") return { state: "not-managed" };
+  if (branch.action === "fetch-failed") return { state: "checkout-failed" };
   if (!branch.baseBranch || !branch.baseCommit) {
     return { state: "not-finalized", ...base };
   }
@@ -1200,6 +1208,336 @@ async function createPullRequest(
     });
     child.on("error", () => resolve(null));
   });
+}
+
+// --- Checkout contamination detection + clean-verification gate (#236) ---
+//
+// `checkoutTaskBranch` above is non-fatal by design: a fetch/resolve/checkout
+// failure returns `fetch-failed` and the CALLER decides what to do. Historically
+// the caller just proceeded anyway (logged a warning, executed the agent
+// against whatever was already on disk). Because a managed working directory
+// is REUSED across tasks (one directory per repo, not per task), that leaves a
+// durable hole: a task whose checkout failed — or whose `checkout -b` silently
+// carried over an earlier task's uncommitted files instead of conflicting —
+// can execute against, and `finalizeTaskBranch` can auto-commit and publish,
+// state that has nothing to do with the current task. A later task then
+// inherits the same contaminated directory.
+//
+// The functions below give the pre-task seam in index.ts a durable
+// contamination marker plus a verification gate: a managed task's checkout is
+// only ever trusted once it is independently proven clean at the exact
+// resolved base commit, and a mutation-capable task whose checkout cannot be
+// proven clean — even after one explicit, verified recovery attempt — is
+// refused before any executor runs. A read-only task (one whose runtime
+// cannot itself write, per Hugin's own permission-profile/runtime gating) may
+// still proceed in an explicitly logged degraded mode, since it cannot
+// compound the contamination.
+
+/** Durable, git-native contamination marker for a reused managed working directory. */
+export interface CheckoutContaminationRecord {
+  contaminatedAt: string;
+  taskId: string;
+  reason: string;
+}
+
+// Stored in the repository's own `.git/config` (via `git config --local`):
+// scoped to exactly this reused working directory, invisible to `git add -A`
+// and `git diff` (git never treats its own metadata directory as trackable
+// content), and durable across dispatcher restarts. `--local` always resolves
+// relative to `cwd`, so this can never leak into a different checkout.
+const CONTAMINATION_CONFIG_KEY = "hugin.checkout-contaminated";
+
+function sanitizeContaminationField(value: string): string {
+  return value.replace(/[\r\n|]+/g, " ").trim();
+}
+
+function encodeContaminationRecord(record: CheckoutContaminationRecord): string {
+  return [
+    record.contaminatedAt,
+    sanitizeContaminationField(record.taskId),
+    sanitizeContaminationField(record.reason),
+  ].join("|");
+}
+
+function decodeContaminationRecord(raw: string): CheckoutContaminationRecord | null {
+  const parts = raw.split("|");
+  if (parts.length < 3) return null;
+  const [contaminatedAt, taskId, ...reasonParts] = parts;
+  return { contaminatedAt, taskId, reason: reasonParts.join("|") };
+}
+
+/** Durably mark a managed working directory CONTAMINATED. Best-effort return value only — callers must still fail closed on the caller-visible outcome, never on whether the marker write itself succeeded. */
+export async function markCheckoutContaminated(
+  workingDir: string,
+  taskId: string,
+  reason: string,
+): Promise<boolean> {
+  const record: CheckoutContaminationRecord = {
+    contaminatedAt: new Date().toISOString(),
+    taskId,
+    reason,
+  };
+  const result = await runGitCapture(workingDir, [
+    "config", "--local", CONTAMINATION_CONFIG_KEY, encodeContaminationRecord(record),
+  ]);
+  if (!result.ok) {
+    console.error(
+      `Failed to durably mark checkout contaminated in ${workingDir}: ${result.stderr || "unknown error"}`,
+    );
+  }
+  return result.ok;
+}
+
+/** Read the durable contamination marker, if any. Never throws. */
+export async function readCheckoutContamination(
+  workingDir: string,
+): Promise<CheckoutContaminationRecord | null> {
+  const result = await runGitCapture(workingDir, [
+    "config", "--local", "--get", CONTAMINATION_CONFIG_KEY,
+  ]);
+  if (!result.ok) return null;
+  const raw = result.stdout.toString("utf8").trim();
+  if (!raw) return null;
+  return decodeContaminationRecord(raw);
+}
+
+/**
+ * Explicitly clear the durable contamination marker. Callers must only call
+ * this AFTER independently verifying the checkout is clean — never merely
+ * because a recovery step reported success (see {@link prepareManagedCheckout}).
+ */
+export async function clearCheckoutContamination(workingDir: string): Promise<void> {
+  // --unset-all succeeds even when the key was never set — "no longer
+  // present" is the only postcondition this needs, not "was present before".
+  await runGitCapture(workingDir, ["config", "--local", "--unset-all", CONTAMINATION_CONFIG_KEY]);
+}
+
+export interface CleanCheckoutVerification {
+  clean: boolean;
+  reason?: string;
+  headCommit?: string;
+}
+
+/**
+ * Verify the working tree has no dirty/untracked state and HEAD matches the
+ * expected commit. Run immediately after `checkoutTaskBranch` succeeds and
+ * before any executor runs: `git checkout -b` does not require a clean tree
+ * to succeed, so a prior task's uncommitted leftovers can survive onto the
+ * new branch without the checkout step itself failing.
+ */
+export async function verifyCleanCheckout(
+  workingDir: string,
+  expectedCommit: string,
+): Promise<CleanCheckoutVerification> {
+  const normalizedExpected = expectedCommit.trim().toLowerCase();
+  if (!GIT_COMMIT_ID.test(normalizedExpected)) {
+    return {
+      clean: false,
+      reason: `expected commit ${JSON.stringify(expectedCommit)} is not a valid commit id`,
+    };
+  }
+  // `--ignored` is deliberate (M5 review, #236): plain `--porcelain` never
+  // reports gitignored paths, so a prior task's leftover ignored garbage
+  // (e.g. a stale `.env`, build cache, or partial `node_modules`) would
+  // otherwise verify as "clean" and never trigger `recoverCleanCheckout`
+  // (whose `git clean -fdx` DOES remove ignored files) — silently leaving
+  // untracked-but-invisible state for the next task to inherit.
+  const status = await runGitCapture(workingDir, ["status", "--porcelain", "--ignored"]);
+  if (!status.ok) {
+    return { clean: false, reason: `git status failed: ${status.stderr || "unknown error"}` };
+  }
+  if (status.stdout.toString("utf8").trim().length > 0) {
+    return { clean: false, reason: "working tree has uncommitted, untracked, or ignored leftover state" };
+  }
+  const head = await runGitCapture(workingDir, ["rev-parse", "HEAD"]);
+  if (!head.ok) {
+    return { clean: false, reason: `git rev-parse HEAD failed: ${head.stderr || "unknown error"}` };
+  }
+  const headCommit = head.stdout.toString("utf8").trim().toLowerCase();
+  if (!GIT_COMMIT_ID.test(headCommit) || headCommit !== normalizedExpected) {
+    return {
+      clean: false,
+      reason: `HEAD ${headCommit || "(empty)"} does not match resolved base commit ${normalizedExpected}`,
+      headCommit,
+    };
+  }
+  return { clean: true, headCommit };
+}
+
+async function runGitVoid(workingDir: string, args: string[]): Promise<{ ok: boolean; output: string }> {
+  return new Promise((resolve) => {
+    const child = spawn("git", args, {
+      cwd: workingDir,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, HOME: "/home/magnus" },
+    });
+    let output = "";
+    child.stdout?.on("data", (d: Buffer) => (output += d.toString()));
+    child.stderr?.on("data", (d: Buffer) => (output += d.toString()));
+    child.on("close", (code) => resolve({ ok: code === 0, output }));
+    child.on("error", (err) => resolve({ ok: false, output: err.message }));
+  });
+}
+
+/**
+ * Explicit, verified-by-the-caller recovery: hard-reset the working tree to
+ * `targetCommit` and remove untracked/ignored files. Only ever touches the
+ * LOCAL working directory (no push, no remote mutation) — the remote is the
+ * source of truth this recovers back to. Callers must re-run
+ * {@link verifyCleanCheckout} afterward; this function never asserts its own
+ * success is sufficient.
+ */
+export async function recoverCleanCheckout(
+  workingDir: string,
+  targetCommit: string,
+): Promise<{ ok: boolean; reason?: string }> {
+  const normalizedTarget = targetCommit.trim().toLowerCase();
+  if (!GIT_COMMIT_ID.test(normalizedTarget)) {
+    return { ok: false, reason: `recovery target ${JSON.stringify(targetCommit)} is not a valid commit id` };
+  }
+  const reset = await runGitVoid(workingDir, ["reset", "--hard", normalizedTarget]);
+  if (!reset.ok) {
+    return { ok: false, reason: `git reset --hard ${normalizedTarget} failed: ${reset.output.trim()}` };
+  }
+  const clean = await runGitVoid(workingDir, ["clean", "-fdx"]);
+  if (!clean.ok) {
+    return { ok: false, reason: `git clean -fdx failed: ${clean.output.trim()}` };
+  }
+  return { ok: true };
+}
+
+export interface ManagedCheckoutGateOptions extends TaskBranchOptions {
+  /**
+   * Whether THIS task's runtime/permission profile can itself write to the
+   * working directory. Read-only tasks may proceed in explicit degraded mode
+   * against an unverified checkout (AC: "distinguish read-only tasks where
+   * degraded execution is explicitly permitted"); mutation-capable tasks
+   * never may.
+   */
+  mutationCapable: boolean;
+}
+
+export interface ManagedCheckoutGateResult {
+  /** The underlying checkout attempt — unchanged semantics, still feeds `deriveRepositoryOutcome`. */
+  branch: TaskBranchResult;
+  /** Set only when a mutation-capable task must be refused before any executor runs. */
+  refusalReason?: string;
+  /** True when a contaminated/unverified checkout was explicitly cleaned and reverified before this task proceeded. */
+  recovered?: boolean;
+  /** True when execution proceeded in explicit degraded mode against an unverified/unresolved checkout because this task cannot mutate it. Callers must skip publication (finalizeTaskBranch) whenever this is true — a read-only task must never have a PRIOR task's leftover dirty state auto-committed and published in its name. */
+  degraded?: boolean;
+  degradedReason?: string;
+  /** The pre-existing durable marker, if the working directory was already contaminated when this task started (context for logging/results, not a gating input — the checkout is always independently reverified regardless). */
+  priorContamination?: CheckoutContaminationRecord | null;
+}
+
+/**
+ * Pre-execution isolation/verification gate around the managed-checkout seam.
+ * Wraps {@link checkoutTaskBranch} with a durable contamination marker and a
+ * clean-at-the-resolved-commit verification, so a managed task only ever
+ * executes once its checkout is proven trustworthy:
+ *
+ * - `skipped` (not a managed repo): gate does not apply, unchanged behavior.
+ * - Checkout itself could not be prepared (`fetch-failed`): mutation-capable →
+ *   mark contaminated + refuse (no safe target to recover to). Read-only →
+ *   explicit degraded pass-through.
+ * - Checkout created but NOT verified clean at the pinned base commit:
+ *   mutation-capable → mark contaminated, attempt exactly one explicit
+ *   reset+clean recovery, re-verify; refuse if still unverified. Read-only →
+ *   explicit degraded pass-through (contamination left marked for the next
+ *   mutation-capable task to recover).
+ * - Verified clean: any pre-existing marker is explicitly cleared (never
+ *   assumed) and the task proceeds normally.
+ */
+export async function prepareManagedCheckout(
+  workingDir: string,
+  taskId: string,
+  options: ManagedCheckoutGateOptions,
+): Promise<ManagedCheckoutGateResult> {
+  const { mutationCapable, ...checkoutOptions } = options;
+  const branch = await checkoutTaskBranch(workingDir, taskId, {
+    ...checkoutOptions,
+    captureBaseCommit: true,
+  });
+
+  if (branch.action === "skipped") {
+    return { branch };
+  }
+
+  const priorContamination = await readCheckoutContamination(workingDir);
+
+  // Detection and marking are UNCONDITIONAL — a proven-untrustworthy checkout
+  // is durably recorded regardless of whether the discovering task can itself
+  // mutate the tree, so the evidence survives for whichever task (read-only or
+  // mutation-capable) looks at this directory next. Only the RECOVERY attempt
+  // below is gated on `mutationCapable`.
+  if (branch.action === "fetch-failed") {
+    const reason = branch.error ?? "managed checkout failed";
+    await markCheckoutContaminated(workingDir, taskId, reason);
+    if (!mutationCapable) {
+      return {
+        branch,
+        degraded: true,
+        degradedReason: `checkout failed (${reason}); proceeding read-only against the existing working tree`,
+        priorContamination,
+      };
+    }
+    return {
+      branch,
+      refusalReason: `Managed checkout failed and the working directory state cannot be trusted: ${reason}`,
+      priorContamination,
+    };
+  }
+
+  const expectedCommit = branch.baseCommit;
+  if (!expectedCommit) {
+    // captureBaseCommit is always forced true above; this should be
+    // unreachable, but never assume a checkout is safe without evidence.
+    const reason = "resolved checkout has no pinned base commit to verify against";
+    await markCheckoutContaminated(workingDir, taskId, reason);
+    if (!mutationCapable) {
+      return { branch, degraded: true, degradedReason: reason, priorContamination };
+    }
+    return { branch, refusalReason: reason, priorContamination };
+  }
+
+  let verification = await verifyCleanCheckout(workingDir, expectedCommit);
+  if (verification.clean) {
+    // Explicit + verified: only ever clear a PRIOR marker once THIS checkout
+    // has been independently proven clean at the intended commit — never
+    // merely because no marker blocked us from getting this far.
+    await clearCheckoutContamination(workingDir);
+    return { branch, priorContamination };
+  }
+
+  const dirtyReason = verification.reason ?? "checkout is not clean";
+  await markCheckoutContaminated(workingDir, taskId, dirtyReason);
+  if (!mutationCapable) {
+    return {
+      branch,
+      degraded: true,
+      degradedReason: `checkout unverified (${dirtyReason}); proceeding read-only against the existing working tree`,
+      priorContamination,
+    };
+  }
+
+  const recovery = await recoverCleanCheckout(workingDir, expectedCommit);
+  if (recovery.ok) {
+    verification = await verifyCleanCheckout(workingDir, expectedCommit);
+  }
+
+  if (!recovery.ok || !verification.clean) {
+    return {
+      branch,
+      refusalReason:
+        `Managed checkout could not be verified clean at ${expectedCommit} after an explicit recovery attempt: ` +
+        (verification.reason ?? recovery.reason ?? "unknown recovery failure"),
+      priorContamination,
+    };
+  }
+
+  await clearCheckoutContamination(workingDir);
+  return { branch, recovered: true, priorContamination };
 }
 
 // --- Publication failure recovery (#225) ---

--- a/src/task-result-schema.ts
+++ b/src/task-result-schema.ts
@@ -367,6 +367,11 @@ export const repositoryOutcomeSchema = z.object({
     // the recorded exact head) and the failure is terminal without a rerun.
     "publication-recovered",
     "publication-abandoned",
+    // Issue #236: the pre-execution clean-verification gate refused to run a
+    // mutation-capable task because the managed checkout could not be proven
+    // clean at the intended commit — even after one explicit recovery
+    // attempt. Reached only via the pre-task gate, never the executor path.
+    "checkout-contaminated",
   ]),
   baseBranch: repositoryChangeEvidenceSchema.shape.baseBranch,
   baseCommit: z.string().regex(/^[0-9a-f]{40,64}$/).optional(),

--- a/tests/checkout-isolation.test.ts
+++ b/tests/checkout-isolation.test.ts
@@ -1,0 +1,524 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventEmitter } from "node:events";
+
+// Mock child_process.spawn before importing the module — same style as
+// repo-sync.test.ts (#217/#225), but with NO auto-resolution shortcuts: every
+// git call in a scenario is scripted explicitly so the exact sequence issued
+// by the #236 pre-execution gate is visible and asserted.
+const spawnCalls: Array<{ cmd: string; args: string[]; opts: Record<string, unknown> }> = [];
+let spawnBehaviors: Array<{ exitCode: number; stdout?: string; stderr?: string }> = [];
+let spawnCallIndex = 0;
+
+class MockChildProcess extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+}
+
+vi.mock("node:child_process", () => ({
+  spawn: (cmd: string, args: string[], opts: Record<string, unknown>) => {
+    const child = new MockChildProcess();
+    spawnCalls.push({ cmd, args, opts });
+    const behavior = spawnBehaviors[spawnCallIndex] ?? { exitCode: 0 };
+    spawnCallIndex++;
+    setImmediate(() => {
+      if (behavior.stdout) child.stdout.emit("data", Buffer.from(behavior.stdout));
+      if (behavior.stderr) child.stderr.emit("data", Buffer.from(behavior.stderr));
+      child.emit("close", behavior.exitCode);
+    });
+    return child;
+  },
+}));
+
+const {
+  markCheckoutContaminated,
+  readCheckoutContamination,
+  clearCheckoutContamination,
+  verifyCleanCheckout,
+  recoverCleanCheckout,
+  prepareManagedCheckout,
+} = await import("../src/task-helpers.js");
+
+beforeEach(() => {
+  spawnCalls.length = 0;
+  spawnBehaviors = [];
+  spawnCallIndex = 0;
+});
+
+const WORKDIR = "/home/magnus/repos/demo";
+
+describe("checkout contamination marker (durable, git-native)", () => {
+  it("marks contamination via `git config --local` scoped to exactly this working directory", async () => {
+    spawnBehaviors = [{ exitCode: 0 }];
+    const ok = await markCheckoutContaminated(WORKDIR, "task-1", "checkout is dirty");
+    expect(ok).toBe(true);
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0].cmd).toBe("git");
+    expect(spawnCalls[0].args[0]).toBe("config");
+    expect(spawnCalls[0].args).toContain("--local");
+    expect(spawnCalls[0].args).toContain("hugin.checkout-contaminated");
+    expect(spawnCalls[0].opts.cwd).toBe(WORKDIR);
+  });
+
+  it("round-trips the record through an independent later read (durability)", async () => {
+    spawnBehaviors = [{ exitCode: 0 }];
+    await markCheckoutContaminated(WORKDIR, "task-1", "checkout is dirty");
+    const storedValue = spawnCalls[0].args[3];
+
+    spawnCalls.length = 0;
+    spawnCallIndex = 0;
+    spawnBehaviors = [{ exitCode: 0, stdout: `${storedValue}\n` }];
+    const record = await readCheckoutContamination(WORKDIR);
+    expect(record).toMatchObject({ taskId: "task-1", reason: "checkout is dirty" });
+    expect(record?.contaminatedAt).toEqual(expect.any(String));
+  });
+
+  it("reads no contamination when the git config key was never set", async () => {
+    spawnBehaviors = [{ exitCode: 1 }]; // `git config --get`: key not found
+    const record = await readCheckoutContamination(WORKDIR);
+    expect(record).toBeNull();
+  });
+
+  it("sanitizes newlines/pipes in the reason so the encoded record cannot be corrupted", async () => {
+    spawnBehaviors = [{ exitCode: 0 }];
+    await markCheckoutContaminated(WORKDIR, "task-2", "line one\nline two|with a pipe");
+    const storedValue = spawnCalls[0].args[3];
+    expect(storedValue).not.toContain("\n");
+
+    spawnCalls.length = 0;
+    spawnCallIndex = 0;
+    spawnBehaviors = [{ exitCode: 0, stdout: `${storedValue}\n` }];
+    const record = await readCheckoutContamination(WORKDIR);
+    expect(record?.taskId).toBe("task-2");
+    expect(record?.reason).not.toContain("\n");
+  });
+
+  it("clears the marker via --unset-all (idempotent: safe even when nothing was set)", async () => {
+    spawnBehaviors = [{ exitCode: 5 }]; // --unset-all: key not found — still a success postcondition
+    await expect(clearCheckoutContamination(WORKDIR)).resolves.toBeUndefined();
+    expect(spawnCalls[0].args).toContain("--unset-all");
+    expect(spawnCalls[0].args).toContain("hugin.checkout-contaminated");
+  });
+});
+
+describe("verifyCleanCheckout", () => {
+  const commit = "a".repeat(40);
+
+  it("fails closed on an invalid expected commit without touching git", async () => {
+    const result = await verifyCleanCheckout(WORKDIR, "not-a-commit");
+    expect(result.clean).toBe(false);
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  it("passes only when the tree is clean AND HEAD matches the expected commit", async () => {
+    spawnBehaviors = [
+      { exitCode: 0, stdout: "" }, // status --porcelain
+      { exitCode: 0, stdout: `${commit}\n` }, // rev-parse HEAD
+    ];
+    const result = await verifyCleanCheckout(WORKDIR, commit);
+    expect(result).toEqual({ clean: true, headCommit: commit });
+  });
+
+  it("fails when the working tree has uncommitted or untracked changes", async () => {
+    spawnBehaviors = [{ exitCode: 0, stdout: "M leftover.txt\n" }];
+    const result = await verifyCleanCheckout(WORKDIR, commit);
+    expect(result.clean).toBe(false);
+    expect(result.reason).toContain("uncommitted, untracked, or ignored");
+    // Never bothers checking HEAD once dirtiness is already proven.
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0].args).toEqual(["status", "--porcelain", "--ignored"]);
+  });
+
+  it("fails when HEAD does not match the expected commit even though the tree is clean", async () => {
+    const other = "b".repeat(40);
+    spawnBehaviors = [
+      { exitCode: 0, stdout: "" },
+      { exitCode: 0, stdout: `${other}\n` },
+    ];
+    const result = await verifyCleanCheckout(WORKDIR, commit);
+    expect(result.clean).toBe(false);
+    expect(result.reason).toContain(other);
+    expect(result.reason).toContain(commit);
+  });
+
+  it("fails closed when `git status` itself errors", async () => {
+    spawnBehaviors = [{ exitCode: 128, stderr: "fatal: not a git repository" }];
+    const result = await verifyCleanCheckout(WORKDIR, commit);
+    expect(result.clean).toBe(false);
+    expect(result.reason).toContain("git status failed");
+  });
+
+  it("is idempotent: calling it repeatedly on an already-clean tree keeps returning clean", async () => {
+    spawnBehaviors = [
+      { exitCode: 0, stdout: "" },
+      { exitCode: 0, stdout: `${commit}\n` },
+    ];
+    const first = await verifyCleanCheckout(WORKDIR, commit);
+    spawnCallIndex = 0;
+    const second = await verifyCleanCheckout(WORKDIR, commit);
+    expect(first).toEqual(second);
+    expect(second.clean).toBe(true);
+  });
+});
+
+describe("recoverCleanCheckout", () => {
+  const commit = "a".repeat(40);
+
+  it("rejects an invalid recovery target before touching git", async () => {
+    const result = await recoverCleanCheckout(WORKDIR, "not-a-commit");
+    expect(result.ok).toBe(false);
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  it("resets and cleans the tree on success", async () => {
+    spawnBehaviors = [
+      { exitCode: 0 }, // reset --hard
+      { exitCode: 0 }, // clean -fdx
+    ];
+    const result = await recoverCleanCheckout(WORKDIR, commit);
+    expect(result.ok).toBe(true);
+    expect(spawnCalls[0].args).toEqual(["reset", "--hard", commit]);
+    expect(spawnCalls[1].args).toEqual(["clean", "-fdx"]);
+  });
+
+  it("stops before attempting clean when `git reset --hard` fails", async () => {
+    spawnBehaviors = [{ exitCode: 128, stderr: "fatal: ambiguous argument" }];
+    const result = await recoverCleanCheckout(WORKDIR, commit);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("reset --hard");
+    expect(spawnCalls).toHaveLength(1);
+  });
+
+  it("fails when `git clean -fdx` fails after a successful reset", async () => {
+    spawnBehaviors = [
+      { exitCode: 0 },
+      { exitCode: 1, stderr: "permission denied" },
+    ];
+    const result = await recoverCleanCheckout(WORKDIR, commit);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("clean -fdx");
+  });
+});
+
+// Sequence for prepareManagedCheckout's happy-path checkoutTaskBranch leg
+// (baseBranchOverride is always used here to keep the resolution to a single
+// `rev-parse --verify` call instead of the full origin/HEAD probing chain —
+// that chain is already covered by repo-sync.test.ts):
+//   1. git rev-parse --git-dir
+//   2. git remote get-url origin
+//   3. git fetch origin
+//   4. git rev-parse --verify refs/remotes/origin/<override>^{commit}
+//   5. git checkout -b hugin/<taskId> origin/<override>
+//   6. git config --local --get hugin.checkout-contaminated  (readCheckoutContamination)
+describe("prepareManagedCheckout — the #236 pre-execution isolation/verification gate", () => {
+  it("passes through unchanged when the directory is not managed (skipped)", async () => {
+    const result = await prepareManagedCheckout("/home/magnus/workspace", "task-skip", {
+      mutationCapable: true,
+    });
+    expect(result.branch.action).toBe("skipped");
+    expect(result.refusalReason).toBeUndefined();
+    expect(result.degraded).toBeUndefined();
+    expect(spawnCalls).toHaveLength(0);
+  });
+
+  it("marks the directory contaminated durably and refuses a mutation-capable task when the managed checkout itself fails", async () => {
+    spawnBehaviors = [
+      { exitCode: 0 }, // rev-parse --git-dir
+      { exitCode: 0 }, // remote get-url origin
+      { exitCode: 128, stderr: "network unreachable" }, // fetch attempt 1
+      { exitCode: 128, stderr: "network unreachable" }, // fetch attempt 2
+      { exitCode: 128, stderr: "network unreachable" }, // fetch attempt 3
+      { exitCode: 1 }, // readCheckoutContamination: not previously set
+      { exitCode: 0 }, // markCheckoutContaminated
+    ];
+    const result = await prepareManagedCheckout(WORKDIR, "task-fetchfail", {
+      mutationCapable: true,
+      fetchRetryDelaysMs: [0, 0],
+    });
+    expect(result.branch.action).toBe("fetch-failed");
+    expect(result.refusalReason).toContain("cannot be trusted");
+    expect(result.degraded).toBeUndefined();
+
+    const markCall = spawnCalls[6];
+    expect(markCall.args[0]).toBe("config");
+    expect(markCall.args).toContain("hugin.checkout-contaminated");
+    expect(markCall.args).not.toContain("--get");
+
+    // Durable: an independent later read call proves the marker persists
+    // (a spy proving "the next task can see this" without re-running the gate).
+    spawnCalls.length = 0;
+    spawnCallIndex = 0;
+    spawnBehaviors = [{ exitCode: 0, stdout: `${markCall.args[3]}\n` }];
+    const marker = await readCheckoutContamination(WORKDIR);
+    expect(marker?.taskId).toBe("task-fetchfail");
+  });
+
+  it("still marks contamination for a read-only task when the checkout itself fails, but proceeds in explicit degraded mode", async () => {
+    spawnBehaviors = [
+      { exitCode: 0 },
+      { exitCode: 0 },
+      { exitCode: 128 },
+      { exitCode: 128 },
+      { exitCode: 128 },
+      { exitCode: 1 }, // readCheckoutContamination: not set
+      { exitCode: 0 }, // markCheckoutContaminated — detection is unconditional
+    ];
+    const result = await prepareManagedCheckout(WORKDIR, "task-readonly-fetchfail", {
+      mutationCapable: false,
+      fetchRetryDelaysMs: [0, 0],
+    });
+    expect(result.degraded).toBe(true);
+    expect(result.degradedReason).toContain("checkout failed");
+    expect(result.refusalReason).toBeUndefined();
+    expect(spawnCalls).toHaveLength(7);
+    expect(spawnCalls[6].args).toContain("hugin.checkout-contaminated");
+  });
+
+  it("recovers a checkout that succeeded but was left dirty: explicit reset+clean, re-verified, marker cleared only after independent proof", async () => {
+    const commit = "c".repeat(40);
+    spawnBehaviors = [
+      { exitCode: 0 }, // 0 rev-parse --git-dir
+      { exitCode: 0 }, // 1 remote get-url origin
+      { exitCode: 0 }, // 2 fetch origin
+      { exitCode: 0, stdout: `${commit}\n` }, // 3 rev-parse --verify (override)
+      { exitCode: 0 }, // 4 checkout -b
+      { exitCode: 1 }, // 5 readCheckoutContamination: not set
+      { exitCode: 0, stdout: "M leftover.txt\n" }, // 6 status --porcelain: dirty
+      { exitCode: 0 }, // 7 markCheckoutContaminated
+      { exitCode: 0 }, // 8 reset --hard
+      { exitCode: 0 }, // 9 clean -fdx
+      { exitCode: 0, stdout: "" }, // 10 status --porcelain: clean
+      { exitCode: 0, stdout: `${commit}\n` }, // 11 rev-parse HEAD
+      { exitCode: 0 }, // 12 clearCheckoutContamination
+    ];
+    const result = await prepareManagedCheckout(WORKDIR, "task-recover", {
+      mutationCapable: true,
+      fetchRetryDelaysMs: [0, 0],
+      baseBranchOverride: "main",
+    });
+    expect(result.branch).toMatchObject({ action: "created", baseBranch: "main", baseCommit: commit });
+    expect(result.recovered).toBe(true);
+    expect(result.refusalReason).toBeUndefined();
+    expect(spawnCalls).toHaveLength(13);
+    expect(spawnCalls[8].args).toEqual(["reset", "--hard", commit]);
+    expect(spawnCalls[9].args).toEqual(["clean", "-fdx"]);
+    expect(spawnCalls[12].args).toContain("--unset-all");
+  });
+
+  it("fails closed and leaves the marker in place (durable) when the tree is still dirty after an explicit recovery attempt — never re-contaminates by assuming success", async () => {
+    const commit = "d".repeat(40);
+    spawnBehaviors = [
+      { exitCode: 0 },
+      { exitCode: 0 },
+      { exitCode: 0 },
+      { exitCode: 0, stdout: `${commit}\n` },
+      { exitCode: 0 },
+      { exitCode: 1 }, // readCheckoutContamination: not set
+      { exitCode: 0, stdout: "M leftover.txt\n" }, // dirty
+      { exitCode: 0 }, // markCheckoutContaminated
+      { exitCode: 0 }, // reset --hard succeeds
+      { exitCode: 0 }, // clean -fdx succeeds
+      { exitCode: 0, stdout: "?? still-dirty.txt\n" }, // re-verify: STILL dirty
+    ];
+    const result = await prepareManagedCheckout(WORKDIR, "task-recover-fail", {
+      mutationCapable: true,
+      fetchRetryDelaysMs: [0, 0],
+      baseBranchOverride: "main",
+    });
+    expect(result.recovered).toBeUndefined();
+    expect(result.refusalReason).toContain("could not be verified clean");
+    expect(spawnCalls).toHaveLength(11);
+    expect(spawnCalls.some((c) => c.args.includes("--unset-all"))).toBe(false);
+
+    const markCall = spawnCalls[7];
+    expect(markCall.args).toContain("hugin.checkout-contaminated");
+
+    // The marker set at step 7 is exactly what a LATER task would see —
+    // proving contamination durably outlives this single gate invocation.
+    spawnCalls.length = 0;
+    spawnCallIndex = 0;
+    spawnBehaviors = [{ exitCode: 0, stdout: `${markCall.args[3]}\n` }];
+    const marker = await readCheckoutContamination(WORKDIR);
+    expect(marker?.taskId).toBe("task-recover-fail");
+    expect(marker?.reason).toContain("uncommitted, untracked, or ignored");
+  });
+
+  it("treats gitignored leftover state as NOT clean (M5-review fix): `--ignored` catches what plain `--porcelain` would miss", async () => {
+    const commit = "3".repeat(40);
+    spawnBehaviors = [
+      { exitCode: 0 },
+      { exitCode: 0 },
+      { exitCode: 0 },
+      { exitCode: 0, stdout: `${commit}\n` },
+      { exitCode: 0 },
+      { exitCode: 1 }, // readCheckoutContamination: not set
+      // status --porcelain --ignored: nothing tracked/untracked is dirty, but
+      // an ignored leftover (e.g. a stale .env from a crashed prior task) is
+      // still present — `!!` is git's ignored-file marker.
+      { exitCode: 0, stdout: "!! .env\n" },
+      { exitCode: 0 }, // markCheckoutContaminated
+      { exitCode: 0 }, // reset --hard
+      { exitCode: 0 }, // clean -fdx (removes the ignored file, -x)
+      { exitCode: 0, stdout: "" }, // re-verify: now genuinely clean
+      { exitCode: 0, stdout: `${commit}\n` },
+      { exitCode: 0 }, // clearCheckoutContamination
+    ];
+    const result = await prepareManagedCheckout(WORKDIR, "task-ignored-leftover", {
+      mutationCapable: true,
+      fetchRetryDelaysMs: [0, 0],
+      baseBranchOverride: "main",
+    });
+    expect(result.recovered).toBe(true);
+    const statusCall = spawnCalls[6];
+    expect(statusCall.args).toEqual(["status", "--porcelain", "--ignored"]);
+  });
+
+  it("marks contamination for a read-only task when the checkout is dirty, but never attempts recovery (no reset/clean calls)", async () => {
+    const commit = "e".repeat(40);
+    spawnBehaviors = [
+      { exitCode: 0 },
+      { exitCode: 0 },
+      { exitCode: 0 },
+      { exitCode: 0, stdout: `${commit}\n` },
+      { exitCode: 0 },
+      { exitCode: 1 }, // readCheckoutContamination: not set
+      { exitCode: 0, stdout: "M leftover.txt\n" }, // dirty
+      { exitCode: 0 }, // markCheckoutContaminated
+    ];
+    const result = await prepareManagedCheckout(WORKDIR, "task-readonly-dirty", {
+      mutationCapable: false,
+      fetchRetryDelaysMs: [0, 0],
+      baseBranchOverride: "main",
+    });
+    expect(result.degraded).toBe(true);
+    expect(result.degradedReason).toContain("checkout unverified");
+    expect(spawnCalls).toHaveLength(8);
+    expect(spawnCalls.some((c) => c.args.includes("reset"))).toBe(false);
+    expect(spawnCalls.some((c) => c.args.includes("clean"))).toBe(false);
+  });
+
+  it("proceeds normally and clears any stale prior marker when the checkout is verified clean on the first try", async () => {
+    const commit = "f".repeat(40);
+    spawnBehaviors = [
+      { exitCode: 0 },
+      { exitCode: 0 },
+      { exitCode: 0 },
+      { exitCode: 0, stdout: `${commit}\n` },
+      { exitCode: 0 },
+      { exitCode: 0, stdout: `${"2026-01-01T00:00:00.000Z"}|old-task|old dirt\n` }, // priorContamination present
+      { exitCode: 0, stdout: "" }, // status --porcelain: clean
+      { exitCode: 0, stdout: `${commit}\n` }, // rev-parse HEAD matches
+      { exitCode: 0 }, // clearCheckoutContamination — explicit, only after independent proof
+    ];
+    const result = await prepareManagedCheckout(WORKDIR, "task-clean", {
+      mutationCapable: true,
+      fetchRetryDelaysMs: [0, 0],
+      baseBranchOverride: "main",
+    });
+    expect(result.recovered).toBeUndefined();
+    expect(result.refusalReason).toBeUndefined();
+    expect(result.degraded).toBeUndefined();
+    expect(result.priorContamination).toMatchObject({ taskId: "old-task" });
+    expect(spawnCalls.at(-1)?.args).toContain("--unset-all");
+  });
+
+  it("is idempotent: two consecutive gate runs against a checkout that never becomes clean both refuse, without duplicating side effects beyond the expected recovery attempt each time", async () => {
+    const commit = "1".repeat(40);
+    const dirtySequence = () => [
+      { exitCode: 0 },
+      { exitCode: 0 },
+      { exitCode: 0 },
+      { exitCode: 0, stdout: `${commit}\n` },
+      { exitCode: 0 },
+      { exitCode: 1 },
+      { exitCode: 0, stdout: "M forever-dirty.txt\n" },
+      { exitCode: 0 },
+      { exitCode: 0 },
+      { exitCode: 0 },
+      { exitCode: 0, stdout: "M forever-dirty.txt\n" },
+    ];
+
+    spawnBehaviors = dirtySequence();
+    const first = await prepareManagedCheckout(WORKDIR, "task-a", {
+      mutationCapable: true,
+      fetchRetryDelaysMs: [0, 0],
+      baseBranchOverride: "main",
+    });
+    expect(first.refusalReason).toBeDefined();
+
+    spawnCalls.length = 0;
+    spawnCallIndex = 0;
+    spawnBehaviors = dirtySequence();
+    const second = await prepareManagedCheckout(WORKDIR, "task-b", {
+      mutationCapable: true,
+      fetchRetryDelaysMs: [0, 0],
+      baseBranchOverride: "main",
+    });
+    expect(second.refusalReason).toBeDefined();
+    expect(spawnCalls.some((c) => c.args.includes("--unset-all"))).toBe(false);
+  });
+});
+
+// Proves the actual policy index.ts wires around the gate: a task that
+// receives a `refusalReason` must never reach the executor. This mirrors the
+// spy-based assertion style of publication-recovery-no-rerun.test.ts (#225),
+// applied to the pre-execution seam instead of the post-execution one.
+describe("gate-refusal-must-block-execution contract", () => {
+  it("never invokes the executor when the gate reports a refusal, and always does when it does not", async () => {
+    const executeAgent = vi.fn().mockResolvedValue({ exitCode: 0 });
+
+    async function runTaskUnderGate(mutationCapable: boolean, dirty: boolean) {
+      const commit = "9".repeat(40);
+      spawnBehaviors = dirty
+        ? [
+            { exitCode: 0 },
+            { exitCode: 0 },
+            { exitCode: 0 },
+            { exitCode: 0, stdout: `${commit}\n` },
+            { exitCode: 0 },
+            { exitCode: 1 },
+            { exitCode: 0, stdout: "M x.txt\n" },
+            { exitCode: 0 },
+            { exitCode: 0 },
+            { exitCode: 0 },
+            { exitCode: 0, stdout: "M x.txt\n" },
+          ]
+        : [
+            { exitCode: 0 },
+            { exitCode: 0 },
+            { exitCode: 0 },
+            { exitCode: 0, stdout: `${commit}\n` },
+            { exitCode: 0 },
+            { exitCode: 1 },
+            { exitCode: 0, stdout: "" },
+            { exitCode: 0, stdout: `${commit}\n` },
+            { exitCode: 0 },
+          ];
+      const gate = await prepareManagedCheckout(WORKDIR, "task-x", {
+        mutationCapable,
+        fetchRetryDelaysMs: [0, 0],
+        baseBranchOverride: "main",
+      });
+      // This is the exact policy wired in src/index.ts around the dispatch
+      // chain: `if (checkoutGateRefusalReason) { <synthesize failure> } else
+      // { <run executor> }` — never both.
+      if (!gate.refusalReason) {
+        await executeAgent();
+      }
+      return gate;
+    }
+
+    executeAgent.mockClear();
+    spawnCalls.length = 0;
+    spawnCallIndex = 0;
+    const refused = await runTaskUnderGate(true, true);
+    expect(refused.refusalReason).toBeDefined();
+    expect(executeAgent).not.toHaveBeenCalled();
+
+    executeAgent.mockClear();
+    spawnCalls.length = 0;
+    spawnCallIndex = 0;
+    const clean = await runTaskUnderGate(true, false);
+    expect(clean.refusalReason).toBeUndefined();
+    expect(executeAgent).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Refs #236

## What

Hugin runs managed-repository tasks against **reused** working directories — one directory per repo name, shared across many sequential tasks over time, not a fresh checkout per task. `checkoutTaskBranch`'s pre-task fetch/checkout failure was historically non-fatal: the caller logged a warning and executed the agent anyway (`repositoryOutcome: "checkout-failed"`, execution continued). Worse, `git checkout -b` can succeed while silently carrying an earlier task's uncommitted/untracked leftovers onto the new branch instead of conflicting — so "checkout succeeded" was never proof the tree was actually clean. A dirty checkout could then be auto-committed and published by `finalizeTaskBranch` as if it were the *current* task's own output, and the *next* task inherits the same contaminated directory.

This PR adds a pre-execution isolation/verification gate around the managed-checkout seam:

- **Durable contamination marker** — `markCheckoutContaminated` / `readCheckoutContamination` / `clearCheckoutContamination` (`src/task-helpers.ts`) store a git-native record via `git config --local hugin.checkout-contaminated`, scoped to exactly the reused working directory, invisible to `git add -A`/`git diff` (git never tracks its own metadata dir), and durable across dispatcher restarts.
- **Clean-verification gate** — `verifyCleanCheckout(workingDir, expectedCommit)` proves the tree has no uncommitted/untracked/**ignored** state (`git status --porcelain --ignored`) *and* that `HEAD` matches the exact resolved base commit, before any executor runs.
- **`prepareManagedCheckout`** wraps `checkoutTaskBranch` with detection + capability-gated recovery: a mutation-capable task gets exactly one explicit recovery attempt (hard reset to the pinned commit + remove untracked/ignored files) and a re-verify; if still unverified, it fails closed and the marker stays (never cleared on assumption). A read-only task proceeds in explicit degraded mode instead, and `index.ts` skips `finalizeTaskBranch` for it so a prior task's leftover dirty state is never auto-committed/published in the degraded task's name.
- **`index.ts` wiring** — on `refusalReason`, the entire runtime dispatch chain is skipped (no ollama/claude-sdk/codex-spawn/opencode/orchestrator invocation); a failed result is synthesized instead. The model-execution path itself is untouched.
- New `checkout-contaminated` `repositoryOutcome` state distinguishes a gate refusal from the existing `checkout-failed` (fetch/network) outcome.

## Design decisions

**Contamination marking (durable + discoverable).** Stored via `git config --local` inside the repo's own `.git/config` rather than a sidecar file or Munin record — it's naturally scoped to exactly the reused directory (no path-hashing needed), it's invisible to any tree-scanning git command (`add -A`, `diff`, `status`), and it needs no new fs-mocking test infrastructure (stays consistent with the existing `spawn`-based test style in `repo-sync.test.ts`). Detection/marking is **unconditional** — a proven-untrustworthy checkout is recorded regardless of whether the *discovering* task can itself mutate the tree, so the evidence survives for whichever task looks at the directory next. Only the *recovery attempt* is gated on mutation capability.

**Fail-closed vs. isolate.** The issue offered two options: fail closed, or switch to a fresh disposable worktree with equivalent provenance. I chose **fail-closed with one explicit, verified in-place recovery attempt** rather than disposable `git worktree` isolation: recovery here (`git reset --hard <pinned-commit>` + `git clean -fdx`) only ever touches the local working directory — no push, no remote mutation, fully re-derivable from the remote — so it carries none of the external-side-effect risk that made #225's publication recovery operator-only. A disposable worktree would add real complexity (creation, cleanup, provenance-matching against the existing branch-per-task-in-shared-directory model) for no safety benefit over a verified in-place reset. If the one recovery attempt doesn't produce a *verified*-clean tree, the task refuses — never falls through to execution, never assumes success.

**The clean-verification gate.** `checkoutTaskBranch` succeeding is not proof the tree is clean (git doesn't require a clean tree for `checkout -b` unless there's a literal conflict), so verification is a **separate, mandatory** step: `git status --porcelain --ignored` (empty) + `git rev-parse HEAD` == the pinned base commit captured *before* the checkout ran. `--ignored` was added after an M5 review caught that plain `--porcelain` would let gitignored leftovers (e.g. a stale `.env` from a crashed prior task) verify as "clean" while `git clean -fdx`'s `-x` flag would remove them — closing that gap so verification and recovery agree on what "clean" means.

## Verification

- `npm run build` — clean, no errors.
- `npm test` — full suite: **133 test files / 2137 tests, all passing** (baseline before this change: 132 files / 2112 tests; +1 file / +25 tests, zero regressions).
- New `tests/checkout-isolation.test.ts` (spawn-mocked, mirrors `repo-sync.test.ts`/#225's style): durable marking + independent read-back, the verification gate (dirty tree, HEAD mismatch, invalid commit, git errors, idempotent-when-clean, gitignored-leftover regression), recovery (success / reset-failure / clean-failure), the full gate flow (skip / fetch-failure mark+refuse / fetch-failure mark+degrade / dirty-recover / dirty-recovery-fails-stays-marked / dirty-degrade-no-recovery-attempted / clean-clears-stale-marker / two-runs-idempotent-both-refuse), and a spy-based contract test proving a refused gate never reaches a stand-in executor while a clean one always does.
- **M5 review** (qwen3-30b-instruct, bounded completeness check on the contamination/verification logic): 1 of ~4 claimed gaps was real and was fixed (gitignored leftovers invisible to plain `git status --porcelain`, added `--ignored`); the rest were noise — it described the agent's own legitimate writes during execution as a "TOCTOU flaw," and its ".git/config corruption defaults to clean" claim is factually wrong (the gate always independently re-verifies via `verifyCleanCheckout` regardless of whether the marker is present, readable, or lost).
