### PR TITLE
Experiment cadence fuel: candidate-pool assembler + gille evidence resolver

### DIFF
--- a/scripts/deploy-pi.sh
+++ b/scripts/deploy-pi.sh
@@ -120,7 +120,9 @@ ssh "$REMOTE" "
 echo "==> Installing user-level systemd services..."
 ssh "$REMOTE" "
   mkdir -p ~/.config/systemd/user ~/.hugin/daily-exam-candidates ~/.hugin/experiment-cadence
-  [ -f ~/.hugin/experiment-cadence/candidates.json ] || echo '[]' > ~/.hugin/experiment-cadence/candidates.json
+  # hugin#272: no candidates.json seed needed -- the cadence CLI's default
+  # production candidate-pool assembler scans the #232 registry itself.
+  # A leftover file from an older deploy is simply never read.
   cp $REMOTE_DIR/hugin.service ~/.config/systemd/user/hugin.service
   cp $REMOTE_DIR/systemd/hugin-daily-exam-factory.service ~/.config/systemd/user/hugin-daily-exam-factory.service
   cp $REMOTE_DIR/systemd/hugin-daily-exam-factory.timer ~/.config/systemd/user/hugin-daily-exam-factory.timer

--- a/src/experiment-cadence-cli.ts
+++ b/src/experiment-cadence-cli.ts
@@ -13,14 +13,13 @@
  * experiment's reviewable summary records `outcomeExport.status: "skipped"`
  * with a reason, per experiment-cadence.ts's documented limitation.
  *
- * Documented limitation: there is no production-ready bulk assembler for the
- * full `PackagerCandidateInput[]` evidence pool yet (see
- * experiment-cadence.ts's module doc comment) -- this CLI reads that pool
- * from an operator/cron-supplied JSON snapshot file (`--candidates <path>`)
- * rather than inventing a whole-ledger scan under this ticket's narrower
- * orchestration scope. A future ticket can point `--candidates` at a real
- * generator's output, or replace the flag with a direct call, without
- * touching `experiment-cadence.ts` at all.
+ * Candidate source (hugin#272): the DEFAULT is the production bulk assembler
+ * (`candidate-pool-assembler.ts`), which scans the #232 registry itself --
+ * no manual snapshot required. `--candidates <path>` remains as an explicit
+ * override (a JSON `PackagerCandidateInput[]` snapshot) for tests and manual
+ * runs; when omitted, the deploy-seeded empty
+ * `~/.hugin/experiment-cadence/candidates.json` (if still present from an
+ * older deploy) is simply never read -- its presence is harmless.
  */
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
@@ -30,6 +29,8 @@ import { LearningRegistryStore } from "./learning-registry-store.js";
 import { LearningExperimentStore } from "./learning/experiment-store.js";
 import { packagerCandidateInputSchema } from "./learning/candidate-packager-schema.js";
 import { createGilleOutcomeExportClient } from "./learning/experiment-outcome-export.js";
+import { createCandidatePoolAssembler } from "./learning/candidate-pool-assembler.js";
+import { createGilleOutcomeEvidenceResolver } from "./learning/gille-outcome-evidence-resolver.js";
 import { runExperimentCadenceTick, type CadenceTickResult } from "./learning/experiment-cadence.js";
 
 export const DEFAULT_CADENCE_PRINCIPAL = "service:hugin-experiment-cadence";
@@ -41,7 +42,7 @@ interface CliOptions {
 
 function usage(): string {
   return [
-    "Usage: npm run experiment:cadence -- --candidates <path> [options]",
+    "Usage: npm run experiment:cadence -- [options]",
     "",
     "Run one continuous-improvement experiment-cadence tick: propose (#234) ->",
     "package (#233) -> observe running experiments -> conclude terminal ones",
@@ -49,8 +50,10 @@ function usage(): string {
     "promotes. Idempotent -- re-running against unchanged state is a no-op.",
     "",
     "Options:",
-    "  --candidates <path>   Required. JSON file containing a",
-    "                        PackagerCandidateInput[] evidence snapshot.",
+    "  --candidates <path>   Optional. JSON file containing a",
+    "                        PackagerCandidateInput[] evidence snapshot,",
+    "                        overriding the default production candidate-pool",
+    "                        assembler (which scans the #232 registry itself).",
     "  --dry-run             Report the would-be actions; mutate nothing.",
     "  --help                Show this help",
   ].join("\n");
@@ -73,9 +76,6 @@ export function parseArgs(argv: string[]): CliOptions {
     } else {
       throw new Error(`unknown option: ${arg}`);
     }
-  }
-  if (!options.candidatesPath) {
-    throw new Error("--candidates <path> is required (see --help)");
   }
   return options;
 }
@@ -126,11 +126,16 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     gatewayUrl && adminApiKey
       ? createGilleOutcomeExportClient({ gatewayBaseUrl: gatewayUrl, apiKey: adminApiKey })
       : undefined;
+  const evidenceResolver = gilleExport
+    ? createGilleOutcomeEvidenceResolver({ munin, registry })
+    : undefined;
 
-  const candidates = loadCandidatesFromFile(options.candidatesPath!);
+  const loadCandidates = options.candidatesPath
+    ? async () => loadCandidatesFromFile(options.candidatesPath!)
+    : createCandidatePoolAssembler({ registry, munin });
 
   const result = await runExperimentCadenceTick(
-    { registry, experimentStore, munin, principal, loadCandidates: async () => candidates, gilleExport },
+    { registry, experimentStore, munin, principal, loadCandidates, gilleExport, evidenceResolver },
     { dryRun: options.dryRun },
   );
 

--- a/src/learning/admitted-attempt-evidence.ts
+++ b/src/learning/admitted-attempt-evidence.ts
@@ -1,0 +1,54 @@
+/**
+ * Shared read of one Hugin attempt's admitted LearningTaskContract evidence
+ * row (`learning-task-handshake.ts`'s `LearningTaskExecutionEvidence`), keyed
+ * by the #232 registry's own `RegistryEvidenceRef` (the `attempt-reference`/
+ * `terminal-outcome` payload's optional `attemptOutcomeRef`).
+ *
+ * Used by BOTH the #272 candidate-pool assembler
+ * (`candidate-pool-assembler.ts`, to recover the prompt/harness/tool-policy
+ * identity a `LearningConfiguration` needs) and the #272 gille outcome-export
+ * evidence resolver (`gille-outcome-evidence-resolver.ts`, to recover the
+ * same fields for gille-inference#8's nine-field evidence-identity bundle) --
+ * one read-only resolution, not two independently drifting copies.
+ *
+ * Read-only, content-blind at the caller boundary: this returns the FULL
+ * durable evidence row, which itself only ever carries digests/labels, never
+ * raw prompt bytes (`DurableLearningTaskAttemptStart` deliberately omits
+ * `renderedPrompt` -- see learning-task-handshake.ts's own module doc). A row
+ * that is not `state: "m5-admitted"` / `evidenceAccepted: true` is treated as
+ * unresolved (`null`), never partially trusted: a preflight-failed or
+ * join-failed attempt never produced a genuinely admitted identity, and
+ * `evidenceAccepted` can only be `true` together with `state ===
+ * "m5-admitted"` per that schema's own superRefine. The caller's `taskId`/
+ * `attemptId` are additionally cross-checked against the resolved row's own
+ * identity -- a misdirected or stale ref (e.g. two registry events
+ * accidentally pointing at the same Munin key) must never silently donate
+ * one attempt's evidence to a different attempt.
+ */
+
+import type { MuninClient } from "../munin-client.js";
+import {
+  learningTaskExecutionEvidenceSchema,
+  type LearningTaskExecutionEvidence,
+} from "../learning-task-handshake.js";
+import type { RegistryEvidenceRef } from "../learning-registry-schema.js";
+
+export async function resolveAdmittedAttemptOutcomeEvidence(
+  munin: Pick<MuninClient, "read">,
+  ref: RegistryEvidenceRef,
+  identity: { taskId: string; attemptId: string },
+): Promise<LearningTaskExecutionEvidence | null> {
+  const entry = await munin.read(ref.namespace, ref.key);
+  if (!entry) return null;
+  let raw: unknown;
+  try {
+    raw = JSON.parse(entry.content);
+  } catch {
+    return null;
+  }
+  const parsed = learningTaskExecutionEvidenceSchema.safeParse(raw);
+  if (!parsed.success) return null;
+  if (parsed.data.state !== "m5-admitted" || !parsed.data.evidenceAccepted) return null;
+  if (parsed.data.taskId !== identity.taskId || parsed.data.attemptId !== identity.attemptId) return null;
+  return parsed.data;
+}

--- a/src/learning/candidate-pool-assembler.ts
+++ b/src/learning/candidate-pool-assembler.ts
@@ -1,0 +1,361 @@
+/**
+ * Production candidate-pool assembler (hugin#272) -- fuel for the #266
+ * experiment cadence.
+ *
+ * `experiment-cadence.ts`'s module doc comment names an explicit,
+ * intentional gap: assembling the full production `PackagerCandidateInput[]`
+ * pool is out of #234/#233's scope, so the cadence tick takes `loadCandidates`
+ * as a REQUIRED injected dependency rather than building a bulk evidence scan
+ * itself. Before this module, `experiment-cadence-cli.ts` filled that gap
+ * with an operator/cron-supplied JSON snapshot file (`--candidates <path>`) --
+ * deploy seeded an empty `[]`, so the daily tick only ever observed/concluded
+ * already-packaged experiments and never proposed or packaged a new one. This
+ * module is the "future ticket" the CLI's doc comment already anticipated: it
+ * becomes the tick's DEFAULT candidate source; `--candidates` remains as an
+ * explicit override for tests and manual runs.
+ *
+ * Scope boundary, same discipline as candidate-packager.ts/experiment-
+ * proposer.ts: this module is read-only over the #232 registry, the #216
+ * quality-receipt ledger, and the durable LearningTaskContract admitted-
+ * evidence row. It never mutates anything, never qualifies or floors a
+ * candidate itself (that stays entirely `qualifyCandidate`'s job, invoked
+ * downstream by BOTH `proposeExperimentsFromRegistry` -- floor "wrong", the
+ * full outcome spectrum -- and `packageAndHandOff`/`packageExperimentCandidates`
+ * -- floor "pass" -- exactly the deliberate floor difference #269 documents),
+ * and never fabricates configuration bytes it cannot honestly attribute.
+ *
+ * Discovery mechanism: the registry has no "list every task" primitive, only
+ * `listTerminalOutcomesForPeriod(occurrencePeriodUtc)` -- a cross-task scan of
+ * one UTC calendar month. This module scans a configurable trailing window of
+ * months (default: the current month plus the previous one, to cover
+ * month-boundary stragglers) and resolves each completed terminal outcome
+ * into a candidate, or records why it could not.
+ *
+ * Per-(taskId, attemptId) resolution -- every step below fails closed by
+ * EXCLUDING the candidate, never by defaulting or guessing a value:
+ *
+ *   1. `payload.outcome !== "completed"` -> excluded ("outcome-not-completed").
+ *   2. `payload.delegation?.modelId` absent -> excluded
+ *      ("missing-model-identity"). Hugin's own registry only durably records a
+ *      real model identity via the standing harness-lane sampler's (#267)
+ *      `delegation` field; a terminal outcome the sampler never touched
+ *      carries no model identity Hugin can honestly attribute.
+ *   3. `payload.delegation?.taskType` absent or not a valid Broker task type
+ *      -> excluded ("missing-or-invalid-task-type").
+ *   4. `payload.attemptOutcomeRef` absent, or it does not resolve to an
+ *      `m5-admitted`+`evidenceAccepted` `LearningTaskExecutionEvidence` row
+ *      (`admitted-attempt-evidence.ts`) -> excluded
+ *      ("missing-attempt-outcome-ref" / "attempt-outcome-not-admitted"). This
+ *      durable row is the proof that a real, gateway-admitted
+ *      LearningTaskContract handshake produced this attempt's prompt/harness
+ *      identity (`requestStamp.origin_config`).
+ *   5. No effective, binding-matched quality receipt resolves for this
+ *      (taskId, attemptId) (`quality-receipt-resolution.ts`) -> excluded
+ *      ("missing-quality-receipt").
+ *   6. Otherwise, a `PackagerCandidateInput` is built:
+ *        - `prompt`/`harness` from `requestStamp.origin_config.prompt`/
+ *          `.harness` (id/version + the config document's own sha256 digest;
+ *          `harness.toolPolicyVersion` from `origin_config.tool_policy.version`).
+ *        - `model` from `delegation.modelId`, with `provider`/`runtime`
+ *          naming the one dispatch surface Hugin's own registry can honestly
+ *          attribute today (the M5 gateway's `/delegate` lane); `config: {}`
+ *          because Hugin does not durably record per-task model-config detail
+ *          (quantization/temperature/etc) -- left empty rather than guessed.
+ *        - `logging`/`testHarness`/`routing`: Hugin does not yet durably
+ *          track per-task variation on these three axes. Each is a FIXED,
+ *          versioned, digested sentinel identical for every real candidate
+ *          today -- the exact "digest a real, if trivial, constant document"
+ *          pattern `learning-task-handshake.ts`'s own `originConfig()` already
+ *          uses for prompt/harness/tool-policy identity. This is a documented
+ *          simplification, not a fabrication: these axes never register as
+ *          "the changed axis" and never masquerade as differentiated
+ *          evidence. Today's only real per-candidate axis Hugin's own
+ *          registry can observe is `model` (the M5 gateway is free to route a
+ *          nominal request to different underlying models -- exactly what the
+ *          harness-lane sampler's comparison exists to surface).
+ *
+ * Dedup: natural key `${taskId}/${attemptId}`. The registry's own natural-key
+ * write-time dedup already prevents a duplicate event within one scanned
+ * month; this module additionally dedupes across scanned months (in case of
+ * an overlapping window) so the returned pool never contains the same
+ * candidate twice.
+ *
+ * Determinism / idempotency: the returned pool is sorted by
+ * `${taskId}/${attemptId}` and depends only on durable state (registry,
+ * quality-receipt ledger, admitted-evidence rows) -- re-running against
+ * unchanged state yields a byte-identical pool.
+ *
+ * Fail-closed on truncation: if `listTerminalOutcomesForPeriod` reports
+ * `truncated: true` for ANY scanned period, this module THROWS rather than
+ * silently returning a partial pool as if it were complete. The cadence
+ * tick's existing `loadCandidates` error handling
+ * (`experiment-cadence.ts`'s `"load-candidates"` stage) already records this
+ * as a durable, discoverable failure and continues the tick with zero
+ * candidates for that run -- no new error path is needed.
+ */
+
+import type { MuninClient } from "../munin-client.js";
+import type { LearningRegistryStore } from "../learning-registry-store.js";
+import {
+  jcsDigestHex,
+  occurrencePeriodUtcFromInstant,
+  type TerminalOutcomeEvent,
+} from "../learning-registry-schema.js";
+import { taskTypeSchema } from "../broker/task-type-metadata.js";
+import {
+  computeConfigurationFingerprint,
+  learningConfigurationSchema,
+  type LearningConfiguration,
+} from "./experiment-schema.js";
+import {
+  packagerCandidateInputSchema,
+  type PackagerCandidateInput,
+} from "./candidate-packager-schema.js";
+import { resolveAdmittedAttemptOutcomeEvidence } from "./admitted-attempt-evidence.js";
+import { resolveEffectiveQualityReceipt } from "./quality-receipt-resolution.js";
+import type { LearningTaskExecutionEvidence } from "../learning-task-handshake.js";
+
+const DEFAULT_LOOKBACK_MONTHS = 2;
+
+/** The one dispatch surface Hugin's own registry can honestly attribute a
+ * model identity through today -- the M5 gateway's `/delegate` endpoint (see
+ * `m5-provenance.ts` and `learning-task-handshake.ts`'s
+ * `HARNESS_CONFIG_DOCUMENT.settings.adapter`). Never a guess at the
+ * underlying model's own real provider/runtime, which Hugin does not own
+ * (AGENTS.md: "the M5 gateway owns model selection ... Hugin ... must not
+ * build a competing capability truth"). */
+const HUGIN_MODEL_PROVIDER = "m5-gateway";
+const HUGIN_MODEL_RUNTIME = "m5-gateway-delegate";
+
+/**
+ * Fixed, versioned, digested sentinel documents for the three axes Hugin
+ * does not yet durably differentiate per candidate -- mirroring
+ * `learning-task-handshake.ts`'s own `originConfig()` pattern (digest a real,
+ * declared constant document, never a fabricated per-task value).
+ */
+const HUGIN_CANDIDATE_LOGGING_DOCUMENT = {
+  schema_version: "hugin-candidate-pool-sentinel/v1",
+  axis: "logging",
+  note: "Hugin does not yet durably record per-task logging-schema variation; every assembled candidate shares this fixed identity.",
+};
+const HUGIN_CANDIDATE_TEST_HARNESS_DOCUMENT = {
+  schema_version: "hugin-candidate-pool-sentinel/v1",
+  axis: "test-harness",
+  note: "Hugin does not yet durably record a per-task test-harness/corpus identity for ad-hoc coding tasks; every assembled candidate shares this fixed identity.",
+};
+const HUGIN_CANDIDATE_ROUTING_DOCUMENT = {
+  schema_version: "hugin-candidate-pool-sentinel/v1",
+  axis: "routing",
+  note: "Hugin does not yet durably record a per-task routing-policy identity distinct from the M5 gateway's own delegate lane; every assembled candidate shares this fixed identity.",
+};
+
+const HUGIN_CANDIDATE_LOGGING_REF = {
+  schemaVersion: "hugin-candidate-pool-sentinel-v1",
+  requiredFieldsSha256: jcsDigestHex(HUGIN_CANDIDATE_LOGGING_DOCUMENT),
+};
+const HUGIN_CANDIDATE_TEST_HARNESS_REF = {
+  id: "hugin-candidate-pool-sentinel",
+  version: "v1",
+  corpusSha256: jcsDigestHex(HUGIN_CANDIDATE_TEST_HARNESS_DOCUMENT),
+  oracleVersion: "hugin-candidate-pool-sentinel-v1",
+  holdoutRevision: "hugin-candidate-pool-sentinel-v1",
+};
+const HUGIN_CANDIDATE_ROUTING_REF = {
+  policyId: "hugin-candidate-pool-sentinel",
+  version: "v1",
+  configSha256: jcsDigestHex(HUGIN_CANDIDATE_ROUTING_DOCUMENT),
+};
+
+export interface CandidatePoolAssemblerDeps {
+  registry: Pick<LearningRegistryStore, "listTerminalOutcomesForPeriod">;
+  munin: Pick<MuninClient, "read">;
+  now?: () => string;
+}
+
+export interface AssembleCandidatePoolOptions {
+  /** Trailing UTC calendar months to scan, most-recent first. Default 2 (current + previous). */
+  lookbackMonths?: number;
+  /** Explicit period override for tests/manual runs (bypasses `lookbackMonths`/`now`). */
+  periods?: string[];
+}
+
+export type SkippedCandidateReason =
+  | "outcome-not-completed"
+  | "missing-model-identity"
+  | "missing-or-invalid-task-type"
+  | "missing-attempt-outcome-ref"
+  | "attempt-outcome-not-admitted"
+  | "missing-quality-receipt"
+  | "candidate-schema-invalid";
+
+export interface SkippedCandidate {
+  taskId: string;
+  attemptId: string;
+  reason: SkippedCandidateReason;
+}
+
+export interface CandidatePoolAssemblyResult {
+  candidates: PackagerCandidateInput[];
+  scannedPeriods: string[];
+  scannedTerminalOutcomes: number;
+  skipped: SkippedCandidate[];
+}
+
+/** Trailing `count` UTC calendar months ending at (and including) `period`, most-recent first. */
+function monthsBack(period: string, count: number): string[] {
+  const [yearStr, monthStr] = period.split("-");
+  let year = Number(yearStr);
+  let month = Number(monthStr);
+  const periods: string[] = [];
+  for (let i = 0; i < Math.max(count, 1); i += 1) {
+    periods.push(`${year}-${String(month).padStart(2, "0")}`);
+    month -= 1;
+    if (month === 0) {
+      month = 12;
+      year -= 1;
+    }
+  }
+  return periods;
+}
+
+function buildConfiguration(
+  evidence: LearningTaskExecutionEvidence,
+  modelId: string,
+): LearningConfiguration {
+  const stamp = evidence.requestStamp;
+  if (!stamp) {
+    throw new Error("m5-admitted evidence is missing its request stamp");
+  }
+  const payload = {
+    prompt: {
+      id: stamp.origin_config.prompt.id,
+      version: stamp.origin_config.prompt.version,
+      sha256: stamp.origin_config.prompt.config_digest.digest,
+    },
+    harness: {
+      id: stamp.origin_config.harness.id,
+      version: stamp.origin_config.harness.version,
+      configSha256: stamp.origin_config.harness.config_digest.digest,
+      toolPolicyVersion: stamp.origin_config.tool_policy.version,
+    },
+    model: {
+      id: modelId,
+      provider: HUGIN_MODEL_PROVIDER,
+      runtime: HUGIN_MODEL_RUNTIME,
+      config: {},
+    },
+    logging: HUGIN_CANDIDATE_LOGGING_REF,
+    testHarness: HUGIN_CANDIDATE_TEST_HARNESS_REF,
+    routing: HUGIN_CANDIDATE_ROUTING_REF,
+  };
+  const fingerprint = computeConfigurationFingerprint(payload);
+  return learningConfigurationSchema.parse({ ...payload, fingerprint });
+}
+
+async function resolveCandidate(
+  munin: Pick<MuninClient, "read">,
+  event: TerminalOutcomeEvent,
+): Promise<{ candidate: PackagerCandidateInput } | { skip: SkippedCandidate }> {
+  const taskId = event.taskId;
+  const attemptId = event.attemptId;
+
+  if (event.payload.outcome !== "completed") {
+    return { skip: { taskId, attemptId, reason: "outcome-not-completed" } };
+  }
+
+  const modelId = event.payload.delegation?.modelId;
+  if (!modelId) {
+    return { skip: { taskId, attemptId, reason: "missing-model-identity" } };
+  }
+
+  const rawTaskType = event.payload.delegation?.taskType;
+  const taskTypeParsed = rawTaskType ? taskTypeSchema.safeParse(rawTaskType) : undefined;
+  if (!taskTypeParsed || !taskTypeParsed.success) {
+    return { skip: { taskId, attemptId, reason: "missing-or-invalid-task-type" } };
+  }
+
+  const attemptOutcomeRef = event.payload.attemptOutcomeRef;
+  if (!attemptOutcomeRef) {
+    return { skip: { taskId, attemptId, reason: "missing-attempt-outcome-ref" } };
+  }
+
+  const evidence = await resolveAdmittedAttemptOutcomeEvidence(munin, attemptOutcomeRef, { taskId, attemptId });
+  if (!evidence) {
+    return { skip: { taskId, attemptId, reason: "attempt-outcome-not-admitted" } };
+  }
+
+  const qualityReceipt = await resolveEffectiveQualityReceipt(munin, taskId, attemptId);
+  if (!qualityReceipt) {
+    return { skip: { taskId, attemptId, reason: "missing-quality-receipt" } };
+  }
+
+  try {
+    const configuration = buildConfiguration(evidence, modelId);
+    const candidate = packagerCandidateInputSchema.parse({
+      taskId,
+      attemptId,
+      taskType: taskTypeParsed.data,
+      configuration,
+      qualityReceipt,
+    });
+    return { candidate };
+  } catch {
+    return { skip: { taskId, attemptId, reason: "candidate-schema-invalid" } };
+  }
+}
+
+/**
+ * Scan the trailing window of UTC months and resolve every honestly
+ * resolvable `PackagerCandidateInput`. Never throws for an individual
+ * unresolvable candidate (recorded in `skipped` instead); throws only when a
+ * scanned period's registry query cannot prove completeness (see the module
+ * doc comment's fail-closed-on-truncation note).
+ */
+export async function assembleCandidatePool(
+  deps: CandidatePoolAssemblerDeps,
+  options: AssembleCandidatePoolOptions = {},
+): Promise<CandidatePoolAssemblyResult> {
+  const now = deps.now ?? (() => new Date().toISOString());
+  const periods = options.periods
+    ?? monthsBack(occurrencePeriodUtcFromInstant(now()), options.lookbackMonths ?? DEFAULT_LOOKBACK_MONTHS);
+
+  const byKey = new Map<string, PackagerCandidateInput>();
+  const skipped: SkippedCandidate[] = [];
+  let scannedTerminalOutcomes = 0;
+
+  for (const period of periods) {
+    const { events, truncated } = await deps.registry.listTerminalOutcomesForPeriod(period);
+    if (truncated) {
+      throw new Error(
+        `candidate-pool assembler: terminal-outcome scan for ${period} was truncated; refusing a partial pool`,
+      );
+    }
+    scannedTerminalOutcomes += events.length;
+    for (const event of events) {
+      const key = `${event.taskId}/${event.attemptId}`;
+      if (byKey.has(key)) continue; // already resolved from an earlier-scanned, overlapping period
+      const resolved = await resolveCandidate(deps.munin, event);
+      if ("candidate" in resolved) {
+        byKey.set(key, resolved.candidate);
+      } else {
+        skipped.push(resolved.skip);
+      }
+    }
+  }
+
+  const candidates = [...byKey.values()].sort((a, b) =>
+    `${a.taskId}/${a.attemptId}`.localeCompare(`${b.taskId}/${b.attemptId}`));
+
+  return { candidates, scannedPeriods: periods, scannedTerminalOutcomes, skipped };
+}
+
+/**
+ * Thin adapter matching `ExperimentCadenceDeps["loadCandidates"]`'s exact
+ * shape, for direct injection as the cadence tick's DEFAULT candidate source.
+ */
+export function createCandidatePoolAssembler(
+  deps: CandidatePoolAssemblerDeps,
+  options: AssembleCandidatePoolOptions = {},
+): () => Promise<PackagerCandidateInput[]> {
+  return async () => (await assembleCandidatePool(deps, options)).candidates;
+}

--- a/src/learning/gille-outcome-evidence-resolver.ts
+++ b/src/learning/gille-outcome-evidence-resolver.ts
@@ -1,0 +1,241 @@
+/**
+ * Evidence resolver for the #266 gille outcome-export leg (hugin#272).
+ *
+ * `experiment-outcome-export.ts`'s module doc comment names the gap this
+ * closes: gille-inference#8's import contract requires each arm to carry a
+ * raw `prompt` string and a nine-field `evidenceIdentity` bundle, but
+ * Hugin's own `LearningExperimentState`/`RecordedLearningObservation` are
+ * deliberately content-blind (digests only, never raw prompt bytes) -- BY
+ * DESIGN, so the registry itself never has to store raw content. That module
+ * therefore accepts an optional, pluggable `GilleOutcomeEvidenceResolver`;
+ * until now nothing implemented one, so the cadence tick's export leg always
+ * recorded `"skipped: evidence-resolver-or-export-port-not-configured"`.
+ *
+ * This module reconstructs the required evidence AT EXPORT TIME, per
+ * observation, from the original durable sources -- never from the registry
+ * (which stays content-blind) and never fabricated:
+ *
+ *   - `prompt`: the Broker task envelope's own `prompt` field, durably held
+ *     at `tasks/<taskId>` / `status` (the task's OWN original submission
+ *     document -- not a copy this module makes, and not something the
+ *     registry or experiment store ever holds). Requires
+ *     `observation.task_id`; a sample without one cannot be anchored to a
+ *     real source and is left unresolved.
+ *   - `evidenceIdentity`: derived from the SAME admitted
+ *     `LearningTaskExecutionEvidence` row (`admitted-attempt-evidence.ts`,
+ *     shared with `candidate-pool-assembler.ts`) that already proves this
+ *     attempt's prompt/harness/tool-policy identity, following exactly the
+ *     field mapping gille-inference's own `evidenceIdentityFromAdmittedStamp`
+ *     (src/homeserver/evidence-identity.ts) uses for the fields Hugin's
+ *     stamp genuinely carries (`logicalTask`, `renderedPrompt`, `harness`,
+ *     `toolPolicy`, `taxonomyVersion`). `modelArtifact`/`configEpoch` are
+ *     gille/M5-side SERVER-OBSERVED facts (the exact llama-swap process
+ *     identity currently serving the model) that Hugin has no visibility
+ *     into at all -- honestly `{kind: "unknown", reason: "not-observed"}`,
+ *     never guessed. `verifierRubric` comes from the effective quality
+ *     receipt's own `rubric` (schemaVersion 2 only; a legacy schemaVersion-1
+ *     receipt carries none, so this field is `unknown("legacy")`).
+ *     `sampling` comes from the arm's own resolved `LearningConfiguration`
+ *     model config when non-empty (real, if the candidate pool ever supplies
+ *     one), else `unknown("not-observed")`. `lane` is always `"delegate"` --
+ *     the only lane this resolver handles requires an admitted
+ *     LearningTaskContract stamp, which is specific to the M5 `/delegate`
+ *     flow (`learning-task-handshake.ts`).
+ *   - `verifier`: mapped from `observation.verifier` (mechanical -> a
+ *     deterministic verifier; human -> human; judge -> `advisory-judge`,
+ *     never overclaiming `calibrated-judge`, since Hugin does not track
+ *     calibration evidence). An observation with `verifier.kind === "none"`
+ *     genuinely has no verifier evidence to attribute -- this module treats
+ *     the WHOLE sample as unresolved rather than inventing a required
+ *     `VerifierIdentityWire` for a verifier that never ran (`verifier` is a
+ *     mandatory field of `GilleOutcomeArmEvidence`, unlike gille's own wire
+ *     schema, which allows its outright absence).
+ *   - `exposure`: a fixed, honest `{contaminationStatus: "coverage-incomplete"}`
+ *     -- Hugin does not yet durably track sample-level contamination status;
+ *     this is the weakest ("we cannot fully attest") value, never the
+ *     stronger "clean" claim.
+ *   - `review`: deliberately OMITTED. Hugin's richer `product_outcome`
+ *     taxonomy (accepted-unchanged/minor-edit/major-rewrite/discarded/
+ *     unrated) and gille's narrower one (accepted/rejected/conflicted/
+ *     unrated) do not map cleanly, and Hugin does not track per-observation
+ *     reviewer independence -- inventing that mapping risks overclaiming.
+ *     Named, deliberate simplification; a future ticket can add it once a
+ *     faithful mapping exists.
+ *   - `policyEpoch`: the observation's own `configuration_fingerprint` -- a
+ *     real, content-derived identity of the exact configuration in force for
+ *     this arm.
+ *
+ * Per-experiment / per-sample, not global: `buildOutcomeExportBundle`
+ * already drops any observation this resolver returns `null` for from the
+ * export bundle (recording it in `unresolvedSamples`) rather than failing
+ * the whole experiment's export -- exactly #272's required semantics.
+ */
+
+import type { MuninClient } from "../munin-client.js";
+import type { LearningRegistryStore } from "../learning-registry-store.js";
+import { buildTaskLifecycleTimeline } from "../learning-registry-view.js";
+import { namespaceForTaskId, parseStoredEnvelope } from "../broker/task-store.js";
+import { jcsDigestHex } from "../learning-registry-schema.js";
+import type {
+  LearningExperimentState,
+  RecordedLearningObservation,
+} from "./experiment-schema.js";
+import type {
+  EvidenceIdentityWire,
+  ExposureIdentityWire,
+  GilleOutcomeArmEvidence,
+  GilleOutcomeEvidenceResolver,
+  IdentityField,
+  IdentityOrigin,
+  IdentityUnknownReason,
+  VerifierIdentityWire,
+} from "./experiment-outcome-export.js";
+import { resolveAdmittedAttemptOutcomeEvidence } from "./admitted-attempt-evidence.js";
+import { resolveEffectiveQualityReceipt } from "./quality-receipt-resolution.js";
+
+export interface GilleOutcomeEvidenceResolverDeps {
+  munin: Pick<MuninClient, "read">;
+  registry: Pick<LearningRegistryStore, "listEventsForTask">;
+}
+
+const STAMP_ORIGIN: IdentityOrigin = "learning-task-stamp";
+
+function digestField(input: { id: string; version: string; digest: string }): IdentityField {
+  return { kind: "digest", id: input.id, version: input.version, digest: input.digest, origin: STAMP_ORIGIN };
+}
+
+function labelField(label: string, origin: IdentityOrigin = STAMP_ORIGIN): IdentityField {
+  return { kind: "label", label, origin };
+}
+
+function unknownField(reason: IdentityUnknownReason, detail?: string): IdentityField {
+  return detail === undefined ? { kind: "unknown", reason } : { kind: "unknown", reason, detail };
+}
+
+const EXPOSURE_UNKNOWN: ExposureIdentityWire = { contaminationStatus: "coverage-incomplete" };
+
+function buildEvidenceIdentity(input: {
+  stamp: NonNullable<Awaited<ReturnType<typeof resolveAdmittedAttemptOutcomeEvidence>>>["requestStamp"];
+  rubric: unknown;
+  modelConfig: Record<string, unknown>;
+}): EvidenceIdentityWire {
+  const stamp = input.stamp;
+  if (!stamp) {
+    throw new Error("m5-admitted evidence is missing its request stamp");
+  }
+  return {
+    modelArtifact: unknownField(
+      "not-observed",
+      "Hugin has no visibility into the M5 gateway's local serving-process identity",
+    ),
+    configEpoch: unknownField(
+      "not-observed",
+      "Hugin has no visibility into the M5 gateway's serving-configuration epoch",
+    ),
+    logicalTask: digestField({
+      id: stamp.raw_input.source_ref,
+      version: stamp.raw_input.source_version,
+      digest: stamp.raw_input.digest,
+    }),
+    renderedPrompt: digestField({
+      id: stamp.hugin_envelope.source_ref,
+      version: stamp.hugin_envelope.source_version,
+      digest: stamp.hugin_envelope.digest,
+    }),
+    harness: digestField({
+      id: stamp.origin_config.harness.id,
+      version: stamp.origin_config.harness.version,
+      digest: stamp.origin_config.harness.config_digest.digest,
+    }),
+    taxonomyVersion: labelField(`${stamp.task_type.taxonomy_id}@${stamp.task_type.taxonomy_version}`),
+    verifierRubric: input.rubric !== undefined
+      ? digestField({ id: "quality-receipt-rubric", version: "v2", digest: jcsDigestHex(input.rubric) })
+      : unknownField("legacy", "the effective quality receipt for this attempt carries no rubric (schemaVersion 1)"),
+    sampling: Object.keys(input.modelConfig).length > 0
+      ? digestField({ id: "model-config", version: "resolved", digest: jcsDigestHex(input.modelConfig) })
+      : unknownField("not-observed", "Hugin does not durably record per-task model sampling parameters"),
+    toolPolicy: digestField({
+      id: stamp.origin_config.tool_policy.id,
+      version: stamp.origin_config.tool_policy.version,
+      digest: stamp.origin_config.tool_policy.config_digest.digest,
+    }),
+    lane: "delegate",
+  };
+}
+
+function buildVerifier(verifier: RecordedLearningObservation["verifier"]): VerifierIdentityWire | null {
+  if (verifier.kind === "none") return null;
+  const mode: VerifierIdentityWire["mode"] =
+    verifier.kind === "mechanical" ? "deterministic"
+    : verifier.kind === "human" ? "human"
+    // Hugin does not track calibration evidence for a "judge" verifier -- never
+    // overclaim "calibrated-judge" without it.
+    : "advisory-judge";
+  return {
+    name: verifier.id ?? verifier.kind,
+    independent: verifier.independent,
+  mode,
+  };
+}
+
+/**
+ * Build the pluggable resolver `experiment-cadence.ts` injects as
+ * `deps.evidenceResolver`. Read-only over Munin and the #232 registry.
+ */
+export function createGilleOutcomeEvidenceResolver(
+  deps: GilleOutcomeEvidenceResolverDeps,
+): GilleOutcomeEvidenceResolver {
+  return {
+    async resolveArmEvidence(input: {
+      experiment: LearningExperimentState;
+      observation: RecordedLearningObservation;
+    }): Promise<GilleOutcomeArmEvidence | null> {
+      const { experiment, observation } = input;
+      const taskId = observation.task_id;
+      if (!taskId) return null;
+
+      if (observation.verifier.kind === "none") return null;
+      const verifier = buildVerifier(observation.verifier);
+      if (!verifier) return null;
+
+      const statusEntry = await deps.munin.read(namespaceForTaskId(taskId), "status");
+      if (!statusEntry) return null;
+      const envelope = parseStoredEnvelope(statusEntry.content);
+      if (!envelope || !envelope.prompt) return null;
+
+      const timeline = await buildTaskLifecycleTimeline(deps.registry, taskId);
+      if (timeline.truncated) return null;
+      const outcomeEntry = timeline.entries.find(
+        (entry) => entry.event.recordKind === "terminal-outcome" && !entry.superseded && !entry.excluded,
+      );
+      if (!outcomeEntry || outcomeEntry.event.recordKind !== "terminal-outcome") return null;
+      const attemptOutcomeRef = outcomeEntry.event.payload.attemptOutcomeRef;
+      if (!attemptOutcomeRef) return null;
+
+      const attemptId = outcomeEntry.event.attemptId;
+      const evidence = await resolveAdmittedAttemptOutcomeEvidence(deps.munin, attemptOutcomeRef, { taskId, attemptId });
+      if (!evidence || !evidence.requestStamp) return null;
+      const receipt = await resolveEffectiveQualityReceipt(deps.munin, taskId, attemptId);
+      if (!receipt) return null;
+
+      const configuration = observation.arm === "champion" ? experiment.champion : experiment.challenger;
+      const evidenceIdentity = buildEvidenceIdentity({
+        stamp: evidence.requestStamp,
+        rubric: receipt.schemaVersion === 2 ? receipt.rubric : undefined,
+        modelConfig: configuration.model.config,
+      });
+
+      const nodeId = outcomeEntry.event.payload.delegation?.nodeId;
+      const validNodeId = nodeId === "m5" || nodeId === "orin" ? nodeId : undefined;
+
+      return {
+        prompt: envelope.prompt,
+        evidenceIdentity,
+        verifier,
+        exposure: EXPOSURE_UNKNOWN,
+        policyEpoch: observation.configuration_fingerprint,
+        ...(validNodeId ? { nodeId: validNodeId } : {}),
+      };
+    },
+  };
+}

--- a/src/learning/quality-receipt-resolution.ts
+++ b/src/learning/quality-receipt-resolution.ts
@@ -1,0 +1,97 @@
+/**
+ * Shared resolution of the currently-EFFECTIVE, binding-matched quality
+ * receipt for one Hugin task/attempt (issue #216's append-only ledger,
+ * durable at `tasks/<taskId>` / `feedback`).
+ *
+ * Mirrors `quality-receipt.ts`'s own `summarizeQualityReceipts`
+ * correction-chain-resolution rule (a schemaVersion-2 correction supersedes
+ * the receipt it names in `correctsReceiptId`), but returns the NATIVE
+ * receipt object. `summarizeQualityReceipts` intentionally strips free-text
+ * `ratingReason` into a hash for its own dashboard-facing
+ * `QualityReceiptEvidence` view -- the wrong shape for
+ * `PackagerCandidateInput.qualityReceipt` (candidate-packager-schema.ts),
+ * whose caller is trusted to hold the native receipt transiently in memory
+ * (see `candidate-packager.ts`'s `qualifyCandidate` doc comment) even though
+ * the package it eventually freezes only ever projects `receiptId`/`rating`
+ * out of it -- content-blindness is enforced at the FROZEN PACKAGE boundary,
+ * not this transient in-memory candidate.
+ *
+ * Used by both the #272 candidate-pool assembler and the #272 gille
+ * outcome-export evidence resolver (which needs a v2 receipt's `rubric` for
+ * gille-inference#8's `verifierRubric` identity field).
+ */
+
+import type { MuninClient } from "../munin-client.js";
+import {
+  buildQualityBinding,
+  qualityBindingsEqual,
+  qualityReceiptLedgerSchema,
+  type NativeQualityReceipt,
+} from "../quality-receipt.js";
+
+/**
+ * `null` when the task's status/result documents are missing (nothing to
+ * bind against), the feedback ledger is missing/unreadable/unparseable, no
+ * receipt is bound to the CURRENT task content, or no bound receipt survives
+ * as the effective one for this exact attempt. Never fabricates or guesses.
+ *
+ * A schemaVersion-2 (attempt-bound) effective receipt naming this exact
+ * `attemptId` wins. Otherwise a legacy schemaVersion-1 (task-level, no
+ * attempt binding) effective receipt applies -- mirroring
+ * `qualifyCandidate`'s own permissive rule for v1 receipts (candidate-
+ * packager.ts: it only checks `receipt.taskId`, never an attempt id, for
+ * schemaVersion 1). Multiple equally-eligible effective receipts (e.g. two
+ * independent reviewers, neither superseding the other) are broken by most-
+ * recent `ratedAt` -- a documented simplification, not a fabrication: every
+ * candidate receipt considered is itself completely real.
+ */
+export async function resolveEffectiveQualityReceipt(
+  munin: Pick<MuninClient, "read">,
+  taskId: string,
+  attemptId: string,
+): Promise<NativeQualityReceipt | null> {
+  const namespace = `tasks/${taskId}`;
+  const [statusEntry, resultEntry, feedbackEntry] = await Promise.all([
+    munin.read(namespace, "status"),
+    munin.read(namespace, "result-structured"),
+    munin.read(namespace, "feedback"),
+  ]);
+  if (!statusEntry || !resultEntry || !feedbackEntry) return null;
+
+  let binding: ReturnType<typeof buildQualityBinding>;
+  try {
+    binding = buildQualityBinding({
+      statusContent: statusEntry.content,
+      structuredResultContent: resultEntry.content,
+    });
+  } catch {
+    return null;
+  }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(feedbackEntry.content);
+  } catch {
+    return null;
+  }
+  const ledger = qualityReceiptLedgerSchema.safeParse(raw);
+  if (!ledger.success) return null;
+
+  const bound = ledger.data.receipts.filter((receipt) => qualityBindingsEqual(receipt.binding, binding));
+  if (bound.length === 0) return null;
+  const superseded = new Set(
+    bound.flatMap((receipt) => (receipt.schemaVersion === 2 ? [receipt.correctsReceiptId] : [])),
+  );
+  const effective = bound.filter((receipt) => !superseded.has(receipt.receiptId));
+  if (effective.length === 0) return null;
+
+  const attemptBound = effective
+    .filter((receipt) => receipt.schemaVersion === 2 && receipt.attemptId === attemptId)
+    .sort((a, b) => b.ratedAt.localeCompare(a.ratedAt));
+  if (attemptBound.length > 0) return attemptBound[0]!;
+
+  const taskLevel = effective
+    .filter((receipt) => receipt.schemaVersion === 1)
+    .sort((a, b) => b.ratedAt.localeCompare(a.ratedAt));
+  return taskLevel[0] ?? null;
+}

--- a/systemd/hugin-experiment-cadence.service
+++ b/systemd/hugin-experiment-cadence.service
@@ -7,7 +7,11 @@ Wants=network-online.target
 Type=oneshot
 User=magnus
 WorkingDirectory=/home/magnus/repos/hugin
-ExecStart=/usr/bin/node dist/experiment-cadence-cli.js --candidates /home/magnus/.hugin/experiment-cadence/candidates.json
+# hugin#272: no --candidates flag -- the default production candidate-pool
+# assembler scans the #232 registry itself. A leftover
+# ~/.hugin/experiment-cadence/candidates.json from an older deploy is simply
+# never read; its presence on disk is harmless.
+ExecStart=/usr/bin/node dist/experiment-cadence-cli.js
 EnvironmentFile=/home/magnus/repos/hugin/.env
 TimeoutStartSec=120
 

--- a/tests/candidate-pool-assembler.test.ts
+++ b/tests/candidate-pool-assembler.test.ts
@@ -1,0 +1,393 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { MuninWriteRejectedError, type MuninClient } from "../src/munin-client.js";
+import { LearningRegistryStore } from "../src/learning-registry-store.js";
+import { buildQualityBinding, buildQualityReceipt } from "../src/quality-receipt.js";
+import {
+  assembleCandidatePool,
+  createCandidatePoolAssembler,
+} from "../src/learning/candidate-pool-assembler.js";
+import {
+  buildFixtureAdmittedAttempt,
+  buildFixtureResultStructuredDocument,
+  buildFixtureStatusDocument,
+} from "./helpers/candidate-evidence-fixtures.js";
+
+// ---------------------------------------------------------------------------
+// In-memory Munin double -- same contract copied across this codebase's own
+// learning-* test files (see tests/experiment-cadence.test.ts's own copy).
+// ---------------------------------------------------------------------------
+
+interface StoredEntry {
+  namespace: string;
+  key: string;
+  content: string;
+  tags: string[];
+  classification?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+class InMemoryMunin {
+  private entries: StoredEntry[] = [];
+  private seq = 0;
+
+  private clock(): string {
+    this.seq += 1;
+    return new Date(Date.UTC(2026, 6, 1, 0, 0, 0, 0) + this.seq).toISOString();
+  }
+
+  private find(namespace: string, key: string): StoredEntry | undefined {
+    return this.entries.find((e) => e.namespace === namespace && e.key === key);
+  }
+
+  async read(namespace: string, key: string) {
+    const entry = this.find(namespace, key);
+    if (!entry) return null;
+    return { ...entry, found: true } as unknown as { content: string; updated_at: string; found: true };
+  }
+
+  async write(
+    namespace: string,
+    key: string,
+    content: string,
+    tags?: string[],
+    expectedUpdatedAt?: string,
+    classification?: string,
+    createIfAbsent?: boolean,
+  ) {
+    const existing = this.find(namespace, key);
+    if (createIfAbsent === true && existing) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        message: "Entry already exists.",
+        conflict_reason: "already_exists",
+        current_updated_at: existing.updated_at,
+      });
+    }
+    if (expectedUpdatedAt !== undefined && (!existing || existing.updated_at !== expectedUpdatedAt)) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        message: "Entry version changed.",
+        conflict_reason: "version_mismatch",
+        current_updated_at: existing?.updated_at,
+      });
+    }
+    const updated_at = this.clock();
+    const created_at = existing?.created_at ?? updated_at;
+    const next: StoredEntry = { namespace, key, content, tags: tags ?? [], classification, created_at, updated_at };
+    if (existing) Object.assign(existing, next); else this.entries.push(next);
+    return { ok: true, status: existing ? "updated" : "created", updated_at };
+  }
+
+  async query(opts: { namespace?: string; tags?: string[]; limit?: number; entry_type?: string }) {
+    let rows = this.entries.filter((e) =>
+      (!opts.namespace || e.namespace.startsWith(opts.namespace))
+      && (opts.tags ?? []).every((tag) => e.tags.includes(tag)));
+    rows = [...rows].sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+    const limited = rows.slice(0, opts.limit ?? 50);
+    return {
+      results: limited.map((e) => ({
+        id: `${e.namespace}/${e.key}`,
+        namespace: e.namespace,
+        key: e.key,
+        entry_type: "state",
+        content_preview: e.content.slice(0, 80),
+        tags: e.tags,
+        classification: e.classification,
+        created_at: e.created_at,
+        updated_at: e.updated_at,
+      })),
+      total: rows.length,
+    };
+  }
+
+  async log() {
+    // unused by this module
+  }
+}
+
+function munin(): InMemoryMunin & MuninClient {
+  return new InMemoryMunin() as unknown as InMemoryMunin & MuninClient;
+}
+
+const ref = (namespace: string, key: string) => ({ namespace, key });
+const hash = (seed: string) => createHash("sha256").update(seed).digest("hex");
+const PERIOD = "2026-07";
+
+/**
+ * Seed one fully resolvable production candidate: registry submission +
+ * attempt-reference + terminal-outcome (completed, carrying `delegation`
+ * with a real modelId+taskType and a real `attemptOutcomeRef`), the admitted
+ * evidence row at that ref, and a bound, effective quality receipt.
+ */
+async function seedResolvableCandidate(
+  m: InMemoryMunin & MuninClient,
+  store: LearningRegistryStore,
+  input: { taskId: string; taskType: string; modelId: string; rating: "pass" | "partial" | "redo" | "wrong"; occurredAt: string },
+): Promise<{ attemptId: string }> {
+  const { attemptId, attemptOutcomeRef, evidence } = buildFixtureAdmittedAttempt({
+    taskId: input.taskId,
+    taskType: input.taskType,
+  });
+  await m.write(attemptOutcomeRef.namespace, attemptOutcomeRef.key, JSON.stringify(evidence), ["learning-task-attempt"]);
+
+  const taskOutcomeRef = ref(`tasks/${input.taskId}`, "result-structured");
+  await store.recordSubmission({ taskId: input.taskId, taskOutcomeRef, occurredAt: input.occurredAt });
+  await store.recordAttemptReference({
+    taskId: input.taskId,
+    attemptId,
+    attemptStartRef: ref(`tasks/${input.taskId}`, `learning-attempt-${attemptId}`),
+    taskOutcomeRef,
+    occurredAt: input.occurredAt,
+  });
+  await store.recordTerminalOutcome({
+    taskId: input.taskId,
+    attemptId,
+    outcome: "completed",
+    taskOutcomeRef,
+    attemptOutcomeRef,
+    delegation: { modelId: input.modelId, taskType: input.taskType, lane: "harness" },
+    occurredAt: input.occurredAt,
+  });
+
+  const statusContent = buildFixtureStatusDocument(input.taskId, `prompt for ${input.taskId}`);
+  const resultContent = buildFixtureResultStructuredDocument(input.taskId);
+  await m.write(`tasks/${input.taskId}`, "status", statusContent, ["status"]);
+  await m.write(`tasks/${input.taskId}`, "result-structured", resultContent, ["result"]);
+
+  const binding = buildQualityBinding({ statusContent, structuredResultContent: resultContent });
+  const receipt = buildQualityReceipt({
+    taskId: input.taskId,
+    reviewerPrincipal: "codex",
+    reviewerIndependence: "independent",
+    rating: input.rating,
+    ratingReason: `SECRET-RAW-EVIDENCE-TEXT-${input.taskId}`,
+    verificationOutcome: input.rating === "pass" ? "accepted_unchanged" : "major_rewrite",
+    ratedAt: input.occurredAt,
+    bindingAttestation: "server-bound",
+    binding,
+  });
+  await m.write(`tasks/${input.taskId}`, "feedback", JSON.stringify({ schemaVersion: 1, taskId: input.taskId, receipts: [receipt] }), ["feedback"]);
+
+  return { attemptId };
+}
+
+describe("assembleCandidatePool", () => {
+  it("resolves a candidate per (taskId, attemptId), regardless of quality rating -- no floor applied here", async () => {
+    const m = munin();
+    const store = new LearningRegistryStore(m);
+    await seedResolvableCandidate(m, store, {
+      taskId: "task-pass", taskType: "code-edit", modelId: "model-a", rating: "pass", occurredAt: "2026-07-05T00:00:00.000Z",
+    });
+    await seedResolvableCandidate(m, store, {
+      taskId: "task-wrong", taskType: "code-edit", modelId: "model-b", rating: "wrong", occurredAt: "2026-07-06T00:00:00.000Z",
+    });
+
+    const result = await assembleCandidatePool({ registry: store, munin: m }, { periods: [PERIOD] });
+    expect(result.skipped).toEqual([]);
+    expect(result.candidates).toHaveLength(2);
+    const byTask = new Map(result.candidates.map((c) => [c.taskId, c]));
+    expect(byTask.get("task-pass")?.qualityReceipt.rating).toBe("pass");
+    expect(byTask.get("task-wrong")?.qualityReceipt.rating).toBe("wrong");
+    expect(byTask.get("task-pass")?.configuration.model.id).toBe("model-a");
+    expect(byTask.get("task-wrong")?.configuration.model.id).toBe("model-b");
+  });
+
+  it("is content-blind: no raw prompt/task bytes ever appear in the assembled pool", async () => {
+    const m = munin();
+    const store = new LearningRegistryStore(m);
+    await seedResolvableCandidate(m, store, {
+      taskId: "task-content-blind", taskType: "code-edit", modelId: "model-a", rating: "pass", occurredAt: "2026-07-05T00:00:00.000Z",
+    });
+    const result = await assembleCandidatePool({ registry: store, munin: m }, { periods: [PERIOD] });
+    const serialized = JSON.stringify(result.candidates);
+    expect(serialized).not.toContain("fixture rendered prompt");
+    expect(serialized).not.toContain("fixture raw task text");
+    expect(serialized).not.toContain("prompt for task-content-blind");
+  });
+
+  it("dedupes by natural key across overlapping scanned periods", async () => {
+    const m = munin();
+    const store = new LearningRegistryStore(m);
+    await seedResolvableCandidate(m, store, {
+      taskId: "task-dedup", taskType: "code-edit", modelId: "model-a", rating: "pass", occurredAt: "2026-07-05T00:00:00.000Z",
+    });
+    const result = await assembleCandidatePool({ registry: store, munin: m }, { periods: [PERIOD, PERIOD] });
+    expect(result.candidates).toHaveLength(1);
+  });
+
+  it("is deterministic and idempotent across repeated runs against unchanged state", async () => {
+    const m = munin();
+    const store = new LearningRegistryStore(m);
+    await seedResolvableCandidate(m, store, {
+      taskId: "task-b", taskType: "code-edit", modelId: "model-b", rating: "pass", occurredAt: "2026-07-05T00:00:00.000Z",
+    });
+    await seedResolvableCandidate(m, store, {
+      taskId: "task-a", taskType: "code-edit", modelId: "model-a", rating: "pass", occurredAt: "2026-07-06T00:00:00.000Z",
+    });
+    const run1 = await assembleCandidatePool({ registry: store, munin: m }, { periods: [PERIOD] });
+    const run2 = await assembleCandidatePool({ registry: store, munin: m }, { periods: [PERIOD] });
+    expect(run1.candidates.map((c) => c.taskId)).toEqual(["task-a", "task-b"]); // sorted
+    expect(run2.candidates).toEqual(run1.candidates);
+  });
+
+  it("skips a non-completed terminal outcome", async () => {
+    const m = munin();
+    const store = new LearningRegistryStore(m);
+    const taskId = "task-failed";
+    const { attemptId, attemptOutcomeRef } = buildFixtureAdmittedAttempt({ taskId, taskType: "code-edit" });
+    const taskOutcomeRef = ref(`tasks/${taskId}`, "result-structured");
+    await store.recordSubmission({ taskId, taskOutcomeRef, occurredAt: "2026-07-05T00:00:00.000Z" });
+    await store.recordAttemptReference({
+      taskId, attemptId, attemptStartRef: ref(`tasks/${taskId}`, `learning-attempt-${attemptId}`), taskOutcomeRef,
+      occurredAt: "2026-07-05T00:00:00.000Z",
+    });
+    await store.recordTerminalOutcome({
+      taskId, attemptId, outcome: "failed", taskOutcomeRef, attemptOutcomeRef,
+      delegation: { modelId: "model-a", taskType: "code-edit" },
+      occurredAt: "2026-07-05T00:00:00.000Z",
+    });
+
+    const result = await assembleCandidatePool({ registry: store, munin: m }, { periods: [PERIOD] });
+    expect(result.candidates).toEqual([]);
+    expect(result.skipped).toEqual([{ taskId, attemptId, reason: "outcome-not-completed" }]);
+  });
+
+  it("skips a completed outcome with no delegation-carried model identity", async () => {
+    const m = munin();
+    const store = new LearningRegistryStore(m);
+    const taskId = "task-no-model";
+    const attemptId = "some-attempt-id";
+    const taskOutcomeRef = ref(`tasks/${taskId}`, "result-structured");
+    await store.recordSubmission({ taskId, taskOutcomeRef, occurredAt: "2026-07-05T00:00:00.000Z" });
+    await store.recordAttemptReference({
+      taskId, attemptId, attemptStartRef: ref(`tasks/${taskId}`, `learning-attempt-${attemptId}`), taskOutcomeRef,
+      occurredAt: "2026-07-05T00:00:00.000Z",
+    });
+    await store.recordTerminalOutcome({
+      taskId, attemptId, outcome: "completed", taskOutcomeRef,
+      occurredAt: "2026-07-05T00:00:00.000Z",
+    });
+
+    const result = await assembleCandidatePool({ registry: store, munin: m }, { periods: [PERIOD] });
+    expect(result.candidates).toEqual([]);
+    expect(result.skipped).toEqual([{ taskId, attemptId, reason: "missing-model-identity" }]);
+  });
+
+  it("skips a completed outcome missing an attempt-outcome ref", async () => {
+    const m = munin();
+    const store = new LearningRegistryStore(m);
+    const taskId = "task-no-ref";
+    const attemptId = "some-attempt-id";
+    const taskOutcomeRef = ref(`tasks/${taskId}`, "result-structured");
+    await store.recordSubmission({ taskId, taskOutcomeRef, occurredAt: "2026-07-05T00:00:00.000Z" });
+    await store.recordAttemptReference({
+      taskId, attemptId, attemptStartRef: ref(`tasks/${taskId}`, `learning-attempt-${attemptId}`), taskOutcomeRef,
+      occurredAt: "2026-07-05T00:00:00.000Z",
+    });
+    await store.recordTerminalOutcome({
+      taskId, attemptId, outcome: "completed", taskOutcomeRef,
+      delegation: { modelId: "model-a", taskType: "code-edit" },
+      occurredAt: "2026-07-05T00:00:00.000Z",
+    });
+
+    const result = await assembleCandidatePool({ registry: store, munin: m }, { periods: [PERIOD] });
+    expect(result.candidates).toEqual([]);
+    expect(result.skipped).toEqual([{ taskId, attemptId, reason: "missing-attempt-outcome-ref" }]);
+  });
+
+  it("skips when the attempt-outcome ref resolves to a non-admitted (e.g. join-failed) row", async () => {
+    const m = munin();
+    const store = new LearningRegistryStore(m);
+    const taskId = "task-not-admitted";
+    const attemptId = "some-attempt-id";
+    const attemptOutcomeRef = ref(`tasks/${taskId}`, "learning-attempt-x-outcome");
+    await m.write(attemptOutcomeRef.namespace, attemptOutcomeRef.key, JSON.stringify({
+      schemaVersion: 1,
+      contractVersion: "grimnir.learning-task/v1",
+      state: "join-failed",
+      evidenceAccepted: false,
+      taskId,
+      attemptId,
+      attemptStartedAt: "2026-07-05T00:00:00.000Z",
+      taskOutcomeRef: { namespace: `tasks/${taskId}`, key: "result-structured" },
+      rawFingerprint: { algorithm: "sha256", version: "trim-utf8-sha256-v1", digest: hash("x") },
+    }), []);
+
+    const taskOutcomeRef = ref(`tasks/${taskId}`, "result-structured");
+    await store.recordSubmission({ taskId, taskOutcomeRef, occurredAt: "2026-07-05T00:00:00.000Z" });
+    await store.recordAttemptReference({
+      taskId, attemptId, attemptStartRef: ref(`tasks/${taskId}`, `learning-attempt-${attemptId}`), taskOutcomeRef,
+      occurredAt: "2026-07-05T00:00:00.000Z",
+    });
+    await store.recordTerminalOutcome({
+      taskId, attemptId, outcome: "completed", taskOutcomeRef, attemptOutcomeRef,
+      delegation: { modelId: "model-a", taskType: "code-edit" },
+      occurredAt: "2026-07-05T00:00:00.000Z",
+    });
+
+    const result = await assembleCandidatePool({ registry: store, munin: m }, { periods: [PERIOD] });
+    expect(result.candidates).toEqual([]);
+    expect(result.skipped).toEqual([{ taskId, attemptId, reason: "attempt-outcome-not-admitted" }]);
+  });
+
+  it("skips a fully-admitted attempt with no resolvable quality receipt", async () => {
+    const m = munin();
+    const store = new LearningRegistryStore(m);
+    const taskId = "task-no-receipt";
+    const { attemptId, attemptOutcomeRef, evidence } = buildFixtureAdmittedAttempt({ taskId, taskType: "code-edit" });
+    await m.write(attemptOutcomeRef.namespace, attemptOutcomeRef.key, JSON.stringify(evidence), []);
+    const taskOutcomeRef = ref(`tasks/${taskId}`, "result-structured");
+    await store.recordSubmission({ taskId, taskOutcomeRef, occurredAt: "2026-07-05T00:00:00.000Z" });
+    await store.recordAttemptReference({
+      taskId, attemptId, attemptStartRef: ref(`tasks/${taskId}`, `learning-attempt-${attemptId}`), taskOutcomeRef,
+      occurredAt: "2026-07-05T00:00:00.000Z",
+    });
+    await store.recordTerminalOutcome({
+      taskId, attemptId, outcome: "completed", taskOutcomeRef, attemptOutcomeRef,
+      delegation: { modelId: "model-a", taskType: "code-edit" },
+      occurredAt: "2026-07-05T00:00:00.000Z",
+    });
+    // No status/result-structured/feedback docs written -- nothing to bind a receipt against.
+
+    const result = await assembleCandidatePool({ registry: store, munin: m }, { periods: [PERIOD] });
+    expect(result.candidates).toEqual([]);
+    expect(result.skipped).toEqual([{ taskId, attemptId, reason: "missing-quality-receipt" }]);
+  });
+
+  it("throws on a truncated period scan rather than returning a partial pool", async () => {
+    const truncatedRegistry: Pick<LearningRegistryStore, "listTerminalOutcomesForPeriod"> = {
+      listTerminalOutcomesForPeriod: async () => ({ events: [], truncated: true }),
+    };
+    await expect(
+      assembleCandidatePool({ registry: truncatedRegistry as LearningRegistryStore, munin: munin() }, { periods: [PERIOD] }),
+    ).rejects.toThrow(/truncated/);
+  });
+
+  it("createCandidatePoolAssembler returns a bare loadCandidates()-shaped function", async () => {
+    const m = munin();
+    const store = new LearningRegistryStore(m);
+    await seedResolvableCandidate(m, store, {
+      taskId: "task-loader", taskType: "code-edit", modelId: "model-a", rating: "pass", occurredAt: "2026-07-05T00:00:00.000Z",
+    });
+    const loadCandidates = createCandidatePoolAssembler({ registry: store, munin: m }, { periods: [PERIOD] });
+    const candidates = await loadCandidates();
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]!.taskId).toBe("task-loader");
+  });
+
+  it("defaults to scanning the current and previous UTC month when no periods are given", async () => {
+    const m = munin();
+    const store = new LearningRegistryStore(m);
+    await seedResolvableCandidate(m, store, {
+      taskId: "task-default-window", taskType: "code-edit", modelId: "model-a", rating: "pass", occurredAt: "2026-06-15T00:00:00.000Z",
+    });
+    const result = await assembleCandidatePool(
+      { registry: store, munin: m, now: () => "2026-07-20T00:00:00.000Z" },
+      {},
+    );
+    expect(result.scannedPeriods).toEqual(["2026-07", "2026-06"]);
+    expect(result.candidates.map((c) => c.taskId)).toEqual(["task-default-window"]);
+  });
+});

--- a/tests/experiment-cadence-cli.test.ts
+++ b/tests/experiment-cadence-cli.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from "vitest";
 import { parseArgs } from "../src/experiment-cadence-cli.js";
 
 describe("experiment cadence CLI arg parsing", () => {
-  it("requires --candidates", () => {
-    expect(() => parseArgs([])).toThrow("--candidates <path> is required");
-    expect(() => parseArgs(["--dry-run"])).toThrow("--candidates <path> is required");
+  it("--candidates is optional -- absent means the default assembler is used", () => {
+    expect(parseArgs([])).toEqual({ dryRun: false, candidatesPath: undefined });
+    expect(parseArgs(["--dry-run"])).toEqual({ dryRun: true, candidatesPath: undefined });
   });
 
   it("parses --candidates", () => {

--- a/tests/experiment-cadence-with-assembler.test.ts
+++ b/tests/experiment-cadence-with-assembler.test.ts
@@ -1,0 +1,367 @@
+import { createServer, type Server } from "node:http";
+import { once } from "node:events";
+import { describe, expect, it, afterEach } from "vitest";
+import { MuninWriteRejectedError, type MuninClient } from "../src/munin-client.js";
+import { LearningRegistryStore } from "../src/learning-registry-store.js";
+import { LearningExperimentStore } from "../src/learning/experiment-store.js";
+import { buildQualityBinding, buildQualityReceipt } from "../src/quality-receipt.js";
+import { createCandidatePoolAssembler } from "../src/learning/candidate-pool-assembler.js";
+import { createGilleOutcomeEvidenceResolver } from "../src/learning/gille-outcome-evidence-resolver.js";
+import { createGilleOutcomeExportClient } from "../src/learning/experiment-outcome-export.js";
+import { runExperimentCadenceTick, type ExperimentCadenceDeps } from "../src/learning/experiment-cadence.js";
+import {
+  buildFixtureAdmittedAttempt,
+  buildFixtureResultStructuredDocument,
+  buildFixtureStatusDocument,
+} from "./helpers/candidate-evidence-fixtures.js";
+
+// ---------------------------------------------------------------------------
+// In-memory Munin double -- same contract copied across this codebase's own
+// learning-* test files (see tests/experiment-cadence.test.ts's own copy).
+// ---------------------------------------------------------------------------
+
+interface StoredEntry {
+  namespace: string;
+  key: string;
+  content: string;
+  tags: string[];
+  classification?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+class InMemoryMunin {
+  private entries: StoredEntry[] = [];
+  private seq = 0;
+  readonly logs: Array<{ namespace: string; content: string; tags?: string[] }> = [];
+
+  private clock(): string {
+    this.seq += 1;
+    return new Date(Date.UTC(2026, 6, 1, 0, 0, 0, 0) + this.seq).toISOString();
+  }
+
+  private find(namespace: string, key: string): StoredEntry | undefined {
+    return this.entries.find((e) => e.namespace === namespace && e.key === key);
+  }
+
+  async read(namespace: string, key: string) {
+    const entry = this.find(namespace, key);
+    if (!entry) return null;
+    return { ...entry, found: true } as unknown as { content: string; updated_at: string; found: true };
+  }
+
+  async write(
+    namespace: string,
+    key: string,
+    content: string,
+    tags?: string[],
+    expectedUpdatedAt?: string,
+    classification?: string,
+    createIfAbsent?: boolean,
+  ) {
+    const existing = this.find(namespace, key);
+    if (createIfAbsent === true && existing) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        message: "Entry already exists.",
+        conflict_reason: "already_exists",
+        current_updated_at: existing.updated_at,
+      });
+    }
+    if (expectedUpdatedAt !== undefined && (!existing || existing.updated_at !== expectedUpdatedAt)) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        message: "Entry version changed.",
+        conflict_reason: "version_mismatch",
+        current_updated_at: existing?.updated_at,
+      });
+    }
+    const updated_at = this.clock();
+    const created_at = existing?.created_at ?? updated_at;
+    const next: StoredEntry = { namespace, key, content, tags: tags ?? [], classification, created_at, updated_at };
+    if (existing) Object.assign(existing, next); else this.entries.push(next);
+    return { ok: true, status: existing ? "updated" : "created", updated_at };
+  }
+
+  async query(opts: { namespace?: string; tags?: string[]; limit?: number; entry_type?: string }) {
+    let rows = this.entries.filter((e) =>
+      (!opts.namespace || e.namespace.startsWith(opts.namespace))
+      && (opts.tags ?? []).every((tag) => e.tags.includes(tag)));
+    rows = [...rows].sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+    const limited = rows.slice(0, opts.limit ?? 50);
+    return {
+      results: limited.map((e) => ({
+        id: `${e.namespace}/${e.key}`,
+        namespace: e.namespace,
+        key: e.key,
+        entry_type: "state",
+        content_preview: e.content.slice(0, 80),
+        tags: e.tags,
+        classification: e.classification,
+        created_at: e.created_at,
+        updated_at: e.updated_at,
+      })),
+      total: rows.length,
+    };
+  }
+
+  async log(namespace: string, content: string, tags?: string[]) {
+    this.logs.push({ namespace, content, tags });
+  }
+}
+
+function munin(): InMemoryMunin & MuninClient {
+  return new InMemoryMunin() as unknown as InMemoryMunin & MuninClient;
+}
+
+const ref = (namespace: string, key: string) => ({ namespace, key });
+
+/** Seed one fully resolvable production candidate (registry + admitted evidence + bound receipt). */
+async function seedResolvableCandidate(
+  m: InMemoryMunin & MuninClient,
+  store: LearningRegistryStore,
+  input: { taskId: string; taskType: string; modelId: string; rating: "pass" | "partial" | "redo" | "wrong"; occurredAt: string },
+): Promise<void> {
+  const { attemptId, attemptOutcomeRef, evidence } = buildFixtureAdmittedAttempt({
+    taskId: input.taskId,
+    taskType: input.taskType,
+  });
+  await m.write(attemptOutcomeRef.namespace, attemptOutcomeRef.key, JSON.stringify(evidence), []);
+
+  const taskOutcomeRef = ref(`tasks/${input.taskId}`, "result-structured");
+  await store.recordSubmission({ taskId: input.taskId, taskOutcomeRef, occurredAt: input.occurredAt });
+  await store.recordAttemptReference({
+    taskId: input.taskId, attemptId, attemptStartRef: ref(`tasks/${input.taskId}`, `learning-attempt-${attemptId}`),
+    taskOutcomeRef, occurredAt: input.occurredAt,
+  });
+  await store.recordTerminalOutcome({
+    taskId: input.taskId, attemptId, outcome: "completed", taskOutcomeRef, attemptOutcomeRef,
+    delegation: { modelId: input.modelId, taskType: input.taskType, nodeId: "m5" },
+    occurredAt: input.occurredAt,
+  });
+
+  const statusContent = buildFixtureStatusDocument(input.taskId, `prompt for ${input.taskId}`);
+  const resultContent = buildFixtureResultStructuredDocument(input.taskId);
+  await m.write(`tasks/${input.taskId}`, "status", statusContent, ["status"]);
+  await m.write(`tasks/${input.taskId}`, "result-structured", resultContent, ["result"]);
+
+  const binding = buildQualityBinding({ statusContent, structuredResultContent: resultContent });
+  const receipt = buildQualityReceipt({
+    taskId: input.taskId, reviewerPrincipal: "codex", reviewerIndependence: "independent",
+    rating: input.rating, ratingReason: `SECRET-${input.taskId}`,
+    verificationOutcome: input.rating === "pass" ? "accepted_unchanged" : "major_rewrite",
+    ratedAt: input.occurredAt, bindingAttestation: "server-bound", binding,
+  });
+  await m.write(`tasks/${input.taskId}`, "feedback", JSON.stringify({ schemaVersion: 1, taskId: input.taskId, receipts: [receipt] }), []);
+}
+
+/** One-axis (model) population: champion arm has 2 pass + 2 wrong (proposer-visible
+ * rate 0.5), challenger arm is 4 pass (rate 1.0) -- a 0.5 delta comfortably above the
+ * proposer's 0.1 default and enough pass-rated candidates for the packager's floor.
+ * Mirrors experiment-cadence.test.ts's own `seedOneAxisPopulation`, but built from REAL
+ * registry/receipt/evidence state instead of hand-seeded `PackagerCandidateInput`s. */
+async function seedOneAxisPopulation(
+  m: InMemoryMunin & MuninClient,
+  store: LearningRegistryStore,
+  input: { taskType: string; idPrefix: string; startIso: string },
+): Promise<void> {
+  const championRatings: Array<"pass" | "wrong"> = ["pass", "pass", "wrong", "wrong"];
+  for (let i = 0; i < 4; i += 1) {
+    await seedResolvableCandidate(m, store, {
+      taskId: `${input.idPrefix}-champ-${i}`, taskType: input.taskType, modelId: `${input.idPrefix}-champion-model`,
+      rating: championRatings[i]!, occurredAt: new Date(Date.parse(input.startIso) + i * 86_400_000).toISOString(),
+    });
+  }
+  for (let i = 0; i < 4; i += 1) {
+    await seedResolvableCandidate(m, store, {
+      taskId: `${input.idPrefix}-chall-${i}`, taskType: input.taskType, modelId: `${input.idPrefix}-challenger-model`,
+      rating: "pass", occurredAt: new Date(Date.parse(input.startIso) + (5 + i) * 86_400_000).toISOString(),
+    });
+  }
+}
+
+const MECHANICAL_VERIFIER = { kind: "mechanical" as const, independent: true, id: "protected-check", version: "1" };
+const HOLDOUT_SAMPLES = new Set(["case-1", "case-2"]);
+
+/** Drive an experiment to its frozen conclusion gate (matches experiment-cadence.test.ts's
+ * own `observePairs`), optionally anchoring each sample to a resolvable Hugin task_id so the
+ * evidence resolver can reconstruct real export evidence for it. */
+async function observePairsWithTaskIds(
+  experimentStore: LearningExperimentStore,
+  principal: string,
+  experimentId: string,
+  count: number,
+  taskIdFor?: (sample: string, arm: "champion" | "challenger") => string | undefined,
+): Promise<void> {
+  for (let i = 1; i <= count; i += 1) {
+    const sample = `case-${i}`;
+    const holdout = HOLDOUT_SAMPLES.has(sample);
+    await experimentStore.observe(principal, {
+      experiment_id: experimentId, run_id: `${sample}-champion`, sample_id: sample, arm: "champion", holdout,
+      configuration_fingerprint: (await experimentStore.read(principal, experimentId)).champion.fingerprint,
+      quality_outcome: "fail", product_outcome: "discarded", verifier: MECHANICAL_VERIFIER,
+      latency_ms: 1000, cost_usd: 0,
+      ...(taskIdFor?.(sample, "champion") ? { task_id: taskIdFor(sample, "champion") } : {}),
+    });
+    await experimentStore.observe(principal, {
+      experiment_id: experimentId, run_id: `${sample}-challenger`, sample_id: sample, arm: "challenger", holdout,
+      configuration_fingerprint: (await experimentStore.read(principal, experimentId)).challenger.fingerprint,
+      quality_outcome: "pass", product_outcome: "accepted-unchanged", verifier: MECHANICAL_VERIFIER,
+      latency_ms: 1000, cost_usd: 0,
+      ...(taskIdFor?.(sample, "challenger") ? { task_id: taskIdFor(sample, "challenger") } : {}),
+    });
+  }
+}
+
+function baseDeps(
+  m: InMemoryMunin & MuninClient,
+  registry: LearningRegistryStore,
+  experimentStore: LearningExperimentStore,
+  principal: string,
+  overrides: Partial<ExperimentCadenceDeps> = {},
+): ExperimentCadenceDeps {
+  return {
+    registry,
+    experimentStore,
+    munin: m,
+    principal,
+    loadCandidates: createCandidatePoolAssembler({ registry, munin: m }, { periods: ["2026-07"] }),
+    now: () => "2026-07-10T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("runExperimentCadenceTick with the production candidate-pool assembler", () => {
+  it("proposes and packages exactly one experiment from real registry/receipt/evidence state, idempotently", async () => {
+    const m = munin();
+    const registry = new LearningRegistryStore(m);
+    const experimentStore = new LearningExperimentStore(m);
+    await seedOneAxisPopulation(m, registry, { taskType: "code-edit", idPrefix: "cadence-a", startIso: "2026-07-01T00:00:00.000Z" });
+    const principal = "service:test-cadence-assembler";
+    const deps = baseDeps(m, registry, experimentStore, principal);
+
+    const tick1 = await runExperimentCadenceTick(deps);
+    expect(tick1.errors).toEqual([]);
+    expect(tick1.candidatesLoaded).toBe(8);
+    expect(tick1.proposalsConsidered).toBe(1);
+    expect(tick1.packaged).not.toBeNull();
+    expect(tick1.packaged!.reused).toBe(false);
+
+    const experimentId = tick1.packaged!.experimentId;
+    const created = await experimentStore.read(principal, experimentId);
+    expect(created.status).toBe("running");
+    expect(created.changeAxis).toBe("model");
+
+    // Re-running against unchanged registry/receipt state proposes the same
+    // population again but packages nothing new -- already in flight.
+    const tick2 = await runExperimentCadenceTick(deps);
+    expect(tick2.errors).toEqual([]);
+    expect(tick2.skippedInFlight).toHaveLength(1);
+    expect(tick2.packaged).toBeNull();
+  });
+});
+
+describe("runExperimentCadenceTick's gille export leg with a real evidence resolver", () => {
+  let server: Server | undefined;
+  let gatewayBaseUrl: string;
+  const receivedBundles: unknown[] = [];
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server!.close(() => resolve()));
+      server = undefined;
+    }
+    receivedBundles.length = 0;
+  });
+
+  async function startFixtureGateway(): Promise<void> {
+    server = createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (chunk) => chunks.push(chunk));
+      req.on("end", () => {
+        const bundle = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+        receivedBundles.push(bundle);
+        const body = JSON.stringify({
+          experimentId: bundle.experimentId,
+          runId: bundle.runId,
+          arms: bundle.arms.map((arm: { armId: string; sampleId: string }) => ({
+            armId: arm.armId, sampleId: arm.sampleId, status: "imported",
+          })),
+        });
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(body);
+      });
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("fixture gateway failed to bind a port");
+    gatewayBaseUrl = `http://127.0.0.1:${address.port}`;
+  }
+
+  it("exports a resolvable concluded experiment exactly once; a second tick does not duplicate the export", async () => {
+    await startFixtureGateway();
+    const m = munin();
+    const registry = new LearningRegistryStore(m);
+    const experimentStore = new LearningExperimentStore(m);
+    await seedOneAxisPopulation(m, registry, { taskType: "code-edit", idPrefix: "export-ok", startIso: "2026-07-01T00:00:00.000Z" });
+    const principal = "service:test-cadence-export-ok";
+
+    const gilleExport = createGilleOutcomeExportClient({ gatewayBaseUrl, apiKey: "test-key" });
+    const evidenceResolver = createGilleOutcomeEvidenceResolver({ munin: m, registry });
+    const deps = baseDeps(m, registry, experimentStore, principal, { gilleExport, evidenceResolver });
+
+    const tick1 = await runExperimentCadenceTick(deps);
+    const experimentId = tick1.packaged!.experimentId;
+
+    // Anchor every observation sample to one of the already-resolvable seeded
+    // candidate tasks so the evidence resolver can reconstruct real evidence.
+    await observePairsWithTaskIds(experimentStore, principal, experimentId, 6, (sample, arm) => {
+      const index = Number(sample.split("-")[1]) - 1;
+      return arm === "champion" ? `export-ok-champ-${index % 4}` : `export-ok-chall-${index % 4}`;
+    });
+
+    const tick2 = await runExperimentCadenceTick(deps);
+    expect(tick2.errors).toEqual([]);
+    expect(tick2.concluded).toHaveLength(1);
+    expect(tick2.concluded[0]!.exportStatus).toBe("attempted");
+    expect(receivedBundles).toHaveLength(1);
+    const bundle = receivedBundles[0] as { experimentId: string; arms: unknown[] };
+    expect(bundle.experimentId).toBe(experimentId);
+    expect((bundle.arms as unknown[]).length).toBeGreaterThan(0);
+
+    // Re-running the tick again: the reviewable summary already exists, so
+    // conclusion (and therefore export) is a no-op -- never a duplicate POST.
+    const tick3 = await runExperimentCadenceTick(deps);
+    expect(tick3.concluded).toEqual([
+      expect.objectContaining({ experimentId, alreadyConcluded: true, summaryWritten: false }),
+    ]);
+    expect(receivedBundles).toHaveLength(1);
+  });
+
+  it("leaves an unresolvable concluded experiment skipped-with-reason -- never fabricates evidence", async () => {
+    await startFixtureGateway();
+    const m = munin();
+    const registry = new LearningRegistryStore(m);
+    const experimentStore = new LearningExperimentStore(m);
+    await seedOneAxisPopulation(m, registry, { taskType: "summarize", idPrefix: "export-skip", startIso: "2026-07-01T00:00:00.000Z" });
+    const principal = "service:test-cadence-export-skip";
+
+    const gilleExport = createGilleOutcomeExportClient({ gatewayBaseUrl, apiKey: "test-key" });
+    const evidenceResolver = createGilleOutcomeEvidenceResolver({ munin: m, registry });
+    const deps = baseDeps(m, registry, experimentStore, principal, { gilleExport, evidenceResolver });
+
+    const tick1 = await runExperimentCadenceTick(deps);
+    const experimentId = tick1.packaged!.experimentId;
+
+    // No task_id on any observation -- nothing for the resolver to anchor
+    // evidence to, so every sample is genuinely unresolvable.
+    await observePairsWithTaskIds(experimentStore, principal, experimentId, 6);
+
+    const tick2 = await runExperimentCadenceTick(deps);
+    expect(tick2.concluded).toHaveLength(1);
+    expect(tick2.concluded[0]!.exportStatus).toBe("skipped");
+    expect(tick2.concluded[0]!.exportDetail).toContain("no-resolvable-evidence");
+    expect(receivedBundles).toHaveLength(0);
+  });
+});

--- a/tests/gille-outcome-evidence-resolver.test.ts
+++ b/tests/gille-outcome-evidence-resolver.test.ts
@@ -1,0 +1,306 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { MuninWriteRejectedError, type MuninClient } from "../src/munin-client.js";
+import { LearningRegistryStore } from "../src/learning-registry-store.js";
+import { LearningExperimentStore } from "../src/learning/experiment-store.js";
+import {
+  buildQualityBinding,
+  buildQualityCorrectionReceipt,
+  buildQualityReceipt,
+} from "../src/quality-receipt.js";
+import { createGilleOutcomeEvidenceResolver } from "../src/learning/gille-outcome-evidence-resolver.js";
+import { makeExperimentInput, makeObservation } from "./fixtures/learning.js";
+import {
+  buildFixtureAdmittedAttempt,
+  buildFixtureResultStructuredDocument,
+  buildFixtureStatusDocument,
+} from "./helpers/candidate-evidence-fixtures.js";
+
+// ---------------------------------------------------------------------------
+// In-memory Munin double -- same contract copied across this codebase's own
+// learning-* test files (see tests/experiment-cadence.test.ts's own copy).
+// ---------------------------------------------------------------------------
+
+interface StoredEntry {
+  namespace: string;
+  key: string;
+  content: string;
+  tags: string[];
+  classification?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+class InMemoryMunin {
+  private entries: StoredEntry[] = [];
+  private seq = 0;
+
+  private clock(): string {
+    this.seq += 1;
+    return new Date(Date.UTC(2026, 6, 1, 0, 0, 0, 0) + this.seq).toISOString();
+  }
+
+  private find(namespace: string, key: string): StoredEntry | undefined {
+    return this.entries.find((e) => e.namespace === namespace && e.key === key);
+  }
+
+  async read(namespace: string, key: string) {
+    const entry = this.find(namespace, key);
+    if (!entry) return null;
+    return { ...entry, found: true } as unknown as { content: string; updated_at: string; found: true };
+  }
+
+  async write(
+    namespace: string,
+    key: string,
+    content: string,
+    tags?: string[],
+    expectedUpdatedAt?: string,
+    classification?: string,
+    createIfAbsent?: boolean,
+  ) {
+    const existing = this.find(namespace, key);
+    if (createIfAbsent === true && existing) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        message: "Entry already exists.",
+        conflict_reason: "already_exists",
+        current_updated_at: existing.updated_at,
+      });
+    }
+    if (expectedUpdatedAt !== undefined && (!existing || existing.updated_at !== expectedUpdatedAt)) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        message: "Entry version changed.",
+        conflict_reason: "version_mismatch",
+        current_updated_at: existing?.updated_at,
+      });
+    }
+    const updated_at = this.clock();
+    const created_at = existing?.created_at ?? updated_at;
+    const next: StoredEntry = { namespace, key, content, tags: tags ?? [], classification, created_at, updated_at };
+    if (existing) Object.assign(existing, next); else this.entries.push(next);
+    return { ok: true, status: existing ? "updated" : "created", updated_at };
+  }
+
+  async query(opts: { namespace?: string; tags?: string[]; limit?: number; entry_type?: string }) {
+    let rows = this.entries.filter((e) =>
+      (!opts.namespace || e.namespace.startsWith(opts.namespace))
+      && (opts.tags ?? []).every((tag) => e.tags.includes(tag)));
+    rows = [...rows].sort((a, b) => b.updated_at.localeCompare(a.updated_at));
+    const limited = rows.slice(0, opts.limit ?? 50);
+    return {
+      results: limited.map((e) => ({
+        id: `${e.namespace}/${e.key}`,
+        namespace: e.namespace,
+        key: e.key,
+        entry_type: "state",
+        content_preview: e.content.slice(0, 80),
+        tags: e.tags,
+        classification: e.classification,
+        created_at: e.created_at,
+        updated_at: e.updated_at,
+      })),
+      total: rows.length,
+    };
+  }
+
+  async log() {
+    // unused by this module
+  }
+}
+
+function munin(): InMemoryMunin & MuninClient {
+  return new InMemoryMunin() as unknown as InMemoryMunin & MuninClient;
+}
+
+const ref = (namespace: string, key: string) => ({ namespace, key });
+const hash = (seed: string) => createHash("sha256").update(seed).digest("hex");
+const PRINCIPAL = "service:test-resolver";
+
+/** Register a completed, admitted, resolvable Hugin attempt for `taskId`. */
+async function seedAdmittedAttempt(
+  m: InMemoryMunin & MuninClient,
+  store: LearningRegistryStore,
+  taskId: string,
+  occurredAt: string,
+): Promise<{ attemptId: string; taskOutcomeRef: { namespace: string; key: string }; statusContent: string; resultContent: string }> {
+  const { attemptId, attemptOutcomeRef, evidence } = buildFixtureAdmittedAttempt({ taskId, taskType: "code-edit" });
+  await m.write(attemptOutcomeRef.namespace, attemptOutcomeRef.key, JSON.stringify(evidence), []);
+
+  const taskOutcomeRef = ref(`tasks/${taskId}`, "result-structured");
+  await store.recordSubmission({ taskId, taskOutcomeRef, occurredAt });
+  await store.recordAttemptReference({
+    taskId, attemptId, attemptStartRef: ref(`tasks/${taskId}`, `learning-attempt-${attemptId}`), taskOutcomeRef, occurredAt,
+  });
+  await store.recordTerminalOutcome({
+    taskId, attemptId, outcome: "completed", taskOutcomeRef, attemptOutcomeRef,
+    delegation: { modelId: "model-a", taskType: "code-edit", nodeId: "m5" },
+    occurredAt,
+  });
+
+  const statusContent = buildFixtureStatusDocument(taskId, `prompt bytes for ${taskId}`);
+  const resultContent = buildFixtureResultStructuredDocument(taskId);
+  await m.write(`tasks/${taskId}`, "status", statusContent, ["status"]);
+  await m.write(`tasks/${taskId}`, "result-structured", resultContent, ["result"]);
+
+  return { attemptId, taskOutcomeRef, statusContent, resultContent };
+}
+
+async function createExperimentWithObservation(
+  m: InMemoryMunin & MuninClient,
+  taskId: string,
+  overrides: Partial<Parameters<typeof makeObservation>[2]> = {},
+) {
+  const experimentStore = new LearningExperimentStore(m);
+  await experimentStore.create(PRINCIPAL, makeExperimentInput());
+  await experimentStore.observe(PRINCIPAL, makeObservation("case-1", "champion", { task_id: taskId, ...overrides }));
+  return experimentStore.read(PRINCIPAL, "wave-six-edit-deadline");
+}
+
+describe("createGilleOutcomeEvidenceResolver", () => {
+  it("resolves prompt, evidence identity, verifier, exposure, and policy epoch for a fully admitted sample", async () => {
+    const m = munin();
+    const store = new LearningRegistryStore(m);
+    const taskId = "task-resolvable";
+    await seedAdmittedAttempt(m, store, taskId, "2026-07-05T00:00:00.000Z");
+
+    const statusContent = buildFixtureStatusDocument(taskId, `prompt bytes for ${taskId}`);
+    const resultContent = buildFixtureResultStructuredDocument(taskId);
+    const binding = buildQualityBinding({ statusContent, structuredResultContent: resultContent });
+    const receipt = buildQualityReceipt({
+      taskId, reviewerPrincipal: "codex", reviewerIndependence: "independent",
+      rating: "pass", ratingReason: "SECRET-RAW-TEXT", verificationOutcome: "accepted_unchanged",
+      ratedAt: "2026-07-05T00:00:00.000Z", bindingAttestation: "server-bound", binding,
+    });
+    await m.write(`tasks/${taskId}`, "feedback", JSON.stringify({ schemaVersion: 1, taskId, receipts: [receipt] }), []);
+
+    const experiment = await createExperimentWithObservation(m, taskId);
+    const observation = experiment.observations[0]!;
+
+    const resolver = createGilleOutcomeEvidenceResolver({ munin: m, registry: store });
+    const evidence = await resolver.resolveArmEvidence({ experiment, observation });
+
+    expect(evidence).not.toBeNull();
+    expect(evidence!.prompt).toBe(`prompt bytes for ${taskId}`);
+    expect(evidence!.evidenceIdentity.lane).toBe("delegate");
+    expect(evidence!.evidenceIdentity.logicalTask.kind).toBe("digest");
+    expect(evidence!.evidenceIdentity.renderedPrompt.kind).toBe("digest");
+    expect(evidence!.evidenceIdentity.harness.kind).toBe("digest");
+    expect(evidence!.evidenceIdentity.toolPolicy.kind).toBe("digest");
+    expect(evidence!.evidenceIdentity.taxonomyVersion.kind).toBe("label");
+    // Hugin genuinely has no visibility into these -- must stay honestly unknown.
+    expect(evidence!.evidenceIdentity.modelArtifact).toEqual(
+      expect.objectContaining({ kind: "unknown", reason: "not-observed" }),
+    );
+    expect(evidence!.evidenceIdentity.configEpoch).toEqual(
+      expect.objectContaining({ kind: "unknown", reason: "not-observed" }),
+    );
+    // v1 legacy receipt carries no rubric.
+    expect(evidence!.evidenceIdentity.verifierRubric).toEqual(
+      expect.objectContaining({ kind: "unknown", reason: "legacy" }),
+    );
+    expect(evidence!.verifier).toEqual({ name: "protected-check", independent: true, mode: "deterministic" });
+    expect(evidence!.exposure).toEqual({ contaminationStatus: "coverage-incomplete" });
+    expect(evidence!.policyEpoch).toBe(observation.configuration_fingerprint);
+    expect(evidence!.nodeId).toBe("m5");
+
+    // Never leaks the receipt's own free-text rating reason.
+    expect(JSON.stringify(evidence)).not.toContain("SECRET-RAW-TEXT");
+  });
+
+  it("resolves a real digest verifierRubric from a schemaVersion-2 (attempt-bound) correction receipt", async () => {
+    const m = munin();
+    const store = new LearningRegistryStore(m);
+    const taskId = "task-v2-rubric";
+    const { attemptId } = await seedAdmittedAttempt(m, store, taskId, "2026-07-05T00:00:00.000Z");
+
+    const statusContent = buildFixtureStatusDocument(taskId, `prompt bytes for ${taskId}`);
+    const resultContent = buildFixtureResultStructuredDocument(taskId);
+    const binding = buildQualityBinding({ statusContent, structuredResultContent: resultContent });
+    const v1 = buildQualityReceipt({
+      taskId, reviewerPrincipal: "codex", reviewerIndependence: "independent",
+      rating: "partial", ratingReason: "SECRET-V1", verificationOutcome: "minor_edit",
+      ratedAt: "2026-07-05T00:00:00.000Z", bindingAttestation: "server-bound", binding,
+    });
+    const v2 = buildQualityCorrectionReceipt({
+      taskId, attemptId, correctsReceiptId: v1.receiptId,
+      reviewerPrincipal: "codex", reviewerIndependence: "independent",
+      rating: "pass", ratingReason: "SECRET-V2", verificationOutcome: "accepted_unchanged",
+      ratedAt: "2026-07-06T00:00:00.000Z",
+      rubric: {
+        id: "default-rubric", version: "1",
+        config_digest: {
+          algorithm: "sha256", canonicalization: "jcs-rfc8785-utf8-v1",
+          source_ref: "source-doc:hugin/rubric/default", source_type: "rubric-config", source_version: "v1",
+          digest: hash("rubric"),
+        },
+      },
+      verifier: { id: "codex-verifier", version: "1" },
+      failure: { taxonomy: { id: "hugin-failure-taxonomy", version: "1" }, code: "none" },
+      bindingAttestation: "server-bound", binding,
+    });
+    await m.write(`tasks/${taskId}`, "feedback", JSON.stringify({ schemaVersion: 2, taskId, receipts: [v1, v2] }), []);
+
+    const experiment = await createExperimentWithObservation(m, taskId);
+    const observation = experiment.observations[0]!;
+    const resolver = createGilleOutcomeEvidenceResolver({ munin: m, registry: store });
+    const evidence = await resolver.resolveArmEvidence({ experiment, observation });
+
+    expect(evidence).not.toBeNull();
+    expect(evidence!.evidenceIdentity.verifierRubric.kind).toBe("digest");
+  });
+
+  it("returns null (unresolved) when the observation has no task_id to anchor evidence to", async () => {
+    const m = munin();
+    const store = new LearningRegistryStore(m);
+    const experimentStore = new LearningExperimentStore(m);
+    await experimentStore.create(PRINCIPAL, makeExperimentInput());
+    await experimentStore.observe(PRINCIPAL, makeObservation("case-1", "champion", { task_id: undefined }));
+    const experiment = await experimentStore.read(PRINCIPAL, "wave-six-edit-deadline");
+
+    const resolver = createGilleOutcomeEvidenceResolver({ munin: m, registry: store });
+    const evidence = await resolver.resolveArmEvidence({ experiment, observation: experiment.observations[0]! });
+    expect(evidence).toBeNull();
+  });
+
+  it("returns null when the observation carries no verifier (kind 'none') rather than fabricating one", async () => {
+    const m = munin();
+    const store = new LearningRegistryStore(m);
+    const taskId = "task-no-verifier";
+    await seedAdmittedAttempt(m, store, taskId, "2026-07-05T00:00:00.000Z");
+    const experiment = await createExperimentWithObservation(m, taskId, {
+      verifier: { kind: "none", independent: false },
+    });
+    const resolver = createGilleOutcomeEvidenceResolver({ munin: m, registry: store });
+    const evidence = await resolver.resolveArmEvidence({ experiment, observation: experiment.observations[0]! });
+    expect(evidence).toBeNull();
+  });
+
+  it("returns null when no admitted attempt-outcome evidence resolves for the task (unresolvable, per-sample)", async () => {
+    const m = munin();
+    const store = new LearningRegistryStore(m);
+    const taskId = "task-unregistered";
+    // No registry events, no evidence row, no status doc seeded for this task.
+    const experimentStore = new LearningExperimentStore(m);
+    await experimentStore.create(PRINCIPAL, makeExperimentInput());
+    await experimentStore.observe(PRINCIPAL, makeObservation("case-1", "champion", { task_id: taskId }));
+    const experiment = await experimentStore.read(PRINCIPAL, "wave-six-edit-deadline");
+
+    const resolver = createGilleOutcomeEvidenceResolver({ munin: m, registry: store });
+    const evidence = await resolver.resolveArmEvidence({ experiment, observation: experiment.observations[0]! });
+    expect(evidence).toBeNull();
+  });
+
+  it("returns null when no quality receipt is bound to the task's current content", async () => {
+    const m = munin();
+    const store = new LearningRegistryStore(m);
+    const taskId = "task-no-receipt-resolver";
+    await seedAdmittedAttempt(m, store, taskId, "2026-07-05T00:00:00.000Z");
+    // No feedback ledger written.
+    const experiment = await createExperimentWithObservation(m, taskId);
+    const resolver = createGilleOutcomeEvidenceResolver({ munin: m, registry: store });
+    const evidence = await resolver.resolveArmEvidence({ experiment, observation: experiment.observations[0]! });
+    expect(evidence).toBeNull();
+  });
+});

--- a/tests/helpers/candidate-evidence-fixtures.ts
+++ b/tests/helpers/candidate-evidence-fixtures.ts
@@ -1,0 +1,255 @@
+/**
+ * Hand-built (not executor-driven) fixtures for an admitted LearningTaskContract
+ * evidence row, used by tests/candidate-pool-assembler.test.ts and
+ * tests/gille-outcome-evidence-resolver.test.ts (hugin#272). Simpler than
+ * tests/helpers/learning-task.ts's executor-path fixtures: `.strict()` Zod
+ * schemas here carry no cross-field superRefine of their own except
+ * `learningTaskExecutionEvidenceSchema`, so a hand-built object that
+ * satisfies that schema's bindings/digests is sufficient -- no need to run
+ * the real preflight/dispatch pipeline.
+ */
+import { createHash, randomUUID } from "node:crypto";
+import {
+  LEARNING_TASK_CAPABILITIES,
+  LEARNING_TASK_CONTRACT_VERSION,
+  LEARNING_TASK_GATEWAY_PRINCIPAL,
+  LEARNING_TASK_PREFLIGHT_ENDPOINT,
+  LEARNING_TASK_PREFLIGHT_PROTOCOL,
+  gatewayEchoDigest,
+  jcsCanonicalize,
+  learningTaskAttemptKey,
+  learningTaskExecutionEvidenceSchema,
+  requestStampDigest,
+  type HuginRequestStamp,
+  type LearningTaskExecutionEvidence,
+} from "../../src/learning-task-handshake.js";
+import {
+  BROKER_TASK_TYPE_TAXONOMY_ID,
+  BROKER_TASK_TYPE_TAXONOMY_VERSION,
+} from "../../src/broker/task-type-metadata.js";
+
+function sha256(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+export interface FixtureAdmittedAttemptInput {
+  taskId: string;
+  taskType: string;
+  promptId?: string;
+  promptVersion?: string;
+  harnessId?: string;
+  harnessVersion?: string;
+  toolPolicyId?: string;
+  toolPolicyVersion?: string;
+  /** Base wall-clock instant (ms); every stamp/echo timestamp derives from it. */
+  baseMs?: number;
+}
+
+export interface FixtureAdmittedAttempt {
+  attemptId: string;
+  attemptOutcomeRef: { namespace: string; key: string };
+  evidence: LearningTaskExecutionEvidence;
+}
+
+/** Build a schema-valid, `m5-admitted` `LearningTaskExecutionEvidence` row for one fresh attempt. */
+export function buildFixtureAdmittedAttempt(input: FixtureAdmittedAttemptInput): FixtureAdmittedAttempt {
+  const attemptId = `hugin-attempt:${randomUUID()}`;
+  const attemptKey = learningTaskAttemptKey(attemptId);
+  const namespace = `tasks/${input.taskId}`;
+  const base = input.baseMs ?? Date.parse("2026-07-01T00:00:00.000Z");
+
+  const promptId = input.promptId ?? "hugin-direct-delegate-prompt";
+  const promptVersion = input.promptVersion ?? "v1";
+  const harnessId = input.harnessId ?? "homeserver-executor";
+  const harnessVersion = input.harnessVersion ?? "learning-task-v1";
+  const toolPolicyId = input.toolPolicyId ?? "bounded-delegate";
+  const toolPolicyVersion = input.toolPolicyVersion ?? "learning-task-v1";
+
+  const rawTaskText = `fixture raw task text for ${input.taskId}`;
+  const renderedPrompt = `fixture rendered prompt for ${input.taskId}`;
+  const rawFingerprint = {
+    algorithm: "sha256" as const,
+    version: "trim-utf8-sha256-v1" as const,
+    digest: sha256(rawTaskText),
+  };
+
+  const stamp: HuginRequestStamp = {
+    task_instance_id: input.taskId,
+    attempt_id: attemptId,
+    client_id: "hugin",
+    expected_transport_principal_id: "principal:test-owner",
+    idempotency_key: `opaque:${randomUUID()}`,
+    request_id: `opaque:${randomUUID()}`,
+    stamped_at: new Date(base).toISOString(),
+    contract_request: structuredClone(LEARNING_TASK_CAPABILITIES),
+    preflight: {
+      request: {
+        request_id: `opaque:${randomUUID()}`,
+        endpoint: LEARNING_TASK_PREFLIGHT_ENDPOINT,
+        protocol_version: LEARNING_TASK_PREFLIGHT_PROTOCOL,
+        requested_at: new Date(base - 3_000).toISOString(),
+        requested_capabilities: structuredClone(LEARNING_TASK_CAPABILITIES),
+      },
+      response: {
+        advertisement_id: `opaque:${randomUUID()}`,
+        endpoint: LEARNING_TASK_PREFLIGHT_ENDPOINT,
+        protocol_version: LEARNING_TASK_PREFLIGHT_PROTOCOL,
+        advertised_at: new Date(base - 2_000).toISOString(),
+        expires_at: new Date(base + 10 * 60_000).toISOString(),
+        authenticated_principal_id: LEARNING_TASK_GATEWAY_PRINCIPAL,
+        authentication: "service-auth",
+        capabilities: structuredClone(LEARNING_TASK_CAPABILITIES),
+      },
+    },
+    source: {
+      component: "hugin",
+      system: "test",
+      id: namespace,
+      created_at: new Date(base - 5_000).toISOString(),
+      accepted_at: new Date(base - 4_000).toISOString(),
+      principal: { id: "principal:test-owner", authentication: "verified-signature", scope: "owner" },
+      content_owner: { id: "principal:test-owner", authority: "authenticated-owner" },
+    },
+    task_type: {
+      id: input.taskType,
+      taxonomy_id: BROKER_TASK_TYPE_TAXONOMY_ID,
+      taxonomy_version: BROKER_TASK_TYPE_TAXONOMY_VERSION,
+    },
+    raw_input: {
+      algorithm: "sha256",
+      canonicalization: "jcs-rfc8785-utf8-v1",
+      source_ref: `source-doc:hugin/raw/${sha256(rawTaskText)}`,
+      source_type: "raw-input",
+      source_version: "raw-input-v1",
+      digest: sha256(rawTaskText),
+    },
+    raw_fingerprint: rawFingerprint,
+    hugin_envelope: {
+      algorithm: "sha256",
+      canonicalization: "jcs-rfc8785-utf8-v1",
+      source_ref: `source-doc:hugin/prompt/${attemptId.replace(/^hugin-attempt:/, "")}`,
+      source_type: "prompt-stage",
+      source_version: "prompt-stage-v2",
+      digest: sha256(renderedPrompt),
+    },
+    origin_config: {
+      prompt: {
+        id: promptId,
+        version: promptVersion,
+        config_digest: {
+          algorithm: "sha256",
+          canonicalization: "jcs-rfc8785-utf8-v1",
+          source_ref: "source-doc:hugin/config/direct-delegate-prompt-v1",
+          source_type: "origin-prompt-config",
+          source_version: "config-source-v1",
+          digest: sha256(`${promptId}@${promptVersion}`),
+        },
+      },
+      harness: {
+        id: harnessId,
+        version: harnessVersion,
+        config_digest: {
+          algorithm: "sha256",
+          canonicalization: "jcs-rfc8785-utf8-v1",
+          source_ref: "source-doc:hugin/config/homeserver-learning-task-v1",
+          source_type: "origin-harness-config",
+          source_version: "config-source-v1",
+          digest: sha256(`${harnessId}@${harnessVersion}`),
+        },
+      },
+      tool_policy: {
+        id: toolPolicyId,
+        version: toolPolicyVersion,
+        config_digest: {
+          algorithm: "sha256",
+          canonicalization: "jcs-rfc8785-utf8-v1",
+          source_ref: "source-doc:hugin/config/bounded-delegate-learning-task-v1",
+          source_type: "origin-tool-policy-config",
+          source_version: "config-source-v1",
+          digest: sha256(`${toolPolicyId}@${toolPolicyVersion}`),
+        },
+      },
+    },
+    macro_decision: {
+      policy_id: "hugin-runtime-selection",
+      version: "homeserver-delegate-learning-task-v1",
+      decision_id: `learning-task:${attemptId.replace(/^hugin-attempt:/, "")}`,
+      target: "m5",
+      service: "gille-inference",
+    },
+  };
+
+  const stampDigest = requestStampDigest(stamp);
+  const admittedAt = new Date(base + 1_000).toISOString();
+  const authenticatedPrincipalId = stamp.expected_transport_principal_id;
+  const bindingDigest = sha256(
+    jcsCanonicalize({ authenticated_principal_id: authenticatedPrincipalId, request_stamp: stamp }),
+  );
+  const gatewayEcho = {
+    echoed_request: structuredClone(stamp),
+    gateway_request_id: `opaque:${randomUUID()}`,
+    admission_id: `opaque:${randomUUID()}`,
+    admitted_at: admittedAt,
+    authenticated_principal_id: authenticatedPrincipalId,
+    authentication: "gateway-owner-auth" as const,
+    principal_binding_digest: {
+      algorithm: "sha256" as const,
+      version: "gateway-principal-request-binding-jcs-v1" as const,
+      digest: bindingDigest,
+    },
+    capabilities: structuredClone(stamp.contract_request),
+  };
+  const echoDigest = gatewayEchoDigest(gatewayEcho);
+  const attemptOutcomeRef = { namespace, key: `${attemptKey}-outcome` };
+
+  const evidence: LearningTaskExecutionEvidence = {
+    schemaVersion: 1,
+    contractVersion: LEARNING_TASK_CONTRACT_VERSION,
+    state: "m5-admitted",
+    evidenceAccepted: true,
+    taskId: input.taskId,
+    attemptId,
+    attemptStartedAt: new Date(base - 4_500).toISOString(),
+    attemptStartRef: { namespace, key: attemptKey },
+    preparedDispatchRef: { namespace, key: `${attemptKey}-prepared` },
+    replayPayloadRef: { namespace, key: `${attemptKey}-replay` },
+    replayPayloadDigest: {
+      algorithm: "sha256",
+      version: "hugin-replay-payload-jcs-v1",
+      digest: sha256(`${attemptId}-replay`),
+    },
+    attemptOutcomeRef,
+    taskOutcomeRef: { namespace, key: "result-structured" },
+    rawFingerprint,
+    requestStamp: stamp,
+    requestStampDigest: stampDigest,
+    gatewayEcho,
+    gatewayEchoDigest: echoDigest,
+  };
+
+  const parsed = learningTaskExecutionEvidenceSchema.parse(evidence);
+  return { attemptId, attemptOutcomeRef, evidence: parsed };
+}
+
+/** Minimal "status" document content: hashable as-is by `buildQualityBinding`,
+ * and parseable by `broker/task-store.ts`'s `parseStoredEnvelope` (which does
+ * a bare `JSON.parse` + type cast, not schema validation) to recover a
+ * `prompt` field. */
+export function buildFixtureStatusDocument(taskId: string, prompt: string): string {
+  const envelope = { task_id: taskId, prompt };
+  return [
+    `## Task: fixture-${taskId}`,
+    "",
+    "### Broker envelope",
+    "```json",
+    JSON.stringify(envelope),
+    "```",
+  ].join("\n");
+}
+
+/** Minimal "result-structured" content: `buildQualityBinding` only requires
+ * `task_id` + `result_schema_version: 1` when the full structured-result
+ * schema does not match (its own documented fallback path). */
+export function buildFixtureResultStructuredDocument(taskId: string): string {
+  return JSON.stringify({ task_id: taskId, result_schema_version: 1 });
+}


### PR DESCRIPTION
Closes #272

## What

Two gaps kept the #266 daily experiment cadence a partial no-op:

1. **Production candidate-pool assembler** (`src/learning/candidate-pool-assembler.ts`). `experiment-cadence-cli.ts` previously required a hand-seeded `--candidates <path>` JSON snapshot (deploy seeded `[]`), so the tick only ever observed/concluded already-packaged experiments and never proposed or packaged a new one. The assembler now scans the #232 registry itself (`listTerminalOutcomesForPeriod` over a trailing window of UTC months) and resolves each completed terminal outcome into a `PackagerCandidateInput`, or records a specific reason it could not. It is now the tick's DEFAULT `loadCandidates`; `--candidates <path>` becomes an explicit override for tests/manual runs. `systemd/hugin-experiment-cadence.service` and `scripts/deploy-pi.sh` no longer pass/seed a `candidates.json` — a leftover file from an older deploy is simply never read.

2. **Gille outcome-export evidence resolver** (`src/learning/gille-outcome-evidence-resolver.ts`). The #266 export leg was fully wired with a real HTTP client but always skipped, because `experiment-cadence-cli.ts` never constructed an `evidenceResolver` — `deps.gilleExport && deps.evidenceResolver` was always false. This resolver reconstructs gille-inference#8's required per-arm evidence (`prompt` + nine-field `evidenceIdentity`) AT EXPORT TIME from the original durable sources (the Broker task's own envelope, the admitted LearningTaskContract evidence row, the effective quality receipt) — never from the registry, which stays content-blind. `experiment-cadence-cli.ts` now wires this resolver whenever `gilleExport` is configured.

Two small shared helpers factor the "read one attempt's admitted evidence row" and "resolve one task's effective quality receipt" logic used by both the assembler and the resolver: `src/learning/admitted-attempt-evidence.ts` and `src/learning/quality-receipt-resolution.ts`.

`experiment-cadence.ts` itself is untouched — the one-axis discipline and no-promotion boundary are unchanged.

## Design decisions

- **Assembler rules**: no quality floor is applied by the assembler itself — `qualifyCandidate`, invoked downstream by both the proposer (floor `"wrong"`) and the packager (floor `"pass"`, #269's documented split), still owns that. A candidate is only resolved when Hugin can honestly attribute a real model identity (`delegation.modelId`, the #267 harness-lane sampler's field) and a genuinely admitted (`m5-admitted` + `evidenceAccepted`) LearningTaskContract evidence row exists — anything else is excluded, never defaulted or fabricated. `prompt`/`harness` identity comes from that row's `origin_config`; `model` comes from `delegation.modelId` with `config: {}` (no per-task model-config detail is durably known); `logging`/`testHarness`/`routing` are fixed, digested sentinel documents (the same "digest a real, if trivial, constant document" pattern `learning-task-handshake.ts`'s own `originConfig()` already uses) because Hugin does not yet differentiate those axes per candidate. `model` is therefore the one axis real candidates can vary on today — exactly what #267's harness-lane comparison exists to surface. The pool is natural-key deduped and sorted for determinism/idempotency; a truncated registry scan throws rather than silently returning a partial pool (caught by the tick's existing `"load-candidates"` error path).
- **Resolver edge-resolution**: the resolver mirrors gille-inference's own `evidenceIdentityFromAdmittedStamp` mapping for the fields Hugin's admitted stamp genuinely carries (`logicalTask`, `renderedPrompt`, `harness`, `toolPolicy`, `taxonomyVersion`). Fields Hugin has no visibility into at all (`modelArtifact`/`configEpoch` — gille/M5-side server-observed facts) stay honestly `{kind: "unknown", reason: "not-observed"}`, never guessed. `verifierRubric` comes from the effective quality receipt's schemaVersion-2 `rubric` when present, else `unknown("legacy")`. `review` is deliberately omitted — Hugin's richer product-outcome taxonomy doesn't map cleanly onto gille's narrower one and per-observation reviewer independence isn't tracked; a named simplification, not a fabrication.
- **Per-experiment skip semantics**: an observation missing `task_id`, or whose `verifier.kind` is `"none"`, resolves to `null` (unresolved) rather than inventing required evidence. `buildOutcomeExportBundle` already drops such samples from the export bundle per-sample rather than failing the whole experiment's export — so a partially-resolvable experiment still exports what it honestly can, and a fully-unresolvable one stays `skipped-with-reason`, exactly as #266 already documented. Fail-closed + idempotent per #266's tick semantics: natural-keyed on experiment id via the existing reviewable-summary mechanism, so re-running a tick after a successful export never re-POSTs.

## Verification

- `npm run build` — clean.
- `npm test` — **145 files / 2253 tests** passed (baseline 142/2232 + 3 new test files / 21 new tests).
- `bash scripts/deploy-pi.test.sh` — passed.
- `shellcheck scripts/deploy-pi.sh` — same pre-existing info-level findings as `origin/main`, zero new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)