### PR TITLE
Standing harness-lane sampler and rolling comparison report

### DIFF
--- a/docs/harness-lane-standing-sampler.md
+++ b/docs/harness-lane-standing-sampler.md
@@ -1,0 +1,142 @@
+# Standing harness-lane sampler (#267)
+
+**Status:** mechanism implemented; not yet wired into the live dispatch loop.
+`src/harness-lane-sampler.ts`, `src/harness-lane-executor.ts`, and
+`src/harness-lane-comparison-report.ts` are a self-contained, tested library —
+same "ship the mechanism first" shape as `docs/learning-registry.md` (#232)
+and `docs/external-receipt-intake.md` (#237). `runHarnessLaneSampledAttempt`
+takes both lane executors as injected callbacks rather than calling any real
+runtime itself, per #267's explicit instruction not to build a new executor.
+Wiring real callbacks (the Broker `/delegate` one-shot path and
+`src/opencode-executor.ts` / `src/learning/m5-code-loop-*` for harness) into
+`src/index.ts`'s dispatch loop is deliberately left to a follow-up so this
+ships as an independently testable, zero-blast-radius library — exactly like
+#232 did. The env default (`0%`) means that even once wired, the lane stays
+fully shadowed until a human deliberately raises it.
+
+## Why a standing lane, not another campaign
+
+hugin#192 was a one-off wave-5 harvest campaign: a human picked a few real
+tickets and manually ran both the one-shot broker lane and the harness lane
+(`code_loop` / `opencode`) on matched sub-tasks, then graded both by hand.
+That produced the first real evidence that the harness lane exists at all —
+but a single campaign is a snapshot. Nothing keeps sampling new evidence once
+the campaign ends, so the moment the model, harness version, or task mix
+shifts, the evidence goes stale and nobody notices.
+
+This ticket turns that one-off comparison into a standing, sampled harvest:
+a configurable fraction of *real*, already-happening bounded coding sub-tasks
+gets *additionally* routed through the harness lane, graded with the same
+discipline as the one-shot lane, and recorded into the same durable #232
+registry the rest of the continuous-improvement cadence (#234 proposer, #266
+scheduler) already reads. The result is a rolling, queryable comparison
+instead of a dated one-time write-up.
+
+## The three pieces
+
+1. **`src/harness-lane-sampler.ts` — `decideHarnessLane`.** Pure, deterministic,
+   side-effect-free. Given a task's natural key (`taskId` + `taskType`), decides
+   `"one-shot"` or `"harness"`. No execution, no I/O, no shared state.
+2. **`src/harness-lane-executor.ts` — `runHarnessLaneSampledAttempt`.** Asks the
+   sampler for a lane, calls the caller-injected executor for that lane
+   (`HarnessLaneExecutors.oneShot` / `.harness`), then folds the result into
+   the #232 registry (`recordSubmission` → `recordAttemptReference` →
+   `recordTerminalOutcome`) with harness identity attached.
+3. **`src/harness-lane-comparison-report.ts` + `harness-lane-comparison-report-cli.ts`
+   — `npm run report:harness-comparison`.** Read-only. Queries the registry's
+   own `terminal-outcome` partition tag for the requested UTC month(s), groups
+   by `(taskType, lane)`, and prints attempts / verified attempts / pass rate /
+   escalation rate per cell.
+
+## The env var
+
+```
+HUGIN_HARNESS_LANE_FRACTION=0.1   # sample 10% of ELIGIBLE tasks into harness
+```
+
+- **Absent, empty, or `"0"`** → the lane is fully OFF: every eligible task
+  resolves to `"one-shot"` (today's status quo). This is the default.
+- **Any other value that is not a finite number in `[0, 1]`** is a **sampler
+  malfunction**, not silently treated as off or thrown at the caller:
+  `decideHarnessLane` fails closed to `"one-shot"` (the safe default) and
+  stamps `reason: "sampler-malfunction"` plus a `malfunctionDetail` string, so
+  the misconfiguration stays visible in the #232 registry (`delegation.policyAction
+  === "sampler-malfunction"`) instead of masquerading as a clean 0%.
+- A digest/hash failure inside the sampler is treated identically — same
+  fallback, same recorded reason.
+
+Raising the fraction above 0 is a deliberate, reviewed decision made *after*
+reading `npm run report:harness-comparison` and confirming the harness lane
+clears whatever gate the operator sets for a given task type — not a default
+this ticket flips on its own.
+
+## Eligibility
+
+Only `code-implement`, `code-edit`, and `unit-test-gen` are eligible
+(`HARNESS_LANE_ELIGIBLE_TASK_TYPES`) — bounded, multi-file code-edit task
+types where an agentic tool loop plausibly has something to iterate against.
+hugin#192's one datapoint found the harness's only known soft spot is
+import/export wiring across files, which is exactly what these types cover.
+Judgment/one-shot types (`extract`, `classify`, `qa-factual`, `summarize`,
+`rewrite`, `translate`, ...) are never sampled into the harness lane,
+regardless of the configured fraction — a one-shot classification gives an
+agentic loop nothing to inspect or edit.
+
+## Determinism
+
+The sampler hashes `HARNESS_LANE_SAMPLER_VERSION + taskType + taskId` (SHA-256,
+first 8 hex chars → a `[0, 1)` value) and compares it against the configured
+fraction. The same task always lands on the same lane, on every call, on
+every process, forever — until a deliberate version bump reshuffles every
+assignment on purpose. This is what makes the harvest reproducible: replaying
+or re-inspecting a task can never flip its recorded lane.
+
+## Grading discipline and harness identity
+
+Both lanes are graded identically. `LaneAttemptOutcome` (the contract each
+injected executor must resolve to) carries the same self-verify → grade shape
+as the one-shot lane: a `verifierKind` (`"mechanical"` or `"none"`) and an
+M5-style `verdict` (`"pass" | "partial" | "fail" | "error" | "unverified"`).
+
+The harness identity distinguishing the lane reuses the **existing** #163
+evidence-identity shape (`delegationProvenanceSchema` in
+`src/task-result-schema.ts`) rather than inventing a second, competing
+provenance shape. #267 adds exactly one new field to it:
+
+```ts
+lane: z.enum(["one-shot", "harness"]).optional();
+```
+
+`terminalOutcomeEventSchema.payload` (in `src/learning-registry-schema.ts`)
+now optionally carries this exact shape as `delegation`. Both additions are
+additive/optional, non-breaking, no schema version bump — the same pattern
+every other optional field in these two files already follows.
+
+## Fail-closed semantics
+
+- **Sampler malfunction** (bad env, hash error) → falls back to the one-shot
+  lane and is recorded as such (see above). The task still runs; nothing is
+  ever aborted because the sampler broke.
+- **Harness-lane failure** (the harness executor itself fails) → recorded
+  *as the harness lane*, never silently rerouted into a fresh one-shot retry.
+  Rerouting would double-spend the task and hide the harness failure from the
+  comparison. Escalation of a failed harness attempt follows exactly the same
+  path a failed one-shot attempt already follows today — this module does not
+  change or duplicate that path.
+- **Executor contract violation** (an injected executor rejects instead of
+  resolving with a `LaneAttemptOutcome`) → `runHarnessLaneSampledAttempt`
+  rethrows rather than fabricating registry evidence for work that produced
+  none. An infrastructure fault is a recovery fault, not something to paper
+  over with a made-up evidence ref — the same philosophy `AGENTS.md` already
+  states for `finalizeTaskCompletion`.
+- **No duplicate/lost tasks**: registry writes reuse the store's own
+  natural-key idempotency (`taskId`/`attemptId`-derived event ids), so
+  replaying the same attempt is a safe no-op — never a duplicate, never lost.
+
+## No routing impact
+
+The sampler and its wiring never touch `src/runtime-registry.ts`'s alias
+resolution, auto-routing, or any promotion gate. Sampling a task into the
+harness lane only produces **additional, side-channel evidence** for the
+comparison report; it never changes which runtime actually serves the
+production task. That stays true even once the fraction is raised above 0.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "harvest:daily-exams": "node dist/daily-exam-harvest-cli.js",
     "recover:publication": "node dist/publication-recovery-cli.js",
     "experiment:cadence": "node dist/experiment-cadence-cli.js",
+    "report:harness-comparison": "node dist/harness-lane-comparison-report-cli.js",
     "pilot:harbor": "tsx scripts/harbor_pilot/run-pilot.ts",
     "pilot:harbor:import": "tsx scripts/harbor_pilot/import-learning-report.ts",
     "test": "vitest run",

--- a/src/harness-lane-comparison-report-cli.ts
+++ b/src/harness-lane-comparison-report-cli.ts
@@ -1,0 +1,93 @@
+#!/usr/bin/env tsx
+
+/**
+ * Operator CLI for hugin#267: print the rolling one-shot-vs-harness
+ * comparison computed straight from the durable #232 registry. Read-only —
+ * never mutates the registry, never calls a runtime, never touches routing.
+ *
+ *   npm run report:harness-comparison -- [--months 2026-06,2026-07]
+ *
+ * Defaults to the current and previous UTC calendar month when `--months` is
+ * omitted, since that is where a standing (even shadowed, 0%-fraction) lane's
+ * recent evidence lives.
+ */
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { MuninClient } from "./munin-client.js";
+import { LearningRegistryStore } from "./learning-registry-store.js";
+import {
+  buildHarnessLaneComparisonReport,
+  formatHarnessLaneComparisonReport,
+} from "./harness-lane-comparison-report.js";
+
+function usage(): string {
+  return [
+    "Usage: npm run report:harness-comparison -- [options]",
+    "",
+    "Print the rolling one-shot-vs-harness comparison (hugin#267), computed",
+    "read-only from the durable #232 learning registry. Never mutates",
+    "anything, never calls a runtime, never affects routing.",
+    "",
+    "Options:",
+    "  --months <YYYY-MM[,YYYY-MM...]>   UTC occurrence period(s) to query",
+    "                                    (default: current + previous month)",
+    "  --help                            Show this help",
+  ].join("\n");
+}
+
+const PERIOD_PATTERN = /^\d{4}-(0[1-9]|1[0-2])$/;
+
+export function parseArgs(argv: string[], now: () => Date = () => new Date()): { months: string[] } {
+  let months: string[] | undefined;
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]!;
+    if (arg === "--help") {
+      process.stdout.write(`${usage()}\n`);
+      process.exit(0);
+    } else if (arg === "--months") {
+      const value = argv[index + 1];
+      if (!value) throw new Error("--months requires a value");
+      months = value.split(",").map((s) => s.trim()).filter((s) => s.length > 0);
+      index += 1;
+    } else {
+      throw new Error(`unknown option: ${arg}`);
+    }
+  }
+  if (months === undefined) {
+    const current = now();
+    const currentPeriod = current.toISOString().slice(0, 7);
+    const previous = new Date(Date.UTC(current.getUTCFullYear(), current.getUTCMonth() - 1, 1));
+    const previousPeriod = previous.toISOString().slice(0, 7);
+    months = [previousPeriod, currentPeriod];
+  }
+  if (months.length === 0) throw new Error("--months requires at least one period");
+  for (const month of months) {
+    if (!PERIOD_PATTERN.test(month)) {
+      throw new Error(`invalid --months value "${month}" — expected UTC "YYYY-MM"`);
+    }
+  }
+  return { months };
+}
+
+export async function main(argv = process.argv.slice(2)): Promise<void> {
+  const { months } = parseArgs(argv);
+  const apiKey = process.env.MUNIN_API_KEY?.trim();
+  if (!apiKey) throw new Error("MUNIN_API_KEY is required");
+  const munin = new MuninClient({
+    baseUrl: process.env.MUNIN_URL?.trim() || "http://localhost:3030",
+    apiKey,
+  });
+  const registry = new LearningRegistryStore(munin);
+
+  const report = await buildHarnessLaneComparisonReport(registry, months);
+  process.stdout.write(`${formatHarnessLaneComparisonReport(report)}\n`);
+  if (report.truncated) process.exitCode = 1;
+}
+
+const invokedPath = process.argv[1] ? pathToFileURL(resolve(process.argv[1])).href : "";
+if (import.meta.url === invokedPath) {
+  main().catch((error) => {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/src/harness-lane-comparison-report.ts
+++ b/src/harness-lane-comparison-report.ts
@@ -1,0 +1,159 @@
+/**
+ * Rolling one-shot-vs-harness comparison report (hugin#267).
+ *
+ * Reads terminal-outcome events straight out of the durable #232 registry —
+ * no separate index, no denormalized cache — and aggregates the ones the
+ * standing harness-lane sampler stamped (`payload.delegation.lane` present)
+ * by task type and lane. This is the queryable evidence the ticket asks for:
+ * per task type, one-shot vs harness attempts, verified pass rates,
+ * escalation rates, and `n`.
+ *
+ * Content-blind throughout: this only ever reads opaque registry event
+ * fields (task type string, lane, verdict enum, booleans, counts) — never
+ * prompt/response bytes, which the registry never stored to begin with.
+ */
+
+import type { LearningRegistryStore } from "./learning-registry-store.js";
+import type { TerminalOutcomeEvent } from "./learning-registry-schema.js";
+import type { LaneKind } from "./harness-lane-sampler.js";
+
+export interface HarnessLaneComparisonRow {
+  taskType: string;
+  lane: LaneKind;
+  /** Total attempts recorded for this (taskType, lane) — includes
+   * unverified/failed/escalated attempts, never just the successes. */
+  attempts: number;
+  /** Attempts where a verifier actually ran (`outcome` present and not
+   * `"unverified"`). */
+  verifiedAttempts: number;
+  /** Attempts whose verifier verdict was `"pass"`. */
+  passed: number;
+  /** Attempts flagged `escalated`. */
+  escalated: number;
+  /** `passed / verifiedAttempts`, or `null` when nothing was ever verified —
+   * never silently reported as 0, which would misread as "verified and
+   * failed every time" instead of "no verified evidence yet". */
+  verifiedPassRate: number | null;
+  /** `escalated / attempts`, or `null` when there were no attempts at all. */
+  escalationRate: number | null;
+}
+
+/**
+ * Aggregate a flat list of terminal-outcome events into per-(taskType, lane)
+ * comparison rows. Events without sampler-stamped `delegation.lane` (i.e.
+ * every terminal outcome recorded before hugin#267, or recorded by something
+ * other than the standing lane) are skipped — they carry no lane signal to
+ * compare.
+ */
+export function computeHarnessLaneComparison(
+  events: readonly TerminalOutcomeEvent[],
+): HarnessLaneComparisonRow[] {
+  interface Bucket {
+    taskType: string;
+    lane: LaneKind;
+    attempts: number;
+    verified: number;
+    passed: number;
+    escalated: number;
+  }
+  const buckets = new Map<string, Bucket>();
+
+  for (const event of events) {
+    const delegation = event.payload.delegation;
+    const lane = delegation?.lane;
+    const taskType = delegation?.taskType;
+    if (!lane || !taskType) continue;
+
+    const bucketKey = `${taskType}\0${lane}`;
+    const bucket = buckets.get(bucketKey) ?? {
+      taskType,
+      lane,
+      attempts: 0,
+      verified: 0,
+      passed: 0,
+      escalated: 0,
+    };
+    bucket.attempts += 1;
+    if (delegation.outcome !== undefined && delegation.outcome !== "unverified") bucket.verified += 1;
+    if (delegation.outcome === "pass") bucket.passed += 1;
+    if (delegation.escalated === true) bucket.escalated += 1;
+    buckets.set(bucketKey, bucket);
+  }
+
+  return [...buckets.values()]
+    .map((bucket): HarnessLaneComparisonRow => ({
+      taskType: bucket.taskType,
+      lane: bucket.lane,
+      attempts: bucket.attempts,
+      verifiedAttempts: bucket.verified,
+      passed: bucket.passed,
+      escalated: bucket.escalated,
+      verifiedPassRate: bucket.verified > 0 ? bucket.passed / bucket.verified : null,
+      escalationRate: bucket.attempts > 0 ? bucket.escalated / bucket.attempts : null,
+    }))
+    .sort((a, b) => a.taskType.localeCompare(b.taskType) || a.lane.localeCompare(b.lane));
+}
+
+export interface HarnessLaneComparisonReport {
+  periodsQueried: string[];
+  rows: HarnessLaneComparisonRow[];
+  /** True when any queried period's underlying registry read could not prove
+   * completeness (Munin pagination budget exhausted) — treat the report as a
+   * lower bound, not a final count. */
+  truncated: boolean;
+}
+
+/**
+ * Build the full report across one or more UTC occurrence periods
+ * (`"YYYY-MM"`), reading directly from the live #232 registry.
+ */
+export async function buildHarnessLaneComparisonReport(
+  registry: Pick<LearningRegistryStore, "listTerminalOutcomesForPeriod">,
+  occurrencePeriodsUtc: readonly string[],
+): Promise<HarnessLaneComparisonReport> {
+  const allEvents: TerminalOutcomeEvent[] = [];
+  let truncated = false;
+  for (const period of occurrencePeriodsUtc) {
+    const { events, truncated: periodTruncated } = await registry.listTerminalOutcomesForPeriod(period);
+    allEvents.push(...events);
+    truncated = truncated || periodTruncated;
+  }
+  return {
+    periodsQueried: [...occurrencePeriodsUtc],
+    rows: computeHarnessLaneComparison(allEvents),
+    truncated,
+  };
+}
+
+/** Render the report as a simple, fixed-width, content-blind text table. */
+export function formatHarnessLaneComparisonReport(report: HarnessLaneComparisonReport): string {
+  const header = ["task_type", "lane", "n", "verified_n", "verified_pass_rate", "escalation_rate"];
+  const formatRate = (value: number | null): string => (value === null ? "n/a" : `${(value * 100).toFixed(1)}%`);
+  const rows = report.rows.map((row) => [
+    row.taskType,
+    row.lane,
+    String(row.attempts),
+    String(row.verifiedAttempts),
+    formatRate(row.verifiedPassRate),
+    formatRate(row.escalationRate),
+  ]);
+  const widths = header.map((title, col) =>
+    Math.max(title.length, ...rows.map((row) => row[col]?.length ?? 0)));
+  const renderRow = (cells: string[]): string =>
+    cells.map((cell, col) => cell.padEnd(widths[col] ?? 0)).join("  ");
+
+  const lines = [
+    `Harness-lane comparison — periods: ${report.periodsQueried.join(", ") || "(none)"}`,
+    renderRow(header),
+    widths.map((w) => "-".repeat(w)).join("  "),
+    ...rows.map(renderRow),
+  ];
+  if (report.rows.length === 0) {
+    lines.push("(no sampler-stamped terminal outcomes found for the queried period(s))");
+  }
+  if (report.truncated) {
+    lines.push("");
+    lines.push("WARNING: at least one queried period's registry read was truncated; counts are a lower bound.");
+  }
+  return lines.join("\n");
+}

--- a/src/harness-lane-executor.ts
+++ b/src/harness-lane-executor.ts
@@ -1,0 +1,237 @@
+/**
+ * Standing harness-lane execution wiring (hugin#267).
+ *
+ * This module owns exactly two things: (1) asking the deterministic sampler
+ * (`src/harness-lane-sampler.ts`) which lane an eligible sub-task belongs to,
+ * and (2) folding whatever that lane's EXISTING execution path produced into
+ * the durable #232 registry (`src/learning-registry-store.ts`) with harness
+ * identity attached. It never spawns a runtime itself — per hugin#267's
+ * explicit instruction, the one-shot and harness lanes are whatever the
+ * codebase already exposes (the Broker `/delegate` submit path for one-shot;
+ * `src/opencode-executor.ts` or `src/learning/m5-code-loop-*` for harness).
+ * Callers inject those as `HarnessLaneExecutors`.
+ *
+ * Grading discipline: both lanes are graded identically — a mechanical
+ * self-verify (or an explicit "none" when no verifier applies) folds into the
+ * SAME #163 evidence-identity shape (`delegationProvenanceSchema`) already
+ * used for M5 delegation provenance, with one new field (`lane`) added in
+ * hugin#267 to distinguish which lane produced it. Nothing here duplicates a
+ * capability verdict into a Hugin-owned capability store — this is a content-
+ * blind TRACE, exactly like the #163 fields it reuses.
+ *
+ * Fail-closed contract:
+ *  - A SAMPLER malfunction (bad env, hash error) is handled entirely inside
+ *    `decideHarnessLane` — it degrades to the one-shot lane and is recorded
+ *    as such (see `HarnessLaneDecision.reason === "sampler-malfunction"`).
+ *    This module never re-derives or second-guesses that decision.
+ *  - Once a lane is chosen, this module calls exactly that lane's executor
+ *    and records exactly that lane's outcome — success or failure. It never
+ *    silently reroutes a failed harness attempt into a fresh one-shot retry
+ *    (that would double-spend the task and hide the harness failure from the
+ *    comparison), and it never fabricates registry evidence for an executor
+ *    that did not produce any: `HarnessLaneExecutors` callbacks are contract-
+ *    bound to resolve — never reject — with a `LaneAttemptOutcome`, exactly
+ *    like the dispatcher's own `finalizeTaskCompletion` already guarantees a
+ *    durable structured result before any terminal status flip (see
+ *    AGENTS.md). If an executor breaks that contract and rejects anyway, this
+ *    module rethrows rather than inventing evidence — an infrastructure fault
+ *    is a recovery fault, never something to paper over with a made-up ref.
+ *  - Registry writes reuse the store's own natural-key idempotency: replaying
+ *    the same attempt (same taskId/attemptId) is a safe no-op, never a
+ *    duplicate and never a lost event.
+ */
+
+import type { AppendResult, LearningRegistryStore } from "./learning-registry-store.js";
+import type {
+  AttemptReferenceEvent,
+  RegistryEvidenceRef,
+  RegistryOriginComponent,
+  SubmissionEvent,
+  TerminalOutcomeEvent,
+} from "./learning-registry-schema.js";
+import {
+  decideHarnessLane,
+  type HarnessLaneDecision,
+  type HarnessLaneSamplerDeps,
+  type LaneKind,
+} from "./harness-lane-sampler.js";
+import { delegationProvenanceSchema, type DelegationProvenance } from "./task-result-schema.js";
+import type { M5Outcome } from "./m5-provenance.js";
+
+/**
+ * One executed lane attempt's content-blind, already-graded outcome —
+ * produced by whichever EXISTING execution path actually ran the sub-task.
+ * Callers build this from the real executor's own result (e.g. `opencode-
+ * executor.ts`'s exit code / test commands, or an M5 `code_loop_result` via
+ * `src/learning/m5-code-loop-adapter.ts`'s `qualityOf`-style classification).
+ */
+export interface LaneAttemptOutcome {
+  /** Dispatcher-level execution result — mirrors `taskExecutionOutcomeSchema`. */
+  outcome: "completed" | "failed" | "timed_out" | "cancelled";
+  repositoryOutcomeState?: TerminalOutcomeEvent["payload"]["repositoryOutcomeState"];
+  /** Durable evidence this attempt's own executor already wrote (e.g. the
+   * dispatcher's `result-structured` doc). Required — this module never
+   * invents evidence for an executor that produced none. */
+  taskOutcomeRef: RegistryEvidenceRef;
+  attemptOutcomeRef?: RegistryEvidenceRef;
+  /** Same-discipline self-verify → grade signal as the one-shot lane. `"none"`
+   * means no mechanical verifier applied (rare for harness leaves, since
+   * hugin#192's discipline is "attach a verifier wherever possible"). */
+  verifierKind: "mechanical" | "none";
+  /** M5-style verdict; `"unverified"` when `verifierKind` is `"none"` or the
+   * verifier itself could not run. */
+  verdict: M5Outcome;
+  verifierNotes?: string;
+  modelId?: string;
+  nodeId?: string;
+  /** Harness-specific iteration signal (rounds/turns taken). Absent for
+   * one-shot leaves; present when the harness executor reports it. */
+  iterations?: number;
+  escalated?: boolean;
+  escalationReason?: string;
+}
+
+export interface HarnessLaneTaskRef {
+  taskId: string;
+  taskType: string;
+}
+
+export interface HarnessLaneExecutors {
+  oneShot: (task: HarnessLaneTaskRef) => Promise<LaneAttemptOutcome>;
+  harness: (task: HarnessLaneTaskRef) => Promise<LaneAttemptOutcome>;
+}
+
+export interface RunHarnessLaneSampledAttemptInput {
+  taskId: string;
+  attemptId: string;
+  taskType: string;
+  /** RFC 3339 UTC instant the underlying fact happened — see
+   * `registryTimestampSchema`. */
+  occurredAt: string;
+  originComponent?: RegistryOriginComponent;
+}
+
+export interface HarnessLaneAttemptResult {
+  decision: HarnessLaneDecision;
+  lane: LaneKind;
+  execution: LaneAttemptOutcome;
+  delegation: DelegationProvenance;
+  registry: {
+    submission: AppendResult<SubmissionEvent>;
+    attemptReference: AppendResult<AttemptReferenceEvent>;
+    terminalOutcome: AppendResult<TerminalOutcomeEvent>;
+  };
+}
+
+type RegistryDeps = Pick<
+  LearningRegistryStore,
+  "recordSubmission" | "recordAttemptReference" | "recordTerminalOutcome"
+>;
+
+/**
+ * Build the #163 evidence-identity payload for one lane attempt.
+ *
+ * Registry events are JCS-canonicalized for digesting (`jcsDigestHex`, used
+ * throughout `learning-registry-store.ts`), and JCS explicitly REJECTS a key
+ * whose value is the literal `undefined` (see `jcsCanonicalize` in
+ * `learning-task-handshake.ts`) — a field zod would happily treat as
+ * "optional and absent" is not the same as a key present with value
+ * `undefined`. Every optional field below is therefore conditionally
+ * spread in, never assigned `undefined` directly, mirroring the exact
+ * pattern `recordTerminalOutcome` already uses for its own optional fields.
+ */
+/** hugin#192's rating discipline calls out iterations/rounds taken as "the
+ * harness-specific signal we have none of" — fold it into the verifier-notes
+ * free-text field alongside whatever notes the executor itself supplied,
+ * rather than growing a dedicated schema field for one lane's telemetry. */
+function withIterationsNote(iterations: number | undefined, verifierNotes: string | undefined): string | undefined {
+  if (iterations === undefined) return verifierNotes;
+  const note = `iterations=${iterations}`;
+  return verifierNotes ? `${verifierNotes}; ${note}` : note;
+}
+
+function buildDelegationProvenance(
+  input: RunHarnessLaneSampledAttemptInput,
+  decision: HarnessLaneDecision,
+  execution: LaneAttemptOutcome,
+): DelegationProvenance {
+  const verifierNotes = withIterationsNote(execution.iterations, execution.verifierNotes);
+  return delegationProvenanceSchema.parse({
+    lane: decision.lane,
+    taskType: input.taskType,
+    outcome: execution.verdict,
+    verifier: execution.verifierKind === "mechanical" ? "mechanical" : "none",
+    // Sampler audit trail — reuses the generic policy trio rather than
+    // growing a second competing shape. `policyMode` names the decision
+    // maker, `policyAction` is the sampler's own reason enum,
+    // `policyReason` carries WHY when that reason is a malfunction.
+    policyMode: "harness-lane-sampler",
+    policyAction: decision.reason,
+    ...(execution.escalated !== undefined ? { escalated: execution.escalated } : {}),
+    ...(execution.modelId !== undefined ? { modelId: execution.modelId } : {}),
+    ...(execution.nodeId !== undefined ? { nodeId: execution.nodeId } : {}),
+    ...(decision.malfunctionDetail !== undefined ? { policyReason: decision.malfunctionDetail } : {}),
+    ...(execution.escalationReason !== undefined ? { decisionReason: execution.escalationReason } : {}),
+    ...(verifierNotes !== undefined ? { verifierNotes } : {}),
+  });
+}
+
+/**
+ * Decide the lane for one eligible bounded coding sub-task, execute it
+ * through whichever injected executor matches that lane, and record the
+ * attempt into the durable #232 registry with harness identity. Idempotent:
+ * calling this twice with the same `taskId`/`attemptId` and equivalent
+ * execution evidence is a safe no-op on the registry side (natural-key
+ * dedup) — the executor itself may still be invoked twice, since re-running
+ * an already-graded lane attempt is the caller's concern, not this module's.
+ */
+export async function runHarnessLaneSampledAttempt(
+  registry: RegistryDeps,
+  input: RunHarnessLaneSampledAttemptInput,
+  executors: HarnessLaneExecutors,
+  samplerDeps: HarnessLaneSamplerDeps = {},
+): Promise<HarnessLaneAttemptResult> {
+  const decision = decideHarnessLane({ taskId: input.taskId, taskType: input.taskType }, samplerDeps);
+  const lane = decision.lane;
+  const taskRef: HarnessLaneTaskRef = { taskId: input.taskId, taskType: input.taskType };
+
+  // Whichever lane the sampler picked is EXACTLY the lane that runs. A
+  // harness-lane failure below is never caught-and-rerouted into a one-shot
+  // retry here — see the module doc for why that would corrupt the
+  // comparison this ticket exists to produce.
+  const execution = lane === "harness" ? await executors.harness(taskRef) : await executors.oneShot(taskRef);
+
+  const delegation = buildDelegationProvenance(input, decision, execution);
+
+  const submission = await registry.recordSubmission({
+    taskId: input.taskId,
+    taskOutcomeRef: execution.taskOutcomeRef,
+    occurredAt: input.occurredAt,
+    originComponent: input.originComponent,
+  });
+  const attemptReference = await registry.recordAttemptReference({
+    taskId: input.taskId,
+    attemptId: input.attemptId,
+    attemptStartRef: execution.taskOutcomeRef,
+    taskOutcomeRef: execution.taskOutcomeRef,
+    occurredAt: input.occurredAt,
+  });
+  const terminalOutcome = await registry.recordTerminalOutcome({
+    taskId: input.taskId,
+    attemptId: input.attemptId,
+    outcome: execution.outcome,
+    repositoryOutcomeState: execution.repositoryOutcomeState,
+    taskOutcomeRef: execution.taskOutcomeRef,
+    attemptOutcomeRef: execution.attemptOutcomeRef,
+    occurredAt: input.occurredAt,
+    delegation,
+  });
+
+  return {
+    decision,
+    lane,
+    execution,
+    delegation,
+    registry: { submission, attemptReference, terminalOutcome },
+  };
+}

--- a/src/harness-lane-sampler.ts
+++ b/src/harness-lane-sampler.ts
@@ -1,0 +1,236 @@
+/**
+ * Standing harness-lane sampler (hugin#267).
+ *
+ * hugin#192 was a one-off campaign that hand-picked a few tickets and ran
+ * BOTH the one-shot broker lane and the M5 harness lane (`code_loop` /
+ * `opencode`) on matched sub-tasks, then graded both by hand. That produced
+ * the first real evidence that the harness lane exists at all, but a single
+ * campaign is a snapshot, not continuous improvement: nothing keeps sampling
+ * new evidence once the campaign ends.
+ *
+ * This module is the deterministic decision at the center of the standing
+ * lane: given one eligible bounded coding sub-task, decide — reproducibly,
+ * with no side effects and no execution — whether it *additionally* gets
+ * sampled into the harness lane for shadow evidence-gathering. It never
+ * executes anything and never changes production routing; see
+ * `src/harness-lane-executor.ts` for the wiring that acts on this decision.
+ *
+ * Determinism is the whole point: the same task (same natural key) must
+ * always land on the same lane, on every call, on every process, forever
+ * (until a deliberate `HARNESS_LANE_SAMPLER_VERSION` bump reshuffles
+ * assignments on purpose). That is what makes the harvest reproducible and
+ * idempotent — replaying or re-inspecting a task can never flip its lane.
+ */
+
+import { createHash } from "node:crypto";
+import type { TaskType } from "./broker/task-type-metadata.js";
+
+/** Bump this when the sampling function itself changes on purpose (e.g. a
+ * different hash construction) — it is folded into the digest input, so a
+ * version bump is a deliberate, auditable re-shuffle of every assignment
+ * rather than a silent one. */
+export const HARNESS_LANE_SAMPLER_VERSION = "v1" as const;
+
+/**
+ * `HUGIN_HARNESS_LANE_FRACTION` — fraction in `[0, 1]` of ELIGIBLE bounded
+ * coding sub-tasks to additionally sample into the harness lane for shadow
+ * evidence-gathering.
+ *
+ * Absent, empty, or `"0"` means the standing lane is fully OFF: every
+ * eligible task still resolves to the one-shot lane (today's status quo).
+ * That is the default — the lane ships shadowed until a human raises the
+ * fraction above 0 after reviewing the rolling comparison this ticket
+ * produces (`npm run report:harness-comparison`).
+ *
+ * Any value that does not parse as a finite number in `[0, 1]` is treated as
+ * a SAMPLER MALFUNCTION, not silently coerced to "off" or thrown at the
+ * caller: `decideHarnessLane` fails closed to the one-shot lane (the safe,
+ * already-shipping default) and stamps the decision with
+ * `reason: "sampler-malfunction"` so the misconfiguration stays visible in
+ * evidence instead of masquerading as a clean 0% fraction.
+ */
+export const HARNESS_LANE_FRACTION_ENV = "HUGIN_HARNESS_LANE_FRACTION";
+
+/**
+ * Task types where an agentic tool-loop plausibly matters: multi-file code
+ * edits. hugin#192's one datapoint found the harness's only known soft spot
+ * is import/export wiring across files — exactly what these types cover.
+ * Judgment/one-shot types (`extract`, `classify`, `qa-factual`, `summarize`,
+ * ...) are deliberately excluded: a one-shot classification gives an agentic
+ * loop nothing to inspect, edit, or iterate against, so routing it through a
+ * harness would only add latency for zero signal.
+ */
+export const HARNESS_LANE_ELIGIBLE_TASK_TYPES = [
+  "code-implement",
+  "code-edit",
+  "unit-test-gen",
+] as const;
+export type HarnessLaneEligibleTaskType = (typeof HARNESS_LANE_ELIGIBLE_TASK_TYPES)[number];
+
+// Compile-time proof the eligible list is actually a subset of the canonical
+// task-type taxonomy — a typo here would otherwise silently never match.
+const _eligibleIsTaskTypeSubset: readonly TaskType[] = HARNESS_LANE_ELIGIBLE_TASK_TYPES;
+void _eligibleIsTaskTypeSubset;
+
+const ELIGIBLE_TASK_TYPE_SET: ReadonlySet<string> = new Set(HARNESS_LANE_ELIGIBLE_TASK_TYPES);
+
+export function isHarnessLaneEligibleTaskType(taskType: string): taskType is HarnessLaneEligibleTaskType {
+  return ELIGIBLE_TASK_TYPE_SET.has(taskType);
+}
+
+export type LaneKind = "one-shot" | "harness";
+
+export type LaneDecisionReason =
+  | "not-eligible-task-type"
+  | "fraction-zero-or-absent"
+  | "sampled-one-shot"
+  | "sampled-harness"
+  | "sampler-malfunction";
+
+export interface HarnessLaneDecision {
+  lane: LaneKind;
+  eligible: boolean;
+  /** The effective fraction actually applied. Always `0` when off, ineligible,
+   * or malfunctioning. */
+  fraction: number;
+  reason: LaneDecisionReason;
+  /** Present only when `reason === "sampler-malfunction"` — human-readable,
+   * content-blind (never echoes task content, only the env/hash fault). */
+  malfunctionDetail?: string;
+  /** Hex digest of the sampled natural key. Empty only in the (defensive,
+   * practically unreachable) case where digesting itself threw. */
+  keyDigestHex: string;
+  samplerVersion: typeof HARNESS_LANE_SAMPLER_VERSION;
+}
+
+export interface HarnessLaneTaskKey {
+  /** Stable natural key identifying the eligible sub-task — the durable
+   * Hugin taskId (or, for a sub-task inside a larger task, taskId plus a
+   * stable sub-task discriminator baked in by the caller). Must be identical
+   * on every call for the same logical task: the sampler has no memory of
+   * its own, so reproducibility comes entirely from this key being stable. */
+  taskId: string;
+  taskType: string;
+}
+
+export interface HarnessLaneSamplerDeps {
+  /** Defaults to `process.env`. Overridable for tests. */
+  env?: NodeJS.ProcessEnv;
+  /** Hex-digest function, defaults to SHA-256. Overridable so a test can force
+   * the "hash error" malfunction path deterministically without contriving an
+   * actual crypto failure. */
+  digest?: (input: string) => string;
+}
+
+function defaultDigest(input: string): string {
+  return createHash("sha256").update(input, "utf8").digest("hex");
+}
+
+function parseFraction(raw: string | undefined): { fraction: number } | { malfunction: string } {
+  if (raw === undefined || raw.trim() === "") return { fraction: 0 };
+  const trimmed = raw.trim();
+  const value = Number(trimmed);
+  if (!Number.isFinite(value)) {
+    return { malfunction: `${HARNESS_LANE_FRACTION_ENV}="${raw}" is not a finite number` };
+  }
+  if (value < 0 || value > 1) {
+    return { malfunction: `${HARNESS_LANE_FRACTION_ENV}=${value} is outside the valid [0, 1] range` };
+  }
+  return { fraction: value };
+}
+
+/** Deterministic `[0, 1)` sample derived from the sampler version + natural
+ * key. The first 8 hex chars of the digest become a uint32, scaled to the
+ * unit interval — cheap, stable across processes/platforms, and independent
+ * of insertion order or call count (no shared mutable state). */
+function sampleUnitInterval(
+  naturalKey: string,
+  digest: (input: string) => string,
+): { value: number; digestHex: string } {
+  const digestHex = digest(`harness-lane-sampler:${HARNESS_LANE_SAMPLER_VERSION}\0${naturalKey}`);
+  const uint32 = Number.parseInt(digestHex.slice(0, 8), 16);
+  if (!Number.isFinite(uint32)) {
+    throw new Error(`harness-lane sampler digest did not yield a usable prefix: "${digestHex.slice(0, 8)}"`);
+  }
+  return { value: uint32 / 0x1_0000_0000, digestHex };
+}
+
+/**
+ * Decide, deterministically, which lane one eligible task's sub-task should
+ * additionally run through. Never throws: a hash failure or malformed digest
+ * is itself a "sampler malfunction" and falls back to the one-shot lane, same
+ * as a bad env value.
+ */
+export function decideHarnessLane(
+  key: HarnessLaneTaskKey,
+  deps: HarnessLaneSamplerDeps = {},
+): HarnessLaneDecision {
+  const env = deps.env ?? process.env;
+  const digest = deps.digest ?? defaultDigest;
+  const naturalKey = `${key.taskType}\0${key.taskId}`;
+
+  let keyDigestHex = "";
+  let sample = 0;
+  try {
+    const sampled = sampleUnitInterval(naturalKey, digest);
+    keyDigestHex = sampled.digestHex;
+    sample = sampled.value;
+  } catch (err) {
+    return {
+      lane: "one-shot",
+      eligible: isHarnessLaneEligibleTaskType(key.taskType),
+      fraction: 0,
+      reason: "sampler-malfunction",
+      malfunctionDetail: err instanceof Error ? err.message : String(err),
+      keyDigestHex: "",
+      samplerVersion: HARNESS_LANE_SAMPLER_VERSION,
+    };
+  }
+
+  const eligible = isHarnessLaneEligibleTaskType(key.taskType);
+  if (!eligible) {
+    return {
+      lane: "one-shot",
+      eligible: false,
+      fraction: 0,
+      reason: "not-eligible-task-type",
+      keyDigestHex,
+      samplerVersion: HARNESS_LANE_SAMPLER_VERSION,
+    };
+  }
+
+  const parsedFraction = parseFraction(env[HARNESS_LANE_FRACTION_ENV]);
+  if ("malfunction" in parsedFraction) {
+    return {
+      lane: "one-shot",
+      eligible: true,
+      fraction: 0,
+      reason: "sampler-malfunction",
+      malfunctionDetail: parsedFraction.malfunction,
+      keyDigestHex,
+      samplerVersion: HARNESS_LANE_SAMPLER_VERSION,
+    };
+  }
+
+  const { fraction } = parsedFraction;
+  if (fraction <= 0) {
+    return {
+      lane: "one-shot",
+      eligible: true,
+      fraction,
+      reason: "fraction-zero-or-absent",
+      keyDigestHex,
+      samplerVersion: HARNESS_LANE_SAMPLER_VERSION,
+    };
+  }
+
+  const lane: LaneKind = sample < fraction ? "harness" : "one-shot";
+  return {
+    lane,
+    eligible: true,
+    fraction,
+    reason: lane === "harness" ? "sampled-harness" : "sampled-one-shot",
+    keyDigestHex,
+    samplerVersion: HARNESS_LANE_SAMPLER_VERSION,
+  };
+}

--- a/src/learning-registry-schema.ts
+++ b/src/learning-registry-schema.ts
@@ -17,7 +17,7 @@
 import { createHash } from "node:crypto";
 import { z } from "zod";
 import { jcsCanonicalize } from "./learning-task-handshake.js";
-import { taskExecutionOutcomeSchema } from "./task-result-schema.js";
+import { taskExecutionOutcomeSchema, delegationProvenanceSchema } from "./task-result-schema.js";
 
 export const LEARNING_REGISTRY_SCHEMA_VERSION = 1 as const;
 /** Every #232-mechanism event is owned and counted by Hugin itself. Cross-owner
@@ -253,6 +253,13 @@ export const terminalOutcomeEventSchema = z.object({
     ]).optional(),
     taskOutcomeRef: registryEvidenceRefSchema,
     attemptOutcomeRef: registryEvidenceRefSchema.optional(),
+    // Standing harness-lane sampler (hugin#267) — additive + optional, same
+    // non-breaking rationale as every other optional field in this file: old
+    // readers strip it. Reuses the exact #163 evidence-identity shape
+    // (`delegationProvenanceSchema`) rather than growing a second, competing
+    // provenance shape; its new `lane` field is what the rolling one-shot-
+    // vs-harness comparison report groups by.
+    delegation: delegationProvenanceSchema.optional(),
   }).strict(),
 }).strict();
 

--- a/src/learning-registry-store.ts
+++ b/src/learning-registry-store.ts
@@ -308,6 +308,11 @@ export class LearningRegistryStore {
     repositoryOutcomeState?: TerminalOutcomeEvent["payload"]["repositoryOutcomeState"];
     taskOutcomeRef: RegistryEvidenceRef;
     attemptOutcomeRef?: RegistryEvidenceRef;
+    /** Standing harness-lane sampler (hugin#267) — the #163 evidence-identity
+     * shape, carrying `lane: "one-shot" | "harness"` plus whatever other
+     * delegation fields the caller has (model/node/verifier/outcome). Omit
+     * entirely for terminal outcomes the sampler never touched. */
+    delegation?: TerminalOutcomeEvent["payload"]["delegation"];
     occurredAt: string;
   }): Promise<AppendResult<TerminalOutcomeEvent>> {
     const naturalKey: RegistryNaturalKey = {
@@ -336,6 +341,8 @@ export class LearningRegistryStore {
           ? { repositoryOutcomeState: input.repositoryOutcomeState } : {}),
         ...(input.attemptOutcomeRef !== undefined
           ? { attemptOutcomeRef: input.attemptOutcomeRef } : {}),
+        ...(input.delegation !== undefined
+          ? { delegation: input.delegation } : {}),
       },
     });
     return appendRegistryEvent(this.munin, event, recordedAt);
@@ -531,6 +538,38 @@ export class LearningRegistryStore {
     const events = reads
       .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
       .map((entry) => registryEventSchema.parse(JSON.parse(entry.content)))
+      .sort((a, b) => a.occurredAt.localeCompare(b.occurredAt) || a.eventId.localeCompare(b.eventId));
+    return { events, truncated: paged.truncated };
+  }
+
+  /**
+   * Cross-task read of every terminal-outcome event recorded in one UTC
+   * occurrence period (#267's harness-lane comparison report and any future
+   * cross-task reader). This reuses exactly the partition tag every
+   * terminal-outcome event is already stamped with at append time
+   * (`registryPartitionTag`), the same mechanism `findPartitionOrphans`
+   * relies on internally — no second index to keep in sync. Content-blind:
+   * this returns full registry events (opaque ids/refs/digests only, never
+   * prompt/response bytes), same as `listEventsForTask`.
+   */
+  async listTerminalOutcomesForPeriod(
+    occurrencePeriodUtc: string,
+  ): Promise<{ events: TerminalOutcomeEvent[]; truncated: boolean }> {
+    const tag = registryPartitionTag("terminal-outcome", occurrencePeriodUtc);
+    const paged = await queryAllMuninEntries(
+      this.munin,
+      { tags: [REGISTRY_EVENT_TAG, tag], entry_type: "state" },
+      this.partitionCompletenessQueryBudget,
+    );
+    const reads = await Promise.all(
+      paged.results
+        .filter((result) => typeof result.key === "string" && result.key.startsWith("reg-"))
+        .map((result) => this.munin.read(result.namespace, result.key as string)),
+    );
+    const events = reads
+      .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
+      .map((entry) => registryEventSchema.parse(JSON.parse(entry.content)))
+      .filter((event): event is TerminalOutcomeEvent => event.recordKind === "terminal-outcome")
       .sort((a, b) => a.occurredAt.localeCompare(b.occurredAt) || a.eventId.localeCompare(b.eventId));
     return { events, truncated: paged.truncated };
   }

--- a/src/task-result-schema.ts
+++ b/src/task-result-schema.ts
@@ -118,6 +118,13 @@ export const delegationProvenanceSchema = z.object({
   nodeId: z.string().min(1).optional(),
   modelId: z.string().min(1).optional(),
   taskType: z.string().min(1).optional(),
+  // Standing harness-lane sampler (hugin#267). Distinguishes a one-shot
+  // delegation from one additionally sampled through the harness (code_loop /
+  // opencode) lane, so the SAME #163 evidence-identity shape carries the
+  // one-shot-vs-harness signal the rolling comparison report groups by.
+  // Additive + optional: absent on every delegation this schema already
+  // described before #267, exactly like every other field here.
+  lane: z.enum(["one-shot", "harness"]).optional(),
   // Enum + bounds declared here as well as in the sanitizer, so the contract
   // cannot silently drift between the two (Codex review of #163).
   outcome: z.enum(M5_OUTCOMES).optional(),

--- a/tests/harness-lane-comparison-report.test.ts
+++ b/tests/harness-lane-comparison-report.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from "vitest";
+import { MuninWriteRejectedError, type MuninClient, type MuninQueryResult } from "../src/munin-client.js";
+import { LearningRegistryStore } from "../src/learning-registry-store.js";
+import {
+  runHarnessLaneSampledAttempt,
+  type HarnessLaneExecutors,
+  type LaneAttemptOutcome,
+} from "../src/harness-lane-executor.js";
+import { HARNESS_LANE_FRACTION_ENV } from "../src/harness-lane-sampler.js";
+import {
+  buildHarnessLaneComparisonReport,
+  computeHarnessLaneComparison,
+  formatHarnessLaneComparisonReport,
+} from "../src/harness-lane-comparison-report.js";
+import type { TerminalOutcomeEvent } from "../src/learning-registry-schema.js";
+
+interface StoredEntry {
+  namespace: string;
+  key: string;
+  content: string;
+  tags: string[];
+  classification?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+class InMemoryMunin {
+  private entries: StoredEntry[] = [];
+  private seq = 0;
+
+  private clock(): string {
+    this.seq += 1;
+    return new Date(Date.UTC(2026, 6, 1, 0, 0, 0, 0) + this.seq).toISOString();
+  }
+
+  private find(namespace: string, key: string): StoredEntry | undefined {
+    return this.entries.find((e) => e.namespace === namespace && e.key === key);
+  }
+
+  async read(namespace: string, key: string) {
+    const entry = this.find(namespace, key);
+    if (!entry) return null;
+    return { ...entry, found: true } as unknown as (MuninQueryResult & { found: true });
+  }
+
+  async write(
+    namespace: string,
+    key: string,
+    content: string,
+    tags?: string[],
+    expectedUpdatedAt?: string,
+    classification?: string,
+    createIfAbsent?: boolean,
+  ) {
+    const existing = this.find(namespace, key);
+    if (createIfAbsent && existing) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        message: "Entry already exists.",
+        conflict_reason: "already_exists",
+        current_updated_at: existing.updated_at,
+      });
+    }
+    if (expectedUpdatedAt !== undefined && (!existing || existing.updated_at !== expectedUpdatedAt)) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        message: "Entry version changed.",
+        conflict_reason: "version_mismatch",
+        current_updated_at: existing?.updated_at,
+      });
+    }
+    const updated_at = this.clock();
+    const created_at = existing?.created_at ?? updated_at;
+    const next: StoredEntry = { namespace, key, content, tags: tags ?? [], classification, created_at, updated_at };
+    if (existing) {
+      Object.assign(existing, next);
+    } else {
+      this.entries.push(next);
+    }
+    return { ok: true, status: existing ? "updated" : "created", updated_at };
+  }
+
+  async query(opts: { namespace?: string; tags?: string[]; limit?: number; since?: string; until?: string }) {
+    let rows = this.entries.filter((e) =>
+      (!opts.namespace || e.namespace.startsWith(opts.namespace))
+      && (opts.tags ?? []).every((tag) => e.tags.includes(tag)));
+    if (opts.since) rows = rows.filter((e) => e.updated_at >= opts.since!);
+    if (opts.until) rows = rows.filter((e) => e.updated_at <= opts.until!);
+    rows = [...rows].sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+    const limited = rows.slice(0, opts.limit ?? 50);
+    return {
+      results: limited.map((e) => ({
+        id: `${e.namespace}/${e.key}`,
+        namespace: e.namespace,
+        key: e.key,
+        entry_type: "state",
+        content_preview: e.content.slice(0, 80),
+        tags: e.tags,
+        classification: e.classification,
+        created_at: e.created_at,
+        updated_at: e.updated_at,
+      })),
+      total: rows.length,
+    };
+  }
+}
+
+function munin(): InMemoryMunin & MuninClient {
+  return new InMemoryMunin() as unknown as InMemoryMunin & MuninClient;
+}
+
+function ref(taskId: string, key: string) {
+  return { namespace: `tasks/${taskId}`, key };
+}
+
+function outcome(overrides: Partial<LaneAttemptOutcome> & { taskOutcomeRef: LaneAttemptOutcome["taskOutcomeRef"] }): LaneAttemptOutcome {
+  return {
+    outcome: "completed",
+    verifierKind: "mechanical",
+    verdict: "pass",
+    ...overrides,
+  };
+}
+
+function fixedExecutors(result: LaneAttemptOutcome): HarnessLaneExecutors {
+  return { oneShot: async () => result, harness: async () => result };
+}
+
+const OCCURRED_AT = "2026-07-20T10:00:00.000Z";
+
+describe("computeHarnessLaneComparison — pure aggregation", () => {
+  it("computes per-(taskType, lane) attempts/verified/passed/escalated and rates", async () => {
+    const store = new LearningRegistryStore(munin());
+    // Build directly via the store's own terminal-outcome writer so this test
+    // exercises the exact persisted event shape, not a hand-rolled fixture.
+    const events: TerminalOutcomeEvent[] = [];
+
+    async function record(taskId: string, taskType: string, lane: "one-shot" | "harness", verdict: "pass" | "fail" | "unverified", escalated = false) {
+      const result = await store.recordTerminalOutcome({
+        taskId,
+        attemptId: "attempt-1",
+        outcome: verdict === "fail" ? "failed" : "completed",
+        taskOutcomeRef: ref(taskId, "result-structured"),
+        occurredAt: OCCURRED_AT,
+        delegation: { lane, taskType, outcome: verdict, escalated },
+      });
+      events.push(result.event);
+    }
+
+    await record("t1", "code-edit", "one-shot", "pass");
+    await record("t2", "code-edit", "one-shot", "pass");
+    await record("t3", "code-edit", "one-shot", "fail");
+    await record("t4", "code-edit", "harness", "pass");
+    await record("t5", "code-edit", "harness", "fail", true);
+    await record("t6", "code-implement", "harness", "unverified");
+
+    const rows = computeHarnessLaneComparison(events);
+    const codeEditOneShot = rows.find((r) => r.taskType === "code-edit" && r.lane === "one-shot")!;
+    expect(codeEditOneShot.attempts).toBe(3);
+    expect(codeEditOneShot.verifiedAttempts).toBe(3);
+    expect(codeEditOneShot.passed).toBe(2);
+    expect(codeEditOneShot.verifiedPassRate).toBeCloseTo(2 / 3);
+    expect(codeEditOneShot.escalationRate).toBe(0);
+
+    const codeEditHarness = rows.find((r) => r.taskType === "code-edit" && r.lane === "harness")!;
+    expect(codeEditHarness.attempts).toBe(2);
+    expect(codeEditHarness.verifiedAttempts).toBe(2);
+    expect(codeEditHarness.passed).toBe(1);
+    expect(codeEditHarness.verifiedPassRate).toBeCloseTo(0.5);
+    expect(codeEditHarness.escalationRate).toBeCloseTo(0.5);
+
+    const codeImplementHarness = rows.find((r) => r.taskType === "code-implement" && r.lane === "harness")!;
+    expect(codeImplementHarness.attempts).toBe(1);
+    expect(codeImplementHarness.verifiedAttempts).toBe(0);
+    expect(codeImplementHarness.verifiedPassRate).toBeNull();
+  });
+
+  it("skips terminal outcomes with no sampler-stamped lane", async () => {
+    const store = new LearningRegistryStore(munin());
+    const result = await store.recordTerminalOutcome({
+      taskId: "t-legacy",
+      attemptId: "attempt-1",
+      outcome: "completed",
+      taskOutcomeRef: ref("t-legacy", "result-structured"),
+      occurredAt: OCCURRED_AT,
+      // no `delegation` at all — a pre-#267 or externally-ingested row.
+    });
+    const rows = computeHarnessLaneComparison([result.event]);
+    expect(rows).toHaveLength(0);
+  });
+});
+
+describe("buildHarnessLaneComparisonReport — end-to-end from a fixture registry", () => {
+  it("reads across the queried periods and reports content-blind rows", async () => {
+    const store = new LearningRegistryStore(munin());
+    const executors = fixedExecutors(outcome({ taskOutcomeRef: ref("dummy", "result-structured"), verdict: "pass" }));
+
+    // Two harness-lane attempts and one one-shot for the same task type, all
+    // via the real wiring, in the same UTC month as OCCURRED_AT.
+    await runHarnessLaneSampledAttempt(
+      store,
+      { taskId: "cmp-1", attemptId: "a1", taskType: "unit-test-gen", occurredAt: OCCURRED_AT },
+      { oneShot: executors.oneShot, harness: async () => outcome({ taskOutcomeRef: ref("cmp-1", "r"), verdict: "pass" }) },
+      { env: { [HARNESS_LANE_FRACTION_ENV]: "1" } },
+    );
+    await runHarnessLaneSampledAttempt(
+      store,
+      { taskId: "cmp-2", attemptId: "a1", taskType: "unit-test-gen", occurredAt: OCCURRED_AT },
+      { oneShot: executors.oneShot, harness: async () => outcome({ taskOutcomeRef: ref("cmp-2", "r"), verdict: "fail" }) },
+      { env: { [HARNESS_LANE_FRACTION_ENV]: "1" } },
+    );
+    await runHarnessLaneSampledAttempt(
+      store,
+      { taskId: "cmp-3", attemptId: "a1", taskType: "unit-test-gen", occurredAt: OCCURRED_AT },
+      { oneShot: async () => outcome({ taskOutcomeRef: ref("cmp-3", "r"), verdict: "pass" }), harness: executors.harness },
+      { env: {} }, // off -> one-shot
+    );
+
+    const report = await buildHarnessLaneComparisonReport(store, ["2026-07"]);
+    expect(report.truncated).toBe(false);
+    expect(report.periodsQueried).toEqual(["2026-07"]);
+
+    const harnessRow = report.rows.find((r) => r.taskType === "unit-test-gen" && r.lane === "harness")!;
+    expect(harnessRow.attempts).toBe(2);
+    expect(harnessRow.passed).toBe(1);
+    expect(harnessRow.verifiedPassRate).toBeCloseTo(0.5);
+
+    const oneShotRow = report.rows.find((r) => r.taskType === "unit-test-gen" && r.lane === "one-shot")!;
+    expect(oneShotRow.attempts).toBe(1);
+    expect(oneShotRow.passed).toBe(1);
+
+    const text = formatHarnessLaneComparisonReport(report);
+    expect(text).toContain("unit-test-gen");
+    expect(text).toContain("harness");
+    expect(text).toContain("one-shot");
+    // Content-blind: never echoes anything task-specific beyond type/lane/counts.
+    expect(text).not.toContain("cmp-1");
+  });
+
+  it("queries only the requested period and does not leak other months' evidence", async () => {
+    const store = new LearningRegistryStore(munin());
+    await store.recordTerminalOutcome({
+      taskId: "other-month",
+      attemptId: "attempt-1",
+      outcome: "completed",
+      taskOutcomeRef: ref("other-month", "result-structured"),
+      occurredAt: "2026-06-15T00:00:00.000Z",
+      delegation: { lane: "harness", taskType: "code-edit", outcome: "pass" },
+    });
+
+    const julyReport = await buildHarnessLaneComparisonReport(store, ["2026-07"]);
+    expect(julyReport.rows).toHaveLength(0);
+
+    const juneReport = await buildHarnessLaneComparisonReport(store, ["2026-06"]);
+    expect(juneReport.rows).toHaveLength(1);
+  });
+});

--- a/tests/harness-lane-executor.test.ts
+++ b/tests/harness-lane-executor.test.ts
@@ -1,0 +1,327 @@
+import { describe, expect, it } from "vitest";
+import { MuninWriteRejectedError, type MuninClient, type MuninQueryResult } from "../src/munin-client.js";
+import { LearningRegistryStore } from "../src/learning-registry-store.js";
+import {
+  runHarnessLaneSampledAttempt,
+  type HarnessLaneExecutors,
+  type LaneAttemptOutcome,
+} from "../src/harness-lane-executor.js";
+import { HARNESS_LANE_FRACTION_ENV } from "../src/harness-lane-sampler.js";
+
+interface StoredEntry {
+  namespace: string;
+  key: string;
+  content: string;
+  tags: string[];
+  classification?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Same in-memory create-if-absent / CAS Munin double used across the
+ * registry test suite (tests/learning-registry-store.test.ts,
+ * tests/external-receipt-intake.test.ts). */
+class InMemoryMunin {
+  private entries: StoredEntry[] = [];
+  private seq = 0;
+
+  private clock(): string {
+    this.seq += 1;
+    return new Date(Date.UTC(2026, 6, 20, 0, 0, 0, 0) + this.seq).toISOString();
+  }
+
+  private find(namespace: string, key: string): StoredEntry | undefined {
+    return this.entries.find((e) => e.namespace === namespace && e.key === key);
+  }
+
+  async read(namespace: string, key: string) {
+    const entry = this.find(namespace, key);
+    if (!entry) return null;
+    return { ...entry, found: true } as unknown as (MuninQueryResult & { found: true });
+  }
+
+  async write(
+    namespace: string,
+    key: string,
+    content: string,
+    tags?: string[],
+    expectedUpdatedAt?: string,
+    classification?: string,
+    createIfAbsent?: boolean,
+  ) {
+    const existing = this.find(namespace, key);
+    if (createIfAbsent && existing) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        message: "Entry already exists.",
+        conflict_reason: "already_exists",
+        current_updated_at: existing.updated_at,
+      });
+    }
+    if (expectedUpdatedAt !== undefined && (!existing || existing.updated_at !== expectedUpdatedAt)) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        message: "Entry version changed.",
+        conflict_reason: "version_mismatch",
+        current_updated_at: existing?.updated_at,
+      });
+    }
+    const updated_at = this.clock();
+    const created_at = existing?.created_at ?? updated_at;
+    const next: StoredEntry = { namespace, key, content, tags: tags ?? [], classification, created_at, updated_at };
+    if (existing) {
+      Object.assign(existing, next);
+    } else {
+      this.entries.push(next);
+    }
+    return { ok: true, status: existing ? "updated" : "created", updated_at };
+  }
+
+  async query(opts: { namespace?: string; tags?: string[]; limit?: number; since?: string; until?: string }) {
+    let rows = this.entries.filter((e) =>
+      (!opts.namespace || e.namespace.startsWith(opts.namespace))
+      && (opts.tags ?? []).every((tag) => e.tags.includes(tag)));
+    if (opts.since) rows = rows.filter((e) => e.updated_at >= opts.since!);
+    if (opts.until) rows = rows.filter((e) => e.updated_at <= opts.until!);
+    rows = [...rows].sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+    const limited = rows.slice(0, opts.limit ?? 50);
+    return {
+      results: limited.map((e) => ({
+        id: `${e.namespace}/${e.key}`,
+        namespace: e.namespace,
+        key: e.key,
+        entry_type: "state",
+        content_preview: e.content.slice(0, 80),
+        tags: e.tags,
+        classification: e.classification,
+        created_at: e.created_at,
+        updated_at: e.updated_at,
+      })),
+      total: rows.length,
+    };
+  }
+}
+
+function munin(): InMemoryMunin & MuninClient {
+  return new InMemoryMunin() as unknown as InMemoryMunin & MuninClient;
+}
+
+function ref(taskId: string, key: string) {
+  return { namespace: `tasks/${taskId}`, key };
+}
+
+function passOutcome(overrides: Partial<LaneAttemptOutcome> = {}): LaneAttemptOutcome {
+  return {
+    outcome: "completed",
+    taskOutcomeRef: ref("task-x", "result-structured"),
+    verifierKind: "mechanical",
+    verdict: "pass",
+    ...overrides,
+  };
+}
+
+interface RecordingExecutors extends HarnessLaneExecutors {
+  oneShotCalls: number;
+  harnessCalls: number;
+}
+
+function makeExecutors(opts: {
+  oneShot?: () => Promise<LaneAttemptOutcome>;
+  harness?: () => Promise<LaneAttemptOutcome>;
+} = {}): RecordingExecutors {
+  const recorder: RecordingExecutors = {
+    oneShotCalls: 0,
+    harnessCalls: 0,
+    oneShot: async () => {
+      recorder.oneShotCalls += 1;
+      return (opts.oneShot ?? (async () => passOutcome({ modelId: "claude-sdk", nodeId: "claude-sdk" })))();
+    },
+    harness: async () => {
+      recorder.harnessCalls += 1;
+      return (opts.harness ?? (async () => passOutcome({ modelId: "qwen3-coder-next-80b", nodeId: "opencode-m5", iterations: 4 })))();
+    },
+  };
+  return recorder;
+}
+
+const OCCURRED_AT = "2026-07-20T10:00:00.000Z";
+
+describe("runHarnessLaneSampledAttempt — harness lane recording", () => {
+  it("records a sampled harness attempt into #232 with harness identity, graded like one-shot", async () => {
+    const store = new LearningRegistryStore(munin());
+    const executors = makeExecutors({
+      harness: async () => passOutcome({
+        modelId: "qwen3-coder-next-80b",
+        nodeId: "opencode-m5",
+        iterations: 5,
+        taskOutcomeRef: ref("task-h1", "result-structured"),
+      }),
+    });
+
+    const result = await runHarnessLaneSampledAttempt(
+      store,
+      { taskId: "task-h1", attemptId: "attempt-1", taskType: "code-edit", occurredAt: OCCURRED_AT },
+      executors,
+      { env: { [HARNESS_LANE_FRACTION_ENV]: "1" } },
+    );
+
+    expect(result.lane).toBe("harness");
+    expect(executors.harnessCalls).toBe(1);
+    expect(executors.oneShotCalls).toBe(0);
+
+    const delegation = result.registry.terminalOutcome.event.payload.delegation;
+    expect(delegation?.lane).toBe("harness");
+    expect(delegation?.taskType).toBe("code-edit");
+    expect(delegation?.outcome).toBe("pass");
+    expect(delegation?.verifier).toBe("mechanical");
+    expect(delegation?.modelId).toBe("qwen3-coder-next-80b");
+    expect(delegation?.nodeId).toBe("opencode-m5");
+    // hugin#192's rating discipline: iterations/rounds is "the harness-
+    // specific signal we have none of" from a one-shot lane — verify it
+    // actually lands in the durable evidence, not just the in-memory result.
+    expect(delegation?.verifierNotes).toContain("iterations=5");
+
+    const { events } = await store.listEventsForTask("task-h1");
+    expect(events.map((e) => e.recordKind).sort()).toEqual(
+      ["attempt-reference", "submission", "terminal-outcome"].sort(),
+    );
+  });
+
+  it("records a not-sampled attempt as one-shot, graded the same way", async () => {
+    const store = new LearningRegistryStore(munin());
+    const executors = makeExecutors();
+
+    const result = await runHarnessLaneSampledAttempt(
+      store,
+      { taskId: "task-o1", attemptId: "attempt-1", taskType: "code-edit", occurredAt: OCCURRED_AT },
+      executors,
+      { env: {} }, // absent fraction -> off
+    );
+
+    expect(result.lane).toBe("one-shot");
+    expect(executors.oneShotCalls).toBe(1);
+    expect(executors.harnessCalls).toBe(0);
+    expect(result.registry.terminalOutcome.event.payload.delegation?.lane).toBe("one-shot");
+  });
+
+  it("routes an ineligible task type to one-shot regardless of fraction", async () => {
+    const store = new LearningRegistryStore(munin());
+    const executors = makeExecutors();
+
+    const result = await runHarnessLaneSampledAttempt(
+      store,
+      { taskId: "task-extract-1", attemptId: "attempt-1", taskType: "extract", occurredAt: OCCURRED_AT },
+      executors,
+      { env: { [HARNESS_LANE_FRACTION_ENV]: "1" } },
+    );
+
+    expect(result.lane).toBe("one-shot");
+    expect(executors.harnessCalls).toBe(0);
+    expect(result.decision.eligible).toBe(false);
+  });
+});
+
+describe("runHarnessLaneSampledAttempt — sampler malfunction", () => {
+  it("falls back to one-shot and records the malfunction, without ever touching the harness executor", async () => {
+    const store = new LearningRegistryStore(munin());
+    const executors = makeExecutors();
+
+    const result = await runHarnessLaneSampledAttempt(
+      store,
+      { taskId: "task-malfunction-1", attemptId: "attempt-1", taskType: "code-edit", occurredAt: OCCURRED_AT },
+      executors,
+      { env: { [HARNESS_LANE_FRACTION_ENV]: "not-a-number" } },
+    );
+
+    expect(result.lane).toBe("one-shot");
+    expect(executors.oneShotCalls).toBe(1);
+    expect(executors.harnessCalls).toBe(0);
+    expect(result.decision.reason).toBe("sampler-malfunction");
+
+    const delegation = result.registry.terminalOutcome.event.payload.delegation;
+    expect(delegation?.policyMode).toBe("harness-lane-sampler");
+    expect(delegation?.policyAction).toBe("sampler-malfunction");
+    expect(delegation?.policyReason).toMatch(/not a finite number/);
+  });
+});
+
+describe("runHarnessLaneSampledAttempt — fail-closed harness failure", () => {
+  it("records a harness-lane failure AS the harness lane, never silently as one-shot", async () => {
+    const store = new LearningRegistryStore(munin());
+    const executors = makeExecutors({
+      harness: async () => ({
+        outcome: "failed",
+        taskOutcomeRef: ref("task-fail-1", "result-structured"),
+        verifierKind: "mechanical",
+        verdict: "fail",
+        escalated: true,
+        escalationReason: "check_cmd failed after 3 rounds; escalated to frontier",
+      }),
+    });
+
+    const result = await runHarnessLaneSampledAttempt(
+      store,
+      { taskId: "task-fail-1", attemptId: "attempt-1", taskType: "code-edit", occurredAt: OCCURRED_AT },
+      executors,
+      { env: { [HARNESS_LANE_FRACTION_ENV]: "1" } },
+    );
+
+    expect(result.lane).toBe("harness");
+    expect(executors.harnessCalls).toBe(1);
+    expect(executors.oneShotCalls).toBe(0); // never silently rerouted
+
+    const delegation = result.registry.terminalOutcome.event.payload.delegation;
+    expect(delegation?.lane).toBe("harness");
+    expect(delegation?.outcome).toBe("fail");
+    expect(delegation?.escalated).toBe(true);
+    expect(result.registry.terminalOutcome.event.payload.outcome).toBe("failed");
+  });
+
+  it("never fabricates registry evidence when the harness executor breaks contract and throws", async () => {
+    const store = new LearningRegistryStore(munin());
+    const executors = makeExecutors({
+      harness: async () => {
+        throw new Error("opencode process crashed unexpectedly");
+      },
+    });
+
+    await expect(
+      runHarnessLaneSampledAttempt(
+        store,
+        { taskId: "task-crash-1", attemptId: "attempt-1", taskType: "code-edit", occurredAt: OCCURRED_AT },
+        executors,
+        { env: { [HARNESS_LANE_FRACTION_ENV]: "1" } },
+      ),
+    ).rejects.toThrow(/opencode process crashed/);
+
+    expect(executors.oneShotCalls).toBe(0); // never silently rerouted into one-shot
+    const { events } = await store.listEventsForTask("task-crash-1");
+    expect(events).toHaveLength(0); // nothing fabricated, nothing lost-and-hidden
+  });
+});
+
+describe("runHarnessLaneSampledAttempt — no duplicate/lost tasks", () => {
+  it("replaying the same attempt is idempotent: no duplicate events, nothing lost", async () => {
+    const store = new LearningRegistryStore(munin());
+    const executors = makeExecutors({
+      harness: async () => passOutcome({
+        modelId: "qwen3-coder-next-80b",
+        nodeId: "opencode-m5",
+        taskOutcomeRef: ref("task-replay-1", "result-structured"),
+      }),
+    });
+
+    const input = { taskId: "task-replay-1", attemptId: "attempt-1", taskType: "code-edit" as const, occurredAt: OCCURRED_AT };
+    const samplerDeps = { env: { [HARNESS_LANE_FRACTION_ENV]: "1" } };
+
+    const first = await runHarnessLaneSampledAttempt(store, input, executors, samplerDeps);
+    const second = await runHarnessLaneSampledAttempt(store, input, executors, samplerDeps);
+
+    expect(first.registry.submission.status).toBe("created");
+    expect(second.registry.submission.status).toBe("exact-existing");
+    expect(first.registry.terminalOutcome.event.eventId).toBe(second.registry.terminalOutcome.event.eventId);
+
+    const { events } = await store.listEventsForTask("task-replay-1");
+    expect(events).toHaveLength(3); // submission + attempt-reference + terminal-outcome, no duplicates
+  });
+});

--- a/tests/harness-lane-sampler.test.ts
+++ b/tests/harness-lane-sampler.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import {
+  HARNESS_LANE_ELIGIBLE_TASK_TYPES,
+  HARNESS_LANE_FRACTION_ENV,
+  decideHarnessLane,
+  isHarnessLaneEligibleTaskType,
+} from "../src/harness-lane-sampler.js";
+
+const ELIGIBLE_TYPE = "code-edit";
+const INELIGIBLE_TYPE = "extract";
+
+describe("isHarnessLaneEligibleTaskType", () => {
+  it("marks bounded multi-file code-edit task types eligible", () => {
+    for (const taskType of HARNESS_LANE_ELIGIBLE_TASK_TYPES) {
+      expect(isHarnessLaneEligibleTaskType(taskType)).toBe(true);
+    }
+  });
+
+  it("excludes one-shot judgment/extraction task types", () => {
+    for (const taskType of ["extract", "classify", "qa-factual", "summarize", "rewrite", "translate"]) {
+      expect(isHarnessLaneEligibleTaskType(taskType)).toBe(false);
+    }
+  });
+});
+
+describe("decideHarnessLane — eligibility filter", () => {
+  it("always resolves an ineligible task type to one-shot, even at fraction 1", () => {
+    const decision = decideHarnessLane(
+      { taskId: "task-1", taskType: INELIGIBLE_TYPE },
+      { env: { [HARNESS_LANE_FRACTION_ENV]: "1" } },
+    );
+    expect(decision.lane).toBe("one-shot");
+    expect(decision.eligible).toBe(false);
+    expect(decision.reason).toBe("not-eligible-task-type");
+    expect(decision.fraction).toBe(0);
+  });
+});
+
+describe("decideHarnessLane — default/absent env", () => {
+  it("defaults to one-shot when the env var is entirely absent", () => {
+    const decision = decideHarnessLane({ taskId: "task-1", taskType: ELIGIBLE_TYPE }, { env: {} });
+    expect(decision.lane).toBe("one-shot");
+    expect(decision.eligible).toBe(true);
+    expect(decision.reason).toBe("fraction-zero-or-absent");
+    expect(decision.fraction).toBe(0);
+  });
+
+  it("defaults to one-shot when the env var is explicitly \"0\"", () => {
+    const decision = decideHarnessLane(
+      { taskId: "task-1", taskType: ELIGIBLE_TYPE },
+      { env: { [HARNESS_LANE_FRACTION_ENV]: "0" } },
+    );
+    expect(decision.lane).toBe("one-shot");
+    expect(decision.reason).toBe("fraction-zero-or-absent");
+  });
+
+  it("defaults to one-shot when the env var is blank", () => {
+    const decision = decideHarnessLane(
+      { taskId: "task-1", taskType: ELIGIBLE_TYPE },
+      { env: { [HARNESS_LANE_FRACTION_ENV]: "   " } },
+    );
+    expect(decision.lane).toBe("one-shot");
+    expect(decision.reason).toBe("fraction-zero-or-absent");
+  });
+
+  it("never samples into harness lane across a keyspace when off", () => {
+    for (let i = 0; i < 500; i += 1) {
+      const decision = decideHarnessLane({ taskId: `task-${i}`, taskType: ELIGIBLE_TYPE }, { env: {} });
+      expect(decision.lane).toBe("one-shot");
+    }
+  });
+});
+
+describe("decideHarnessLane — determinism", () => {
+  it("the same task key always yields the same lane, repeatedly", () => {
+    const env = { [HARNESS_LANE_FRACTION_ENV]: "0.5" };
+    const first = decideHarnessLane({ taskId: "task-42", taskType: ELIGIBLE_TYPE }, { env });
+    for (let i = 0; i < 20; i += 1) {
+      const again = decideHarnessLane({ taskId: "task-42", taskType: ELIGIBLE_TYPE }, { env });
+      expect(again.lane).toBe(first.lane);
+      expect(again.keyDigestHex).toBe(first.keyDigestHex);
+    }
+  });
+
+  it("is reproducible across independent processes (no hidden shared state)", () => {
+    const env = { [HARNESS_LANE_FRACTION_ENV]: "0.3" };
+    const keys = Array.from({ length: 50 }, (_, i) => `reproducible-${i}`);
+    const firstPass = keys.map((taskId) => decideHarnessLane({ taskId, taskType: ELIGIBLE_TYPE }, { env }).lane);
+    const secondPass = keys.map((taskId) => decideHarnessLane({ taskId, taskType: ELIGIBLE_TYPE }, { env }).lane);
+    expect(secondPass).toEqual(firstPass);
+  });
+
+  it("different task ids do not all collapse onto the same lane", () => {
+    const env = { [HARNESS_LANE_FRACTION_ENV]: "0.5" };
+    const lanes = new Set(
+      Array.from({ length: 100 }, (_, i) =>
+        decideHarnessLane({ taskId: `distinct-${i}`, taskType: ELIGIBLE_TYPE }, { env }).lane),
+    );
+    expect(lanes.size).toBe(2);
+  });
+});
+
+describe("decideHarnessLane — fraction respected across a keyspace", () => {
+  it("samples roughly the configured fraction into the harness lane at 10%", () => {
+    const env = { [HARNESS_LANE_FRACTION_ENV]: "0.1" };
+    const total = 4000;
+    let harnessCount = 0;
+    for (let i = 0; i < total; i += 1) {
+      const decision = decideHarnessLane({ taskId: `key-${i}`, taskType: ELIGIBLE_TYPE }, { env });
+      if (decision.lane === "harness") harnessCount += 1;
+    }
+    const rate = harnessCount / total;
+    // Statistical tolerance, not an exact match — this is a hash-derived
+    // sample, not a precise counter.
+    expect(rate).toBeGreaterThan(0.07);
+    expect(rate).toBeLessThan(0.13);
+  });
+
+  it("samples ~100% into the harness lane at fraction 1", () => {
+    const env = { [HARNESS_LANE_FRACTION_ENV]: "1" };
+    for (let i = 0; i < 200; i += 1) {
+      const decision = decideHarnessLane({ taskId: `all-${i}`, taskType: ELIGIBLE_TYPE }, { env });
+      expect(decision.lane).toBe("harness");
+      expect(decision.reason).toBe("sampled-harness");
+    }
+  });
+});
+
+describe("decideHarnessLane — sampler malfunction", () => {
+  it("falls back to one-shot on a non-numeric fraction env value", () => {
+    const decision = decideHarnessLane(
+      { taskId: "task-1", taskType: ELIGIBLE_TYPE },
+      { env: { [HARNESS_LANE_FRACTION_ENV]: "not-a-number" } },
+    );
+    expect(decision.lane).toBe("one-shot");
+    expect(decision.reason).toBe("sampler-malfunction");
+    expect(decision.malfunctionDetail).toMatch(/not a finite number/);
+  });
+
+  it("falls back to one-shot on an out-of-range fraction env value", () => {
+    for (const raw of ["-0.1", "1.5", "100"]) {
+      const decision = decideHarnessLane(
+        { taskId: "task-1", taskType: ELIGIBLE_TYPE },
+        { env: { [HARNESS_LANE_FRACTION_ENV]: raw } },
+      );
+      expect(decision.lane).toBe("one-shot");
+      expect(decision.reason).toBe("sampler-malfunction");
+      expect(decision.malfunctionDetail).toMatch(/outside the valid \[0, 1\] range/);
+    }
+  });
+
+  it("falls back to one-shot when the digest function itself throws", () => {
+    const decision = decideHarnessLane(
+      { taskId: "task-1", taskType: ELIGIBLE_TYPE },
+      {
+        env: { [HARNESS_LANE_FRACTION_ENV]: "0.5" },
+        digest: () => {
+          throw new Error("simulated hash backend failure");
+        },
+      },
+    );
+    expect(decision.lane).toBe("one-shot");
+    expect(decision.reason).toBe("sampler-malfunction");
+    expect(decision.malfunctionDetail).toMatch(/simulated hash backend failure/);
+    expect(decision.keyDigestHex).toBe("");
+  });
+
+  it("falls back to one-shot when the digest function returns unusable output", () => {
+    const decision = decideHarnessLane(
+      { taskId: "task-1", taskType: ELIGIBLE_TYPE },
+      {
+        env: { [HARNESS_LANE_FRACTION_ENV]: "0.5" },
+        digest: () => "not-hex!!",
+      },
+    );
+    expect(decision.lane).toBe("one-shot");
+    expect(decision.reason).toBe("sampler-malfunction");
+  });
+
+  it("never throws out of decideHarnessLane itself", () => {
+    expect(() =>
+      decideHarnessLane(
+        { taskId: "task-1", taskType: ELIGIBLE_TYPE },
+        { env: { [HARNESS_LANE_FRACTION_ENV]: "NaN" }, digest: () => {
+          throw new Error("boom");
+        } },
+      ),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #267

## What

Turns hugin#192's one-off harness-vs-one-shot campaign into a **standing, sampled harvest**: a configurable fraction of eligible bounded coding sub-tasks (`code-implement` / `code-edit` / `unit-test-gen`) is additionally routed through the harness lane (`code_loop` / `opencode`) for shadow evidence-gathering, graded with the same self-verify discipline as the one-shot lane, and recorded into the durable #232 registry with harness identity. A read-only report computes a rolling one-shot-vs-harness comparison per task type straight from that registry.

New/changed:
- `src/harness-lane-sampler.ts` (236 lines) — pure, deterministic `decideHarnessLane`. Seeded SHA-256 hash of `(samplerVersion, taskType, taskId)` compared against `HUGIN_HARNESS_LANE_FRACTION` (default absent/`0` = fully off).
- `src/harness-lane-executor.ts` (237 lines) — `runHarnessLaneSampledAttempt`: asks the sampler for a lane, calls the caller-injected executor for that lane (no new executor built — callers wire in the existing Broker one-shot path / opencode / code_loop), then folds the result into #232 with harness identity.
- `src/harness-lane-comparison-report.ts` (159 lines) + `src/harness-lane-comparison-report-cli.ts` (93 lines) — `npm run report:harness-comparison`, read-only aggregation by `(taskType, lane)`.
- `src/task-result-schema.ts` — `delegationProvenanceSchema` gains one additive optional field, `lane: "one-shot" | "harness"` (the #163 evidence-identity shape).
- `src/learning-registry-schema.ts` / `src/learning-registry-store.ts` — `terminalOutcomeEventSchema.payload` gains an additive optional `delegation` field carrying that shape; `recordTerminalOutcome` threads it through; new read method `listTerminalOutcomesForPeriod` (reuses the existing partition tag, no new index).
- `docs/harness-lane-standing-sampler.md` — design doc, env var, eligibility, fail-closed semantics.
- `package.json` — new `report:harness-comparison` script.

## Design decisions

- **Deterministic sampler.** Same `(taskType, taskId)` always yields the same lane, on every process, forever — reproducible and idempotent. A version bump to `HARNESS_LANE_SAMPLER_VERSION` is the only deliberate way to reshuffle assignments.
- **Default-off shadow posture.** `HUGIN_HARNESS_LANE_FRACTION` absent/empty/`"0"` (the default) means every eligible task still resolves to one-shot — today's status quo. Raising it above 0 is a separate, reviewed decision made after reading the comparison report. Any non-numeric or out-of-range value is a **sampler malfunction**, not silently coerced to "off": it falls back to one-shot but is recorded with `reason: "sampler-malfunction"` so the misconfiguration stays visible.
- **Same-discipline grading.** Both lanes resolve to the same `LaneAttemptOutcome` contract (mechanical-or-none verifier, M5-style pass/partial/fail/error/unverified verdict) and land in the same #163 evidence-identity shape, with one new `lane` field distinguishing them — no second, competing provenance shape.
- **Comparison report.** Computed read-only from `listTerminalOutcomesForPeriod`, which reuses the exact partition tag every terminal-outcome event is already stamped with — no new index to keep in sync. Content-blind: only task type, lane, counts, and rates are ever printed.
- **Fail-closed contracts, explicitly tested:** a harness-lane failure is recorded *as harness*, never silently rerouted to one-shot (that would hide the failure from the comparison and double-spend the task); an executor that rejects instead of resolving with a graded outcome causes the wiring to rethrow rather than fabricate registry evidence; replaying the same attempt is idempotent (no duplicate or lost registry events) via the store's existing natural-key dedup.
- **No routing impact.** The sampler and its wiring never touch `runtime-registry.ts` aliasing, auto-routing, or promotion — it only ever diversifies evidence.
- Not yet wired into the live dispatch loop (mechanism-first, same shape as #232/#237's own PRs) — `HarnessLaneExecutors` are injected callbacks; wiring real one-shot/opencode/code_loop callbacks into `src/index.ts` is left to a follow-up so this ships as a self-contained, independently testable library.

## Verification

- `npm run build` — clean.
- `npm test` — **139 files / 2210 tests, all passing** (136 pre-existing files/tests + 3 new test files: 17 sampler + 7 executor + 4 comparison-report tests = 28 new).
- Manual CLI smoke: `node dist/harness-lane-comparison-report-cli.js --help` prints usage; without `MUNIN_API_KEY` it fails closed with a clear message and non-zero exit.

M5 dogfood round skipped for this PR (spend discipline, per orchestrator instruction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)