### PR TITLE
Ingest external Codex/Pi task receipts into the learning registry

### DIFF
--- a/docs/external-receipt-intake.md
+++ b/docs/external-receipt-intake.md
@@ -1,0 +1,193 @@
+# External task/outcome receipt intake (#237)
+
+**Status:** mechanism implemented (`src/external-receipt-schema.ts`,
+`src/external-receipt-signing.ts`, `src/external-receipt-intake.ts`); not yet
+wired into an HTTP/MCP surface. Wiring `ingestExternalReceipt` behind an actual
+endpoint (and provisioning real `HUGIN_RECEIPT_PRODUCER_KEYS` for Codex CLI /
+Codex App / Pi) is left to a follow-up so this change stays a self-contained,
+independently testable library, matching how #232 itself shipped.
+
+## Why
+
+Magnus's day-to-day work is moving toward Codex App, Codex CLI, and Pi
+surfaces that complete real tasks **without** ever entering Hugin's
+dispatcher. Without an intake path, the durable learning registry (#232)
+stays systematically incomplete and success-biased toward Hugin-managed
+execution — every task Hugin never saw is invisible to the registry that is
+supposed to be the durable record of what actually happened. Importing whole
+chat transcripts would create weak task boundaries and unnecessary privacy
+exposure, so external work instead gets an explicit, content-governed
+receipt path.
+
+This is the Hugin-side of the pair with `gille-inference#10` (the exposure-
+receipt side); `grimnir#90` is the broader rollout/certification program.
+
+## What a receipt is, and is not
+
+A receipt is a small, versioned, content-blind fact: "surface X, capacity
+principal Y, using provider/model/harness Z, observed/completed task instance
+W, at time T." It is never a transcript, prompt, diff, or output. This is
+enforced structurally in `src/external-receipt-schema.ts`, not just by
+convention:
+
+- Every envelope object is `.strict()` — Zod rejects any unrecognised field
+  outright (e.g. a `transcript` field) rather than stripping it silently.
+- Every identity/instance string is an **opaque token**
+  (`externalReceiptTokenSchema` / `externalReceiptRefTokenSchema`): a bounded
+  character class with no whitespace or control characters, so free text
+  structurally cannot fit through an identity field either.
+- The one required "independence" annotation
+  (`CAPACITY_PRINCIPAL_INDEPENDENCE_NOTE`) is a fixed literal, never
+  caller-supplied prose.
+
+## Admission pipeline
+
+`ingestExternalReceipt` (`src/external-receipt-intake.ts`) runs, in order,
+each step failing closed with one of `EXTERNAL_RECEIPT_REJECTION_REASONS`:
+
+1. **Structural + content-blindness validation.** `externalReceiptEnvelopeSchema.safeParse`.
+   A failure is classified into a specific reason — `non-content-blind` for an
+   unrecognised field or a free-text-shaped token, `unsupported-schema-version`
+   / `unsupported-contract-version` for a version mismatch, `incomplete-envelope`
+   for everything else (missing/malformed required fields) — never one opaque
+   "invalid" bucket.
+2. **Authenticity.** `verifyExternalReceiptSignature` (`src/external-receipt-signing.ts`)
+   — an HMAC-SHA256 scheme deliberately shaped like `task-signing.ts`'s (sorted
+   canonical `key=value` payload, `v1:<keyId>:<hex>` wire format, keyId must
+   equal or rotation-alias the claimed `capacityPrincipal`), but with its own
+   keystore (`HUGIN_RECEIPT_PRODUCER_KEYS` / `_FILE`) — a receipt producer is a
+   different trust domain from a task submitter. There is no `off`/`warn`
+   policy knob here: this is a brand-new authenticated-only surface, so
+   verification is always mandatory. A missing, unknown, mismatched, or
+   invalid signature is rejected before anything else is even considered.
+3. **Reconciliation binding.** If the receipt asserts
+   `instance.reconcilesHuginTaskId`, intake reads the registry's own native
+   submission event at that taskId (`getEvent(taskId, deriveEventId({recordKind:
+   "submission", taskId}))`) and requires it to exist with
+   `payload.originComponent === "hugin"`. An unresolvable or non-native target
+   is rejected (`reconciliation-target-not-found` /
+   `reconciliation-target-conflict`) rather than silently grafting an import
+   onto an unrelated or fabricated taskId.
+4. **Idempotent mapping into #232.** See below.
+
+## Mapping into the #232 registry — no double counting
+
+This module never reimplements the registry mechanism; it only decides what
+to feed `LearningRegistryStore`'s existing natural-key idempotent API.
+
+- **taskId.** When no reconciliation is asserted, intake derives a stable
+  external taskId deterministically from `sha256(surface, capacityPrincipal,
+  taskInstanceId)`. When reconciliation *is* asserted and verified, intake
+  reuses the **native** taskId instead — so a task done directly on Codex CLI
+  and also dispatched through Hugin accumulates evidence under one taskId,
+  never two.
+- **originComponent.** `submissionEventSchema.payload.originComponent`
+  (#232) was widened from `z.literal("hugin")` to
+  `z.enum(["hugin", "codex_app", "codex_cli", "pi"])` — a minimal, additive,
+  backward-compatible change (every existing native call site still passes
+  `"hugin"`). A submission's natural key is still only `{recordKind:
+  "submission", taskId}`, so an imported submission can never silently
+  overwrite, or be overwritten by, a native one at the same taskId: a
+  genuinely different `originComponent` claimed at an existing taskId is a
+  natural-key payload conflict (`RegistryNaturalKeyConflictError`), not a
+  merge.
+- **Submission is written once per taskId.** Intake checks
+  `getEvent(taskId, deriveEventId({recordKind:"submission", taskId}))` first.
+  If a submission already exists (native, or from an earlier receipt for the
+  same external task), it is left untouched — its `taskOutcomeRef` stays
+  pinned to whichever receipt (or native record) actually established the
+  task, so a later receipt for the same task never fights over that pointer.
+- **attemptId.** Derived from `sha256(surface, capacityPrincipal,
+  taskInstanceId)` with a distinct salt from the taskId derivation — stable
+  across an instance's observation and outcome receipts, so both resolve to
+  the same registry attempt. Attempt-reference is likewise written once per
+  attemptId, on whichever receipt (observation or outcome-only) arrives first.
+- **terminal-outcome** is recorded from an `outcome`-kind receipt via
+  `recordTerminalOutcome`, referencing the stored receipt doc.
+- **Evidence, referenced not copied.** The full validated (already
+  content-blind) receipt envelope, plus intake's own server-stamped
+  verification facts (`verifiedCapacityPrincipal`, `keyId`, `receivedAt`,
+  `coverage`, `reconciledWithNativeTask` — see `storedExternalReceiptSchema`),
+  is persisted once at a content-derived Munin key
+  (`tasks/<taskId>/external-receipt-<kind>-<hash>`) and referenced from the
+  registry events' `taskOutcomeRef` / `attemptStartRef` — the registry
+  mechanism itself never grows a receipt-shaped payload.
+
+## Idempotency and redelivery
+
+A receipt's Munin doc key is content-derived from `(taskId, attemptId, kind,
+receiptId)`. Redelivering the **exact same** receipt (bit-for-bit identical
+except the server-stamped `receivedAt` / derived `coverage`, which
+legitimately differ between two delivery attempts — mirroring
+`appendRegistryEvent`'s own `recordedAt` exclusion) is a genuine no-op: the
+doc write reports `duplicate`, and every downstream registry call
+(`recordSubmission` / `recordAttemptReference` / `recordTerminalOutcome`)
+independently resolves to `"exact-existing"` through the registry's own
+create-if-absent + canonical-equality replay logic. `ingestExternalReceipt`
+reports this back as `{status: "admitted", admission: "exact-existing"}`.
+
+Reusing a `receiptId` for **different** content (a mutated redelivery under
+the same id) is rejected as `receipt-id-reused-with-different-content` — the
+correct fix is a fresh `receiptId`, or (for a genuine correction to already-
+admitted evidence) the registry's own `writeCorrection` path.
+
+## Coverage states — marked honestly, never silently
+
+Every admitted receipt is inherently `"imported"` — it is never claimed as
+native Hugin coverage. A terminal receipt whose `occurredAt` is more than
+`EXTERNAL_RECEIPT_LATE_THRESHOLD_MS` (7 days) before intake's own
+server-stamped `receivedAt` is marked `"imported-late"` instead of silently
+folded in as if it had arrived promptly. An unverifiable or incomplete
+receipt is never admitted at all — see the rejection reasons above; there is
+no "unknown" coverage state for something that was never let in the door.
+
+## Capacity principals are not independent model evidence
+
+A `capacityPrincipal` (e.g. `"codex-cli-work"` vs. a second subscription
+`"codex-cli-personal"`) authenticates *who is allowed to report*, not
+*independent confirmation of a model's behaviour*. Two receipts from two
+different capacity principals — even for what a human would call "the same
+underlying task" — derive **different** taskIds/attemptIds (the derivation
+includes `capacityPrincipal`), so they are never merged into one
+"independently confirmed" record. Every admitted receipt additionally
+carries the fixed `reviewerIndependenceNote:
+"capacity-principal-not-independent-model-evidence"` literal in its stored
+evidence doc, so a downstream reader can never mistake capacity-principal
+plurality for reviewer independence (`quality-receipt.ts`'s actual
+`reviewerIndependence: "independent" | "self" | "unknown"` concept is a
+separate mechanism entirely, and imported receipts never populate it).
+
+## Known limitation — reconciliation proves nativeness, not task identity
+
+Reconciliation (`instance.reconcilesHuginTaskId`) verifies that the claimed
+target taskId is a genuine native Hugin submission
+(`payload.originComponent === "hugin"`) before honouring it. It does **not**
+independently verify that the target is actually *the same underlying unit
+of work* as the receipt claims — #232's native submission events carry only
+`{taskOutcomeRef, originComponent}`, no `sourceTaskRef` to check the
+receipt's own `instance.sourceTaskRef` against. Closing that gap would mean
+growing #232's own submission schema, which is out of this module's scope
+(`docs/learning-registry.md`'s stated boundary: this module consumes #232's
+mechanism, it does not extend it beyond the one additive `originComponent`
+widening documented above).
+
+This is an accepted, bounded limitation, not an open vulnerability in the
+threat model this repo actually operates under (a closed, single-operator
+system — see `docs/security/task-signing.md`'s own framing): only a
+capacity principal already holding an operator-provisioned
+`HUGIN_RECEIPT_PRODUCER_KEYS` entry can attempt reconciliation at all, and a
+wrong or careless reconciliation claim can only *append* an additional
+attempt-reference/terminal-outcome onto an already-existing native task's
+timeline — it can never fabricate, overwrite, double-count, or remove that
+task's own submission or terminal state. A future tightening (e.g. binding
+reconciliation to a shared `sourceTaskRef` once native submissions carry
+one) is a reasonable follow-up, not a blocker for this ticket.
+
+## Non-goals (per #237 scope)
+
+- No raw transcript/prompt/output/diff ingestion — only opaque, bounded
+  identity/reference tokens ever cross this boundary.
+- No treatment of two capacity-principal subscriptions as independent
+  reviewers.
+- No routing or model-promotion decision is ever made from an imported
+  receipt alone — this module only appends registry evidence.

--- a/docs/learning-registry.md
+++ b/docs/learning-registry.md
@@ -4,8 +4,15 @@
 task lifecycle. `src/learning-registry-schema.ts`, `src/learning-registry-store.ts`,
 and `src/learning-registry-view.ts` are a self-contained, tested library. Wiring
 calls into `src/index.ts`/`src/broker/handlers.ts` is deliberately left to the
-tickets that actually need it (#233, #237), to avoid broadening this PR's blast
+tickets that actually need it (#233), to avoid broadening this PR's blast
 radius across in-flight sibling work on `src/broker/handlers.ts` (#250/#251).
+External Codex/Pi receipt ingestion (#237) is now implemented on top of this
+mechanism — see `docs/external-receipt-intake.md`; it widened
+`submissionEventSchema.payload.originComponent` from `z.literal("hugin")` to
+an enum (`"hugin" | "codex_app" | "codex_cli" | "pi"`) as its one additive
+schema change here, and otherwise consumes `recordSubmission` /
+`recordAttemptReference` / `recordTerminalOutcome` / `getEvent` exactly as
+documented below.
 
 ## Scope boundary vs #241
 
@@ -181,7 +188,8 @@ on.
 
 - Monthly closes, cross-owner `gille-inference` accounting, and membership
   tokens for cross-owner erasure — #241.
-- Ingesting external Codex/Pi receipts — #237.
+- Ingesting external Codex/Pi receipts — implemented in #237 as a consumer of
+  this mechanism (`docs/external-receipt-intake.md`), not inside it.
 - Candidate packaging/promotion — #233.
 - Wiring `record*` calls into the live dispatcher lifecycle in
   `src/index.ts`/`src/broker/handlers.ts` — left to the consuming tickets so

--- a/src/external-receipt-intake.ts
+++ b/src/external-receipt-intake.ts
@@ -1,0 +1,378 @@
+/**
+ * External task/outcome receipt intake (hugin#237).
+ *
+ * Narrow, authenticated admission path for task/outcome receipts produced by
+ * surfaces that complete real work WITHOUT ever entering Hugin's dispatcher
+ * (Codex App, Codex CLI, Pi). An admitted receipt is mapped into the durable
+ * append-only learning registry (#232) via its own natural-key idempotent
+ * API — this module never reimplements the registry mechanism, it only
+ * decides what to feed it.
+ *
+ * Admission order, each step fail-closed with a specific reason:
+ *
+ *  1. Structural + content-blindness validation (`externalReceiptEnvelopeSchema`,
+ *     unknown fields and free-text-shaped tokens are rejected, not stripped).
+ *  2. Authenticity (`verifyExternalReceiptSignature`) — an unauthenticated or
+ *     mis-keyed body is never trusted, regardless of what it claims.
+ *  3. Reconciliation binding, when the receipt claims to correspond to an
+ *     already-native Hugin task — verified against the registry's own
+ *     submission record, never taken on the caller's word.
+ *  4. Idempotent, natural-key-safe mapping into #232's registry events.
+ *
+ * Non-goals (hugin#237 scope): no raw transcript ingestion, no treatment of
+ * two capacity-principal subscriptions as independent reviewers, and no
+ * routing/promotion decision is ever made from an imported receipt alone —
+ * this module only appends evidence.
+ */
+
+import { z } from "zod";
+import { MuninWriteRejectedError, type MuninClient } from "./munin-client.js";
+import {
+  LearningRegistryStore,
+  RegistryNaturalKeyConflictError,
+  registryEventNamespace,
+  deriveEventId,
+  canonicalEqual,
+  sha256Hex,
+  type RegistryEvidenceRef,
+} from "./learning-registry-store.js";
+import {
+  externalReceiptEnvelopeSchema,
+  storedExternalReceiptSchema,
+  EXTERNAL_RECEIPT_SCHEMA_VERSION,
+  EXTERNAL_RECEIPT_LATE_THRESHOLD_MS,
+  type ExternalReceiptEnvelope,
+  type ExternalReceiptCoverageState,
+  type StoredExternalReceipt,
+} from "./external-receipt-schema.js";
+import {
+  verifyExternalReceiptSignature,
+  type ExternalReceiptVerifyOptions,
+} from "./external-receipt-signing.js";
+import type { KeyStore } from "./task-signing.js";
+
+export const EXTERNAL_RECEIPT_REJECTION_REASONS = [
+  "incomplete-envelope",
+  "non-content-blind",
+  "unsupported-schema-version",
+  "unsupported-contract-version",
+  "missing-signature",
+  "unknown-producer",
+  "producer-mismatch",
+  "invalid-signature",
+  "reconciliation-target-not-found",
+  "reconciliation-target-conflict",
+  "receipt-id-reused-with-different-content",
+  "registry-natural-key-conflict",
+] as const;
+export type ExternalReceiptRejectionReason = (typeof EXTERNAL_RECEIPT_REJECTION_REASONS)[number];
+
+export interface ExternalReceiptRejection {
+  status: "rejected";
+  reason: ExternalReceiptRejectionReason;
+  detail: string;
+}
+
+export interface ExternalReceiptAdmission {
+  status: "admitted";
+  /** "created" the first time this evidence enters the registry; "exact-existing"
+   * when every underlying registry write was an idempotent no-op (a genuine
+   * re-ingest of the same receipt(s)). */
+  admission: "created" | "exact-existing";
+  taskId: string;
+  attemptId: string;
+  coverage: ExternalReceiptCoverageState;
+  reconciledWithNativeTask: boolean;
+  eventIds: string[];
+}
+
+export type ExternalReceiptIntakeResult = ExternalReceiptAdmission | ExternalReceiptRejection;
+
+export interface ExternalReceiptIntakeDeps {
+  munin: MuninClient;
+  registry: LearningRegistryStore;
+  keys: KeyStore;
+  now?: () => string;
+}
+
+function rejected(reason: ExternalReceiptRejectionReason, detail: string): ExternalReceiptRejection {
+  return { status: "rejected", reason, detail };
+}
+
+/**
+ * Classify a failed `externalReceiptEnvelopeSchema` parse into one of the
+ * intake's specific, auditable rejection reasons rather than one generic
+ * "invalid" bucket — so a caller (and a test) can tell "you sent something
+ * incomplete" apart from "you tried to sneak free text into an identity
+ * field" apart from "you're speaking a version we don't support".
+ */
+function classifyEnvelopeParseError(error: z.ZodError): ExternalReceiptRejection {
+  const issues = error.issues;
+
+  const unrecognized = issues.find((issue) => issue.code === "unrecognized_keys");
+  if (unrecognized) {
+    const keys = (unrecognized as { keys?: string[] }).keys ?? [];
+    return rejected(
+      "non-content-blind",
+      `unexpected field(s) not permitted by the content-blind receipt envelope: ${keys.join(", ") || "(unknown)"}`,
+    );
+  }
+
+  const schemaVersionIssue = issues.find((issue) => issue.path.length === 1 && issue.path[0] === "schemaVersion");
+  if (schemaVersionIssue) {
+    return rejected("unsupported-schema-version", schemaVersionIssue.message);
+  }
+
+  const contractVersionIssue = issues.find((issue) => issue.path.length === 1 && issue.path[0] === "contractVersion");
+  if (contractVersionIssue) {
+    return rejected("unsupported-contract-version", contractVersionIssue.message);
+  }
+
+  const tokenViolation = issues.find((issue) => issue.code === "invalid_format");
+  if (tokenViolation) {
+    return rejected(
+      "non-content-blind",
+      `field "${tokenViolation.path.join(".")}" is not a short opaque token — looks like free text rather than identity metadata: ${tokenViolation.message}`,
+    );
+  }
+
+  const detail = issues
+    .map((issue) => `${issue.path.join(".") || "(root)"}: ${issue.message}`)
+    .join("; ")
+    .slice(0, 500);
+  return rejected("incomplete-envelope", detail || "receipt envelope failed validation");
+}
+
+function deriveExternalTaskId(surface: string, capacityPrincipal: string, taskInstanceId: string): string {
+  return `ext-${sha256Hex(`task\0${surface}\0${capacityPrincipal}\0${taskInstanceId}`).slice(0, 40)}`;
+}
+
+function deriveExternalAttemptId(surface: string, capacityPrincipal: string, taskInstanceId: string): string {
+  return `ext-attempt-${sha256Hex(`attempt\0${surface}\0${capacityPrincipal}\0${taskInstanceId}`).slice(0, 32)}`;
+}
+
+function externalReceiptDocKey(taskId: string, attemptId: string, kind: string, receiptId: string): string {
+  return `external-receipt-${kind}-${sha256Hex(`${taskId}\0${attemptId}\0${kind}\0${receiptId}`).slice(0, 32)}`;
+}
+
+/** `receivedAt` and the `coverage` derived from it are the only fields that
+ * legitimately differ between two deliveries of the exact same logical
+ * receipt (retried now vs. retried tomorrow) — mirrors `appendRegistryEvent`'s
+ * own `recordedAt` exclusion in `learning-registry-store.ts`. */
+function withoutIntakeStampedFields(stored: StoredExternalReceipt): Record<string, unknown> {
+  const { receivedAt: _receivedAt, coverage: _coverage, ...rest } = stored as unknown as Record<string, unknown>;
+  return rest;
+}
+
+async function storeReceiptDoc(
+  munin: MuninClient,
+  stored: StoredExternalReceipt,
+): Promise<{ outcome: "created" | "duplicate"; stored: StoredExternalReceipt } | { outcome: "conflict" }> {
+  const namespace = registryEventNamespace(stored.taskId);
+  const key = externalReceiptDocKey(stored.taskId, stored.attemptId, stored.receipt.kind, stored.receipt.receiptId);
+  const content = JSON.stringify(stored);
+  const tags = ["external-receipt", `external-receipt-surface:${stored.receipt.surface}`];
+
+  try {
+    await munin.write(namespace, key, content, tags, undefined, "internal", true);
+    return { outcome: "created", stored };
+  } catch (err) {
+    if (err instanceof MuninWriteRejectedError && err.conflictReason === "already_exists") {
+      const existing = await munin.read(namespace, key);
+      if (!existing) {
+        throw new Error(`external receipt doc ${namespace}/${key} reported already-existing but could not be read back`);
+      }
+      const existingStored = storedExternalReceiptSchema.parse(JSON.parse(existing.content));
+      if (canonicalEqual(withoutIntakeStampedFields(existingStored), withoutIntakeStampedFields(stored))) {
+        return { outcome: "duplicate", stored: existingStored };
+      }
+      return { outcome: "conflict" };
+    }
+    throw err;
+  }
+}
+
+/**
+ * Admit one external task/outcome receipt into the durable learning
+ * registry, or reject it with a specific auditable reason. Content-blind
+ * throughout: nothing this function reads, writes, or logs is ever raw
+ * prompt/output/transcript/diff content — see `src/external-receipt-schema.ts`.
+ */
+export async function ingestExternalReceipt(
+  deps: ExternalReceiptIntakeDeps,
+  rawEnvelope: unknown,
+  signatureRaw: string | null | undefined,
+  verifyOpts: ExternalReceiptVerifyOptions = {},
+): Promise<ExternalReceiptIntakeResult> {
+  const now = deps.now ?? (() => new Date().toISOString());
+
+  const parsed = externalReceiptEnvelopeSchema.safeParse(rawEnvelope);
+  if (!parsed.success) {
+    return classifyEnvelopeParseError(parsed.error);
+  }
+  const receipt: ExternalReceiptEnvelope = parsed.data;
+
+  // Authenticity — never trust the body's own claimed capacityPrincipal
+  // without a verified signature binding it.
+  const verification = verifyExternalReceiptSignature(receipt, signatureRaw, deps.keys, verifyOpts);
+  if (verification.status !== "valid") {
+    const reason =
+      verification.status === "missing" ? "missing-signature"
+      : verification.status === "unknown-producer" ? "unknown-producer"
+      : verification.status === "producer-mismatch" ? "producer-mismatch"
+      : "invalid-signature"; // malformed | unsupported-version | invalid | expired | future-skew
+    return rejected(reason, verification.reason ?? `signature status: ${verification.status}`);
+  }
+
+  // Reconciliation — an asserted link to a native Hugin task must resolve to
+  // a real native submission event, never be taken on faith.
+  //
+  // Known accepted limitation (flagged by the #237 M5 review): this proves
+  // the target taskId is a genuine native Hugin submission, but not that it
+  // is actually the SAME underlying unit of work as this receipt — native
+  // submission events (#232) do not themselves carry a sourceTaskRef to
+  // check against. Closing that gap would mean growing #232's own
+  // submission schema, which is out of this module's scope (see
+  // docs/learning-registry.md's boundary note). The blast radius is bounded
+  // by the operator-provisioned producer keystore (only a registered,
+  // trusted capacity principal can even attempt reconciliation) and by what
+  // a wrong reconciliation can actually do: it can only append an additional
+  // attempt-reference/terminal-outcome to an already-existing native task's
+  // timeline — it can never fabricate, overwrite, or remove that task's own
+  // submission or terminal state. See docs/external-receipt-intake.md.
+  let taskId: string;
+  let reconciledWithNativeTask = false;
+  const reconcileTarget = receipt.instance.reconcilesHuginTaskId;
+  if (reconcileTarget !== undefined) {
+    const nativeSubmissionId = deriveEventId({ recordKind: "submission", taskId: reconcileTarget });
+    const nativeSubmission = await deps.registry.getEvent(reconcileTarget, nativeSubmissionId);
+    if (!nativeSubmission) {
+      return rejected(
+        "reconciliation-target-not-found",
+        `no native submission event found at declared reconciliation target task "${reconcileTarget}"`,
+      );
+    }
+    if (nativeSubmission.recordKind !== "submission" || nativeSubmission.payload.originComponent !== "hugin") {
+      return rejected(
+        "reconciliation-target-conflict",
+        `reconciliation target task "${reconcileTarget}" is not a native Hugin submission (originComponent=${
+          nativeSubmission.recordKind === "submission" ? nativeSubmission.payload.originComponent : "n/a"
+        })`,
+      );
+    }
+    taskId = reconcileTarget;
+    reconciledWithNativeTask = true;
+  } else {
+    taskId = deriveExternalTaskId(receipt.surface, receipt.capacityPrincipal, receipt.instance.taskInstanceId);
+  }
+
+  const attemptId = deriveExternalAttemptId(receipt.surface, receipt.capacityPrincipal, receipt.instance.taskInstanceId);
+  const receivedAt = now();
+  const lateMs = Date.parse(receivedAt) - Date.parse(receipt.occurredAt);
+  const coverage: ExternalReceiptCoverageState = lateMs > EXTERNAL_RECEIPT_LATE_THRESHOLD_MS ? "imported-late" : "imported";
+
+  const storedCandidate = storedExternalReceiptSchema.parse({
+    schemaVersion: EXTERNAL_RECEIPT_SCHEMA_VERSION,
+    receipt,
+    taskId,
+    attemptId,
+    verifiedCapacityPrincipal: receipt.capacityPrincipal,
+    keyId: verification.keyId,
+    receivedAt,
+    coverage,
+    reconciledWithNativeTask,
+  });
+
+  const docResult = await storeReceiptDoc(deps.munin, storedCandidate);
+  if (docResult.outcome === "conflict") {
+    return rejected(
+      "receipt-id-reused-with-different-content",
+      `receiptId "${receipt.receiptId}" was already ingested with different content for task "${taskId}" / attempt "${attemptId}" — file a distinct receiptId or a correction, do not redeliver a mutated receipt under the same id`,
+    );
+  }
+  const stored = docResult.stored;
+  const docRef: RegistryEvidenceRef = {
+    namespace: registryEventNamespace(stored.taskId),
+    key: externalReceiptDocKey(stored.taskId, stored.attemptId, stored.receipt.kind, stored.receipt.receiptId),
+  };
+
+  const eventIds: string[] = [];
+  let anyCreated = docResult.outcome === "created";
+
+  try {
+    // Submission — only the FIRST receipt to arrive for this taskId creates
+    // it, so its taskOutcomeRef stays pinned to whichever receipt actually
+    // established the task. A reconciled task already has a native
+    // submission and must never get a second, conflicting one.
+    const submissionEventId = deriveEventId({ recordKind: "submission", taskId: stored.taskId });
+    const existingSubmission = await deps.registry.getEvent(stored.taskId, submissionEventId);
+    if (!existingSubmission) {
+      const submissionResult = await deps.registry.recordSubmission({
+        taskId: stored.taskId,
+        taskOutcomeRef: docRef,
+        occurredAt: receipt.occurredAt,
+        originComponent: receipt.surface,
+      });
+      anyCreated = anyCreated || submissionResult.status === "created";
+      eventIds.push(submissionResult.event.eventId);
+    } else {
+      eventIds.push(existingSubmission.eventId);
+    }
+
+    // Attempt-reference — same idempotent-pin logic: only the first receipt
+    // for this attemptId creates it.
+    const attemptRefEventId = deriveEventId({ recordKind: "attempt-reference", taskId: stored.taskId, attemptId: stored.attemptId });
+    const existingAttemptRef = await deps.registry.getEvent(stored.taskId, attemptRefEventId);
+    if (!existingAttemptRef) {
+      const attemptRefResult = await deps.registry.recordAttemptReference({
+        taskId: stored.taskId,
+        attemptId: stored.attemptId,
+        attemptStartRef: docRef,
+        taskOutcomeRef: docRef,
+        occurredAt: receipt.occurredAt,
+      });
+      anyCreated = anyCreated || attemptRefResult.status === "created";
+      eventIds.push(attemptRefResult.event.eventId);
+    } else {
+      eventIds.push(existingAttemptRef.eventId);
+    }
+
+    if (receipt.kind === "outcome") {
+      // Unlike submission/attempt-reference above, terminal-outcome is
+      // written unconditionally rather than pre-checked with getEvent: its
+      // natural key is {taskId, attemptId} and only one genuine terminal
+      // fact is ever expected per attempt, so the registry's own
+      // create-if-absent-or-conflict behaviour (idempotent no-op on an exact
+      // replay, RegistryNaturalKeyConflictError on a genuinely different
+      // second outcome) is already the correct and complete answer — a
+      // pre-check would only add a redundant read.
+      const terminalResult = await deps.registry.recordTerminalOutcome({
+        taskId: stored.taskId,
+        attemptId: stored.attemptId,
+        outcome: receipt.outcome,
+        taskOutcomeRef: docRef,
+        occurredAt: receipt.occurredAt,
+      });
+      anyCreated = anyCreated || terminalResult.status === "created";
+      eventIds.push(terminalResult.event.eventId);
+    }
+  } catch (err) {
+    if (err instanceof RegistryNaturalKeyConflictError) {
+      return rejected(
+        "registry-natural-key-conflict",
+        `registry already holds different evidence at the same natural key: ${err.message}`,
+      );
+    }
+    throw err;
+  }
+
+  return {
+    status: "admitted",
+    admission: anyCreated ? "created" : "exact-existing",
+    taskId: stored.taskId,
+    attemptId: stored.attemptId,
+    coverage: stored.coverage,
+    reconciledWithNativeTask,
+    eventIds,
+  };
+}

--- a/src/external-receipt-schema.ts
+++ b/src/external-receipt-schema.ts
@@ -1,0 +1,203 @@
+/**
+ * External task/outcome receipt intake — schema (hugin#237).
+ *
+ * Magnus's day-to-day work is moving toward Codex App, Codex CLI, and Pi
+ * surfaces that complete real tasks WITHOUT ever entering Hugin's dispatcher.
+ * Without an intake path, the durable learning registry (#232) stays
+ * systematically incomplete and success-biased toward Hugin-managed
+ * execution. This module defines the versioned, content-blind wire shape a
+ * receipt must satisfy to become admissible evidence — see
+ * `src/external-receipt-intake.ts` for authentication and admission, and
+ * `docs/external-receipt-intake.md` for the design writeup.
+ *
+ * Content-blindness is structural, not a convention layered on top:
+ *
+ *  - Every object in this file is `.strict()`, so an attacker (or a careless
+ *    producer) cannot smuggle an extra `transcript`/`prompt`/`diff` field
+ *    past validation — Zod rejects unknown keys outright.
+ *  - Every identity/instance string is an *opaque token*
+ *    (`externalReceiptTokenSchema` / `externalReceiptRefTokenSchema`): a
+ *    bounded character class with no whitespace, so free-text content
+ *    structurally cannot fit through an identity field either.
+ *  - The one required "note" about capacity vs. model independence is a
+ *    fixed literal (`CAPACITY_PRINCIPAL_INDEPENDENCE_NOTE`), never
+ *    caller-supplied prose, so it cannot become a content-smuggling vector.
+ *
+ * Non-goals (see hugin#237 scope): this is not a transcript importer, not a
+ * second reviewer-independence mechanism, and not a routing/promotion input.
+ */
+
+import { z } from "zod";
+import { LEARNING_TASK_CONTRACT_VERSION } from "./learning-task-handshake.js";
+import { registryTimestampSchema } from "./learning-registry-schema.js";
+import { taskExecutionOutcomeSchema } from "./task-result-schema.js";
+
+export const EXTERNAL_RECEIPT_SCHEMA_VERSION = 1 as const;
+
+/** Versioned under the same LearningTaskContract the gateway side (#230/#231/
+ * gille-inference#10) uses, per the #237 scope. An envelope declaring any
+ * other value fails closed as `unsupported-contract-version`. */
+export const EXTERNAL_RECEIPT_CONTRACT_VERSION = LEARNING_TASK_CONTRACT_VERSION;
+
+/** The three non-Hugin surfaces this intake accepts. Native Hugin execution
+ * never goes through this path — it already has `originComponent: "hugin"`. */
+export const EXTERNAL_RECEIPT_SURFACES = ["codex_app", "codex_cli", "pi"] as const;
+export const externalReceiptSurfaceSchema = z.enum(EXTERNAL_RECEIPT_SURFACES);
+export type ExternalReceiptSurface = z.infer<typeof externalReceiptSurfaceSchema>;
+
+export const EXTERNAL_RECEIPT_KINDS = ["observation", "outcome"] as const;
+export const externalReceiptKindSchema = z.enum(EXTERNAL_RECEIPT_KINDS);
+export type ExternalReceiptKind = z.infer<typeof externalReceiptKindSchema>;
+
+/** Producer coverage state a successfully admitted receipt is honestly
+ * marked with (#237 scope: "a late/imported receipt is marked as such
+ * honestly"). Every admitted external receipt is inherently "imported" —
+ * this is never claimed as native Hugin coverage. */
+export const EXTERNAL_RECEIPT_COVERAGE_STATES = ["imported", "imported-late"] as const;
+export const externalReceiptCoverageStateSchema = z.enum(EXTERNAL_RECEIPT_COVERAGE_STATES);
+export type ExternalReceiptCoverageState = z.infer<typeof externalReceiptCoverageStateSchema>;
+
+/** A terminal receipt arriving more than this long after its own `occurredAt`
+ * is marked `imported-late` rather than silently folded in as if it had been
+ * timely. Generous on purpose — external surfaces have no dispatcher
+ * heartbeat forcing prompt reporting. */
+export const EXTERNAL_RECEIPT_LATE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Fixed, non-caller-supplied annotation bound into every admitted receipt's
+ * stored record (#237: "treat separate subscriptions as capacity principals,
+ * NOT independent model evidence... a note in the record"). Being a literal
+ * rather than free text keeps this assertion itself content-blind and
+ * tamper-proof: a producer cannot phrase their way out of it, and it cannot
+ * become a channel for smuggled prose.
+ */
+export const CAPACITY_PRINCIPAL_INDEPENDENCE_NOTE =
+  "capacity-principal-not-independent-model-evidence" as const;
+
+/**
+ * Opaque identity/instance token: letters, digits, and a small punctuation
+ * set used by real identifiers (`.`, `_`, `:`, `@`, `/`, `-`). No whitespace
+ * or control characters, so this can never hold a sentence, let alone a
+ * transcript — it is what makes identity fields structurally content-blind
+ * rather than merely policy-blind.
+ */
+export const externalReceiptTokenSchema = z.string().regex(
+  /^[A-Za-z0-9._:@/-]{1,128}$/,
+  { message: "must be a short opaque token (letters, digits, . _ : @ / -), not free text" },
+);
+
+/** Slightly more permissive token for a source-task reference id (e.g.
+ * `owner/repo#123`), which legitimately needs `#`. Still bounded and
+ * whitespace-free. */
+export const externalReceiptRefTokenSchema = z.string().regex(
+  /^[A-Za-z0-9._:@/#-]{1,256}$/,
+  { message: "must be a short opaque reference token, not free text" },
+);
+
+export const externalTaskIdentitySchema = z.object({
+  /** e.g. "openai", "anthropic". Never used alone as evidence of model
+   * behaviour — always read together with `model` and `harness`. */
+  provider: externalReceiptTokenSchema,
+  model: externalReceiptTokenSchema,
+  /** e.g. "codex-cli@1.4.2", "pi-app@4.5.0". */
+  harness: externalReceiptTokenSchema,
+}).strict();
+export type ExternalTaskIdentity = z.infer<typeof externalTaskIdentitySchema>;
+
+/** Opaque descriptor of the originating task — a reference, never content.
+ * `system` names the reference space (e.g. "github-issue", "github-pr",
+ * "branch"); `id` is that system's own opaque id/slug, never a rendered
+ * prompt, diff, or transcript excerpt. */
+export const sourceTaskRefSchema = z.object({
+  system: externalReceiptTokenSchema,
+  id: externalReceiptRefTokenSchema,
+}).strict();
+export type SourceTaskRef = z.infer<typeof sourceTaskRefSchema>;
+
+export const externalTaskInstanceSchema = z.object({
+  /** Stable across an instance's observation and outcome receipts — this is
+   * what lets both receipts resolve to the same registry attempt. */
+  taskInstanceId: externalReceiptTokenSchema,
+  sourceTaskRef: sourceTaskRefSchema,
+  /**
+   * Optional explicit link to an existing NATIVE Hugin registry taskId for
+   * the same logical unit of work (e.g. the same issue/branch/PR was also
+   * dispatched through Hugin). Intake verifies this points at a real native
+   * submission before honouring it — an unverifiable claim fails closed
+   * (`reconciliation-target-not-found` / `-conflict`) rather than silently
+   * grafting an import onto an unrelated or fabricated taskId.
+   */
+  reconcilesHuginTaskId: externalReceiptTokenSchema.optional(),
+}).strict();
+export type ExternalTaskInstance = z.infer<typeof externalTaskInstanceSchema>;
+
+const externalReceiptBaseFields = {
+  schemaVersion: z.literal(EXTERNAL_RECEIPT_SCHEMA_VERSION),
+  contractVersion: z.literal(EXTERNAL_RECEIPT_CONTRACT_VERSION),
+  surface: externalReceiptSurfaceSchema,
+  /** Delivery-level id for this exact receipt (distinct from the stable
+   * `taskInstanceId` an observation and its later outcome share). */
+  receiptId: externalReceiptTokenSchema,
+  /** The authenticated producer/subscription identity that signed this
+   * receipt — a capacity principal, never independent model evidence (see
+   * `CAPACITY_PRINCIPAL_INDEPENDENCE_NOTE`). */
+  capacityPrincipal: externalReceiptTokenSchema,
+  identity: externalTaskIdentitySchema,
+  instance: externalTaskInstanceSchema,
+  /** When the underlying fact happened, per the producer. */
+  occurredAt: registryTimestampSchema,
+  /** When the producer generated/signed this receipt — may be well after
+   * `occurredAt` for a late report; never before it. */
+  producedAt: registryTimestampSchema,
+  reviewerIndependenceNote: z.literal(CAPACITY_PRINCIPAL_INDEPENDENCE_NOTE),
+};
+
+const externalObservationReceiptSchema = z.object({
+  ...externalReceiptBaseFields,
+  kind: z.literal("observation"),
+}).strict();
+
+const externalOutcomeReceiptSchema = z.object({
+  ...externalReceiptBaseFields,
+  kind: z.literal("outcome"),
+  outcome: taskExecutionOutcomeSchema,
+}).strict();
+
+export const externalReceiptEnvelopeSchema = z.discriminatedUnion("kind", [
+  externalObservationReceiptSchema,
+  externalOutcomeReceiptSchema,
+]).superRefine((value, ctx) => {
+  if (Date.parse(value.occurredAt) > Date.parse(value.producedAt)) {
+    ctx.addIssue({ code: "custom", message: "occurredAt cannot be after producedAt" });
+  }
+});
+export type ExternalObservationReceipt = z.infer<typeof externalObservationReceiptSchema>;
+export type ExternalOutcomeReceipt = z.infer<typeof externalOutcomeReceiptSchema>;
+export type ExternalReceiptEnvelope = z.infer<typeof externalReceiptEnvelopeSchema>;
+
+/**
+ * The durable, content-blind record intake persists once a receipt is
+ * admitted — this is the evidence a registry `taskOutcomeRef` /
+ * `attemptStartRef` / `attemptOutcomeRef` points at (referenced, never
+ * copied into the registry mechanism itself). It carries the full validated
+ * envelope (already proven content-blind above) plus intake's own
+ * server-stamped verification facts, which a caller can never forge because
+ * they are never accepted as caller input.
+ */
+export const storedExternalReceiptSchema = z.object({
+  schemaVersion: z.literal(EXTERNAL_RECEIPT_SCHEMA_VERSION),
+  receipt: externalReceiptEnvelopeSchema,
+  taskId: z.string().min(1),
+  attemptId: z.string().min(1),
+  /** The capacityPrincipal that actually verified — always equal to
+   * `receipt.capacityPrincipal` once stored, but kept as its own field so a
+   * reader never has to trust the nested envelope for the load-bearing fact. */
+  verifiedCapacityPrincipal: externalReceiptTokenSchema,
+  keyId: externalReceiptTokenSchema,
+  /** Hugin-stamped intake time — never caller-supplied, so lateness cannot
+   * be gamed by asserting a favourable receive time. */
+  receivedAt: registryTimestampSchema,
+  coverage: externalReceiptCoverageStateSchema,
+  reconciledWithNativeTask: z.boolean(),
+}).strict();
+export type StoredExternalReceipt = z.infer<typeof storedExternalReceiptSchema>;

--- a/src/external-receipt-signing.ts
+++ b/src/external-receipt-signing.ts
@@ -1,0 +1,214 @@
+/**
+ * External task-receipt signing and verification (hugin#237).
+ *
+ * Mirrors `src/task-signing.ts`'s HMAC-SHA256 / sorted-canonical-payload /
+ * keyId-rotation-alias scheme (see docs/security/task-signing.md) so the two
+ * authenticated-intake surfaces stay recognisably the same shape, but keeps
+ * its own keystore and canonical payload: a receipt producer is a different
+ * trust domain from a task *submitter* (it authenticates a completed
+ * external task/outcome fact, not a prompt Hugin is about to execute), and
+ * the fields being bound differ accordingly. Reuses `task-signing.ts`'s
+ * secret-decoding, keystore-JSON-parsing, and keyId/principal-aliasing
+ * helpers directly rather than re-implementing them.
+ *
+ * Unlike task submission signing (which has an `off`/`warn`/`require`
+ * rollout policy), receipt intake has no policy knob: this is a brand-new
+ * authenticated-only surface, so verification is always mandatory — see
+ * `src/external-receipt-intake.ts`.
+ */
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+import * as fs from "node:fs";
+import {
+  decodeSecret,
+  keyIdMatchesSubmitter,
+  parseKeyStoreJson,
+  parseSignature,
+  type KeyStore,
+} from "./task-signing.js";
+import type { ExternalReceiptEnvelope } from "./external-receipt-schema.js";
+
+export const EXTERNAL_RECEIPT_SIGNATURE_VERSION = "v1" as const;
+
+export type ExternalReceiptSignatureStatus =
+  | "valid"
+  | "invalid"
+  | "missing"
+  | "unknown-producer"
+  | "producer-mismatch"
+  | "malformed"
+  | "unsupported-version"
+  | "expired"
+  | "future-skew";
+
+export interface ExternalReceiptVerification {
+  status: ExternalReceiptSignatureStatus;
+  keyId?: string;
+  reason?: string;
+}
+
+export interface ExternalReceiptVerifyOptions {
+  /** Maximum age in seconds for `producedAt`, measured from now. 0 disables
+   * the check (default) — callers that want enforcement pass the configured
+   * window explicitly, same convention as `verifyTaskSignature`. */
+  maxAgeS?: number;
+  /** Tolerance in seconds for a `producedAt` that appears to be in the
+   * future (clock skew). Default: 60. */
+  futureToleranceS?: number;
+}
+
+/**
+ * Canonical payload over the receipt's own content-blind identity fields.
+ * Sorted `key=value` pairs, newline-delimited, trailing newline — same shape
+ * as `buildCanonicalPayload` in task-signing.ts. Binding every identity/
+ * instance/timestamp field (not just an opaque digest of the whole object)
+ * keeps this auditable and independently reproducible by a human reading
+ * docs/security/task-signing.md's sibling doc for receipts.
+ */
+export function buildExternalReceiptCanonicalPayload(receipt: ExternalReceiptEnvelope): string {
+  const fields: Record<string, string> = {
+    "capacity-principal": receipt.capacityPrincipal,
+    "contract-version": receipt.contractVersion,
+    harness: receipt.identity.harness,
+    kind: receipt.kind,
+    model: receipt.identity.model,
+    "occurred-at": receipt.occurredAt,
+    "produced-at": receipt.producedAt,
+    provider: receipt.identity.provider,
+    "receipt-id": receipt.receiptId,
+    "reconciles-hugin-task-id": receipt.instance.reconcilesHuginTaskId ?? "",
+    "schema-version": String(receipt.schemaVersion),
+    "source-task-ref": `${receipt.instance.sourceTaskRef.system}:${receipt.instance.sourceTaskRef.id}`,
+    surface: receipt.surface,
+    "task-instance-id": receipt.instance.taskInstanceId,
+    ...(receipt.kind === "outcome" ? { outcome: receipt.outcome } : {}),
+  };
+
+  return (
+    Object.keys(fields)
+      .sort()
+      .map((key) => `${key}=${fields[key]}`)
+      .join("\n") + "\n"
+  );
+}
+
+export function signExternalReceipt(
+  receipt: ExternalReceiptEnvelope,
+  keyId: string,
+  secretHex: string,
+): string {
+  const secret = decodeSecret(secretHex);
+  const payload = buildExternalReceiptCanonicalPayload(receipt);
+  const hex = createHmac("sha256", secret).update(payload).digest("hex");
+  return `${EXTERNAL_RECEIPT_SIGNATURE_VERSION}:${keyId}:${hex}`;
+}
+
+/**
+ * Verify an external receipt's signature. Never trusts the envelope's own
+ * `capacityPrincipal` alone — the keyId must resolve to a configured key AND
+ * alias back to that exact `capacityPrincipal` (or a `<principal>-<rotation>`
+ * form), otherwise any signer holding any configured key could mint receipts
+ * claiming to be a different producer's capacity principal.
+ */
+export function verifyExternalReceiptSignature(
+  receipt: ExternalReceiptEnvelope,
+  signatureRaw: string | null | undefined,
+  keys: KeyStore,
+  opts: ExternalReceiptVerifyOptions = {},
+): ExternalReceiptVerification {
+  if (!signatureRaw) return { status: "missing" };
+
+  const parsed = parseSignature(signatureRaw);
+  if (!parsed) return { status: "malformed", reason: "unparseable signature field" };
+
+  if (parsed.version !== EXTERNAL_RECEIPT_SIGNATURE_VERSION) {
+    return {
+      status: "unsupported-version",
+      keyId: parsed.keyId,
+      reason: `unsupported signature version "${parsed.version}" (expected ${EXTERNAL_RECEIPT_SIGNATURE_VERSION})`,
+    };
+  }
+
+  const secretHex = keys[parsed.keyId];
+  if (!secretHex) {
+    return {
+      status: "unknown-producer",
+      keyId: parsed.keyId,
+      reason: `no receipt-producer key configured for "${parsed.keyId}"`,
+    };
+  }
+
+  if (!keyIdMatchesSubmitter(parsed.keyId, receipt.capacityPrincipal)) {
+    return {
+      status: "producer-mismatch",
+      keyId: parsed.keyId,
+      reason: `keyId "${parsed.keyId}" is not authorized to sign for capacity principal "${receipt.capacityPrincipal}"`,
+    };
+  }
+
+  const expectedHex = signExternalReceipt(receipt, parsed.keyId, secretHex).split(":")[2];
+  const actual = Buffer.from(parsed.hex, "hex");
+  const expected = Buffer.from(expectedHex, "hex");
+
+  if (actual.length !== expected.length) {
+    return { status: "invalid", keyId: parsed.keyId, reason: "signature length mismatch" };
+  }
+  if (!timingSafeEqual(actual, expected)) {
+    return { status: "invalid", keyId: parsed.keyId, reason: "signature does not match" };
+  }
+
+  const maxAgeS = opts.maxAgeS ?? 0;
+  const futureToleranceS = opts.futureToleranceS ?? 60;
+
+  if (maxAgeS > 0) {
+    const producedMs = Date.parse(receipt.producedAt);
+    if (Number.isNaN(producedMs)) {
+      return { status: "invalid", keyId: parsed.keyId, reason: "producedAt is not a valid ISO date" };
+    }
+    const ageS = (Date.now() - producedMs) / 1000;
+    if (ageS > maxAgeS) {
+      return {
+        status: "expired",
+        keyId: parsed.keyId,
+        reason: `signature expired: producedAt is ${Math.round(ageS)}s ago (max ${maxAgeS}s)`,
+      };
+    }
+    if (ageS < -futureToleranceS) {
+      return {
+        status: "future-skew",
+        keyId: parsed.keyId,
+        reason: `signature from the future: producedAt is ${Math.round(-ageS)}s ahead (tolerance ${futureToleranceS}s)`,
+      };
+    }
+  }
+
+  return { status: "valid", keyId: parsed.keyId };
+}
+
+/**
+ * Load the receipt-producer keystore from `HUGIN_RECEIPT_PRODUCER_KEYS`
+ * (inline JSON) or `HUGIN_RECEIPT_PRODUCER_KEYS_FILE` (path to JSON file,
+ * takes precedence). Deliberately a *separate* keystore from
+ * `HUGIN_SUBMITTER_KEYS` — a task submitter and a receipt producer are
+ * different trust domains even when the same human operates both.
+ */
+export function loadReceiptProducerKeyStoreFromEnv(env: NodeJS.ProcessEnv = process.env): KeyStore {
+  const filePath = env.HUGIN_RECEIPT_PRODUCER_KEYS_FILE?.trim();
+  if (filePath) {
+    try {
+      const raw = fs.readFileSync(filePath, "utf8");
+      return parseKeyStoreJson(raw, `file ${filePath}`);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[external-receipt-signing] failed to load HUGIN_RECEIPT_PRODUCER_KEYS_FILE (${filePath}): ${msg}`);
+      return {};
+    }
+  }
+
+  const inline = env.HUGIN_RECEIPT_PRODUCER_KEYS?.trim();
+  if (inline) {
+    return parseKeyStoreJson(inline, "HUGIN_RECEIPT_PRODUCER_KEYS");
+  }
+
+  return {};
+}

--- a/src/learning-registry-schema.ts
+++ b/src/learning-registry-schema.ts
@@ -204,12 +204,25 @@ const registryEventBase = {
   recordedAt: registryTimestampSchema,
 };
 
+/**
+ * Which surface originated this task. `"hugin"` is native dispatcher
+ * execution; the other three are content-blind imports of external task/
+ * outcome receipts (hugin#237) — a submission's own natural key is still
+ * only `{recordKind: "submission", taskId}`, so an imported submission never
+ * silently overwrites or is overwritten by a native one at the same taskId:
+ * a genuinely different `originComponent` at an existing taskId is a natural
+ * -key payload conflict (`RegistryNaturalKeyConflictError`), not a merge.
+ */
+export const REGISTRY_ORIGIN_COMPONENTS = ["hugin", "codex_app", "codex_cli", "pi"] as const;
+export const registryOriginComponentSchema = z.enum(REGISTRY_ORIGIN_COMPONENTS);
+export type RegistryOriginComponent = z.infer<typeof registryOriginComponentSchema>;
+
 export const submissionEventSchema = z.object({
   ...registryEventBase,
   recordKind: z.literal("submission"),
   payload: z.object({
     taskOutcomeRef: registryEvidenceRefSchema,
-    originComponent: z.literal("hugin"),
+    originComponent: registryOriginComponentSchema,
   }).strict(),
 }).strict();
 

--- a/src/learning-registry-store.ts
+++ b/src/learning-registry-store.ts
@@ -62,6 +62,7 @@ import {
   type RegistryEvidenceRef,
   type RegistryHighWaterDoc,
   type RegistryNaturalKey,
+  type RegistryOriginComponent,
   type RegistryPartitionProof,
   type RegistryRecordKind,
   type SubmissionEvent,
@@ -250,6 +251,9 @@ export class LearningRegistryStore {
     taskId: string;
     taskOutcomeRef: RegistryEvidenceRef;
     occurredAt: string;
+    /** Defaults to "hugin" (native dispatch). External-receipt intake (#237)
+     * passes the originating surface instead. */
+    originComponent?: RegistryOriginComponent;
   }): Promise<AppendResult<SubmissionEvent>> {
     const naturalKey: RegistryNaturalKey = { recordKind: "submission", taskId: input.taskId };
     const recordedAt = this.now();
@@ -261,7 +265,10 @@ export class LearningRegistryStore {
       membership: buildMembership({ naturalKey, issuedAt: input.occurredAt }),
       occurredAt: input.occurredAt,
       recordedAt,
-      payload: { taskOutcomeRef: input.taskOutcomeRef, originComponent: "hugin" },
+      payload: {
+        taskOutcomeRef: input.taskOutcomeRef,
+        originComponent: input.originComponent ?? "hugin",
+      },
     });
     return appendRegistryEvent(this.munin, event, recordedAt);
   }

--- a/src/task-signing.ts
+++ b/src/task-signing.ts
@@ -314,7 +314,10 @@ export function loadKeyStoreFromEnv(env: NodeJS.ProcessEnv = process.env): KeySt
   return {};
 }
 
-function parseKeyStoreJson(raw: string, source: string): KeyStore {
+/** Exported so other HMAC-keystore surfaces (e.g. hugin#237's external
+ * receipt producer keys) reuse the same tolerant-parse/warn-and-empty
+ * behaviour instead of re-implementing it. */
+export function parseKeyStoreJson(raw: string, source: string): KeyStore {
   try {
     const parsed = JSON.parse(raw);
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
@@ -350,7 +353,14 @@ function sanitizeValue(v: string): string {
   return v.replace(/[\r\n]+/g, " ").trim();
 }
 
-function keyIdMatchesSubmitter(keyId: string, submitter: string): boolean {
+/**
+ * A signer's keyId must equal the claimed principal name or be a rotation
+ * alias `<principal>-<rotation>` (e.g. `codex-cli-2026q3`). Exported so other
+ * authenticated-intake surfaces with the same rotation-alias shape (e.g. the
+ * external task-receipt producer keystore, hugin#237) reuse one aliasing rule
+ * instead of re-deriving it.
+ */
+export function keyIdMatchesSubmitter(keyId: string, submitter: string): boolean {
   if (!keyId || !submitter) return false;
   if (keyId === submitter) return true;
   return keyId.startsWith(`${submitter}-`);
@@ -371,7 +381,9 @@ export function canonicalizePrompt(raw: string): string {
  * arbitrary strings — useful for tests and non-production config. HMAC
  * accepts any byte length, but short secrets weaken the guarantee.
  */
-function decodeSecret(raw: string): Buffer {
+/** Exported so other HMAC-keystore surfaces (e.g. hugin#237's external
+ * receipt producer keys) accept the same hex/base64/utf8 secret shapes. */
+export function decodeSecret(raw: string): Buffer {
   const trimmed = raw.trim();
   if (/^[0-9a-f]+$/i.test(trimmed) && trimmed.length % 2 === 0 && trimmed.length >= 32) {
     return Buffer.from(trimmed, "hex");

--- a/tests/external-receipt-intake.test.ts
+++ b/tests/external-receipt-intake.test.ts
@@ -1,0 +1,417 @@
+import { describe, expect, it } from "vitest";
+import { MuninWriteRejectedError, type MuninClient } from "../src/munin-client.js";
+import { LearningRegistryStore } from "../src/learning-registry-store.js";
+import { buildTaskLifecycleTimeline } from "../src/learning-registry-view.js";
+import {
+  ingestExternalReceipt,
+  type ExternalReceiptIntakeDeps,
+} from "../src/external-receipt-intake.js";
+import { signExternalReceipt } from "../src/external-receipt-signing.js";
+import {
+  CAPACITY_PRINCIPAL_INDEPENDENCE_NOTE,
+  EXTERNAL_RECEIPT_CONTRACT_VERSION,
+  EXTERNAL_RECEIPT_SCHEMA_VERSION,
+  storedExternalReceiptSchema,
+  type ExternalReceiptEnvelope,
+} from "../src/external-receipt-schema.js";
+
+interface StoredEntry {
+  namespace: string;
+  key: string;
+  content: string;
+  tags: string[];
+  classification?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Same in-memory create-if-absent / CAS Munin double used by
+ * tests/learning-registry-store.test.ts, with a controllable clock so
+ * "late" coverage can be tested deterministically. */
+class InMemoryMunin {
+  private entries: StoredEntry[] = [];
+  private seq = 0;
+
+  private clock(): string {
+    this.seq += 1;
+    return new Date(Date.UTC(2026, 6, 20, 0, 0, 0, 0) + this.seq).toISOString();
+  }
+
+  private find(namespace: string, key: string): StoredEntry | undefined {
+    return this.entries.find((e) => e.namespace === namespace && e.key === key);
+  }
+
+  async read(namespace: string, key: string) {
+    const entry = this.find(namespace, key);
+    if (!entry) return null;
+    return { ...entry, found: true } as unknown as Record<string, unknown>;
+  }
+
+  async write(
+    namespace: string,
+    key: string,
+    content: string,
+    tags?: string[],
+    expectedUpdatedAt?: string,
+    classification?: string,
+    createIfAbsent?: boolean,
+  ) {
+    const existing = this.find(namespace, key);
+    if (createIfAbsent && existing) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        conflict_reason: "already_exists",
+        current_updated_at: existing.updated_at,
+      });
+    }
+    if (expectedUpdatedAt !== undefined && (!existing || existing.updated_at !== expectedUpdatedAt)) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        conflict_reason: "version_mismatch",
+        current_updated_at: existing?.updated_at,
+      });
+    }
+    const updated_at = this.clock();
+    const created_at = existing?.created_at ?? updated_at;
+    const next: StoredEntry = { namespace, key, content, tags: tags ?? [], classification, created_at, updated_at };
+    this.entries = [...this.entries.filter((e) => !(e.namespace === namespace && e.key === key)), next];
+    return { ok: true, status: existing ? "updated" : "created", updated_at };
+  }
+
+  async query(opts: { namespace?: string; tags?: string[]; entry_type?: string; cursor?: string }) {
+    let results = this.entries;
+    if (opts.namespace) results = results.filter((e) => e.namespace === opts.namespace);
+    if (opts.tags?.length) results = results.filter((e) => opts.tags!.every((t) => e.tags.includes(t)));
+    return { results: results.map((e) => ({ namespace: e.namespace, key: e.key })), truncated: false };
+  }
+}
+
+const SECRET_HEX = "c".repeat(64);
+const CODEX_CLI_KEY = "codex-cli-work";
+const PI_KEY = "pi-app-home";
+const KEYS = { [CODEX_CLI_KEY]: SECRET_HEX, [PI_KEY]: SECRET_HEX };
+
+function makeReceipt(overrides: Partial<ExternalReceiptEnvelope> = {}): ExternalReceiptEnvelope {
+  return {
+    schemaVersion: EXTERNAL_RECEIPT_SCHEMA_VERSION,
+    contractVersion: EXTERNAL_RECEIPT_CONTRACT_VERSION,
+    surface: "codex_cli",
+    kind: "observation",
+    receiptId: "receipt-obs-1",
+    capacityPrincipal: CODEX_CLI_KEY,
+    identity: { provider: "openai", model: "gpt-5.1-codex", harness: "codex-cli@1.4.2" },
+    instance: {
+      taskInstanceId: "task-instance-1",
+      sourceTaskRef: { system: "github-issue", id: "Magnus-Gille/hugin#237" },
+    },
+    occurredAt: "2026-07-20T09:00:00Z",
+    producedAt: "2026-07-20T09:00:05Z",
+    reviewerIndependenceNote: CAPACITY_PRINCIPAL_INDEPENDENCE_NOTE,
+    ...overrides,
+  } as ExternalReceiptEnvelope;
+}
+
+function makeDeps(munin: MuninClient): ExternalReceiptIntakeDeps {
+  return {
+    munin,
+    registry: new LearningRegistryStore(munin, { now: () => "2026-07-20T09:05:00Z" }),
+    keys: KEYS,
+  };
+}
+
+function sign(receipt: ExternalReceiptEnvelope, keyId = CODEX_CLI_KEY): string {
+  return signExternalReceipt(receipt, keyId, SECRET_HEX);
+}
+
+describe("ingestExternalReceipt — admission of an authentic complete codex_cli receipt", () => {
+  it("ingests observation + outcome into the registry as submission/attempt-reference/terminal-outcome, and is reconstructable", async () => {
+    const munin = new InMemoryMunin() as unknown as MuninClient;
+    const deps = makeDeps(munin);
+
+    const observation = makeReceipt();
+    const observationResult = await ingestExternalReceipt(deps, observation, sign(observation));
+    expect(observationResult.status).toBe("admitted");
+    if (observationResult.status !== "admitted") throw new Error("unreachable");
+    expect(observationResult.admission).toBe("created");
+    expect(observationResult.coverage).toBe("imported");
+    expect(observationResult.reconciledWithNativeTask).toBe(false);
+
+    const outcome = makeReceipt({
+      kind: "outcome",
+      receiptId: "receipt-out-1",
+      outcome: "completed",
+      occurredAt: "2026-07-20T09:04:00Z",
+      producedAt: "2026-07-20T09:04:05Z",
+    });
+    const outcomeResult = await ingestExternalReceipt(deps, outcome, sign(outcome));
+    expect(outcomeResult.status).toBe("admitted");
+    if (outcomeResult.status !== "admitted") throw new Error("unreachable");
+    expect(outcomeResult.taskId).toBe(observationResult.taskId);
+    expect(outcomeResult.attemptId).toBe(observationResult.attemptId);
+
+    const timeline = await buildTaskLifecycleTimeline(deps.registry, outcomeResult.taskId);
+    expect(timeline.truncated).toBe(false);
+    const kinds = timeline.entries.map((e) => e.event.recordKind);
+    // submission and attempt-reference share the observation receipt's
+    // occurredAt (a tie broken arbitrarily by eventId), but terminal-outcome
+    // strictly postdates both, so it must sort last.
+    expect(kinds).toHaveLength(3);
+    expect(kinds).toContain("submission");
+    expect(kinds).toContain("attempt-reference");
+    expect(kinds[2]).toBe("terminal-outcome");
+    expect(timeline.entries.every((e) => !e.superseded && !e.excluded)).toBe(true);
+
+    const submission = timeline.entries.find((e) => e.event.recordKind === "submission")!;
+    expect(submission.event.recordKind === "submission" && submission.event.payload.originComponent).toBe("codex_cli");
+
+    const terminal = timeline.entries.find((e) => e.event.recordKind === "terminal-outcome")!;
+    expect(terminal.event.recordKind === "terminal-outcome" && terminal.event.payload.outcome).toBe("completed");
+  });
+
+  it("ingests a pi surface receipt equivalently", async () => {
+    const munin = new InMemoryMunin() as unknown as MuninClient;
+    const deps = makeDeps(munin);
+    const receipt = makeReceipt({
+      surface: "pi",
+      capacityPrincipal: PI_KEY,
+      identity: { provider: "anthropic", model: "claude-sonnet-5", harness: "pi-app@4.5.0" },
+    });
+    const result = await ingestExternalReceipt(deps, receipt, sign(receipt, PI_KEY));
+    expect(result.status).toBe("admitted");
+    if (result.status !== "admitted") throw new Error("unreachable");
+
+    const timeline = await buildTaskLifecycleTimeline(deps.registry, result.taskId);
+    const submission = timeline.entries.find((e) => e.event.recordKind === "submission")!;
+    expect(submission.event.recordKind === "submission" && submission.event.payload.originComponent).toBe("pi");
+  });
+});
+
+describe("ingestExternalReceipt — idempotent re-ingestion", () => {
+  it("re-ingesting the exact same receipt is a no-op", async () => {
+    const munin = new InMemoryMunin() as unknown as MuninClient;
+    const deps = makeDeps(munin);
+    const receipt = makeReceipt();
+
+    const first = await ingestExternalReceipt(deps, receipt, sign(receipt));
+    expect(first.status).toBe("admitted");
+    if (first.status !== "admitted") throw new Error("unreachable");
+    expect(first.admission).toBe("created");
+
+    const second = await ingestExternalReceipt(deps, receipt, sign(receipt));
+    expect(second.status).toBe("admitted");
+    if (second.status !== "admitted") throw new Error("unreachable");
+    expect(second.admission).toBe("exact-existing");
+    expect(second.taskId).toBe(first.taskId);
+    expect(second.attemptId).toBe(first.attemptId);
+    expect(second.eventIds).toEqual(first.eventIds);
+
+    const timeline = await buildTaskLifecycleTimeline(deps.registry, first.taskId);
+    // One observation receipt yields exactly submission + attempt-reference;
+    // re-ingesting it must not add a third or fourth duplicate row.
+    expect(timeline.entries).toHaveLength(2);
+  });
+
+  it("rejects a redelivered receiptId whose content actually changed", async () => {
+    const munin = new InMemoryMunin() as unknown as MuninClient;
+    const deps = makeDeps(munin);
+    const receipt = makeReceipt();
+    await ingestExternalReceipt(deps, receipt, sign(receipt));
+
+    const mutated = { ...receipt, instance: { ...receipt.instance, sourceTaskRef: { system: "github-issue", id: "Magnus-Gille/hugin#999" } } };
+    const result = await ingestExternalReceipt(deps, mutated, sign(mutated));
+    expect(result.status).toBe("rejected");
+    if (result.status !== "rejected") throw new Error("unreachable");
+    expect(result.reason).toBe("receipt-id-reused-with-different-content");
+  });
+});
+
+describe("ingestExternalReceipt — fail-closed rejections", () => {
+  it("rejects a completely unauthenticated body", async () => {
+    const munin = new InMemoryMunin() as unknown as MuninClient;
+    const deps = makeDeps(munin);
+    const result = await ingestExternalReceipt(deps, makeReceipt(), null);
+    expect(result.status).toBe("rejected");
+    if (result.status !== "rejected") throw new Error("unreachable");
+    expect(result.reason).toBe("missing-signature");
+  });
+
+  it("rejects a signature from an unregistered producer", async () => {
+    const munin = new InMemoryMunin() as unknown as MuninClient;
+    const deps = makeDeps(munin);
+    const receipt = makeReceipt();
+    const badSignature = signExternalReceipt(receipt, "not-a-registered-producer", SECRET_HEX);
+    const result = await ingestExternalReceipt(deps, receipt, badSignature);
+    expect(result.status).toBe("rejected");
+    if (result.status !== "rejected") throw new Error("unreachable");
+    expect(result.reason).toBe("unknown-producer");
+  });
+
+  it("rejects an incomplete envelope (required field missing) with a specific reason", async () => {
+    const munin = new InMemoryMunin() as unknown as MuninClient;
+    const deps = makeDeps(munin);
+    const receipt = makeReceipt() as unknown as Record<string, unknown>;
+    delete receipt.instance;
+    const result = await ingestExternalReceipt(deps, receipt, "v1:codex-cli-work:" + "0".repeat(64));
+    expect(result.status).toBe("rejected");
+    if (result.status !== "rejected") throw new Error("unreachable");
+    expect(result.reason).toBe("incomplete-envelope");
+  });
+
+  it("rejects a non-content-blind envelope (extra field) with a specific reason, never silently stripping it", async () => {
+    const munin = new InMemoryMunin() as unknown as MuninClient;
+    const deps = makeDeps(munin);
+    const receipt = { ...makeReceipt(), transcript: "the full private conversation" };
+    const result = await ingestExternalReceipt(deps, receipt, "v1:codex-cli-work:" + "0".repeat(64));
+    expect(result.status).toBe("rejected");
+    if (result.status !== "rejected") throw new Error("unreachable");
+    expect(result.reason).toBe("non-content-blind");
+  });
+
+  it("never admits an unverifiable receipt even when every other field looks plausible", async () => {
+    const rawMunin = new InMemoryMunin();
+    const munin = rawMunin as unknown as MuninClient;
+    const deps = makeDeps(munin);
+    const receipt = makeReceipt();
+    const wrongSignature = signExternalReceipt(receipt, CODEX_CLI_KEY, "d".repeat(64)); // wrong secret
+    const result = await ingestExternalReceipt(deps, receipt, wrongSignature);
+    expect(result.status).toBe("rejected");
+    if (result.status !== "rejected") throw new Error("unreachable");
+    expect(result.reason).toBe("invalid-signature");
+
+    // A rejected receipt must leave no trace in durable storage — no
+    // receipt doc, no registry event, nothing to accidentally later count.
+    const everything = await rawMunin.query({});
+    expect(everything.results).toHaveLength(0);
+  });
+});
+
+describe("ingestExternalReceipt — reconciliation with a native Hugin task", () => {
+  it("reconciles an external receipt onto an existing native submission instead of double-counting the task", async () => {
+    const munin = new InMemoryMunin() as unknown as MuninClient;
+    const deps = makeDeps(munin);
+
+    const nativeTaskId = "20260715-100000-native1";
+    await deps.registry.recordSubmission({
+      taskId: nativeTaskId,
+      taskOutcomeRef: { namespace: `tasks/${nativeTaskId}`, key: "result-structured" },
+      occurredAt: "2026-07-15T10:00:00Z",
+    });
+
+    const receipt = makeReceipt({
+      instance: { ...makeReceipt().instance, reconcilesHuginTaskId: nativeTaskId },
+    });
+    const result = await ingestExternalReceipt(deps, receipt, sign(receipt));
+    expect(result.status).toBe("admitted");
+    if (result.status !== "admitted") throw new Error("unreachable");
+    expect(result.taskId).toBe(nativeTaskId);
+    expect(result.reconciledWithNativeTask).toBe(true);
+
+    const timeline = await buildTaskLifecycleTimeline(deps.registry, nativeTaskId);
+    const submissions = timeline.entries.filter((e) => e.event.recordKind === "submission");
+    expect(submissions).toHaveLength(1); // still exactly one submission — the native one
+    expect(submissions[0].event.recordKind === "submission" && submissions[0].event.payload.originComponent).toBe("hugin");
+    const attemptRefs = timeline.entries.filter((e) => e.event.recordKind === "attempt-reference");
+    expect(attemptRefs).toHaveLength(1); // the imported attempt, added alongside
+  });
+
+  it("rejects a reconciliation claim against a task with no native submission", async () => {
+    const munin = new InMemoryMunin() as unknown as MuninClient;
+    const deps = makeDeps(munin);
+    const receipt = makeReceipt({
+      instance: { ...makeReceipt().instance, reconcilesHuginTaskId: "does-not-exist" },
+    });
+    const result = await ingestExternalReceipt(deps, receipt, sign(receipt));
+    expect(result.status).toBe("rejected");
+    if (result.status !== "rejected") throw new Error("unreachable");
+    expect(result.reason).toBe("reconciliation-target-not-found");
+  });
+
+  it("rejects a reconciliation claim against a task whose submission is itself an import, not native", async () => {
+    const munin = new InMemoryMunin() as unknown as MuninClient;
+    const deps = makeDeps(munin);
+    const first = makeReceipt();
+    const firstResult = await ingestExternalReceipt(deps, first, sign(first));
+    if (firstResult.status !== "admitted") throw new Error("unreachable");
+
+    const second = makeReceipt({
+      receiptId: "receipt-obs-2",
+      instance: { ...makeReceipt().instance, taskInstanceId: "task-instance-2", reconcilesHuginTaskId: firstResult.taskId },
+    });
+    const result = await ingestExternalReceipt(deps, second, sign(second));
+    expect(result.status).toBe("rejected");
+    if (result.status !== "rejected") throw new Error("unreachable");
+    expect(result.reason).toBe("reconciliation-target-conflict");
+  });
+});
+
+describe("ingestExternalReceipt — honest coverage state", () => {
+  it("marks a promptly-received receipt as imported", async () => {
+    const munin = new InMemoryMunin() as unknown as MuninClient;
+    const deps = makeDeps(munin); // registry clock fixed at 2026-07-20T09:05:00Z
+    const receipt = makeReceipt({ occurredAt: "2026-07-20T09:00:00Z" });
+    const result = await ingestExternalReceipt(
+      { ...deps, now: () => "2026-07-20T09:05:00Z" },
+      receipt,
+      sign(receipt),
+    );
+    expect(result.status).toBe("admitted");
+    if (result.status !== "admitted") throw new Error("unreachable");
+    expect(result.coverage).toBe("imported");
+  });
+
+  it("marks a receipt received long after the fact as imported-late, honestly", async () => {
+    const munin = new InMemoryMunin() as unknown as MuninClient;
+    const deps = makeDeps(munin);
+    const receipt = makeReceipt({ occurredAt: "2026-06-01T09:00:00Z", producedAt: "2026-06-01T09:00:05Z" });
+    const result = await ingestExternalReceipt(
+      { ...deps, now: () => "2026-07-20T09:05:00Z" },
+      receipt,
+      sign(receipt),
+    );
+    expect(result.status).toBe("admitted");
+    if (result.status !== "admitted") throw new Error("unreachable");
+    expect(result.coverage).toBe("imported-late");
+  });
+});
+
+describe("ingestExternalReceipt — capacity principals never confer reviewer independence", () => {
+  it("stores the fixed independence-disclaimer note verbatim on every admitted receipt", async () => {
+    const munin = new InMemoryMunin() as unknown as MuninClient;
+    const deps = makeDeps(munin);
+    const receipt = makeReceipt();
+    const result = await ingestExternalReceipt(deps, receipt, sign(receipt));
+    if (result.status !== "admitted") throw new Error("unreachable");
+
+    const timeline = await buildTaskLifecycleTimeline(deps.registry, result.taskId);
+    const submission = timeline.entries.find((e) => e.event.recordKind === "submission")!;
+    const docRef = submission.event.recordKind === "submission" ? submission.event.payload.taskOutcomeRef : undefined;
+    expect(docRef).toBeDefined();
+    const entry = await munin.read(docRef!.namespace, docRef!.key);
+    const stored = storedExternalReceiptSchema.parse(JSON.parse((entry as { content: string }).content));
+    expect(stored.receipt.reviewerIndependenceNote).toBe(CAPACITY_PRINCIPAL_INDEPENDENCE_NOTE);
+  });
+
+  it("treats two different capacity principals (e.g. two subscriptions) as two distinct, unmerged tasks — never one independently-confirmed task", async () => {
+    const munin = new InMemoryMunin() as unknown as MuninClient;
+    const deps = makeDeps(munin);
+
+    const receiptA = makeReceipt({ capacityPrincipal: "codex-cli-work" });
+    const resultA = await ingestExternalReceipt(deps, receiptA, sign(receiptA, CODEX_CLI_KEY));
+    if (resultA.status !== "admitted") throw new Error("unreachable");
+
+    const secondKeyId = "codex-cli-personal";
+    const receiptB = makeReceipt({ receiptId: "receipt-obs-1-personal", capacityPrincipal: secondKeyId });
+    const keysWithSecond = { ...KEYS, [secondKeyId]: SECRET_HEX };
+    const resultB = await ingestExternalReceipt(
+      { ...deps, keys: keysWithSecond },
+      receiptB,
+      signExternalReceipt(receiptB, secondKeyId, SECRET_HEX),
+    );
+    if (resultB.status !== "admitted") throw new Error("unreachable");
+
+    // Same underlying sourceTaskRef/taskInstanceId, different capacity
+    // principal — this must never collapse into one merged/"independently
+    // confirmed" task. Each capacity principal gets its own task identity.
+    expect(resultB.taskId).not.toBe(resultA.taskId);
+  });
+});

--- a/tests/external-receipt-schema.test.ts
+++ b/tests/external-receipt-schema.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import {
+  CAPACITY_PRINCIPAL_INDEPENDENCE_NOTE,
+  EXTERNAL_RECEIPT_CONTRACT_VERSION,
+  EXTERNAL_RECEIPT_SCHEMA_VERSION,
+  externalReceiptEnvelopeSchema,
+  storedExternalReceiptSchema,
+  type ExternalReceiptEnvelope,
+} from "../src/external-receipt-schema.js";
+
+function makeObservation(overrides: Partial<ExternalReceiptEnvelope> = {}): ExternalReceiptEnvelope {
+  return {
+    schemaVersion: EXTERNAL_RECEIPT_SCHEMA_VERSION,
+    contractVersion: EXTERNAL_RECEIPT_CONTRACT_VERSION,
+    surface: "codex_cli",
+    kind: "observation",
+    receiptId: "receipt-obs-1",
+    capacityPrincipal: "codex-cli-work",
+    identity: { provider: "openai", model: "gpt-5.1-codex", harness: "codex-cli@1.4.2" },
+    instance: {
+      taskInstanceId: "task-instance-1",
+      sourceTaskRef: { system: "github-issue", id: "Magnus-Gille/hugin#237" },
+    },
+    occurredAt: "2026-07-20T10:00:00Z",
+    producedAt: "2026-07-20T10:00:05Z",
+    reviewerIndependenceNote: CAPACITY_PRINCIPAL_INDEPENDENCE_NOTE,
+    ...overrides,
+  } as ExternalReceiptEnvelope;
+}
+
+function makeOutcome(overrides: Partial<ExternalReceiptEnvelope> = {}): ExternalReceiptEnvelope {
+  return {
+    ...makeObservation(),
+    kind: "outcome",
+    receiptId: "receipt-out-1",
+    outcome: "completed",
+    ...overrides,
+  } as ExternalReceiptEnvelope;
+}
+
+describe("externalReceiptEnvelopeSchema", () => {
+  it("accepts a well-formed observation receipt", () => {
+    const result = externalReceiptEnvelopeSchema.safeParse(makeObservation());
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts a well-formed outcome receipt", () => {
+    const result = externalReceiptEnvelopeSchema.safeParse(makeOutcome());
+    expect(result.success).toBe(true);
+  });
+
+  it("requires an outcome field only when kind is outcome", () => {
+    const badOutcome = externalReceiptEnvelopeSchema.safeParse({
+      ...makeObservation(),
+      kind: "outcome",
+      receiptId: "receipt-out-2",
+      // outcome deliberately omitted
+    });
+    expect(badOutcome.success).toBe(false);
+
+    const strayOutcome = externalReceiptEnvelopeSchema.safeParse({
+      ...makeObservation(),
+      outcome: "completed",
+    });
+    expect(strayOutcome.success).toBe(false); // observation must not carry an outcome field
+  });
+
+  it("rejects an unrecognised extra field (content-blindness at the wire boundary)", () => {
+    const result = externalReceiptEnvelopeSchema.safeParse({
+      ...makeObservation(),
+      transcript: "the full private conversation would go here",
+    });
+    expect(result.success).toBe(false);
+    expect(result.success === false && result.error.issues.some((i) => i.code === "unrecognized_keys")).toBe(true);
+  });
+
+  it("rejects free-text-shaped identity tokens (spaces / newlines)", () => {
+    const withSpaces = externalReceiptEnvelopeSchema.safeParse(
+      makeObservation({ identity: { provider: "openai", model: "gpt 5 codex full name", harness: "codex-cli@1.4.2" } }),
+    );
+    expect(withSpaces.success).toBe(false);
+
+    const withNewline = externalReceiptEnvelopeSchema.safeParse(
+      makeObservation({ capacityPrincipal: "codex-cli-work\nsome smuggled line" }),
+    );
+    expect(withNewline.success).toBe(false);
+  });
+
+  it("rejects an overlong identity token (bounding against pasted content)", () => {
+    const result = externalReceiptEnvelopeSchema.safeParse(
+      makeObservation({ identity: { provider: "openai", model: "x".repeat(500), harness: "codex-cli@1.4.2" } }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an unsupported schema version", () => {
+    const result = externalReceiptEnvelopeSchema.safeParse({ ...makeObservation(), schemaVersion: 2 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects an unsupported contract version", () => {
+    const result = externalReceiptEnvelopeSchema.safeParse({
+      ...makeObservation(),
+      contractVersion: "some.other/v9",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a surface outside the three supported external surfaces", () => {
+    const result = externalReceiptEnvelopeSchema.safeParse({ ...makeObservation(), surface: "claude_desktop" });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects producedAt strictly before occurredAt", () => {
+    const result = externalReceiptEnvelopeSchema.safeParse(
+      makeObservation({ occurredAt: "2026-07-20T10:00:05Z", producedAt: "2026-07-20T10:00:00Z" }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("requires the fixed capacity-principal-independence literal, not caller prose", () => {
+    const result = externalReceiptEnvelopeSchema.safeParse(
+      makeObservation({ reviewerIndependenceNote: "this producer is definitely independent, trust me" as never }),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts an optional reconciliation target as an opaque token", () => {
+    const result = externalReceiptEnvelopeSchema.safeParse(
+      makeObservation({ instance: { ...makeObservation().instance, reconcilesHuginTaskId: "20260701-000000-abcd" } }),
+    );
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("storedExternalReceiptSchema", () => {
+  it("round-trips a fully-populated stored record", () => {
+    const stored = {
+      schemaVersion: EXTERNAL_RECEIPT_SCHEMA_VERSION,
+      receipt: makeObservation(),
+      taskId: "ext-abc123",
+      attemptId: "ext-attempt-def456",
+      verifiedCapacityPrincipal: "codex-cli-work",
+      keyId: "codex-cli-work",
+      receivedAt: "2026-07-20T10:00:06Z",
+      coverage: "imported",
+      reconciledWithNativeTask: false,
+    };
+    expect(storedExternalReceiptSchema.safeParse(stored).success).toBe(true);
+  });
+
+  it("rejects an unrecognised extra field on the stored record too", () => {
+    const stored = {
+      schemaVersion: EXTERNAL_RECEIPT_SCHEMA_VERSION,
+      receipt: makeObservation(),
+      taskId: "ext-abc123",
+      attemptId: "ext-attempt-def456",
+      verifiedCapacityPrincipal: "codex-cli-work",
+      keyId: "codex-cli-work",
+      receivedAt: "2026-07-20T10:00:06Z",
+      coverage: "imported",
+      reconciledWithNativeTask: false,
+      rawOutput: "smuggled content",
+    };
+    expect(storedExternalReceiptSchema.safeParse(stored).success).toBe(false);
+  });
+});

--- a/tests/external-receipt-signing.test.ts
+++ b/tests/external-receipt-signing.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildExternalReceiptCanonicalPayload,
+  loadReceiptProducerKeyStoreFromEnv,
+  signExternalReceipt,
+  verifyExternalReceiptSignature,
+} from "../src/external-receipt-signing.js";
+import {
+  CAPACITY_PRINCIPAL_INDEPENDENCE_NOTE,
+  EXTERNAL_RECEIPT_CONTRACT_VERSION,
+  EXTERNAL_RECEIPT_SCHEMA_VERSION,
+  type ExternalReceiptEnvelope,
+} from "../src/external-receipt-schema.js";
+
+const SECRET_HEX = "b".repeat(64);
+const KEY_ID = "codex-cli-work";
+const KEYS = { [KEY_ID]: SECRET_HEX };
+
+function makeReceipt(overrides: Partial<ExternalReceiptEnvelope> = {}): ExternalReceiptEnvelope {
+  return {
+    schemaVersion: EXTERNAL_RECEIPT_SCHEMA_VERSION,
+    contractVersion: EXTERNAL_RECEIPT_CONTRACT_VERSION,
+    surface: "codex_cli",
+    kind: "observation",
+    receiptId: "receipt-1",
+    capacityPrincipal: KEY_ID,
+    identity: { provider: "openai", model: "gpt-5.1-codex", harness: "codex-cli@1.4.2" },
+    instance: {
+      taskInstanceId: "task-instance-1",
+      sourceTaskRef: { system: "github-issue", id: "Magnus-Gille/hugin#237" },
+    },
+    occurredAt: "2026-07-20T10:00:00Z",
+    producedAt: "2026-07-20T10:00:05Z",
+    reviewerIndependenceNote: CAPACITY_PRINCIPAL_INDEPENDENCE_NOTE,
+    ...overrides,
+  } as ExternalReceiptEnvelope;
+}
+
+describe("buildExternalReceiptCanonicalPayload", () => {
+  it("is sorted and newline-terminated", () => {
+    const payload = buildExternalReceiptCanonicalPayload(makeReceipt());
+    expect(payload.endsWith("\n")).toBe(true);
+    const lines = payload.trimEnd().split("\n");
+    expect(lines).toEqual([...lines].sort());
+  });
+
+  it("differs when any bound field changes", () => {
+    const base = buildExternalReceiptCanonicalPayload(makeReceipt());
+    expect(buildExternalReceiptCanonicalPayload(makeReceipt({ capacityPrincipal: "codex-cli-personal" }))).not.toEqual(base);
+    expect(
+      buildExternalReceiptCanonicalPayload(makeReceipt({ instance: { ...makeReceipt().instance, taskInstanceId: "other" } })),
+    ).not.toEqual(base);
+    expect(buildExternalReceiptCanonicalPayload(makeReceipt({ occurredAt: "2026-07-20T10:00:01Z" }))).not.toEqual(base);
+  });
+
+  it("binds the outcome field only for outcome receipts", () => {
+    const observation = buildExternalReceiptCanonicalPayload(makeReceipt());
+    expect(observation).not.toContain("outcome=");
+    const outcome = buildExternalReceiptCanonicalPayload(
+      makeReceipt({ kind: "outcome", receiptId: "receipt-2", outcome: "completed" } as Partial<ExternalReceiptEnvelope>),
+    );
+    expect(outcome).toContain("outcome=completed");
+  });
+});
+
+describe("verifyExternalReceiptSignature", () => {
+  it("verifies a correctly signed receipt", () => {
+    const receipt = makeReceipt();
+    const signature = signExternalReceipt(receipt, KEY_ID, SECRET_HEX);
+    const result = verifyExternalReceiptSignature(receipt, signature, KEYS);
+    expect(result).toEqual({ status: "valid", keyId: KEY_ID });
+  });
+
+  it("rejects a missing signature", () => {
+    const result = verifyExternalReceiptSignature(makeReceipt(), null, KEYS);
+    expect(result.status).toBe("missing");
+  });
+
+  it("rejects an unknown producer key", () => {
+    const receipt = makeReceipt();
+    const signature = signExternalReceipt(receipt, "someone-else", SECRET_HEX);
+    const result = verifyExternalReceiptSignature(receipt, signature, KEYS);
+    expect(result.status).toBe("unknown-producer");
+  });
+
+  it("rejects a keyId that does not alias the claimed capacity principal", () => {
+    const receipt = makeReceipt();
+    const keys = { ...KEYS, "another-principal": SECRET_HEX };
+    const signature = signExternalReceipt(receipt, "another-principal", SECRET_HEX);
+    const result = verifyExternalReceiptSignature(receipt, signature, keys);
+    expect(result.status).toBe("producer-mismatch");
+  });
+
+  it("accepts a rotation-alias keyId of the form <principal>-<rotation>", () => {
+    const receipt = makeReceipt();
+    const rotatedKeyId = `${KEY_ID}-2026q3`;
+    const keys = { [rotatedKeyId]: SECRET_HEX };
+    const signature = signExternalReceipt(receipt, rotatedKeyId, SECRET_HEX);
+    const result = verifyExternalReceiptSignature(receipt, signature, keys);
+    expect(result.status).toBe("valid");
+  });
+
+  it("rejects a tampered field even with a structurally valid signature", () => {
+    const receipt = makeReceipt();
+    const signature = signExternalReceipt(receipt, KEY_ID, SECRET_HEX);
+    const tampered = { ...receipt, occurredAt: "2026-07-20T11:00:00Z" };
+    const result = verifyExternalReceiptSignature(tampered, signature, KEYS);
+    expect(result.status).toBe("invalid");
+  });
+
+  it("rejects a malformed signature string", () => {
+    const result = verifyExternalReceiptSignature(makeReceipt(), "not-a-signature", KEYS);
+    expect(result.status).toBe("malformed");
+  });
+
+  it("rejects an unsupported signature version", () => {
+    const receipt = makeReceipt();
+    const result = verifyExternalReceiptSignature(receipt, `v2:${KEY_ID}:${"0".repeat(64)}`, KEYS);
+    expect(result.status).toBe("unsupported-version");
+  });
+
+  it("enforces maxAgeS when configured", () => {
+    const receipt = makeReceipt({ producedAt: new Date(Date.now() - 3_600_000).toISOString() });
+    const signature = signExternalReceipt(receipt, KEY_ID, SECRET_HEX);
+    const result = verifyExternalReceiptSignature(receipt, signature, KEYS, { maxAgeS: 60 });
+    expect(result.status).toBe("expired");
+  });
+});
+
+describe("loadReceiptProducerKeyStoreFromEnv", () => {
+  it("loads from HUGIN_RECEIPT_PRODUCER_KEYS inline JSON", () => {
+    const store = loadReceiptProducerKeyStoreFromEnv({
+      HUGIN_RECEIPT_PRODUCER_KEYS: JSON.stringify({ [KEY_ID]: SECRET_HEX }),
+    } as NodeJS.ProcessEnv);
+    expect(store[KEY_ID]).toBe(SECRET_HEX);
+  });
+
+  it("returns an empty store when nothing is configured", () => {
+    const store = loadReceiptProducerKeyStoreFromEnv({} as NodeJS.ProcessEnv);
+    expect(store).toEqual({});
+  });
+
+  it("is independent from HUGIN_SUBMITTER_KEYS", () => {
+    const store = loadReceiptProducerKeyStoreFromEnv({
+      HUGIN_SUBMITTER_KEYS: JSON.stringify({ [KEY_ID]: SECRET_HEX }),
+    } as NodeJS.ProcessEnv);
+    expect(store).toEqual({});
+  });
+});


### PR DESCRIPTION
Refs #237

## What

Adds a narrow, authenticated intake for external task/outcome receipts from `codex_app`, `codex_cli`, and `pi` surfaces — work Magnus completes directly through Codex App/CLI or Pi, without it ever entering Hugin's dispatcher. An admitted receipt is mapped into the durable append-only learning registry (#232) as submission / attempt-reference / terminal-outcome events, via the registry's own natural-key idempotent API — this PR does not reimplement or extend that mechanism beyond one additive, backward-compatible field.

New:
- `src/external-receipt-schema.ts` — versioned, content-blind receipt envelope (`.strict()` throughout; identity/instance fields are bounded opaque tokens, never free text; a fixed `reviewerIndependenceNote` literal).
- `src/external-receipt-signing.ts` — HMAC-SHA256 signing/verification shaped like `task-signing.ts`, with its own producer keystore (`HUGIN_RECEIPT_PRODUCER_KEYS[_FILE]`).
- `src/external-receipt-intake.ts` — `ingestExternalReceipt()`: validate → authenticate → optionally reconcile against a native task → idempotently write registry events. Every rejection carries one of twelve specific, auditable reasons.
- `docs/external-receipt-intake.md` — design writeup, including an honestly-flagged accepted limitation (see below).

Changed (minimal, additive):
- `src/learning-registry-schema.ts` / `-store.ts` — `submissionEventSchema.payload.originComponent` widened from `z.literal("hugin")` to an enum (`hugin | codex_app | codex_cli | pi`); `recordSubmission` gained an optional `originComponent` param defaulting to `"hugin"`. No other #232 behavior changed — every existing native call site is unaffected.
- `src/task-signing.ts` — exported three already-existing helpers (`decodeSecret`, `parseKeyStoreJson`, `keyIdMatchesSubmitter`) so the new signing module reuses them instead of duplicating logic.

## Design decisions

**Authenticated intake.** Verification is always mandatory (no `off`/`warn` policy knob, unlike task submission) — this is a brand-new authenticated-only surface. A receipt's `capacityPrincipal` is only trusted once the signature's `keyId` is shown to resolve to a configured key AND alias back to that exact principal (or a `<principal>-<rotation>` form) — the same anti-impersonation binding `task-signing.ts` uses for submitters. Content-blindness is structural: every envelope object is `.strict()` (unrecognized fields rejected, not stripped) and every identity/instance string is a bounded opaque token with no whitespace, so a transcript/prompt/diff cannot fit through even if someone tried.

**#232 reconciliation / no double-count.** A receipt can optionally assert `instance.reconcilesHuginTaskId` to link to an existing native Hugin task. Intake verifies this against the registry's own submission event (`getEvent` + `originComponent === "hugin"`) before honoring it — an unresolvable or non-native target fails closed (`reconciliation-target-not-found` / `-conflict`). taskId/attemptId are otherwise derived deterministically from `sha256(surface, capacityPrincipal, taskInstanceId)`, which is also what makes re-ingestion of the same receipt a structural no-op and makes two different capacity principals (e.g. two subscriptions) derive **different** tasks rather than ever merging into one "independently confirmed" record — a fixed `reviewerIndependenceNote` literal makes that assertion explicit and tamper-proof in every stored record. A submission's own natural key is unchanged (`{taskId}` only), so an imported submission can never silently overwrite, or be overwritten by, a native one — a genuine conflict throws `RegistryNaturalKeyConflictError` rather than merging.

*Accepted limitation (found by review, documented rather than silently left):* reconciliation proves the target is a genuine native submission, but not that it's the *same* underlying unit of work — native submissions don't carry a `sourceTaskRef` to check against, and adding one would be #232 schema scope creep. Blast radius is bounded: only an operator-provisioned producer key can attempt reconciliation, and a wrong claim can only append an attempt onto an already-existing task's timeline, never fabricate or overwrite its submission/terminal state. See `docs/external-receipt-intake.md`.

**Fail-closed coverage states.** Every admitted receipt is honestly marked `imported` or `imported-late` (7-day threshold from `occurredAt` to Hugin's own server-stamped `receivedAt`) — never claimed as native coverage. An unauthenticated, incomplete, or non-content-blind receipt is rejected before admission with a specific reason (`missing-signature`, `unknown-producer`, `producer-mismatch`, `invalid-signature`, `incomplete-envelope`, `non-content-blind`, `unsupported-schema-version`, `unsupported-contract-version`, `reconciliation-target-not-found`, `reconciliation-target-conflict`, `receipt-id-reused-with-different-content`, `registry-natural-key-conflict`) — never silently admitted or silently stripped.

## Verification

- `npm run build` — clean (tsc, no errors).
- `npm test` — **135 test files / 2157 tests passing** (baseline before this change: 132 files / 2112 tests; this PR adds 3 new test files / 45 new tests, all passing, zero regressions).
- Dogfooded `mcp__m5__ask` (qwen3-30b-instruct) for a bounded admissibility/reconciliation review. One real finding accepted (the reconciliation-identity limitation above, now documented); three fabricated findings rejected after checking against actual source (`canonicalEqual` claimed missing but is defined and JCS-based in `learning-registry-schema.ts`; a coverage-lateness sign claim that was backwards; `reviewerIndependenceNote` claimed schema-unenforced but is already a `z.literal`).

Not merging/deploying — leaving for review per house process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)