### PR TITLE
feat(learning): orchestrate the experiment cadence (#266)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "smoke:learning-task:live": "tsx scripts/learning-task-joint-smoke.ts --mode=live",
     "harvest:daily-exams": "node dist/daily-exam-harvest-cli.js",
     "recover:publication": "node dist/publication-recovery-cli.js",
+    "experiment:cadence": "node dist/experiment-cadence-cli.js",
     "pilot:harbor": "tsx scripts/harbor_pilot/run-pilot.ts",
     "pilot:harbor:import": "tsx scripts/harbor_pilot/import-learning-report.ts",
     "test": "vitest run",

--- a/src/experiment-cadence-cli.ts
+++ b/src/experiment-cadence-cli.ts
@@ -1,0 +1,149 @@
+#!/usr/bin/env tsx
+
+/**
+ * Operator/cron CLI for the continuous-improvement experiment cadence
+ * (hugin#266). Runs exactly one `runExperimentCadenceTick` and prints its
+ * result. Mirrors `publication-recovery-cli.ts`'s composition-root shape:
+ * build real clients from env vars, call the pure/durable orchestration
+ * function, translate the result into an exit code.
+ *
+ * Requires `MUNIN_API_KEY` (and optionally `MUNIN_URL`). The gille outcome
+ * export (#8 contract) is wired in only when `HOMESERVER_GATEWAY_URL` and
+ * `HOMESERVER_ADMIN_API_KEY` are both set; otherwise every concluded
+ * experiment's reviewable summary records `outcomeExport.status: "skipped"`
+ * with a reason, per experiment-cadence.ts's documented limitation.
+ *
+ * Documented limitation: there is no production-ready bulk assembler for the
+ * full `PackagerCandidateInput[]` evidence pool yet (see
+ * experiment-cadence.ts's module doc comment) -- this CLI reads that pool
+ * from an operator/cron-supplied JSON snapshot file (`--candidates <path>`)
+ * rather than inventing a whole-ledger scan under this ticket's narrower
+ * orchestration scope. A future ticket can point `--candidates` at a real
+ * generator's output, or replace the flag with a direct call, without
+ * touching `experiment-cadence.ts` at all.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { MuninClient } from "./munin-client.js";
+import { LearningRegistryStore } from "./learning-registry-store.js";
+import { LearningExperimentStore } from "./learning/experiment-store.js";
+import { packagerCandidateInputSchema } from "./learning/candidate-packager-schema.js";
+import { createGilleOutcomeExportClient } from "./learning/experiment-outcome-export.js";
+import { runExperimentCadenceTick, type CadenceTickResult } from "./learning/experiment-cadence.js";
+
+export const DEFAULT_CADENCE_PRINCIPAL = "service:hugin-experiment-cadence";
+
+interface CliOptions {
+  dryRun: boolean;
+  candidatesPath?: string;
+}
+
+function usage(): string {
+  return [
+    "Usage: npm run experiment:cadence -- --candidates <path> [options]",
+    "",
+    "Run one continuous-improvement experiment-cadence tick: propose (#234) ->",
+    "package (#233) -> observe running experiments -> conclude terminal ones",
+    "(gille #8 outcome export attempt + a durable reviewable summary). Never",
+    "promotes. Idempotent -- re-running against unchanged state is a no-op.",
+    "",
+    "Options:",
+    "  --candidates <path>   Required. JSON file containing a",
+    "                        PackagerCandidateInput[] evidence snapshot.",
+    "  --dry-run             Report the would-be actions; mutate nothing.",
+    "  --help                Show this help",
+  ].join("\n");
+}
+
+export function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = { dryRun: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]!;
+    if (arg === "--help") {
+      process.stdout.write(`${usage()}\n`);
+      process.exit(0);
+    } else if (arg === "--dry-run") {
+      options.dryRun = true;
+    } else if (arg === "--candidates") {
+      const value = argv[index + 1];
+      if (!value) throw new Error("--candidates requires a value");
+      options.candidatesPath = value;
+      index += 1;
+    } else {
+      throw new Error(`unknown option: ${arg}`);
+    }
+  }
+  if (!options.candidatesPath) {
+    throw new Error("--candidates <path> is required (see --help)");
+  }
+  return options;
+}
+
+function loadCandidatesFromFile(path: string) {
+  const raw = JSON.parse(readFileSync(path, "utf8"));
+  return packagerCandidateInputSchema.array().parse(raw);
+}
+
+function formatResult(result: CadenceTickResult): string {
+  const lines = [
+    `tick ${result.tickId}${result.dryRun ? " (dry-run)" : ""} at ${result.startedAt}`,
+    `candidates loaded: ${result.candidatesLoaded}; proposals considered: ${result.proposalsConsidered}; skipped in-flight: ${result.skippedInFlight.length}`,
+    result.packaged
+      ? `packaged: ${result.packaged.experimentId} (scope=${result.packaged.scope}, reused=${result.packaged.reused}${result.packaged.wouldPackage ? ", would-package" : ""})`
+      : "packaged: none this tick",
+    `observed: ${result.observed.length}; concluded: ${result.concluded.length}; refusals: ${result.refusals.length}; errors: ${result.errors.length}`,
+  ];
+  for (const refusal of result.refusals) lines.push(`  refused: ${refusal.proposalId} -- ${refusal.reason}`);
+  for (const decline of result.proposalDeclines) lines.push(`  declined-population: ${JSON.stringify(decline)}`);
+  for (const conclusion of result.concluded) {
+    lines.push(
+      `  concluded: ${conclusion.experimentId} (alreadyConcluded=${conclusion.alreadyConcluded}, ` +
+      `export=${conclusion.exportStatus})`,
+    );
+  }
+  for (const error of result.errors) lines.push(`  error[${error.stage}]: ${error.message}`);
+  for (const limitation of result.limitations) lines.push(`  limitation: ${limitation}`);
+  return lines.join("\n");
+}
+
+export async function main(argv = process.argv.slice(2)): Promise<void> {
+  const options = parseArgs(argv);
+  const apiKey = process.env.MUNIN_API_KEY?.trim();
+  if (!apiKey) throw new Error("MUNIN_API_KEY is required");
+  const munin = new MuninClient({
+    baseUrl: process.env.MUNIN_URL?.trim() || "http://localhost:3030",
+    apiKey,
+  });
+
+  const registry = new LearningRegistryStore(munin);
+  const experimentStore = new LearningExperimentStore(munin);
+  const principal = process.env.HUGIN_CADENCE_PRINCIPAL?.trim() || DEFAULT_CADENCE_PRINCIPAL;
+
+  const gatewayUrl = process.env.HOMESERVER_GATEWAY_URL?.trim();
+  const adminApiKey = process.env.HOMESERVER_ADMIN_API_KEY?.trim();
+  const gilleExport =
+    gatewayUrl && adminApiKey
+      ? createGilleOutcomeExportClient({ gatewayBaseUrl: gatewayUrl, apiKey: adminApiKey })
+      : undefined;
+
+  const candidates = loadCandidatesFromFile(options.candidatesPath!);
+
+  const result = await runExperimentCadenceTick(
+    { registry, experimentStore, munin, principal, loadCandidates: async () => candidates, gilleExport },
+    { dryRun: options.dryRun },
+  );
+
+  process.stdout.write(`${formatResult(result)}\n`);
+  if (result.errors.length > 0) {
+    process.exitCode = 1;
+  }
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : "";
+if (import.meta.url === invokedPath) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/src/learning/experiment-cadence.ts
+++ b/src/learning/experiment-cadence.ts
@@ -1,0 +1,688 @@
+/**
+ * Continuous-improvement experiment cadence (hugin#266, grimnir#88 Phase 4).
+ *
+ * One idempotent, fail-closed tick that CHAINS the already-merged
+ * experiment-pipeline pieces on a schedule -- it never reimplements any of
+ * them:
+ *
+ *   (a) propose  -- experiment-proposer.ts (#234), read-only.
+ *   (b) dedupe   -- pick the top ranked proposal not already "in flight" for
+ *                   its (scope, axis, championFingerprint, challengerFingerprint)
+ *                   natural key. This cadence-owned index is additive
+ *                   bookkeeping, not a change to the store's own identity
+ *                   rules.
+ *   (c) package  -- candidate-packager.ts (#233) via `packageAndHandOff`,
+ *                   which itself calls `LearningExperimentStore.create` --
+ *                   already idempotent on content-derived `experiment_id`.
+ *   (d) observe  -- read (never mutate) every experiment this cadence has
+ *                   ever packaged; an experiment still `running` is reported,
+ *                   not concluded.
+ *   (e) conclude -- an experiment whose evaluator decision left "gathering"
+ *                   (i.e. `promotion-ready` or `rejected` -- it reached its
+ *                   frozen sample target) gets: a best-effort gille outcome
+ *                   export attempt (#8 contract, experiment-outcome-export.ts)
+ *                   and a durable, idempotent REVIEWABLE SUMMARY record.
+ *   (f) NEVER promote. `LearningExperimentStore.promote` is not imported by
+ *                   this module. Promotion/adoption is gi#49's job; until
+ *                   that exists, the reviewable summary IS the deliverable.
+ *
+ * Fail-closed composition: a failure in one stage (proposer error, packaging
+ * refusal, store conflict, index/summary read/write error) is RECORDED and
+ * the tick continues with the rest -- it never throws out of
+ * `runExperimentCadenceTick` for a business-rule failure. The caller (the
+ * CLI) decides the process exit code from `result.errors`.
+ *
+ * Idempotency: re-running a tick against unchanged state is a no-op --
+ * nothing new is proposed-and-packaged (already in flight), nothing is
+ * re-concluded (a reviewable summary already exists), and the durable tick
+ * log is the only thing written every time (by design -- "ran and found
+ * nothing new" is itself a fact worth logging).
+ *
+ * Documented limitation (evidence-source scope). Assembling the full
+ * production `PackagerCandidateInput[]` pool -- walking every rated task in
+ * the quality-receipt ledger -- is explicitly out of #234/#233's scope (see
+ * candidate-packager-schema.ts: "the caller ... or a future daily factory
+ * conductor is responsible for resolving configuration and qualityReceipt").
+ * That conductor does not exist yet. This module therefore takes
+ * `loadCandidates` as a required injected dependency rather than building a
+ * bulk evidence scan under this ticket's narrower orchestration scope.
+ *
+ * Documented limitation (gille-side quarantine visibility). The ticket asks
+ * this tick to refuse an axis gille has quarantined, IF that signal is
+ * visible via the #8 import contract. It is not: gille-inference#34's
+ * `POST /admin/experiments/import` is a one-way IMPORT endpoint with no
+ * companion query surface for "is axis X quarantined." No such channel is
+ * invented here; `LIMITATIONS.quarantineVisibility` names the gap on every
+ * tick result instead.
+ */
+
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import { MuninWriteRejectedError } from "../munin-client.js";
+import type { LearningRegistryStore } from "../learning-registry-store.js";
+import { buildTaskLifecycleTimeline, type TaskLifecycleTimeline } from "../learning-registry-view.js";
+import {
+  learningChangeAxisSchema,
+  sha256Schema,
+  type LearningExperimentGates,
+  type LearningExperimentState,
+} from "./experiment-schema.js";
+import {
+  proposeExperimentsFromRegistry,
+  proposalToPackageRequest,
+  type ExperimentProposal,
+  type PopulationDeclineReason,
+  type ProposeRequest,
+} from "./experiment-proposer.js";
+import {
+  packageAndHandOff,
+  packageExperimentCandidates,
+  type PackageRequest,
+} from "./candidate-packager.js";
+import type { PackagerCandidateInput, PackagerQualityRating } from "./candidate-packager-schema.js";
+import { LearningExperimentStore, LearningStoreError } from "./experiment-store.js";
+import {
+  buildOutcomeExportBundle,
+  type GilleOutcomeEvidenceResolver,
+  type GilleOutcomeExportPort,
+} from "./experiment-outcome-export.js";
+
+// ─── Munin surface (minimal, mirrors publication-recovery.ts's own idiom) ──────
+
+export interface CadenceMuninClient {
+  read(namespace: string, key: string): Promise<{ content: string; updated_at: string } | null>;
+  write(
+    namespace: string,
+    key: string,
+    content: string,
+    tags?: string[],
+    expectedUpdatedAt?: string,
+    classification?: string,
+    createIfAbsent?: boolean,
+  ): Promise<unknown>;
+  log(namespace: string, content: string, tags?: string[]): Promise<unknown>;
+}
+
+const CADENCE_SCHEMA_VERSION = 1 as const;
+const CADENCE_INDEX_KEY = "index";
+const MAX_INDEX_MUTATION_ATTEMPTS = 3;
+
+function principalHash(principal: string): string {
+  return createHash("sha256").update(principal).digest("hex").slice(0, 12);
+}
+function cadenceIndexNamespace(principal: string): string {
+  return `experiments/hugin/cadence-index-${principalHash(principal)}`;
+}
+function cadenceSummaryNamespace(principal: string): string {
+  return `experiments/hugin/cadence-summary-${principalHash(principal)}`;
+}
+function cadenceTickLogNamespace(principal: string): string {
+  return `experiments/hugin/cadence-log-${principalHash(principal)}`;
+}
+
+function describeError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+// ─── Dedup index (natural key: scope, axis, championFingerprint, challengerFingerprint) ──
+
+const cadenceIndexEntrySchema = z.object({
+  scope: z.string().min(1),
+  taskType: z.string().min(1),
+  changeAxis: learningChangeAxisSchema,
+  championFingerprint: sha256Schema,
+  challengerFingerprint: sha256Schema,
+  experimentId: z.string().min(1),
+  packagedAt: z.string().min(1),
+}).strict();
+export type CadenceIndexEntry = z.infer<typeof cadenceIndexEntrySchema>;
+
+const cadenceIndexSchema = z.object({
+  schemaVersion: z.literal(CADENCE_SCHEMA_VERSION),
+  entries: z.array(cadenceIndexEntrySchema).max(2_000),
+}).strict();
+
+function sameNaturalKey(a: CadenceIndexEntry, b: Omit<CadenceIndexEntry, "experimentId" | "packagedAt">): boolean {
+  return (
+    a.scope === b.scope &&
+    a.changeAxis === b.changeAxis &&
+    a.championFingerprint === b.championFingerprint &&
+    a.challengerFingerprint === b.challengerFingerprint
+  );
+}
+
+async function readCadenceIndex(
+  munin: CadenceMuninClient,
+  principal: string,
+): Promise<{ entries: CadenceIndexEntry[]; updatedAt?: string }> {
+  const entry = await munin.read(cadenceIndexNamespace(principal), CADENCE_INDEX_KEY);
+  if (!entry) return { entries: [] };
+  const parsed = cadenceIndexSchema.safeParse(JSON.parse(entry.content));
+  if (!parsed.success) throw new Error(`cadence index content is invalid: ${parsed.error.message}`);
+  return { entries: parsed.data.entries, updatedAt: entry.updated_at };
+}
+
+/** Idempotent: a natural key already present is a no-op, never a duplicate entry. */
+async function appendCadenceIndexEntry(
+  munin: CadenceMuninClient,
+  principal: string,
+  newEntry: CadenceIndexEntry,
+): Promise<void> {
+  for (let attempt = 0; attempt < MAX_INDEX_MUTATION_ATTEMPTS; attempt += 1) {
+    const { entries, updatedAt } = await readCadenceIndex(munin, principal);
+    if (entries.some((e) => sameNaturalKey(e, newEntry))) return;
+    const next = { schemaVersion: CADENCE_SCHEMA_VERSION, entries: [...entries, newEntry] };
+    try {
+      if (updatedAt === undefined) {
+        await munin.write(
+          cadenceIndexNamespace(principal), CADENCE_INDEX_KEY, JSON.stringify(next),
+          ["learning:cadence-index"], undefined, "internal", true,
+        );
+      } else {
+        await munin.write(
+          cadenceIndexNamespace(principal), CADENCE_INDEX_KEY, JSON.stringify(next),
+          ["learning:cadence-index"], updatedAt, "internal",
+        );
+      }
+      return;
+    } catch (err) {
+      if (err instanceof MuninWriteRejectedError && attempt < MAX_INDEX_MUTATION_ATTEMPTS - 1) continue;
+      throw err;
+    }
+  }
+  throw new Error("cadence index update lost repeated CAS races");
+}
+
+// ─── Reviewable summary (idempotent, natural-keyed on experimentId) ────────────
+
+const outcomeExportStatusSchema = z.enum(["skipped", "attempted", "would-export", "failed"]);
+
+const reviewableSummarySchema = z.object({
+  schemaVersion: z.literal(CADENCE_SCHEMA_VERSION),
+  experimentId: z.string().min(1),
+  scope: z.string().min(1),
+  taskType: z.string().min(1),
+  changeAxis: learningChangeAxisSchema,
+  championFingerprint: sha256Schema,
+  challengerFingerprint: sha256Schema,
+  championModelId: z.string().min(1),
+  challengerModelId: z.string().min(1),
+  decision: z.enum(["promotion-ready", "reject"]),
+  reason: z.string().min(1),
+  nextAction: z.string().min(1),
+  matchedPairs: z.number().int().nonnegative(),
+  holdoutPairs: z.number().int().nonnegative(),
+  primaryMetric: z.string().min(1),
+  primaryChampion: z.number().nullable(),
+  primaryChallenger: z.number().nullable(),
+  primaryImprovement: z.number().nullable(),
+  guardFailures: z.array(z.string()),
+  narrative: z.string().min(1),
+  documentedGaps: z.array(z.string()),
+  outcomeExport: z.object({
+    status: outcomeExportStatusSchema,
+    detail: z.string().optional(),
+  }).strict(),
+  awaitingReview: z.literal(true),
+  concludedAt: z.string().min(1),
+}).strict();
+export type ReviewableSummaryRecord = z.infer<typeof reviewableSummarySchema>;
+
+function buildNarrative(state: LearningExperimentState): string {
+  const verdict = state.status === "promotion-ready" ? "beat" : "did not beat";
+  const delta = state.evaluation.primaryImprovement === null ? "n/a" : state.evaluation.primaryImprovement.toFixed(4);
+  return (
+    `challenger ${state.challenger.model.id} vs champion ${state.champion.model.id} on task-type ` +
+    `${state.taskType} (axis: ${state.changeAxis}): challenger ${verdict} the champion on ` +
+    `${state.evaluation.primaryMetric} (improvement=${delta}), n=${state.evaluation.matchedPairs} matched pairs ` +
+    `(${state.evaluation.holdoutPairs} holdout). ${state.evaluation.reason} Awaiting review/adoption -- this ` +
+    `tick never promotes; promotion is a separate, explicit action (gi#49).`
+  );
+}
+
+const DOCUMENTED_GAP_NO_CI =
+  "no formal confidence interval is computed here -- the monotonic gate evaluator " +
+  "(experiment-evaluator.ts) reports matchedPairs/primaryImprovement/guardFailures as its decision basis, not a CI.";
+
+function buildReviewableSummary(
+  state: LearningExperimentState,
+  concludedAt: string,
+  outcomeExport: { status: z.infer<typeof outcomeExportStatusSchema>; detail?: string },
+): ReviewableSummaryRecord {
+  const documentedGaps = [DOCUMENTED_GAP_NO_CI];
+  if (outcomeExport.status === "skipped") {
+    documentedGaps.push(
+      "gille outcome export skipped -- Hugin's content-blind experiment records do not carry the raw " +
+      "prompt bytes / full evidence-identity bundle gille-inference#8's import contract requires; see " +
+      "experiment-outcome-export.ts's module doc comment.",
+    );
+  }
+  return reviewableSummarySchema.parse({
+    schemaVersion: CADENCE_SCHEMA_VERSION,
+    experimentId: state.experimentId,
+    scope: state.scope,
+    taskType: state.taskType,
+    changeAxis: state.changeAxis,
+    championFingerprint: state.champion.fingerprint,
+    challengerFingerprint: state.challenger.fingerprint,
+    championModelId: state.champion.model.id,
+    challengerModelId: state.challenger.model.id,
+    decision: state.status === "promotion-ready" ? "promotion-ready" : "reject",
+    reason: state.evaluation.reason,
+    nextAction: state.evaluation.nextAction,
+    matchedPairs: state.evaluation.matchedPairs,
+    holdoutPairs: state.evaluation.holdoutPairs,
+    primaryMetric: state.evaluation.primaryMetric,
+    primaryChampion: state.evaluation.primaryChampion,
+    primaryChallenger: state.evaluation.primaryChallenger,
+    primaryImprovement: state.evaluation.primaryImprovement,
+    guardFailures: state.evaluation.guardFailures,
+    narrative: buildNarrative(state),
+    documentedGaps,
+    outcomeExport,
+    awaitingReview: true,
+    concludedAt,
+  });
+}
+
+/** True if a summary already exists (idempotent no-op) versus freshly written. */
+async function writeReviewableSummaryIfAbsent(
+  munin: CadenceMuninClient,
+  principal: string,
+  summary: ReviewableSummaryRecord,
+): Promise<{ wrote: boolean }> {
+  try {
+    await munin.write(
+      cadenceSummaryNamespace(principal),
+      summary.experimentId,
+      JSON.stringify(summary),
+      ["learning:cadence-summary", `learning:${summary.decision}`, `axis:${summary.changeAxis}`, `type:${summary.taskType}`],
+      undefined,
+      "internal",
+      true,
+    );
+    return { wrote: true };
+  } catch (err) {
+    if (err instanceof MuninWriteRejectedError && err.conflictReason === "already_exists") {
+      return { wrote: false };
+    }
+    throw err;
+  }
+}
+
+async function readReviewableSummary(
+  munin: CadenceMuninClient,
+  principal: string,
+  experimentId: string,
+): Promise<ReviewableSummaryRecord | null> {
+  const entry = await munin.read(cadenceSummaryNamespace(principal), experimentId);
+  if (!entry) return null;
+  const parsed = reviewableSummarySchema.safeParse(JSON.parse(entry.content));
+  if (!parsed.success) throw new Error(`stored reviewable summary for ${experimentId} is invalid: ${parsed.error.message}`);
+  return parsed.data;
+}
+
+// ─── Tick types ─────────────────────────────────────────────────────────────────
+
+export interface ExperimentCadenceDeps {
+  registry: Pick<LearningRegistryStore, "listEventsForTask">;
+  experimentStore: LearningExperimentStore;
+  munin: CadenceMuninClient;
+  /** The owning principal for both the experiment store and this cadence's own durable records. */
+  principal: string;
+  /**
+   * Resolve the current qualified evidence pool. Required, not defaulted: see
+   * the module doc comment's "documented limitation" -- Hugin has no
+   * production-ready bulk assembler for this yet.
+   */
+  loadCandidates: () => Promise<PackagerCandidateInput[]>;
+  /** Injected #8 export port. Omit to always skip export with a recorded reason. */
+  gilleExport?: GilleOutcomeExportPort;
+  /** Injected evidence resolver for the export bundle. Omit to always skip export. */
+  evidenceResolver?: GilleOutcomeEvidenceResolver;
+  now?: () => string;
+}
+
+export interface CadenceTickOptions {
+  dryRun?: boolean;
+  runId?: string;
+  proposerOptions?: ProposeRequest;
+  /** Per-proposal packaging overrides (scope/gates/etc). Defaults to `proposalToPackageRequest`'s own defaults. */
+  packageOverrides?: (proposal: ExperimentProposal) => {
+    scope?: string;
+    gates?: LearningExperimentGates;
+    minCandidatesPerArm?: number;
+    minQualityRating?: PackagerQualityRating;
+  };
+}
+
+export interface CadenceRefusal {
+  stage: "package";
+  proposalId: string;
+  reason: string;
+}
+
+export interface CadenceError {
+  stage: "load-candidates" | "propose" | "index-read" | "package" | "observe-or-conclude";
+  message: string;
+}
+
+export interface CadenceObservedExperiment {
+  experimentId: string;
+  status: LearningExperimentState["status"];
+  matchedPairs: number;
+  holdoutPairs: number;
+}
+
+export interface CadenceConcludedExperiment {
+  experimentId: string;
+  alreadyConcluded: boolean;
+  summaryWritten: boolean;
+  exportStatus: z.infer<typeof outcomeExportStatusSchema>;
+  exportDetail?: string;
+}
+
+export interface CadenceTickResult {
+  tickId: string;
+  dryRun: boolean;
+  startedAt: string;
+  candidatesLoaded: number;
+  proposalsConsidered: number;
+  /**
+   * Populations the #234 proposer itself declined to propose -- includes
+   * `multi-axis-delta` (the one-axis-discipline refusal), `insufficient-
+   * samples`, `no-quality-signal-delta`, etc. This tick never overrides or
+   * reinterprets these; it only surfaces them so "refused, with a reason" is
+   * durable and discoverable even when nothing was ever chosen to package.
+   */
+  proposalDeclines: PopulationDeclineReason[];
+  skippedInFlight: string[];
+  packaged: { experimentId: string; scope: string; reused: boolean; wouldPackage?: boolean } | null;
+  refusals: CadenceRefusal[];
+  observed: CadenceObservedExperiment[];
+  concluded: CadenceConcludedExperiment[];
+  errors: CadenceError[];
+  limitations: string[];
+}
+
+const QUARANTINE_VISIBILITY_LIMITATION =
+  "gille-side axis quarantine is not observable through the gille-inference#8 import contract " +
+  "(POST /admin/experiments/import is import-only; no query surface exists for quarantine state). " +
+  "This tick cannot check it and does not invent a channel to do so.";
+
+function naturalKeyOf(scope: string, proposal: ExperimentProposal): Omit<CadenceIndexEntry, "experimentId" | "packagedAt"> {
+  return {
+    scope,
+    taskType: proposal.taskType,
+    changeAxis: proposal.changeAxis,
+    championFingerprint: proposal.championFingerprint,
+    challengerFingerprint: proposal.challengerFingerprint,
+  };
+}
+
+function resolveMatchedCandidates(
+  candidates: readonly PackagerCandidateInput[],
+  proposal: ExperimentProposal,
+): PackagerCandidateInput[] {
+  const wanted = new Set(proposal.matchedTasks.map((t) => `${t.taskId}/${t.attemptId}`));
+  return candidates.filter((c) => wanted.has(`${c.taskId}/${c.attemptId}`));
+}
+
+async function buildTimelines(
+  registry: Pick<LearningRegistryStore, "listEventsForTask">,
+  candidates: readonly PackagerCandidateInput[],
+): Promise<Map<string, TaskLifecycleTimeline>> {
+  const taskIds = [...new Set(candidates.map((c) => c.taskId))];
+  const timelines = new Map<string, TaskLifecycleTimeline>();
+  for (const taskId of taskIds) {
+    timelines.set(taskId, await buildTaskLifecycleTimeline(registry, taskId));
+  }
+  return timelines;
+}
+
+/** Content-blind: ids, counts, statuses, and reasons only -- never candidate/task content. */
+function buildTickLogContent(result: CadenceTickResult): string {
+  return JSON.stringify({
+    tickId: result.tickId,
+    startedAt: result.startedAt,
+    candidatesLoaded: result.candidatesLoaded,
+    proposalsConsidered: result.proposalsConsidered,
+    proposalDeclines: result.proposalDeclines,
+    skippedInFlight: result.skippedInFlight,
+    packaged: result.packaged,
+    refusals: result.refusals,
+    observed: result.observed,
+    concluded: result.concluded,
+    errors: result.errors,
+    limitations: result.limitations,
+  });
+}
+
+/**
+ * Run exactly one cadence tick. Never throws for a business-rule failure --
+ * see the module doc comment's fail-closed composition note. May reject only
+ * for a genuine programming error (e.g. malformed `deps`).
+ */
+export async function runExperimentCadenceTick(
+  deps: ExperimentCadenceDeps,
+  options: CadenceTickOptions = {},
+): Promise<CadenceTickResult> {
+  const now = deps.now ?? (() => new Date().toISOString());
+  const startedAt = now();
+  const dryRun = options.dryRun ?? false;
+  const tickId = options.runId ?? `tick-${startedAt.replace(/[^0-9]/g, "")}`;
+
+  const refusals: CadenceRefusal[] = [];
+  const errors: CadenceError[] = [];
+  const observed: CadenceObservedExperiment[] = [];
+  const concluded: CadenceConcludedExperiment[] = [];
+  const skippedInFlight: string[] = [];
+  let packaged: CadenceTickResult["packaged"] = null;
+
+  // -- (a) load evidence + propose --------------------------------------------
+  let candidates: PackagerCandidateInput[] = [];
+  try {
+    candidates = await deps.loadCandidates();
+  } catch (err) {
+    errors.push({ stage: "load-candidates", message: describeError(err) });
+  }
+
+  let proposals: ExperimentProposal[] = [];
+  let proposalsConsidered = 0;
+  let proposalDeclines: PopulationDeclineReason[] = [];
+  if (candidates.length > 0) {
+    try {
+      const outcome = await proposeExperimentsFromRegistry(deps.registry, candidates, options.proposerOptions);
+      proposals = outcome.proposals;
+      proposalsConsidered = outcome.proposals.length;
+      proposalDeclines = outcome.declinedPopulations;
+    } catch (err) {
+      errors.push({ stage: "propose", message: describeError(err) });
+    }
+  }
+
+  // -- (b) dedupe against the cadence's own in-flight index --------------------
+  let indexEntries: CadenceIndexEntry[] = [];
+  let indexReadable = true;
+  try {
+    indexEntries = (await readCadenceIndex(deps.munin, deps.principal)).entries;
+  } catch (err) {
+    indexReadable = false;
+    errors.push({ stage: "index-read", message: describeError(err) });
+  }
+
+  let chosenProposal: ExperimentProposal | null = null;
+  let chosenScope = "";
+  if (indexReadable) {
+    for (const proposal of proposals) {
+      const scope = options.packageOverrides?.(proposal)?.scope ?? proposal.suggestedScope;
+      const key = naturalKeyOf(scope, proposal);
+      if (indexEntries.some((e) => sameNaturalKey(e, key))) {
+        skippedInFlight.push(proposal.proposalId);
+        continue;
+      }
+      chosenProposal = proposal;
+      chosenScope = scope;
+      break;
+    }
+  } else if (proposals.length > 0) {
+    refusals.push({
+      stage: "package",
+      proposalId: proposals[0]!.proposalId,
+      reason: "index-unavailable: refusing to package without a safe in-flight dedup read",
+    });
+  }
+
+  // -- (c) package + create (or, in dry-run, package-preview only) -------------
+  if (chosenProposal) {
+    const overrides = options.packageOverrides?.(chosenProposal) ?? {};
+    const packageRequest: PackageRequest = proposalToPackageRequest(chosenProposal, { ...overrides, scope: chosenScope, now });
+    const matchedCandidates = resolveMatchedCandidates(candidates, chosenProposal);
+    if (matchedCandidates.length !== chosenProposal.matchedTasks.length) {
+      refusals.push({
+        stage: "package",
+        proposalId: chosenProposal.proposalId,
+        reason: "matched-candidate-resolution-incomplete: not every proposal.matchedTasks entry was found in the supplied candidate pool",
+      });
+    } else if (dryRun) {
+      try {
+        const timelines = await buildTimelines(deps.registry, matchedCandidates);
+        const preview = packageExperimentCandidates(matchedCandidates, timelines, packageRequest);
+        if (preview.status === "packaged" && preview.package) {
+          packaged = { experimentId: `pkg-${preview.package.packageId.slice(4, 20)}`, scope: chosenScope, reused: false, wouldPackage: true };
+        } else {
+          refusals.push({
+            stage: "package",
+            proposalId: chosenProposal.proposalId,
+            reason: `packaging would be refused: ${JSON.stringify(preview.refusalReasons)}`,
+          });
+        }
+      } catch (err) {
+        errors.push({ stage: "package", message: describeError(err) });
+      }
+    } else {
+      try {
+        const outcome = await packageAndHandOff(
+          deps.registry, deps.experimentStore, deps.principal, matchedCandidates, packageRequest,
+        );
+        if (outcome.status === "packaged" && outcome.experiment && outcome.createInput) {
+          packaged = { experimentId: outcome.createInput.experiment_id, scope: chosenScope, reused: outcome.experiment.reused };
+          await appendCadenceIndexEntry(deps.munin, deps.principal, {
+            ...naturalKeyOf(chosenScope, chosenProposal),
+            experimentId: outcome.createInput.experiment_id,
+            packagedAt: now(),
+          });
+          if (!indexEntries.some((e) => e.experimentId === outcome.createInput!.experiment_id)) {
+            indexEntries = [...indexEntries, {
+              ...naturalKeyOf(chosenScope, chosenProposal),
+              experimentId: outcome.createInput.experiment_id,
+              packagedAt: now(),
+            }];
+          }
+        } else {
+          refusals.push({
+            stage: "package",
+            proposalId: chosenProposal.proposalId,
+            reason: `packaging refused: ${JSON.stringify(outcome.refusalReasons)}`,
+          });
+        }
+      } catch (err) {
+        if (err instanceof LearningStoreError) {
+          errors.push({ stage: "package", message: `${err.code}: ${err.message}` });
+        } else {
+          errors.push({ stage: "package", message: describeError(err) });
+        }
+      }
+    }
+  }
+
+  // -- (d)/(e) observe every tracked experiment; conclude terminal ones --------
+  for (const entry of indexEntries) {
+    try {
+      const state = await deps.experimentStore.read(deps.principal, entry.experimentId);
+      if (state.status === "running") {
+        observed.push({
+          experimentId: entry.experimentId, status: state.status,
+          matchedPairs: state.evaluation.matchedPairs, holdoutPairs: state.evaluation.holdoutPairs,
+        });
+        continue;
+      }
+      if (state.status === "promoted") {
+        // Promotion happened outside this cadence (gi#49's job, or a manual
+        // action) -- nothing left for a tick to do for this experiment.
+        continue;
+      }
+      // "promotion-ready" or "rejected": the frozen sample target was reached.
+      observed.push({
+        experimentId: entry.experimentId, status: state.status,
+        matchedPairs: state.evaluation.matchedPairs, holdoutPairs: state.evaluation.holdoutPairs,
+      });
+      const existingSummary = await readReviewableSummary(deps.munin, deps.principal, entry.experimentId);
+      if (existingSummary) {
+        concluded.push({
+          experimentId: entry.experimentId, alreadyConcluded: true, summaryWritten: false,
+          exportStatus: existingSummary.outcomeExport.status, exportDetail: existingSummary.outcomeExport.detail,
+        });
+        continue;
+      }
+
+      let exportStatus: z.infer<typeof outcomeExportStatusSchema>;
+      let exportDetail: string | undefined;
+      if (deps.gilleExport && deps.evidenceResolver) {
+        try {
+          const runId = `${entry.experimentId}-${tickId}`;
+          const { bundle, unresolvedSamples } = await buildOutcomeExportBundle(state, runId, deps.evidenceResolver);
+          if (!bundle) {
+            exportStatus = "skipped";
+            exportDetail = `no-resolvable-evidence: ${unresolvedSamples.length} sample(s) unresolved`;
+          } else if (dryRun) {
+            exportStatus = "would-export";
+            exportDetail = `${bundle.arms.length} arm(s) ready; ${unresolvedSamples.length} unresolved`;
+          } else {
+            const result = await deps.gilleExport.exportOutcome(bundle);
+            exportStatus = "attempted";
+            exportDetail = JSON.stringify(result.arms.map((a) => ({ armId: a.armId, sampleId: a.sampleId, status: a.status, reason: a.reason })));
+          }
+        } catch (err) {
+          exportStatus = "failed";
+          exportDetail = describeError(err);
+        }
+      } else {
+        exportStatus = "skipped";
+        exportDetail = "evidence-resolver-or-export-port-not-configured (documented limitation)";
+      }
+
+      const summary = buildReviewableSummary(state, now(), { status: exportStatus, detail: exportDetail });
+      let summaryWritten = false;
+      if (!dryRun) {
+        const writeResult = await writeReviewableSummaryIfAbsent(deps.munin, deps.principal, summary);
+        summaryWritten = writeResult.wrote;
+      }
+      concluded.push({ experimentId: entry.experimentId, alreadyConcluded: false, summaryWritten, exportStatus, exportDetail });
+    } catch (err) {
+      errors.push({ stage: "observe-or-conclude", message: `${entry.experimentId}: ${describeError(err)}` });
+    }
+  }
+
+  const result: CadenceTickResult = {
+    tickId,
+    dryRun,
+    startedAt,
+    candidatesLoaded: candidates.length,
+    proposalsConsidered,
+    proposalDeclines,
+    skippedInFlight,
+    packaged,
+    refusals,
+    observed,
+    concluded,
+    errors,
+    limitations: [QUARANTINE_VISIBILITY_LIMITATION],
+  };
+
+  if (!dryRun) {
+    await deps.munin.log(cadenceTickLogNamespace(deps.principal), buildTickLogContent(result), ["learning:cadence-tick"]);
+  }
+
+  return result;
+}

--- a/src/learning/experiment-outcome-export.ts
+++ b/src/learning/experiment-outcome-export.ts
@@ -1,0 +1,342 @@
+/**
+ * Hugin-side export bridge to gille-inference's experiment-outcome import
+ * contract (gille-inference#8, `POST /admin/experiments/import`, shipped in
+ * gille-inference#34's `src/homeserver/experiment-import.ts`). Owned by the
+ * cadence (#266); the wire types here are a Hugin-side mirror of gille's own
+ * `experimentOutcomeBundleWireSchema` -- kept in lockstep by hand since the
+ * two repositories do not share a types package.
+ *
+ * Scope boundary: this module only ever calls the *import* endpoint with a
+ * bundle built from evidence the caller supplies -- it never fabricates
+ * evidence and never re-implements any part of the store, proposer, or
+ * packager. See experiment-cadence.ts for how a concluded
+ * `LearningExperimentState` becomes a bundle.
+ *
+ * Documented limitation (do not "fix" by inventing content): gille's wire
+ * contract requires each arm to carry `prompt` (a non-empty string) and a
+ * nine-field `evidenceIdentity` bundle (model/config/task/prompt/harness/
+ * taxonomy/verifier-rubric/sampling/tool-policy digests). Hugin's own
+ * `LearningExperimentState`/`RecordedLearningObservation`
+ * (experiment-schema.ts) are deliberately CONTENT-BLIND -- they carry
+ * `PromptRef`/`HarnessRef` *digests*, never raw prompt bytes, by design (see
+ * that file's module doc comment). There is today no Hugin-owned durable
+ * store this module can read raw prompt text or the full nine-field identity
+ * bundle back out of without crossing that content-blindness boundary on
+ * purpose. Rather than invent placeholder content (which
+ * `assertAdmissibleEvidenceIdentity` on gille's side is specifically designed
+ * to catch and reject as a placeholder/fictional value anyway), this module
+ * takes an optional, explicitly pluggable `GilleOutcomeEvidenceResolver` --
+ * when none is configured (today's reality), the cadence tick records
+ * `"skipped: evidence-resolver-not-configured"` rather than silently
+ * fabricating a bundle or silently declining to try.
+ */
+
+import { z } from "zod";
+import { resolveGatewayRootUrl } from "../orchestrator/provider-config.js";
+import type {
+  LearningExperimentState,
+  RecordedLearningObservation,
+} from "./experiment-schema.js";
+
+// ─── Wire schema (mirrors gille-inference's experimentOutcomeBundleWireSchema) ──
+
+const identityOriginSchema = z.enum([
+  "learning-task-stamp",
+  "server-observed",
+  "operator-declared",
+]);
+export type IdentityOrigin = z.infer<typeof identityOriginSchema>;
+
+const identityUnknownReasonSchema = z.enum([
+  "not-applicable",
+  "not-observed",
+  "legacy",
+  "producer-error",
+  "policy-unavailable",
+]);
+export type IdentityUnknownReason = z.infer<typeof identityUnknownReasonSchema>;
+
+const SHA256_DIGEST = /^(sha256:)?[a-f0-9]{64}$/;
+
+export const identityFieldSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("digest"),
+    id: z.string().min(1),
+    version: z.string().min(1),
+    digest: z.string().regex(SHA256_DIGEST, "digest must be sha256:<64 lowercase hex>"),
+    origin: identityOriginSchema,
+  }).strict(),
+  z.object({ kind: z.literal("label"), label: z.string().min(1), origin: identityOriginSchema }).strict(),
+  z.object({
+    kind: z.literal("unknown"),
+    reason: identityUnknownReasonSchema,
+    detail: z.string().min(1).optional(),
+  }).strict(),
+]);
+export type IdentityField = z.infer<typeof identityFieldSchema>;
+
+const EVIDENCE_LANES = [
+  "chat",
+  "mcp-ask",
+  "delegate",
+  "delegate-disagreement",
+  "delegate-shadow",
+  "code-loop",
+] as const;
+const evidenceLaneWireSchema = z.union([z.enum(EVIDENCE_LANES), z.literal("unknown")]);
+
+export const evidenceIdentityWireSchema = z.object({
+  modelArtifact: identityFieldSchema,
+  configEpoch: identityFieldSchema,
+  logicalTask: identityFieldSchema,
+  renderedPrompt: identityFieldSchema,
+  harness: identityFieldSchema,
+  taxonomyVersion: identityFieldSchema,
+  verifierRubric: identityFieldSchema,
+  sampling: identityFieldSchema,
+  toolPolicy: identityFieldSchema,
+  lane: evidenceLaneWireSchema,
+}).strict();
+export type EvidenceIdentityWire = z.infer<typeof evidenceIdentityWireSchema>;
+
+export const verifierIdentityWireSchema = z.object({
+  name: z.string().min(1),
+  independent: z.boolean(),
+  mode: z.enum(["deterministic", "human", "calibrated-judge", "advisory-judge"]),
+  calibrationEvidenceId: z.string().min(1).nullish(),
+}).strict();
+export type VerifierIdentityWire = z.infer<typeof verifierIdentityWireSchema>;
+
+export const exposureIdentityWireSchema = z.object({
+  contaminationStatus: z.enum(["clean", "contaminated", "coverage-incomplete"]),
+}).strict();
+export type ExposureIdentityWire = z.infer<typeof exposureIdentityWireSchema>;
+
+export const reviewIdentityWireSchema = z.object({
+  ratingId: z.string().min(1),
+  reviewerId: z.string().min(1),
+  independent: z.boolean(),
+  productOutcome: z.enum(["accepted", "rejected", "conflicted", "unrated"]),
+  reasonDigest: z.string().min(1),
+  ratedAt: z.string().min(1),
+}).strict();
+export type ReviewIdentityWire = z.infer<typeof reviewIdentityWireSchema>;
+
+const outcomeWireSchema = z.enum(["pass", "partial", "fail", "error", "unverified"]);
+const errorClassWireSchema = z.enum(["empty", "truncated", "timeout", "parse", "infra"]);
+
+export const armOutcomeWireSchema = z.object({
+  armId: z.string().min(1),
+  sampleId: z.string().min(1),
+  taskType: z.string().min(1),
+  modelId: z.string().min(1),
+  nodeId: z.enum(["m5", "orin"]).optional(),
+  outcome: outcomeWireSchema,
+  errorClass: errorClassWireSchema.nullish(),
+  score: z.number().nullish(),
+  latencyMs: z.number().nullish(),
+  prompt: z.string().min(1),
+  evidenceIdentity: evidenceIdentityWireSchema.optional(),
+  verifier: verifierIdentityWireSchema.optional(),
+  exposure: exposureIdentityWireSchema.optional(),
+  review: reviewIdentityWireSchema.nullish(),
+  policyEpoch: z.string().min(1),
+  recordedAt: z.string().min(1),
+  expiresAt: z.string().min(1).nullish(),
+  supersedesRunId: z.string().min(1).nullish(),
+  policyQualifiesPartial: z.boolean().optional(),
+}).strict();
+export type ArmOutcomeWire = z.infer<typeof armOutcomeWireSchema>;
+
+export const experimentOutcomeBundleWireSchema = z.object({
+  experimentId: z.string().min(1),
+  runId: z.string().min(1),
+  status: z.enum(["completed", "failed", "inconclusive"]),
+  arms: z.array(armOutcomeWireSchema).min(1),
+}).strict();
+export type HuginExperimentOutcomeBundle = z.infer<typeof experimentOutcomeBundleWireSchema>;
+
+// ─── Evidence resolution (caller-supplied; see module doc comment) ─────────────
+
+/**
+ * Per-(arm, sample) evidence Hugin does not durably carry on
+ * `RecordedLearningObservation` today. A resolver returning `null` for a
+ * given observation means "cannot honestly resolve this" -- the caller MUST
+ * treat that as an exclusion, never substitute a placeholder.
+ */
+export interface GilleOutcomeArmEvidence {
+  prompt: string;
+  evidenceIdentity: EvidenceIdentityWire;
+  verifier: VerifierIdentityWire;
+  exposure: ExposureIdentityWire;
+  review?: ReviewIdentityWire | null;
+  policyEpoch: string;
+  nodeId?: "m5" | "orin";
+  expiresAt?: string | null;
+}
+
+export interface GilleOutcomeEvidenceResolver {
+  resolveArmEvidence(input: {
+    experiment: LearningExperimentState;
+    observation: RecordedLearningObservation;
+  }): Promise<GilleOutcomeArmEvidence | null>;
+}
+
+/**
+ * Build the export bundle for one concluded experiment. Pairs observations by
+ * `sample_id` (same pairing rule `experiment-evaluator.ts` uses) and resolves
+ * each arm's extra evidence via the caller-supplied resolver. Samples the
+ * resolver cannot honestly resolve are DROPPED from the bundle (never
+ * substituted) and returned separately so the caller can record the gap. A
+ * `null` return means no sample resolved at all -- there is nothing
+ * admissible to export this tick.
+ */
+export async function buildOutcomeExportBundle(
+  experiment: LearningExperimentState,
+  runId: string,
+  resolver: GilleOutcomeEvidenceResolver,
+): Promise<{ bundle: HuginExperimentOutcomeBundle | null; unresolvedSamples: string[] }> {
+  const arms: ArmOutcomeWire[] = [];
+  const unresolvedSamples: string[] = [];
+  for (const observation of experiment.observations) {
+    const evidence = await resolver.resolveArmEvidence({ experiment, observation });
+    if (!evidence) {
+      unresolvedSamples.push(`${observation.arm}:${observation.sample_id}`);
+      continue;
+    }
+    const outcome: ArmOutcomeWire["outcome"] =
+      observation.quality_outcome === "infra-error" ? "error" : observation.quality_outcome;
+    arms.push(armOutcomeWireSchema.parse({
+      armId: observation.arm,
+      sampleId: observation.sample_id,
+      taskType: experiment.taskType,
+      modelId: observation.arm === "champion" ? experiment.champion.model.id : experiment.challenger.model.id,
+      ...(evidence.nodeId ? { nodeId: evidence.nodeId } : {}),
+      outcome,
+      score: observation.verifier_score ?? null,
+      latencyMs: observation.latency_ms ?? null,
+      prompt: evidence.prompt,
+      evidenceIdentity: evidence.evidenceIdentity,
+      verifier: evidence.verifier,
+      exposure: evidence.exposure,
+      review: evidence.review ?? null,
+      policyEpoch: evidence.policyEpoch,
+      recordedAt: observation.recorded_at,
+      expiresAt: evidence.expiresAt ?? null,
+    }));
+  }
+  if (arms.length === 0) return { bundle: null, unresolvedSamples };
+  const status: HuginExperimentOutcomeBundle["status"] =
+    experiment.status === "promotion-ready" ? "completed" : "inconclusive";
+  return {
+    bundle: experimentOutcomeBundleWireSchema.parse({
+      experimentId: experiment.experimentId,
+      runId,
+      status,
+      arms,
+    }),
+    unresolvedSamples,
+  };
+}
+
+// ─── Import result (mirrors gille's ExperimentImportResult) ─────────────────────
+
+const armImportResultSchema = z.object({
+  armId: z.string(),
+  sampleId: z.string(),
+  status: z.enum(["imported", "idempotent-noop", "rejected"]),
+  delegationId: z.string().optional(),
+  shadow: z.boolean().optional(),
+  reason: z.string().optional(),
+  detail: z.string().optional(),
+}).passthrough();
+
+const importResultSchema = z.object({
+  experimentId: z.string(),
+  runId: z.string(),
+  arms: z.array(armImportResultSchema),
+}).passthrough();
+
+export type GilleOutcomeArmImportResult = z.infer<typeof armImportResultSchema>;
+export type GilleOutcomeImportResult = z.infer<typeof importResultSchema>;
+
+export interface GilleOutcomeExportPort {
+  exportOutcome(bundle: HuginExperimentOutcomeBundle): Promise<GilleOutcomeImportResult>;
+}
+
+export class GilleOutcomeExportError extends Error {
+  constructor(public readonly code: string) {
+    super(`gille experiment-outcome export failed (${code})`);
+    this.name = "GilleOutcomeExportError";
+  }
+}
+
+/** Resolve the owner-only admin import endpoint, mirroring m5-task-exposure.ts's `resolveTaskExposureLookupEndpoint`. */
+export function resolveExperimentOutcomeExportEndpoint(raw: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(raw.trim());
+  } catch {
+    throw new GilleOutcomeExportError("invalid-gateway-url");
+  }
+  if (parsed.pathname !== "" && parsed.pathname !== "/" && parsed.pathname !== "/v1" && parsed.pathname !== "/v1/") {
+    throw new GilleOutcomeExportError("invalid-gateway-url");
+  }
+  if (parsed.username || parsed.password || parsed.search || parsed.hash) {
+    throw new GilleOutcomeExportError("invalid-gateway-url");
+  }
+  const resolved = resolveGatewayRootUrl({ HOMESERVER_GATEWAY_URL: parsed.origin });
+  if (!resolved.ok) throw new GilleOutcomeExportError("invalid-gateway-url");
+  return `${resolved.baseUrl}/admin/experiments/import`;
+}
+
+/** Real HTTP client for gille-inference#8's import endpoint. Never invoked unless a caller wires it in. */
+export function createGilleOutcomeExportClient(input: {
+  gatewayBaseUrl: string;
+  apiKey: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}): GilleOutcomeExportPort {
+  const endpoint = resolveExperimentOutcomeExportEndpoint(input.gatewayBaseUrl);
+  const apiKey = input.apiKey.trim();
+  if (!apiKey) throw new GilleOutcomeExportError("missing-api-key");
+  const fetchImpl = input.fetchImpl ?? fetch;
+  const timeoutMs = input.timeoutMs ?? 15_000;
+  if (!Number.isInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 60_000) {
+    throw new GilleOutcomeExportError("invalid-timeout");
+  }
+
+  return {
+    async exportOutcome(bundle: HuginExperimentOutcomeBundle): Promise<GilleOutcomeImportResult> {
+      const parsedBundle = experimentOutcomeBundleWireSchema.parse(bundle);
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+      let response: Response;
+      try {
+        response = await fetchImpl(endpoint, {
+          method: "POST",
+          headers: { authorization: `Bearer ${apiKey}`, "content-type": "application/json" },
+          body: JSON.stringify(parsedBundle),
+          redirect: "error",
+          signal: controller.signal,
+        });
+      } catch {
+        clearTimeout(timer);
+        if (controller.signal.aborted) throw new GilleOutcomeExportError("timeout");
+        throw new GilleOutcomeExportError("network-error");
+      }
+      clearTimeout(timer);
+      if (response.status === 400) throw new GilleOutcomeExportError("malformed-bundle");
+      if (!response.ok) throw new GilleOutcomeExportError(`http-${response.status}`);
+      let json: unknown;
+      try {
+        json = await response.json();
+      } catch {
+        throw new GilleOutcomeExportError("invalid-json");
+      }
+      const parsed = importResultSchema.safeParse(json);
+      if (!parsed.success) throw new GilleOutcomeExportError("invalid-response");
+      return parsed.data;
+    },
+  };
+}

--- a/tests/experiment-cadence-cli.test.ts
+++ b/tests/experiment-cadence-cli.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { parseArgs } from "../src/experiment-cadence-cli.js";
+
+describe("experiment cadence CLI arg parsing", () => {
+  it("requires --candidates", () => {
+    expect(() => parseArgs([])).toThrow("--candidates <path> is required");
+    expect(() => parseArgs(["--dry-run"])).toThrow("--candidates <path> is required");
+  });
+
+  it("parses --candidates", () => {
+    expect(parseArgs(["--candidates", "/tmp/pool.json"])).toEqual({
+      dryRun: false,
+      candidatesPath: "/tmp/pool.json",
+    });
+  });
+
+  it("parses --dry-run alongside --candidates", () => {
+    expect(parseArgs(["--candidates", "/tmp/pool.json", "--dry-run"])).toEqual({
+      dryRun: true,
+      candidatesPath: "/tmp/pool.json",
+    });
+  });
+
+  it("requires a value for --candidates", () => {
+    expect(() => parseArgs(["--candidates"])).toThrow("--candidates requires a value");
+  });
+
+  it("rejects unknown options", () => {
+    expect(() => parseArgs(["--candidates", "/tmp/pool.json", "--bogus"])).toThrow("unknown option");
+  });
+});

--- a/tests/experiment-cadence.test.ts
+++ b/tests/experiment-cadence.test.ts
@@ -1,0 +1,471 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { MuninWriteRejectedError, type MuninClient } from "../src/munin-client.js";
+import { LearningRegistryStore } from "../src/learning-registry-store.js";
+import { computeConfigurationFingerprint } from "../src/learning/experiment-schema.js";
+import { buildQualityReceipt, type QualityReceipt } from "../src/quality-receipt.js";
+import { LearningExperimentStore } from "../src/learning/experiment-store.js";
+import type { PackagerCandidateInput } from "../src/learning/candidate-packager-schema.js";
+import {
+  runExperimentCadenceTick,
+  type ExperimentCadenceDeps,
+} from "../src/learning/experiment-cadence.js";
+import { makeLearningConfig } from "./fixtures/learning.js";
+
+// ---------------------------------------------------------------------------
+// In-memory Munin double -- same create-if-absent / CAS contract as the real
+// service, copied from tests/experiment-proposer.test.ts's own copy (itself
+// copied from tests/learning-registry-store.test.ts), extended with `log()`
+// so this file can assert the durable tick log actually gets written.
+// ---------------------------------------------------------------------------
+
+interface StoredEntry {
+  namespace: string;
+  key: string;
+  content: string;
+  tags: string[];
+  classification?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+class InMemoryMunin {
+  private entries: StoredEntry[] = [];
+  private seq = 0;
+  readonly logs: Array<{ namespace: string; content: string; tags?: string[] }> = [];
+
+  private clock(): string {
+    this.seq += 1;
+    return new Date(Date.UTC(2026, 6, 1, 0, 0, 0, 0) + this.seq).toISOString();
+  }
+
+  private find(namespace: string, key: string): StoredEntry | undefined {
+    return this.entries.find((e) => e.namespace === namespace && e.key === key);
+  }
+
+  async read(namespace: string, key: string) {
+    const entry = this.find(namespace, key);
+    if (!entry) return null;
+    return { ...entry, found: true } as unknown as { content: string; updated_at: string; found: true };
+  }
+
+  async write(
+    namespace: string,
+    key: string,
+    content: string,
+    tags?: string[],
+    expectedUpdatedAt?: string,
+    classification?: string,
+    createIfAbsent?: boolean,
+  ) {
+    const existing = this.find(namespace, key);
+    if (createIfAbsent === true && existing) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        message: "Entry already exists.",
+        conflict_reason: "already_exists",
+        current_updated_at: existing.updated_at,
+      });
+    }
+    if (expectedUpdatedAt !== undefined && (!existing || existing.updated_at !== expectedUpdatedAt)) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        message: "Entry version changed.",
+        conflict_reason: "version_mismatch",
+        current_updated_at: existing?.updated_at,
+      });
+    }
+    const updated_at = this.clock();
+    const created_at = existing?.created_at ?? updated_at;
+    const next: StoredEntry = { namespace, key, content, tags: tags ?? [], classification, created_at, updated_at };
+    if (existing) Object.assign(existing, next); else this.entries.push(next);
+    return { ok: true, status: existing ? "updated" : "created", updated_at };
+  }
+
+  async query(opts: { namespace?: string; tags?: string[]; limit?: number; since?: string; until?: string }) {
+    let rows = this.entries.filter((e) =>
+      (!opts.namespace || e.namespace.startsWith(opts.namespace))
+      && (opts.tags ?? []).every((tag) => e.tags.includes(tag)));
+    if (opts.since) rows = rows.filter((e) => e.updated_at >= opts.since!);
+    if (opts.until) rows = rows.filter((e) => e.updated_at <= opts.until!);
+    rows = [...rows].sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+    const limited = rows.slice(0, opts.limit ?? 50);
+    return {
+      results: limited.map((e) => ({
+        id: `${e.namespace}/${e.key}`,
+        namespace: e.namespace,
+        key: e.key,
+        entry_type: "state",
+        content_preview: e.content.slice(0, 80),
+        tags: e.tags,
+        classification: e.classification,
+        created_at: e.created_at,
+        updated_at: e.updated_at,
+      })),
+      total: rows.length,
+    };
+  }
+
+  async log(namespace: string, content: string, tags?: string[]) {
+    this.logs.push({ namespace, content, tags });
+  }
+}
+
+function munin(): InMemoryMunin & MuninClient {
+  return new InMemoryMunin() as unknown as InMemoryMunin & MuninClient;
+}
+
+const ref = (namespace: string, key: string) => ({ namespace, key });
+const hash = (seed: string) => createHash("sha256").update(seed).digest("hex");
+
+async function registerQualifiedAttempt(
+  store: LearningRegistryStore,
+  input: { taskId: string; attemptId: string; occurredAt: string; outcome?: "completed" | "failed" },
+) {
+  const taskOutcomeRef = ref(`tasks/${input.taskId}`, "result-structured");
+  await store.recordSubmission({ taskId: input.taskId, taskOutcomeRef, occurredAt: input.occurredAt });
+  await store.recordAttemptReference({
+    taskId: input.taskId,
+    attemptId: input.attemptId,
+    attemptStartRef: ref(`tasks/${input.taskId}`, `learning-attempt-${input.attemptId}`),
+    taskOutcomeRef,
+    occurredAt: input.occurredAt,
+  });
+  await store.recordTerminalOutcome({
+    taskId: input.taskId,
+    attemptId: input.attemptId,
+    outcome: input.outcome ?? "completed",
+    taskOutcomeRef,
+    occurredAt: input.occurredAt,
+  });
+}
+
+function receiptFor(
+  taskId: string,
+  rating: "pass" | "partial" | "redo" | "wrong",
+  ratedAt: string,
+  overrides: Partial<Parameters<typeof buildQualityReceipt>[0]> = {},
+): QualityReceipt {
+  return buildQualityReceipt({
+    taskId,
+    reviewerPrincipal: "codex",
+    reviewerIndependence: "independent",
+    rating,
+    ratingReason: `SECRET-RAW-EVIDENCE-TEXT-${taskId}-${rating}`,
+    verificationOutcome: rating === "pass" ? "accepted_unchanged" : "major_rewrite",
+    ratedAt,
+    bindingAttestation: "server-bound",
+    binding: {
+      taskDocumentSha256: hash(`${taskId}-doc`),
+      structuredResultSha256: hash(`${taskId}-result`),
+      repository: { state: "no-changes", baseBranch: "main", baseCommit: hash(`${taskId}-base`).slice(0, 40) },
+    },
+    ...overrides,
+  });
+}
+
+/** Register `count` qualified attempts of `taskType` for one config arm. See
+ * tests/experiment-proposer.test.ts's own copy of this helper -- this cadence
+ * suite only ever drives the registry-backed orchestration functions, so it
+ * does not also need to return a timelines map the way that file's does. */
+async function seedArm(
+  store: LearningRegistryStore,
+  input: {
+    taskType: string;
+    arm: "champion" | "challenger";
+    axis: Parameters<typeof makeLearningConfig>[1];
+    idPrefix: string;
+    count: number;
+    ratings: Array<"pass" | "partial" | "redo" | "wrong">;
+    startIso: string;
+  },
+): Promise<PackagerCandidateInput[]> {
+  const candidates: PackagerCandidateInput[] = [];
+  const configuration = makeLearningConfig(input.arm, input.axis);
+  for (let i = 0; i < input.count; i += 1) {
+    const taskId = `${input.idPrefix}-${i}`;
+    const attemptId = `${input.idPrefix}-attempt-${i}`;
+    const occurredAt = new Date(Date.parse(input.startIso) + i * 86_400_000).toISOString();
+    await registerQualifiedAttempt(store, { taskId, attemptId, occurredAt });
+    const rating = input.ratings[i % input.ratings.length]!;
+    candidates.push({
+      taskId,
+      attemptId,
+      taskType: input.taskType as PackagerCandidateInput["taskType"],
+      configuration,
+      qualityReceipt: receiptFor(taskId, rating, occurredAt),
+    });
+  }
+  return candidates;
+}
+
+const MECHANICAL_VERIFIER = { kind: "mechanical" as const, independent: true, id: "protected-check", version: "1" };
+const HOLDOUT_SAMPLES = new Set(["case-1", "case-2"]);
+
+/** Push `count` matched champion/challenger observation pairs (idempotent per
+ * run_id) engineered to clear every default gate once `count` reaches 6:
+ * verified+rated coverage 1.0, 2 holdout pairs, challenger quality-rate 1.0
+ * vs champion 0.0 (>= the 0.05 minPrimaryImprovement default), matched
+ * latency/cost so no ratio guard fires. */
+async function observePairs(
+  store: LearningExperimentStore,
+  principal: string,
+  experimentId: string,
+  count: number,
+): Promise<void> {
+  for (let i = 1; i <= count; i += 1) {
+    const sample = `case-${i}`;
+    const holdout = HOLDOUT_SAMPLES.has(sample);
+    await store.observe(principal, {
+      experiment_id: experimentId,
+      run_id: `${sample}-champion`,
+      sample_id: sample,
+      arm: "champion",
+      holdout,
+      configuration_fingerprint: makeLearningConfig("champion", "agent-prompt").fingerprint,
+      quality_outcome: "fail",
+      product_outcome: "discarded",
+      verifier: MECHANICAL_VERIFIER,
+      latency_ms: 1000,
+      cost_usd: 0,
+    });
+    await store.observe(principal, {
+      experiment_id: experimentId,
+      run_id: `${sample}-challenger`,
+      sample_id: sample,
+      arm: "challenger",
+      holdout,
+      configuration_fingerprint: makeLearningConfig("challenger", "agent-prompt").fingerprint,
+      quality_outcome: "pass",
+      product_outcome: "accepted-unchanged",
+      verifier: MECHANICAL_VERIFIER,
+      latency_ms: 1000,
+      cost_usd: 0,
+    });
+  }
+}
+
+function baseDeps(
+  m: InMemoryMunin & MuninClient,
+  registry: LearningRegistryStore,
+  experimentStore: LearningExperimentStore,
+  principal: string,
+  candidates: PackagerCandidateInput[],
+): ExperimentCadenceDeps {
+  return {
+    registry,
+    experimentStore,
+    munin: m,
+    principal,
+    loadCandidates: async () => candidates,
+    now: () => "2026-07-10T00:00:00.000Z",
+  };
+}
+
+/**
+ * The #234 proposer floors at "wrong" (the whole outcome spectrum) so it can
+ * detect a quality delta at all, but the #233 packager only ever freezes
+ * "pass"-rated candidates (candidate-packager.ts's `DEFAULT_MIN_QUALITY_RATING`).
+ * A realistic proposal-that-packages therefore needs each arm to carry at
+ * least `minCandidatesPerArm` (2) pass-rated candidates while still showing a
+ * proposer-visible delta across the WHOLE arm -- champion here is 2 pass + 2
+ * wrong (proposer-visible rate 0.5), challenger is 4 pass (rate 1.0), a 0.5
+ * delta comfortably above the 0.1 default threshold. The packager will
+ * legitimately reject the 2 non-pass champion candidates and still freeze
+ * the surviving 2 -- exactly the "some matched candidates rejected, enough
+ * survive" behavior `packageExperimentCandidates` is designed for.
+ */
+async function seedOneAxisPopulation(registry: LearningRegistryStore): Promise<PackagerCandidateInput[]> {
+  const champion = await seedArm(registry, {
+    taskType: "code-edit", arm: "champion", axis: "agent-prompt", idPrefix: "champ",
+    count: 4, ratings: ["pass", "pass", "wrong", "wrong"], startIso: "2026-07-01T00:00:00.000Z",
+  });
+  const challenger = await seedArm(registry, {
+    taskType: "code-edit", arm: "challenger", axis: "agent-prompt", idPrefix: "chall",
+    count: 4, ratings: ["pass"], startIso: "2026-07-05T00:00:00.000Z",
+  });
+  return [...champion, ...challenger];
+}
+
+describe("runExperimentCadenceTick", () => {
+  it("packages exactly one experiment from a qualified proposal; a re-tick with unchanged state duplicates nothing", async () => {
+    const m = munin();
+    const registry = new LearningRegistryStore(m);
+    const experimentStore = new LearningExperimentStore(m);
+    const candidates = await seedOneAxisPopulation(registry);
+    const principal = "service:test-cadence-happy-path";
+    const deps = baseDeps(m, registry, experimentStore, principal, candidates);
+
+    const tick1 = await runExperimentCadenceTick(deps);
+    expect(tick1.errors).toEqual([]);
+    expect(tick1.refusals).toEqual([]);
+    expect(tick1.proposalDeclines).toEqual([]);
+    expect(tick1.proposalsConsidered).toBe(1);
+    expect(tick1.skippedInFlight).toEqual([]);
+    expect(tick1.packaged).not.toBeNull();
+    expect(tick1.packaged!.reused).toBe(false);
+    expect(m.logs).toHaveLength(1);
+
+    const experimentId = tick1.packaged!.experimentId;
+    const created = await experimentStore.read(principal, experimentId);
+    expect(created.status).toBe("running");
+    expect(created.changeAxis).toBe("agent-prompt");
+
+    // Re-run against the exact same evidence: the same proposal is produced
+    // again, but it is already in flight -- nothing new is packaged.
+    const tick2 = await runExperimentCadenceTick(deps);
+    expect(tick2.errors).toEqual([]);
+    expect(tick2.refusals).toEqual([]);
+    expect(tick2.proposalsConsidered).toBe(1);
+    expect(tick2.skippedInFlight).toHaveLength(1);
+    expect(tick2.packaged).toBeNull();
+    expect(m.logs).toHaveLength(2);
+
+    const stillOne = await experimentStore.read(principal, experimentId);
+    expect(stillOne.revision).toBe(1);
+  });
+
+  it("dry-run reports the would-be package and mutates nothing", async () => {
+    const m = munin();
+    const registry = new LearningRegistryStore(m);
+    const experimentStore = new LearningExperimentStore(m);
+    const candidates = await seedOneAxisPopulation(registry);
+    const principal = "service:test-cadence-dry-run";
+    const deps = baseDeps(m, registry, experimentStore, principal, candidates);
+
+    const dryTick = await runExperimentCadenceTick(deps, { dryRun: true });
+    expect(dryTick.dryRun).toBe(true);
+    expect(dryTick.packaged).not.toBeNull();
+    expect(dryTick.packaged!.wouldPackage).toBe(true);
+    expect(dryTick.errors).toEqual([]);
+    expect(m.logs).toEqual([]);
+
+    // Nothing was actually created under the previewed id.
+    await expect(experimentStore.read(principal, dryTick.packaged!.experimentId)).rejects.toThrow();
+
+    // A real tick afterwards behaves as if the dry run never happened.
+    const realTick = await runExperimentCadenceTick(deps);
+    expect(realTick.packaged).not.toBeNull();
+    expect(realTick.packaged!.reused).toBe(false);
+    expect(realTick.packaged!.experimentId).toBe(dryTick.packaged!.experimentId);
+  });
+
+  it("surfaces a multi-axis population decline from the #234 proposer and packages nothing", async () => {
+    const m = munin();
+    const registry = new LearningRegistryStore(m);
+    const experimentStore = new LearningExperimentStore(m);
+    const champion = await seedArm(registry, {
+      taskType: "code-edit", arm: "champion", axis: "agent-prompt", idPrefix: "champ",
+      count: 3, ratings: ["partial"], startIso: "2026-07-01T00:00:00.000Z",
+    });
+    const challengerBase = await seedArm(registry, {
+      taskType: "code-edit", arm: "challenger", axis: "agent-prompt", idPrefix: "chall",
+      count: 3, ratings: ["pass"], startIso: "2026-07-05T00:00:00.000Z",
+    });
+    // Contaminate the challenger arm so its harness ALSO differs, not just
+    // the prompt -- this is the same technique
+    // tests/experiment-proposer.test.ts uses to prove one-axis discipline.
+    const contaminatedHarnessDigest = hash("contaminated-harness");
+    const challenger = challengerBase.map((c) => {
+      const configuration = {
+        ...c.configuration,
+        harness: { ...c.configuration.harness, version: "9", configSha256: contaminatedHarnessDigest },
+      };
+      configuration.fingerprint = computeConfigurationFingerprint(configuration);
+      return { ...c, configuration };
+    });
+    const candidates = [...champion, ...challenger];
+    const principal = "service:test-cadence-multiaxis";
+    const deps = baseDeps(m, registry, experimentStore, principal, candidates);
+
+    const tick = await runExperimentCadenceTick(deps);
+    expect(tick.errors).toEqual([]);
+    expect(tick.refusals).toEqual([]);
+    expect(tick.proposalsConsidered).toBe(0);
+    expect(tick.packaged).toBeNull();
+    expect(tick.proposalDeclines).toContainEqual(
+      expect.objectContaining({ code: "multi-axis-delta", taskType: "code-edit" }),
+    );
+  });
+
+  it("a running experiment below target is observed, not concluded; a proposer failure does not abort the tick", async () => {
+    const m = munin();
+    const registry = new LearningRegistryStore(m);
+    const experimentStore = new LearningExperimentStore(m);
+    const candidates = await seedOneAxisPopulation(registry);
+    const principal = "service:test-cadence-observe";
+    const deps = baseDeps(m, registry, experimentStore, principal, candidates);
+
+    const tick1 = await runExperimentCadenceTick(deps);
+    const experimentId = tick1.packaged!.experimentId;
+    await observePairs(experimentStore, principal, experimentId, 2);
+
+    const brokenRegistry: Pick<LearningRegistryStore, "listEventsForTask"> = {
+      listEventsForTask: async () => {
+        throw new Error("registry unavailable (simulated)");
+      },
+    };
+    const brokenDeps: ExperimentCadenceDeps = { ...deps, registry: brokenRegistry as LearningRegistryStore };
+
+    const tick2 = await runExperimentCadenceTick(brokenDeps);
+    expect(tick2.errors).toContainEqual(expect.objectContaining({ stage: "propose" }));
+    expect(tick2.packaged).toBeNull();
+    // The propose-stage failure does not stop the tick from observing the
+    // already-tracked experiment.
+    expect(tick2.observed).toContainEqual(
+      expect.objectContaining({ experimentId, status: "running", matchedPairs: 2 }),
+    );
+    expect(tick2.concluded).toEqual([]);
+  });
+
+  it("reaching the frozen sample target concludes exactly once: one summary, idempotent on re-tick", async () => {
+    const m = munin();
+    const registry = new LearningRegistryStore(m);
+    const experimentStore = new LearningExperimentStore(m);
+    const candidates = await seedOneAxisPopulation(registry);
+    const principal = "service:test-cadence-conclude";
+    const deps = baseDeps(m, registry, experimentStore, principal, candidates);
+
+    const tick1 = await runExperimentCadenceTick(deps);
+    const experimentId = tick1.packaged!.experimentId;
+    await observePairs(experimentStore, principal, experimentId, 6);
+
+    const concludedState = await experimentStore.read(principal, experimentId);
+    expect(concludedState.status).toBe("promotion-ready");
+    expect(concludedState.evaluation.matchedPairs).toBe(6);
+    expect(concludedState.evaluation.holdoutPairs).toBe(2);
+
+    const tick2 = await runExperimentCadenceTick(deps);
+    expect(tick2.errors).toEqual([]);
+    expect(tick2.observed).toContainEqual(
+      expect.objectContaining({ experimentId, status: "promotion-ready", matchedPairs: 6 }),
+    );
+    expect(tick2.concluded).toEqual([
+      expect.objectContaining({
+        experimentId,
+        alreadyConcluded: false,
+        summaryWritten: true,
+        exportStatus: "skipped",
+      }),
+    ]);
+
+    // Re-run: the reviewable summary already exists -- concluding is a no-op.
+    const tick3 = await runExperimentCadenceTick(deps);
+    expect(tick3.concluded).toEqual([
+      expect.objectContaining({ experimentId, alreadyConcluded: true, summaryWritten: false }),
+    ]);
+  });
+
+  it("always names the gille-side quarantine visibility limitation rather than inventing a channel", async () => {
+    const m = munin();
+    const registry = new LearningRegistryStore(m);
+    const experimentStore = new LearningExperimentStore(m);
+    const principal = "service:test-cadence-limitations";
+    const deps = baseDeps(m, registry, experimentStore, principal, []);
+
+    const tick = await runExperimentCadenceTick(deps);
+    expect(tick.limitations).toContainEqual(expect.stringContaining("quarantine"));
+    expect(tick.candidatesLoaded).toBe(0);
+    expect(tick.packaged).toBeNull();
+  });
+});

--- a/tests/experiment-outcome-export.test.ts
+++ b/tests/experiment-outcome-export.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildOutcomeExportBundle,
+  createGilleOutcomeExportClient,
+  experimentOutcomeBundleWireSchema,
+  GilleOutcomeExportError,
+  resolveExperimentOutcomeExportEndpoint,
+  type GilleOutcomeArmEvidence,
+  type GilleOutcomeEvidenceResolver,
+} from "../src/learning/experiment-outcome-export.js";
+import { makeLearningConfig } from "./fixtures/learning.js";
+import type { LearningExperimentState, RecordedLearningObservation } from "../src/learning/experiment-schema.js";
+
+function observation(
+  arm: "champion" | "challenger",
+  sampleId: string,
+  overrides: Partial<RecordedLearningObservation> = {},
+): RecordedLearningObservation {
+  return {
+    experiment_id: "pkg-test",
+    run_id: `${sampleId}-${arm}`,
+    sample_id: sampleId,
+    arm,
+    holdout: false,
+    configuration_fingerprint: makeLearningConfig(arm).fingerprint,
+    quality_outcome: arm === "champion" ? "fail" : "pass",
+    product_outcome: arm === "champion" ? "discarded" : "accepted-unchanged",
+    verifier: { kind: "mechanical", independent: true, id: "protected-check", version: "1" },
+    latency_ms: 1000,
+    cost_usd: 0,
+    recorded_at: "2026-07-10T00:00:00.000Z",
+    recorded_by: "service:test",
+    ...overrides,
+  };
+}
+
+function experimentState(observations: RecordedLearningObservation[]): LearningExperimentState {
+  const champion = makeLearningConfig("champion");
+  const challenger = makeLearningConfig("challenger");
+  return {
+    schemaVersion: 1,
+    experimentId: "pkg-test",
+    scope: "proposed-code-edit-agent-prompt",
+    taskType: "code-edit",
+    ownerPrincipal: "service:test",
+    hypothesis: "test hypothesis",
+    changeAxis: "agent-prompt",
+    champion,
+    challenger,
+    gates: {
+      minMatchedPairs: 2, minHoldoutPairs: 1, minVerifiedCoverage: 0.8, minRatedCoverage: 0.5,
+      minChallengerAgentCheckCoverage: 0, maxQualityRegression: 0, maxUsefulRegression: 0,
+      maxRescueRateIncrease: 0, maxInfraRateIncrease: 0.05, maxLatencyRatio: 1.25, maxCostRatio: 1.25,
+      primaryMetric: "quality-rate", minPrimaryImprovement: 0.05,
+    },
+    status: "promotion-ready",
+    revision: 3,
+    createdAt: "2026-07-01T00:00:00.000Z",
+    updatedAt: "2026-07-10T00:00:00.000Z",
+    observations,
+    evaluation: {
+      decision: "promotion-ready", reason: "cleared every gate", evaluatedAt: "2026-07-10T00:00:00.000Z",
+      matchedPairs: observations.length / 2, holdoutPairs: 0, unmatchedObservations: 0,
+      champion: {
+        samples: 0, verifiedSamples: 0, verifiedCoverage: 0, qualityRate: 0, ratedSamples: 0, ratedCoverage: 0,
+        usefulRate: null, rescueRate: null, infraRate: 0, latencyMeanMs: null, costMeanUsd: null,
+        humanReviewMeanSeconds: null, editStartMeanMs: null, observabilityCoverageMean: null,
+        verifierScoreMean: null, agentCheckSamples: 0, agentCheckCoverage: 0,
+      },
+      challenger: {
+        samples: 0, verifiedSamples: 0, verifiedCoverage: 0, qualityRate: 1, ratedSamples: 0, ratedCoverage: 0,
+        usefulRate: null, rescueRate: null, infraRate: 0, latencyMeanMs: null, costMeanUsd: null,
+        humanReviewMeanSeconds: null, editStartMeanMs: null, observabilityCoverageMean: null,
+        verifierScoreMean: null, agentCheckSamples: 0, agentCheckCoverage: 0,
+      },
+      primaryMetric: "quality-rate", primaryChampion: 0, primaryChallenger: 1, primaryImprovement: 1,
+      guardFailures: [], missingRequirements: [], failureSignals: [], nextAction: "review and promote",
+    },
+  };
+}
+
+const FULL_EVIDENCE: GilleOutcomeArmEvidence = {
+  prompt: "resolved-prompt-text",
+  evidenceIdentity: {
+    modelArtifact: { kind: "digest", id: "m", version: "1", digest: "a".repeat(64), origin: "server-observed" },
+    configEpoch: { kind: "digest", id: "c", version: "1", digest: "b".repeat(64), origin: "server-observed" },
+    logicalTask: { kind: "digest", id: "t", version: "1", digest: "c".repeat(64), origin: "learning-task-stamp" },
+    renderedPrompt: { kind: "digest", id: "p", version: "1", digest: "d".repeat(64), origin: "learning-task-stamp" },
+    harness: { kind: "digest", id: "h", version: "1", digest: "e".repeat(64), origin: "server-observed" },
+    taxonomyVersion: { kind: "label", label: "v1", origin: "server-observed" },
+    verifierRubric: { kind: "label", label: "protected-check-v1", origin: "server-observed" },
+    sampling: { kind: "label", label: "default", origin: "server-observed" },
+    toolPolicy: { kind: "label", label: "default", origin: "server-observed" },
+    lane: "code-loop",
+  },
+  verifier: { name: "protected-check", independent: true, mode: "deterministic" },
+  exposure: { contaminationStatus: "clean" },
+  policyEpoch: "epoch-1",
+};
+
+describe("buildOutcomeExportBundle", () => {
+  it("builds a bundle mapping quality_outcome and pairing arm/sample correctly", async () => {
+    const observations = [observation("champion", "case-1"), observation("challenger", "case-1")];
+    const state = experimentState(observations);
+    const resolver: GilleOutcomeEvidenceResolver = { resolveArmEvidence: async () => FULL_EVIDENCE };
+
+    const { bundle, unresolvedSamples } = await buildOutcomeExportBundle(state, "run-1", resolver);
+
+    expect(unresolvedSamples).toEqual([]);
+    expect(bundle).not.toBeNull();
+    expect(bundle!.experimentId).toBe("pkg-test");
+    expect(bundle!.runId).toBe("run-1");
+    expect(bundle!.status).toBe("completed");
+    expect(bundle!.arms).toHaveLength(2);
+    const champArm = bundle!.arms.find((a) => a.armId === "champion")!;
+    expect(champArm.outcome).toBe("fail");
+    expect(champArm.modelId).toBe(makeLearningConfig("champion").model.id);
+    const challArm = bundle!.arms.find((a) => a.armId === "challenger")!;
+    expect(challArm.outcome).toBe("pass");
+    expect(experimentOutcomeBundleWireSchema.parse(bundle)).toEqual(bundle);
+  });
+
+  it("maps an infra-error quality outcome onto the wire 'error' outcome", async () => {
+    const observations = [
+      observation("champion", "case-1", { quality_outcome: "infra-error" }),
+      observation("challenger", "case-1"),
+    ];
+    const state = experimentState(observations);
+    const resolver: GilleOutcomeEvidenceResolver = { resolveArmEvidence: async () => FULL_EVIDENCE };
+    const { bundle } = await buildOutcomeExportBundle(state, "run-1", resolver);
+    expect(bundle!.arms.find((a) => a.armId === "champion")!.outcome).toBe("error");
+  });
+
+  it("drops samples the resolver cannot honestly resolve rather than fabricating evidence", async () => {
+    const observations = [observation("champion", "case-1"), observation("challenger", "case-1")];
+    const state = experimentState(observations);
+    const resolver: GilleOutcomeEvidenceResolver = { resolveArmEvidence: async () => null };
+
+    const { bundle, unresolvedSamples } = await buildOutcomeExportBundle(state, "run-1", resolver);
+
+    expect(bundle).toBeNull();
+    expect(unresolvedSamples).toEqual(["champion:case-1", "challenger:case-1"]);
+  });
+
+  it("marks a rejected (non-promotion-ready) experiment as inconclusive on the wire", async () => {
+    const observations = [observation("champion", "case-1"), observation("challenger", "case-1")];
+    const state = { ...experimentState(observations), status: "rejected" as const };
+    const resolver: GilleOutcomeEvidenceResolver = { resolveArmEvidence: async () => FULL_EVIDENCE };
+    const { bundle } = await buildOutcomeExportBundle(state, "run-1", resolver);
+    expect(bundle!.status).toBe("inconclusive");
+  });
+});
+
+describe("resolveExperimentOutcomeExportEndpoint", () => {
+  it("resolves the admin import path under a sovereign gateway root", () => {
+    expect(resolveExperimentOutcomeExportEndpoint("http://localhost:8080")).toBe(
+      "http://localhost:8080/admin/experiments/import",
+    );
+  });
+
+  it("rejects a non-root path", () => {
+    expect(() => resolveExperimentOutcomeExportEndpoint("http://localhost:8080/v2")).toThrow(GilleOutcomeExportError);
+  });
+
+  it("rejects an unparseable URL", () => {
+    expect(() => resolveExperimentOutcomeExportEndpoint("not a url")).toThrow(GilleOutcomeExportError);
+  });
+});
+
+describe("createGilleOutcomeExportClient", () => {
+  const bundle = experimentOutcomeBundleWireSchema.parse({
+    experimentId: "pkg-test",
+    runId: "run-1",
+    status: "completed",
+    arms: [{
+      armId: "champion",
+      sampleId: "case-1",
+      taskType: "code-edit",
+      modelId: makeLearningConfig("champion").model.id,
+      outcome: "fail",
+      prompt: "resolved-prompt-text",
+      evidenceIdentity: FULL_EVIDENCE.evidenceIdentity,
+      verifier: FULL_EVIDENCE.verifier,
+      exposure: FULL_EVIDENCE.exposure,
+      policyEpoch: "epoch-1",
+      recordedAt: "2026-07-10T00:00:00.000Z",
+    }],
+  });
+
+  it("POSTs the bundle with bearer auth and returns the parsed per-arm result", async () => {
+    const fetchImpl = vi.fn(async (url: string, init?: RequestInit) => {
+      expect(url).toBe("http://localhost:8080/admin/experiments/import");
+      expect((init?.headers as Record<string, string>).authorization).toBe("Bearer secret-admin-key");
+      expect(JSON.parse(init!.body as string)).toEqual(bundle);
+      return new Response(JSON.stringify({
+        experimentId: "pkg-test",
+        runId: "run-1",
+        arms: [{ armId: "champion", sampleId: "case-1", status: "imported", delegationId: "d1", shadow: false }],
+      }), { status: 200 });
+    });
+
+    const client = createGilleOutcomeExportClient({
+      gatewayBaseUrl: "http://localhost:8080",
+      apiKey: "secret-admin-key",
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    const result = await client.exportOutcome(bundle);
+    expect(result.arms).toEqual([
+      { armId: "champion", sampleId: "case-1", status: "imported", delegationId: "d1", shadow: false },
+    ]);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws on a non-2xx response", async () => {
+    const fetchImpl = vi.fn(async () => new Response("nope", { status: 500 }));
+    const client = createGilleOutcomeExportClient({
+      gatewayBaseUrl: "http://localhost:8080", apiKey: "k", fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    await expect(client.exportOutcome(bundle)).rejects.toThrow(GilleOutcomeExportError);
+  });
+
+  it("throws a distinct error for a 400 malformed-bundle response", async () => {
+    const fetchImpl = vi.fn(async () => new Response("bad", { status: 400 }));
+    const client = createGilleOutcomeExportClient({
+      gatewayBaseUrl: "http://localhost:8080", apiKey: "k", fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    await expect(client.exportOutcome(bundle)).rejects.toThrow("malformed-bundle");
+  });
+
+  it("rejects a missing api key", () => {
+    expect(() => createGilleOutcomeExportClient({ gatewayBaseUrl: "http://localhost:8080", apiKey: "  " }))
+      .toThrow(GilleOutcomeExportError);
+  });
+});


### PR DESCRIPTION
Closes #266

## What

`runExperimentCadenceTick` (`src/learning/experiment-cadence.ts`) chains the already-merged experiment-pipeline pieces on one idempotent, fail-closed tick:

1. **propose** — `experiment-proposer.ts` (#234), read-only, over a caller-supplied evidence pool.
2. **dedupe** — pick the top ranked proposal not already "in flight" for its `(scope, changeAxis, championFingerprint, challengerFingerprint)` natural key, tracked in a cadence-owned durable index.
3. **package** — `candidate-packager.ts` (#233) via `packageAndHandOff`, which itself calls the already-idempotent `LearningExperimentStore.create`.
4. **observe** — read (never mutate) every experiment this cadence has ever packaged; one still `running` is reported, not concluded.
5. **conclude** — an experiment whose evaluator decision left "gathering" (`promotion-ready` or `rejected` — it reached its frozen sample target) gets a best-effort gille outcome-export attempt (#8 contract) and a durable, idempotent REVIEWABLE SUMMARY record.
6. **never promote** — `LearningExperimentStore.promote` is not imported by this module. The reviewable summary is the deliverable until gi#49's autonomy controller exists.

New files:
- `src/learning/experiment-cadence.ts` (688 lines) — the orchestrator.
- `src/learning/experiment-outcome-export.ts` (342 lines) — a Hugin-side mirror of gille-inference#34's `POST /admin/experiments/import` wire contract, a real HTTP client, and a pure bundle builder.
- `src/experiment-cadence-cli.ts` (149 lines) — `npm run experiment:cadence` entrypoint, mirroring the `recover:publication` CLI shape (`--candidates <path>`, `--dry-run`).
- Tests: `tests/experiment-cadence.test.ts` (471 lines, 6 tests), `tests/experiment-outcome-export.test.ts` (234 lines, 11 tests), `tests/experiment-cadence-cli.test.ts` (31 lines, 5 tests).

## Design decisions

**Tick composition.** Each stage is independently try/caught: a proposer error, an index-read failure, a packaging refusal, or a store conflict is recorded in `result.errors`/`result.refusals` and the tick continues with the rest. `runExperimentCadenceTick` only rejects its promise for a genuine programming error, never for a business-rule failure — the CLI decides the process exit code from `result.errors`.

**Dedup / idempotency.** The packager's content-addressed `experiment_id` is already idempotent for byte-identical repackaging, but that alone doesn't stop the SAME axis+champion+challenger pair from being packaged again under a slightly drifted evidence pool (a new matched task added between ticks would produce a different `packageId`). This cadence therefore keeps its own durable natural-key index (`scope, changeAxis, championFingerprint, challengerFingerprint` → `experimentId`) in Munin and skips any ranked proposal whose natural key is already tracked — regardless of that experiment's current status (running/terminal). Conclusion is idempotent via a `createIfAbsent` reviewable-summary write keyed on `experimentId`: a second tick over an already-concluded experiment is a no-op (`alreadyConcluded: true`).

**One-axis discipline is never reimplemented.** The tick surfaces — never overrides or reinterprets — the #234 proposer's own `multi-axis-delta` population declines and the #233 packager's own freeze-time refusal reasons. (A proposer-approved population cannot actually reach a packager refusal within one tick by construction, since both stages read the same `loadCandidates()` snapshot and share the same content-addressed configuration identity — this is a deliberate architectural invariant, not an untested edge case; the multi-axis test exercises the proposer's own decline path instead.)

**gille-side quarantine visibility (documented limitation, not invented).** gille-inference#34's `POST /admin/experiments/import` is a one-way import endpoint with no companion query surface for "is axis X quarantined." No such channel is invented here; every tick result names this gap in `result.limitations` instead.

**gille outcome export (documented limitation, not invented).** gille's import contract requires each arm to carry raw `prompt` text and a nine-field evidence-identity bundle. Hugin's `LearningExperimentState`/`RecordedLearningObservation` are deliberately content-blind (digests only, per that module's own doc comment) and carry neither. Rather than fabricate placeholder content — which gille's own `assertAdmissibleEvidenceIdentity` is specifically designed to catch and reject — this cadence takes an optional, pluggable `GilleOutcomeEvidenceResolver`; the real HTTP export client (`createGilleOutcomeExportClient`) is fully wired and tested, but with no resolver configured (today's production reality) every conclusion records `outcomeExport.status: "skipped"` with the reason, and the reviewable summary is still emitted regardless.

**Candidate-evidence-source scope.** Assembling the full production `PackagerCandidateInput[]` pool (walking every rated task in the quality-receipt ledger) is explicitly called out by `candidate-packager-schema.ts` as a "future daily factory conductor" not yet built — out of #234/#233's own scope, and out of this ticket's narrower orchestration scope. `loadCandidates` is therefore a required injected dependency; the CLI reads an operator/cron-supplied `--candidates <path>` JSON snapshot rather than inventing a whole-ledger scan.

## Verification

- `npm run build` — clean.
- `npm test` — **139 files / 2204 tests passed** (baseline 136/2182; +3 files, +22 tests, all new).
- Manual smoke: `node dist/experiment-cadence-cli.js --help` prints usage as expected.

## M5 dogfood

Skipped this task for spend discipline, per explicit instruction.