### PR TITLE
Add daily systemd timer for experiment cadence

### DIFF
--- a/scripts/deploy-pi.sh
+++ b/scripts/deploy-pi.sh
@@ -119,13 +119,17 @@ ssh "$REMOTE" "
 
 echo "==> Installing user-level systemd services..."
 ssh "$REMOTE" "
-  mkdir -p ~/.config/systemd/user ~/.hugin/daily-exam-candidates
+  mkdir -p ~/.config/systemd/user ~/.hugin/daily-exam-candidates ~/.hugin/experiment-cadence
+  [ -f ~/.hugin/experiment-cadence/candidates.json ] || echo '[]' > ~/.hugin/experiment-cadence/candidates.json
   cp $REMOTE_DIR/hugin.service ~/.config/systemd/user/hugin.service
   cp $REMOTE_DIR/systemd/hugin-daily-exam-factory.service ~/.config/systemd/user/hugin-daily-exam-factory.service
   cp $REMOTE_DIR/systemd/hugin-daily-exam-factory.timer ~/.config/systemd/user/hugin-daily-exam-factory.timer
+  cp $REMOTE_DIR/systemd/hugin-experiment-cadence.service ~/.config/systemd/user/hugin-experiment-cadence.service
+  cp $REMOTE_DIR/systemd/hugin-experiment-cadence.timer ~/.config/systemd/user/hugin-experiment-cadence.timer
   XDG_RUNTIME_DIR=/run/user/1000 systemctl --user daemon-reload
   XDG_RUNTIME_DIR=/run/user/1000 systemctl --user enable hugin.service
   XDG_RUNTIME_DIR=/run/user/1000 systemctl --user enable --now hugin-daily-exam-factory.timer
+  XDG_RUNTIME_DIR=/run/user/1000 systemctl --user enable --now hugin-experiment-cadence.timer
   loginctl enable-linger magnus 2>/dev/null || true
 "
 

--- a/systemd/hugin-experiment-cadence.service
+++ b/systemd/hugin-experiment-cadence.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=Hugin continuous-improvement experiment cadence tick (propose -> package -> observe -> conclude, hugin#266)
+After=network-online.target munin-memory.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=magnus
+WorkingDirectory=/home/magnus/repos/hugin
+ExecStart=/usr/bin/node dist/experiment-cadence-cli.js --candidates /home/magnus/.hugin/experiment-cadence/candidates.json
+EnvironmentFile=/home/magnus/repos/hugin/.env
+TimeoutStartSec=120
+
+# Sandboxing
+ProtectSystem=strict
+ReadOnlyPaths=/home/magnus/repos/hugin /home/magnus/.hugin
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectHome=read-only
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictSUIDSGID=yes
+PrivateDevices=yes
+RestrictNamespaces=yes
+RestrictRealtime=yes
+LockPersonality=yes
+ProtectClock=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+SystemCallArchitectures=native
+
+[Install]
+WantedBy=default.target

--- a/systemd/hugin-experiment-cadence.timer
+++ b/systemd/hugin-experiment-cadence.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Hugin continuous-improvement experiment cadence — daily tick
+
+[Timer]
+OnCalendar=*-*-* 05:00:00
+Persistent=true
+RandomizedDelaySec=300
+Unit=hugin-experiment-cadence.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Refs #266

## What

Wires `npm run experiment:cadence` (merged in #268) into Hugin's established unit-install mechanism so the daily orchestration tick (propose -> package -> observe -> conclude) runs unattended on the Pi, mirroring `hugin-daily-analysis.timer` / `hugin-daily-exam-factory.timer` exactly.

- `systemd/hugin-experiment-cadence.service` -- oneshot. WorkingDirectory/EnvironmentFile/read-only sandboxing conventions copied from `hugin-daily-analysis.service` (the cadence CLI only reads local files and talks to Munin/gille over the network; it never writes locally, so no `ReadWritePaths` needed). `ExecStart` invokes the built CLI directly with flags, same style as `hugin-daily-exam-factory.service`: `node dist/experiment-cadence-cli.js --candidates <snapshot path>`.
- `systemd/hugin-experiment-cadence.timer` -- `OnCalendar=*-*-* 05:00:00`, `Persistent=true`, `RandomizedDelaySec=300`, `WantedBy=timers.target` -- same shape as the two existing timers.
- `scripts/deploy-pi.sh` -- installs + enables the new pair in the same install/enable block as the exam-factory pair (mkdir, cp, `daemon-reload`, `enable --now`). Also seeds `~/.hugin/experiment-cadence/candidates.json` with `[]` if it doesn't already exist yet, so the unit has something to read on day one.

## Known limitation (flagging for review, not fixing here)

`experiment-cadence-cli.ts`'s own doc comment documents that there is no production bulk assembler yet for the `PackagerCandidateInput[]` evidence pool -- that's explicitly out of #234/#233/#268's scope, deferred to a future ticket. Until that generator exists, the timer's `--candidates` snapshot stays the empty-array placeholder seeded by `deploy-pi.sh`. That's still useful, not a no-op: the tick is idempotent and never promotes, and it still safely observes/concludes any already-running experiments each day -- it just won't propose anything new from an empty candidate pool. A follow-up ticket should point `--candidates` at a real generator.

Also checked whether Hugin's docs maintain a consolidated list of systemd timers to extend (per the ticket's item 4) -- no such list exists (only `docs/daily-exam-factory.md`, which documents that one feature specifically), so no doc change was made.

## Verification

- `npm run build` -- clean.
- `npm test` -- **142 files / 2232 tests passed**, matching the stated baseline exactly.
- `shellcheck scripts/deploy-pi.sh` -- shows the same 12 pre-existing info-level `SC2029`/`SC2016`/`SC1091` findings present on `origin/main` (verified by diffing against the unmodified file); zero new findings introduced by this change.
- `systemd-analyze verify` is unavailable on macOS. Verified unit syntax by diffing the new unit files against their templates (`hugin-daily-analysis.service`, `hugin-daily-exam-factory.timer`) -- identical structure except the intended deltas (Description, ExecStart, TimeoutStartSec, OnCalendar, Unit=) -- and by running the built CLI locally with the exact `ExecStart` arguments (`node dist/experiment-cadence-cli.js --candidates /tmp/candidates-empty.json --dry-run`) to confirm it parses flags and executes cleanly.

Not merged or deployed, per scope.

M5 dogfood round skipped this task (spend discipline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)