### PR TITLE
Wire the harness-lane sampler into the production dispatch seam

### DIFF
--- a/src/harness-lane-executor.ts
+++ b/src/harness-lane-executor.ts
@@ -190,8 +190,12 @@ export async function runHarnessLaneSampledAttempt(
   input: RunHarnessLaneSampledAttemptInput,
   executors: HarnessLaneExecutors,
   samplerDeps: HarnessLaneSamplerDeps = {},
+  /** A decision made by a caller only after its mandatory preflight gates.
+   * When absent, this helper makes the decision itself as before. */
+  precomputedDecision?: HarnessLaneDecision,
 ): Promise<HarnessLaneAttemptResult> {
-  const decision = decideHarnessLane({ taskId: input.taskId, taskType: input.taskType }, samplerDeps);
+  const decision = precomputedDecision
+    ?? decideHarnessLane({ taskId: input.taskId, taskType: input.taskType }, samplerDeps);
   const lane = decision.lane;
   const taskRef: HarnessLaneTaskRef = { taskId: input.taskId, taskType: input.taskType };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,7 +140,10 @@ import {
   getPersistentStatusTags,
 } from "./task-status-tags.js";
 import { LearningLoopCollector } from "./learning-loop-collector.js";
+import { LearningRegistryStore } from "./learning-registry-store.js";
 import { LearningExperimentStore } from "./learning/experiment-store.js";
+import { runHarnessLaneSampledAttempt, type LaneAttemptOutcome } from "./harness-lane-executor.js";
+import { decideHarnessLane, isHarnessLaneEligibleTaskType } from "./harness-lane-sampler.js";
 import { sanitizeProviderTokenCount } from "./m5-provenance.js";
 import {
   buildStructuredTaskResult,
@@ -640,6 +643,7 @@ const egressPolicy = installFetchEgressPolicy(
 );
 
 const munin = createMuninClient();
+const learningRegistry = new LearningRegistryStore(munin);
 // Keep lease renewal, active-task cancellation polling, and the independent
 // lease reaper off the main request slot so a long Retry-After on background
 // work cannot delay them past expiry — and so reaper traffic does not queue up
@@ -1943,12 +1947,10 @@ interface PreflightCheckedSdkResult extends SdkExecutorResult {
  * Both short-circuits are fail-open on anything inconclusive; only a
  * confirmed problem blocks.
  */
-async function executeClaudeSdkWithPreflightChecks(
-  cfg: SdkTaskConfig,
+async function runClaudeSdkPreflight(
   taskId: string,
   logDir: string,
-  options?: SdkExecutorOptions,
-): Promise<PreflightCheckedSdkResult> {
+): Promise<PreflightCheckedSdkResult | null> {
   const drift = checkVersionDrift();
   if (drift) {
     const logFile = path.join(logDir, `${taskId}.log`);
@@ -2037,7 +2039,17 @@ async function executeClaudeSdkWithPreflightChecks(
       };
     }
   }
-  return executeSdkTask(cfg, taskId, logDir, options);
+  return null;
+}
+
+async function executeClaudeSdkWithPreflightChecks(
+  cfg: SdkTaskConfig,
+  taskId: string,
+  logDir: string,
+  options?: SdkExecutorOptions,
+): Promise<PreflightCheckedSdkResult> {
+  const refusal = await runClaudeSdkPreflight(taskId, logDir);
+  return refusal ?? executeSdkTask(cfg, taskId, logDir, options);
 }
 
 // --- Invocation journal ---
@@ -2278,12 +2290,12 @@ function spawnRuntime(
   });
 }
 
-async function executeCodexWithPreflightChecks(
+async function runCodexPreflight(
   task: TaskConfig,
   ctx: SpawnContext,
-): Promise<SpawnRuntimeResult> {
+): Promise<SpawnRuntimeResult | null> {
   const probe = await refreshCodexSandboxStatus();
-  if (probe.available) return spawnRuntime(task, ctx);
+  if (probe.available) return null;
 
   const taskId = extractTaskId(ctx.taskNs);
   const logFile = path.join(LOG_DIR, `${taskId}.log`);
@@ -2317,6 +2329,14 @@ async function executeCodexWithPreflightChecks(
     preflightFailureKind: CODEX_SANDBOX_FAILURE_KIND,
     preflightFailureReason: reason,
   };
+}
+
+async function executeCodexWithPreflightChecks(
+  task: TaskConfig,
+  ctx: SpawnContext,
+): Promise<SpawnRuntimeResult> {
+  const refusal = await runCodexPreflight(task, ctx);
+  return refusal ?? spawnRuntime(task, ctx);
 }
 
 // --- Lease helpers ---
@@ -4707,9 +4727,9 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     const startMs = Date.now();
 
     // --- Execute via ollama, SDK, or spawn ---
-    let exitCode: number | "TIMEOUT";
-    let output: string;
-    let logFile: string;
+    let exitCode: number | "TIMEOUT" = 1;
+    let output = "";
+    let logFile = path.join(LOG_DIR, `${taskId}.log`);
     let resultText: string | null = null;
     let costUsd: number | null = null;
     // Verdict layer (V8): per-worker outcomes from the orchestrator engine,
@@ -4732,6 +4752,144 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     let codexPreflightFailureReason: string | undefined;
     let fallbackTriggered = false;
     let fallbackReason: string | null = null;
+
+    // Issue #274: the standing harness sampler belongs at the mutation-task
+    // execution seam, after the managed-checkout gate and the applicable
+    // one-shot runtime preflight. Broker /delegate tasks are deliberately not
+    // included: their authenticated envelope promises tool_policy:none and no
+    // worktree, so silently replacing them with a file-editing harness would
+    // exceed the submitted authority. Direct Claude/Codex tasks carrying one
+    // of #267's canonical bounded-coding task types are the live eligible set.
+    const harnessLaneCheckoutPassed = !checkoutGateRefusalReason;
+    const harnessLaneTaskType =
+      harnessLaneCheckoutPassed &&
+      (isClaude || isCodex) &&
+      task.homeserverTaskType !== undefined &&
+      isHarnessLaneEligibleTaskType(task.homeserverTaskType)
+        ? task.homeserverTaskType
+        : undefined;
+    const harnessLaneDispatchEligible = harnessLaneTaskType !== undefined;
+
+    // These return a synthetic one-shot failure on refusal and null on pass.
+    // Running them here creates the production callback point that did not
+    // previously exist: the sampler cannot bypass checkout, dependency drift,
+    // Claude auth, or the Codex sandbox profile probe.
+    const harnessLaneClaudePreflight = harnessLaneDispatchEligible && isClaude
+      ? await runClaudeSdkPreflight(taskId, LOG_DIR)
+      : undefined;
+    const harnessLaneCodexPreflight = harnessLaneDispatchEligible && isCodex
+      ? await runCodexPreflight(task, { taskNs, muninClient: munin })
+      : undefined;
+    const harnessLanePreflightsPassed =
+      harnessLaneDispatchEligible &&
+      (isClaude ? harnessLaneClaudePreflight === null : harnessLaneCodexPreflight === null);
+    const harnessLaneDecision = harnessLanePreflightsPassed && harnessLaneTaskType
+      ? decideHarnessLane({ taskId, taskType: harnessLaneTaskType })
+      : undefined;
+
+    const harnessLaneTaskOutcomeRef = { namespace: taskNs, key: "result-structured" };
+    const laneOutcomeFromExitCode = (
+      code: number | "TIMEOUT",
+      extras: Omit<LaneAttemptOutcome, "outcome" | "taskOutcomeRef">,
+    ): LaneAttemptOutcome => ({
+      outcome: code === "TIMEOUT" ? "timed_out" : code === 0 ? "completed" : "failed",
+      taskOutcomeRef: harnessLaneTaskOutcomeRef,
+      ...extras,
+    });
+
+    const executeSampledHarness = async (): Promise<LaneAttemptOutcome> => {
+      effectiveExecutor = "opencode-sampled";
+      const opencodeGateway = loadOpencodeGatewayConfig(process.env);
+      if (!opencodeGateway) {
+        exitCode = 1;
+        output =
+          "Sampled harness runtime is not configured: set HOMESERVER_GATEWAY_URL + " +
+          "HOMESERVER_GATEWAY_API_KEY or HUGIN_OPENCODE_BASE_URL + HUGIN_OPENCODE_API_KEY";
+        logFile = path.join(LOG_DIR, `${taskId}.log`);
+        fs.writeFileSync(
+          logFile,
+          [
+            "=== Hugin Task Log (sampled harness) ===",
+            `Task: ${taskNs}`,
+            output,
+            "",
+          ].join("\n"),
+        );
+        opencodeJournalExtras = {
+          runtime_requested: task.runtime,
+          runtime_effective: "none",
+          harness_lane: "harness",
+          opencode_configured: false,
+        };
+        return laneOutcomeFromExitCode(exitCode, {
+          verifierKind: "none",
+          verdict: "error",
+          nodeId: "opencode-m5",
+        });
+      }
+
+      const opencodeAbort = new AbortController();
+      currentOpencodeAbort = opencodeAbort;
+      opencodeResult = await executeOpencodeTask(
+        {
+          prompt: task.prompt,
+          workingDir: task.workingDir,
+          timeoutMs: task.timeoutMs,
+          maxOutputChars: config.maxOutputChars,
+          gatewayBaseUrl: opencodeGateway.gatewayBaseUrl,
+          apiKey: opencodeGateway.apiKey,
+          providerId: opencodeGateway.providerId,
+          model: opencodeGateway.defaultModel,
+          // Preserve the already-admitted write ceiling. Codex is always
+          // full-auto; Claude only writes under trusted-code.
+          permissionProfile: isCodex ? "trusted-code" : task.permissionProfile || "read-only",
+          opencodeCommand: opencodeGateway.opencodeCommand,
+        },
+        taskId,
+        LOG_DIR,
+        { abortController: opencodeAbort },
+      );
+      currentOpencodeAbort = null;
+      exitCode = opencodeResult.exitCode;
+      output = opencodeResult.output;
+      logFile = opencodeResult.logFile;
+      resultText = opencodeResult.resultText;
+      const completedTestCalls = opencodeResult.toolCalls.filter(
+        (call) =>
+          call.tool === "bash" &&
+          call.command !== undefined &&
+          opencodeResult!.testCommands.includes(call.command) &&
+          call.exitCode !== undefined,
+      );
+      const hasMechanicalGrade = completedTestCalls.length > 0;
+      const mechanicalPass = hasMechanicalGrade && completedTestCalls.every((call) => call.exitCode === 0);
+      const iterations = opencodeResult.events.filter((event) => event.type === "step_finish").length;
+      opencodeJournalExtras = {
+        runtime_requested: task.runtime,
+        runtime_effective: "opencode",
+        harness_lane: "harness",
+        opencode_configured: true,
+        model_effective: opencodeResult.model,
+        opencode_agent: opencodeResult.agent,
+        permission_profile: opencodeResult.permissionProfile,
+        tool_calls: opencodeResult.toolCalls.length,
+        changed_files: opencodeResult.changedFiles,
+        test_commands: opencodeResult.testCommands,
+        config_dir_removed: opencodeResult.configDirRemoved,
+      };
+      return laneOutcomeFromExitCode(exitCode, {
+        verifierKind: hasMechanicalGrade ? "mechanical" : "none",
+        verdict: hasMechanicalGrade
+          ? mechanicalPass ? "pass" : "fail"
+          : exitCode === 0 ? "unverified" : "error",
+        ...(hasMechanicalGrade
+          ? { verifierNotes: `test-commands=${completedTestCalls.length}; failed=${completedTestCalls.filter((call) => call.exitCode !== 0).length}` }
+          : {}),
+        modelId: opencodeResult.model,
+        nodeId: "opencode-m5",
+        ...(iterations > 0 ? { iterations } : {}),
+      });
+    };
 
     if (checkoutGateRefusalReason) {
       // Issue #236: the pre-execution clean-verification gate refused this
@@ -5107,11 +5265,11 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
       resultText = homeserverResult.resultText;
     }
     } else if (isClaude) {
-    console.log(`Using Agent SDK executor for task ${taskNs}`);
-    const sdkAbort = new AbortController();
-    currentSdkAbort = sdkAbort;
-    const sdkResult = await executeClaudeSdkWithPreflightChecks(
-      {
+    const executeClaudeOneShot = async (): Promise<LaneAttemptOutcome> => {
+      console.log(`Using Agent SDK executor for task ${taskNs}`);
+      const sdkAbort = new AbortController();
+      currentSdkAbort = sdkAbort;
+      const sdkConfig: SdkTaskConfig = {
         prompt: task.prompt,
         workingDir: task.workingDir,
         timeoutMs: task.timeoutMs,
@@ -5121,10 +5279,8 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         model: task.model,
         muninSessionId: munin.getSessionId(),
         permissionProfile: task.permissionProfile,
-      },
-      taskId,
-      LOG_DIR,
-      {
+      };
+      const sdkOptions: SdkExecutorOptions = {
         abortController: sdkAbort,
         onTimeout: async (partialOutput) => {
           // Write partial result on timeout
@@ -5147,15 +5303,35 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
             console.error("Failed to write partial result on timeout:", err);
           }
         },
-      },
-    );
-    currentSdkAbort = null;
-    exitCode = sdkResult.exitCode;
-    output = sdkResult.output;
-    logFile = sdkResult.logFile;
-    resultText = sdkResult.resultText;
-    costUsd = sdkResult.costUsd;
-    sdkPreflightFailureKind = sdkResult.preflightFailureKind;
+      };
+      const sdkResult: PreflightCheckedSdkResult = harnessLaneDispatchEligible
+        ? harnessLaneClaudePreflight ?? await executeSdkTask(sdkConfig, taskId, LOG_DIR, sdkOptions)
+        : await executeClaudeSdkWithPreflightChecks(sdkConfig, taskId, LOG_DIR, sdkOptions);
+      currentSdkAbort = null;
+      exitCode = sdkResult.exitCode;
+      output = sdkResult.output;
+      logFile = sdkResult.logFile;
+      resultText = sdkResult.resultText;
+      costUsd = sdkResult.costUsd;
+      sdkPreflightFailureKind = sdkResult.preflightFailureKind;
+      return laneOutcomeFromExitCode(exitCode, {
+        verifierKind: "none",
+        verdict: exitCode === 0 ? "unverified" : "error",
+        modelId: task.model || "claude-sdk",
+        nodeId: "claude-sdk",
+      });
+    };
+    if (harnessLaneDecision && harnessLaneTaskType) {
+      await runHarnessLaneSampledAttempt(
+        learningRegistry,
+        { taskId, attemptId: `${taskId}:dispatch`, taskType: harnessLaneTaskType, occurredAt: startedAt },
+        { oneShot: executeClaudeOneShot, harness: executeSampledHarness },
+        {},
+        harnessLaneDecision,
+      );
+    } else {
+      await executeClaudeOneShot();
+    }
     } else if (isOpencode) {
     console.log(`Using OpenCode executor for task ${taskNs}`);
     const opencodeGateway = loadOpencodeGatewayConfig(process.env);
@@ -5273,15 +5449,34 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     orchOutcomes = orchResult.outcomes;
     orchSavings = orchResult.savings;
     } else {
-      const spawnResult = await executeCodexWithPreflightChecks(task, {
-        taskNs,
-        muninClient: munin,
-      });
-      exitCode = spawnResult.exitCode;
-      output = spawnResult.output;
-      logFile = spawnResult.logFile;
-      if (spawnResult.preflightFailureKind === CODEX_SANDBOX_FAILURE_KIND) {
-        codexPreflightFailureReason = spawnResult.preflightFailureReason;
+      const executeCodexOneShot = async (): Promise<LaneAttemptOutcome> => {
+        const spawnContext = { taskNs, muninClient: munin };
+        const spawnResult = harnessLaneDispatchEligible
+          ? harnessLaneCodexPreflight ?? await spawnRuntime(task, spawnContext)
+          : await executeCodexWithPreflightChecks(task, spawnContext);
+        exitCode = spawnResult.exitCode;
+        output = spawnResult.output;
+        logFile = spawnResult.logFile;
+        if (spawnResult.preflightFailureKind === CODEX_SANDBOX_FAILURE_KIND) {
+          codexPreflightFailureReason = spawnResult.preflightFailureReason;
+        }
+        return laneOutcomeFromExitCode(exitCode, {
+          verifierKind: "none",
+          verdict: exitCode === 0 ? "unverified" : "error",
+          modelId: task.model || "codex",
+          nodeId: "codex-spawn",
+        });
+      };
+      if (harnessLaneDecision && harnessLaneTaskType) {
+        await runHarnessLaneSampledAttempt(
+          learningRegistry,
+          { taskId, attemptId: `${taskId}:dispatch`, taskType: harnessLaneTaskType, occurredAt: startedAt },
+          { oneShot: executeCodexOneShot, harness: executeSampledHarness },
+          {},
+          harnessLaneDecision,
+        );
+      } else {
+        await executeCodexOneShot();
       }
     }
 
@@ -5307,6 +5502,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
 
     const durationMs = Date.now() - startMs;
     const completedAt = new Date().toISOString();
+    const sampledHarnessLane = harnessLaneDecision?.lane === "harness";
     let cancellation: CancellationRequest | null = currentCancellation;
     if (!cancellation) {
       const currentEntry = await munin.read(taskNs, "status");
@@ -5479,8 +5675,8 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     let rawBodyText: string;
     let structuredBodyKind: TaskExecutionBodyKind;
 
-    if ((isClaude || isOllama || isOrchestrator || isOpencode || isHomeserver) && resultText) {
-      resultSource = isOpencode
+    if ((isClaude || isOllama || isOrchestrator || isOpencode || isHomeserver || sampledHarnessLane) && resultText) {
+      resultSource = isOpencode || sampledHarnessLane
         ? "opencode-json"
         : isHomeserver
           ? "homeserver-delegate"
@@ -5488,7 +5684,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
       rawBodyText = resultText;
       structuredBodyKind = "response";
       resultBody = `### Response\n\n${resultText}`;
-    } else if (!isClaude && !isOllama && !isOrchestrator && !isOpencode && !isHomeserver) {
+    } else if (!isClaude && !isOllama && !isOrchestrator && !isOpencode && !isHomeserver && !sampledHarnessLane) {
       const hookResult = readHookResult(taskId);
       if (hookResult) {
         resultSource = "hook";
@@ -5782,7 +5978,12 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
       );
     }
     const baseRuntimeMetadata: TaskExecutionRuntimeMetadata | undefined =
-      isHomeserver && homeserverResult
+      sampledHarnessLane && opencodeResult
+        ? {
+            ...(task.model ? { requestedModel: task.model } : {}),
+            effectiveModel: opencodeResult.model,
+          }
+      : isHomeserver && homeserverResult
         ? {
             effectiveModel: homeserverResult.modelId ?? undefined,
             effectiveHost: homeserverResult.nodeId ?? "m5",

--- a/tests/harness-lane-executor.test.ts
+++ b/tests/harness-lane-executor.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { MuninWriteRejectedError, type MuninClient, type MuninQueryResult } from "../src/munin-client.js";
 import { LearningRegistryStore } from "../src/learning-registry-store.js";
@@ -6,7 +7,7 @@ import {
   type HarnessLaneExecutors,
   type LaneAttemptOutcome,
 } from "../src/harness-lane-executor.js";
-import { HARNESS_LANE_FRACTION_ENV } from "../src/harness-lane-sampler.js";
+import { decideHarnessLane, HARNESS_LANE_FRACTION_ENV } from "../src/harness-lane-sampler.js";
 
 interface StoredEntry {
   namespace: string;
@@ -225,12 +226,20 @@ describe("runHarnessLaneSampledAttempt — sampler malfunction", () => {
   it("falls back to one-shot and records the malfunction, without ever touching the harness executor", async () => {
     const store = new LearningRegistryStore(munin());
     const executors = makeExecutors();
+    const decision = decideHarnessLane(
+      { taskId: "task-malfunction-1", taskType: "code-edit" },
+      { env: { [HARNESS_LANE_FRACTION_ENV]: "not-a-number" } },
+    );
 
     const result = await runHarnessLaneSampledAttempt(
       store,
       { taskId: "task-malfunction-1", attemptId: "attempt-1", taskType: "code-edit", occurredAt: OCCURRED_AT },
       executors,
-      { env: { [HARNESS_LANE_FRACTION_ENV]: "not-a-number" } },
+      // Production decides only after the checkout/runtime preflights. Make
+      // the fallback env contradictory to prove that exact decision — and
+      // its malfunction reason — crosses the seam unchanged.
+      { env: { [HARNESS_LANE_FRACTION_ENV]: "1" } },
+      decision,
     );
 
     expect(result.lane).toBe("one-shot");
@@ -323,5 +332,36 @@ describe("runHarnessLaneSampledAttempt — no duplicate/lost tasks", () => {
 
     const { events } = await store.listEventsForTask("task-replay-1");
     expect(events).toHaveLength(3); // submission + attempt-reference + terminal-outcome, no duplicates
+  });
+});
+
+describe("production dispatcher wiring", () => {
+  it("places the sampled lane after checkout and the applicable runtime preflight", () => {
+    const source = readFileSync(new URL("../src/index.ts", import.meta.url), "utf8");
+
+    const checkoutGate = source.indexOf("const harnessLaneCheckoutPassed");
+    const claudePreflight = source.indexOf("runClaudeSdkPreflight", checkoutGate);
+    const codexPreflight = source.indexOf("runCodexPreflight", checkoutGate);
+    const samplerDecision = source.indexOf("decideHarnessLane", checkoutGate);
+    const sampledAttempt = source.indexOf("runHarnessLaneSampledAttempt", samplerDecision);
+
+    expect(checkoutGate).toBeGreaterThan(0);
+    expect(claudePreflight).toBeGreaterThan(checkoutGate);
+    expect(codexPreflight).toBeGreaterThan(checkoutGate);
+    expect(samplerDecision).toBeGreaterThan(claudePreflight);
+    expect(samplerDecision).toBeGreaterThan(codexPreflight);
+    expect(sampledAttempt).toBeGreaterThan(samplerDecision);
+  });
+
+  it("keeps harness and one-shot callbacks exclusive at the live seam", () => {
+    const source = readFileSync(new URL("../src/index.ts", import.meta.url), "utf8");
+    const seamStart = source.indexOf("const harnessLaneCheckoutPassed");
+    const seamEnd = source.indexOf("// The agent run is done.", seamStart);
+    const seam = source.slice(seamStart, seamEnd);
+
+    expect(seam).toContain("runHarnessLaneSampledAttempt");
+    expect(seam).toContain("oneShot:");
+    expect(seam).toContain("harness:");
+    expect(seam).not.toMatch(/harness:[\s\S]*catch[\s\S]*oneShot\(/);
   });
 });


### PR DESCRIPTION
Closes #274.

## What
PR #270's sampler/executor had no production caller — `HUGIN_HARNESS_LANE_FRACTION` was dead config. This wires `decideHarnessLane`/`runHarnessLaneSampledAttempt` into the dispatch seam (src/index.ts:4763; Claude and Codex routing at 5325/5471).

## Design decisions
- Sampling occurs strictly AFTER the checkout-contamination, dependency-drift, Claude-auth, and Codex-sandbox gates — the sampler cannot bypass any pre-existing refusal.
- Both lanes record their decision (one-shot denominator added at the same seam) so the #267 rolling comparison has both sides.
- Fail-closed: harness-executor failure escalates exactly like a one-shot failure; no cross-lane retry. Broker homeserver tasks are excluded (their envelope promises tool_policy:none and no worktree) — documented caveat.

## Verification
Build clean; full suite **145 files / 2,255 tests** at the merged state (includes #273). Implemented headless by Codex (gpt-5.6-sol, high); reviewed by the grimnir gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)