### PR TITLE
fix(dispatcher): finish FIFO starvation hardening (#190)

### DIFF
--- a/docs/scheduling-fifo-hardening.md
+++ b/docs/scheduling-fifo-hardening.md
@@ -1,0 +1,40 @@
+# Scheduling FIFO hardening
+
+The dispatcher enumerates pending tasks with Munin's filter-only timestamp
+paginator, filters for eligibility, and selects the minimum tuple
+`(created_at ASC, namespace ASC)`. The namespace tie-breaker makes tasks created
+in the same millisecond reproducible across polls. Claim ownership remains a
+re-read followed by compare-and-swap.
+
+If a timestamp bucket contains at least 50 rows, Munin cannot prove that bucket
+complete. Hugin reports `pagination_truncated`, treats `queue_depth` and
+`queue_depth_lower_bound` as lower-bound counts, emits a rate-limited warning,
+and continues claiming the oldest eligible task from all visible rows. The
+paginator still walks `updated_at` values older than the overflowing bucket, so
+the ambiguity does not silently stop enumeration at that boundary.
+
+Both `/health` and `tasks/_heartbeat/status` expose the content-blind fields
+`queue_depth`, `queue_depth_lower_bound`, `oldest_pending_age_s`, and
+`pagination_truncated`. No task prompt or metadata is included.
+
+## Follow-up issue: composite Munin cursor
+
+**Problem:** A timestamp-only cursor cannot enumerate or deterministically
+continue within a bucket of 50 or more rows sharing one `updated_at`
+millisecond. Hugin can safely keep working, but cannot claim complete queue
+visibility or exact depth.
+
+**Proposed contract:** Add a Munin continuation cursor ordered by
+`(updated_at DESC, id DESC)`. The cursor must be exclusive and opaque to
+callers, and filters must remain fixed across continuation requests. Hugin can
+then replace exact-timestamp boundary probes with complete composite-cursor
+enumeration.
+
+**Acceptance:**
+
+- Enumerate more than 50 rows with identical `updated_at` without duplicates or
+  omissions.
+- Resume after interruption from the exclusive cursor.
+- Preserve filter-only ordering and reject a cursor reused with changed filters.
+- Remove Hugin's equal-time `pagination_truncated` condition only after the new
+  server contract is deployed and regression-tested.

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ import {
   buildQueueObservabilityFields,
   shouldWarnQueueTruncation,
   snapshotPendingQueue,
-  snapshotPendingQueueAfterClaim,
+  snapshotPendingQueueAfterDeparture,
   type PendingQueueSnapshot,
 } from "./queue-observability.js";
 import { executeSdkTask, type SdkExecutorResult, type SdkExecutorOptions, type SdkTaskConfig, type TaskPermissionProfile } from "./sdk-executor.js";
@@ -4201,18 +4201,34 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
   if (!taskResult) return { hadTask: false, queueDepth };
 
   const taskNs = taskResult.namespace;
+  const updatePendingQueueSnapshotAfterDeparture = (): void => {
+    lastPendingQueueSnapshot = snapshotPendingQueueAfterDeparture(
+      results,
+      pendingPage.truncated,
+      taskNs,
+    );
+  };
+  const pendingTaskDeparted = (hadTask: boolean = true) => {
+    updatePendingQueueSnapshotAfterDeparture();
+    return { hadTask, queueDepth };
+  };
   const entry = await munin.read(taskNs, "status");
   if (!entry) return { hadTask: false, queueDepth };
 
   // Verify it's still pending (another dispatcher might have claimed it)
   if (!entry.tags.includes("pending")) {
     console.log(`Task ${taskNs} no longer pending, skipping`);
-    return { hadTask: false, queueDepth };
+    return pendingTaskDeparted(false);
   }
 
   if (entry.tags.includes(CANCEL_REQUESTED_TAG)) {
     if (parseDeclaredRuntime(entry.content) === "pipeline" || entry.tags.includes("runtime:pipeline")) {
-      await processPipelineCancellationRequest(entry);
+      const processed = await processPipelineCancellationRequest(entry);
+      if (!processed) return { hadTask: true, queueDepth };
+      const refreshedEntry = await munin.read(taskNs, "status");
+      if (refreshedEntry?.tags.includes("pending")) {
+        return { hadTask: true, queueDepth };
+      }
     } else {
       await markTaskCancelled(
         taskNs,
@@ -4224,7 +4240,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         }
       );
     }
-    return { hadTask: true, queueDepth };
+    return pendingTaskDeparted();
   }
 
   const declaredRuntime = parseDeclaredRuntime(entry.content);
@@ -4237,7 +4253,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     );
     await promoteDependents(extractTaskId(taskNs));
     await refreshPipelineSummaryFromContent(entry.content);
-    return { hadTask: true, queueDepth };
+    return pendingTaskDeparted();
   }
 
   const parsedTask =
@@ -4251,7 +4267,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     );
     await promoteDependents(extractTaskId(taskNs));
     await refreshPipelineSummaryFromContent(entry.content);
-    return { hadTask: true, queueDepth };
+    return pendingTaskDeparted();
   }
 
   // Validate submitter against allowlist
@@ -4272,7 +4288,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     );
     await promoteDependents(extractTaskId(taskNs));
     await refreshPipelineSummaryFromContent(entry.content);
-    return { hadTask: true, queueDepth };
+    return pendingTaskDeparted();
   }
 
   // Verify task signature per HUGIN_SIGNING_POLICY
@@ -4298,7 +4314,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     await munin.log(taskNs, `Task rejected by signing policy: ${signingVerdict.message}`);
     await promoteDependents(extractTaskId(taskNs));
     await refreshPipelineSummaryFromContent(entry.content);
-    return { hadTask: true, queueDepth };
+    return pendingTaskDeparted();
   }
 
   if (parsedTask?.baseBranchError) {
@@ -4308,7 +4324,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     await munin.log(taskNs, `Task rejected before execution: ${rejection}`);
     await promoteDependents(extractTaskId(taskNs));
     await refreshPipelineSummaryFromContent(entry.content);
-    return { hadTask: true, queueDepth };
+    return pendingTaskDeparted();
   }
 
   if (declaredRuntime !== "pipeline" && parsedTask) {
@@ -4435,7 +4451,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         );
         await promoteDependents(extractTaskId(taskNs));
         await refreshPipelineSummaryFromContent(entry.content);
-        return { hadTask: true, queueDepth };
+        return pendingTaskDeparted();
       }
     }
 
@@ -4486,7 +4502,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
       await munin.log(taskNs, `Task rejected: ${rejection}`);
       await promoteDependents(extractTaskId(taskNs));
       await refreshPipelineSummaryFromContent(entry.content);
-      return { hadTask: true, queueDepth };
+      return pendingTaskDeparted();
     }
 
     const securityViolation =
@@ -4531,7 +4547,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
       );
       await promoteDependents(extractTaskId(taskNs));
       await refreshPipelineSummaryFromContent(entry.content);
-      return { hadTask: true, queueDepth };
+      return pendingTaskDeparted();
     }
   }
 
@@ -4544,7 +4560,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     // task that can sit for days and may be edited/re-signed before it is
     // returned to pending; it will be assessed again on the next claim.
     taskProvenance.delete(taskNs);
-    return { hadTask: true, queueDepth };
+    return pendingTaskDeparted();
   }
 
   console.log(
@@ -4589,11 +4605,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
 
   // The selected status is now running. Keep /health accurate while the task
   // executes instead of reporting the accepted claim as still pending.
-  lastPendingQueueSnapshot = snapshotPendingQueueAfterClaim(
-    results,
-    pendingPage.truncated,
-    taskNs,
-  );
+  updatePendingQueueSnapshotAfterDeparture();
 
   currentTask = taskNs;
   currentCancellation = null;

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,13 @@ import {
 import { getFoundBatchEntry, extractTaskId, pickEarliestTask, selectNextTask, checkoutTaskBranch, finalizeTaskBranch, deriveRepositoryOutcome, prepareManagedCheckout, shouldReapExpiredLease, decideStartupRecovery, decideDeliveryRetry, finalizeTaskCompletion, resolveTaskWorkingDirectory, normalizeRoot, parseBaseBranchOverride, DEFAULT_REPOS_ROOT, MAX_TASK_OUTPUT_TOKENS, MAX_TASK_TIMEOUT_MS, parseBoundedPositiveInt, PUBLICATION_FAILED_TAG } from "./task-helpers.js";
 import { persistPublicationFailure } from "./publication-recovery.js";
 import { queryAllMuninEntries } from "./munin-pagination.js";
+import {
+  buildQueueObservabilityFields,
+  shouldWarnQueueTruncation,
+  snapshotPendingQueue,
+  snapshotPendingQueueAfterClaim,
+  type PendingQueueSnapshot,
+} from "./queue-observability.js";
 import { executeSdkTask, type SdkExecutorResult, type SdkExecutorOptions, type SdkTaskConfig, type TaskPermissionProfile } from "./sdk-executor.js";
 import {
   classifyClaudeFailure,
@@ -576,7 +583,8 @@ let deliveryRetryReaperInFlight = false;
 let authAlarmTimer: ReturnType<typeof setInterval> | null = null;
 let authAlarmInFlight = false;
 let authAlarmState: AuthAlarmState = INITIAL_AUTH_ALARM_STATE;
-let lastQueueDepth = 0;
+let lastPendingQueueSnapshot: PendingQueueSnapshot = snapshotPendingQueue([], false);
+let lastQueueTruncationWarningAtMs: number | null = null;
 let lastBlockedTaskCount = 0;
 const startedAt = Date.now();
 const pipelineSummaryManager = new PipelineSummaryManager();
@@ -4123,13 +4131,13 @@ async function failTaskWithMessage(
 
 // --- Heartbeat ---
 
-async function emitHeartbeat(queueDepth: number, blockedTasks: number): Promise<void> {
+async function emitHeartbeat(blockedTasks: number): Promise<void> {
   try {
     const heartbeat: Record<string, unknown> = {
       worker_id: workerId,
       process_instance_id: processInstanceId,
       polled_at: new Date().toISOString(),
-      queue_depth: queueDepth,
+      ...buildQueueObservabilityFields(lastPendingQueueSnapshot),
       blocked_tasks: blockedTasks,
       current_task: currentTask,
       uptime_s: Math.round((Date.now() - startedAt) / 1000),
@@ -4163,11 +4171,19 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
   ]);
   const results = pendingPage.results;
   const runningResults = runningPage.results;
-  if (pendingPage.truncated || runningPage.truncated) {
+  lastPendingQueueSnapshot = snapshotPendingQueue(results, pendingPage.truncated);
+  const paginationTruncated = pendingPage.truncated || runningPage.truncated;
+  const warningNowMs = Date.now();
+  if (shouldWarnQueueTruncation(
+    paginationTruncated,
+    warningNowMs,
+    lastQueueTruncationWarningAtMs,
+  )) {
     console.warn(
-      "Task queue enumeration contains a >=50-entry same-millisecond timestamp bucket; " +
-      "queue depth is a lower bound, but repeated claims remain starvation-free",
+      "Task queue pagination is truncated by a >=50-entry same-millisecond updated_at bucket; " +
+      "claiming continues from visible rows and affected enumeration counts are lower bounds",
     );
+    lastQueueTruncationWarningAtMs = warningNowMs;
   }
 
   // Orchestrator v1 tasks (broker-submitted, tagged "orch-v1") are dispatched
@@ -4178,7 +4194,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
   const dispatchableResults = results.filter(
     (r) => !r.tags.includes("orch-v1"),
   );
-  const queueDepth = results.filter((result) => result.key === "status").length;
+  const queueDepth = lastPendingQueueSnapshot.pendingCount;
 
   // Select the next eligible task respecting Group/Sequence ordering (FIFO within eligible set)
   const taskResult = selectNextTask(dispatchableResults, runningResults);
@@ -4570,6 +4586,14 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     console.log(`Failed to claim ${taskNs} (concurrent claim?):`, err);
     return { hadTask: false, queueDepth };
   }
+
+  // The selected status is now running. Keep /health accurate while the task
+  // executes instead of reporting the accepted claim as still pending.
+  lastPendingQueueSnapshot = snapshotPendingQueueAfterClaim(
+    results,
+    pendingPage.truncated,
+    taskNs,
+  );
 
   currentTask = taskNs;
   currentCancellation = null;
@@ -6420,7 +6444,6 @@ async function pollLoop(): Promise<void> {
 
   let pollCount = 0;
   while (!shuttingDown) {
-    let queueDepth = 0;
     try {
       pollCount++;
       await flushVersionDriftFiringState();
@@ -6430,19 +6453,17 @@ async function pollLoop(): Promise<void> {
       const processedResume = await processResumeRequests();
       const processedApproval = await processApprovalDecisions();
       const poll = await pollOnce();
-      queueDepth = poll.queueDepth;
-      lastQueueDepth = queueDepth;
       if (pollCount % 5 === 0) {
         await reconcileBlockedTasks();
       }
       lastBlockedTaskCount = await countTasksWithLifecycle("blocked");
       // Fire-and-forget heartbeat
-      emitHeartbeat(queueDepth, lastBlockedTaskCount);
+      emitHeartbeat(lastBlockedTaskCount);
       if ((processedCancellation || processedResume || processedApproval || poll.hadTask) && !shuttingDown) continue; // Check for more immediately
     } catch (err) {
       console.error("Poll error:", err);
       // Still emit heartbeat on error
-      emitHeartbeat(queueDepth, lastBlockedTaskCount);
+      emitHeartbeat(lastBlockedTaskCount);
     }
 
     // Wait for next poll
@@ -6471,7 +6492,7 @@ app.get("/health", (_req, res) => {
     process_instance_id: processInstanceId,
     current_task: currentTask,
     polling: !shuttingDown,
-    queue_depth: lastQueueDepth,
+    ...buildQueueObservabilityFields(lastPendingQueueSnapshot),
     blocked_tasks: lastBlockedTaskCount,
     ollama_hosts: getHostStatus(),
     egress_policy: {

--- a/src/queue-observability.ts
+++ b/src/queue-observability.ts
@@ -61,9 +61,21 @@ export function snapshotPendingQueueAfterClaim(
   paginationTruncated: boolean,
   claimedNamespace: string,
 ): PendingQueueSnapshot {
+  return snapshotPendingQueueAfterDeparture(
+    results,
+    paginationTruncated,
+    claimedNamespace,
+  );
+}
+
+export function snapshotPendingQueueAfterDeparture(
+  results: MuninQueryResult[],
+  paginationTruncated: boolean,
+  departedNamespace: string,
+): PendingQueueSnapshot {
   return snapshotPendingQueue(
     results.filter((result) =>
-      result.key !== "status" || result.namespace !== claimedNamespace
+      result.key !== "status" || result.namespace !== departedNamespace
     ),
     paginationTruncated,
   );

--- a/src/queue-observability.ts
+++ b/src/queue-observability.ts
@@ -1,0 +1,92 @@
+import type { MuninQueryResult } from "./munin-client.js";
+
+export const QUEUE_TRUNCATION_WARNING_INTERVAL_MS = 5 * 60 * 1000;
+
+export interface PendingQueueSnapshot {
+  pendingCount: number;
+  /** undefined means empty; null means a pending row had an invalid timestamp. */
+  oldestPendingCreatedAt?: string | null;
+  paginationTruncated: boolean;
+}
+
+export interface QueueObservabilityFields {
+  queue_depth: number;
+  queue_depth_lower_bound: number;
+  oldest_pending_age_s: number | null;
+  pagination_truncated: boolean;
+}
+
+export function shouldWarnQueueTruncation(
+  paginationTruncated: boolean,
+  nowMs: number,
+  lastWarningAtMs: number | null,
+): boolean {
+  if (!paginationTruncated) return false;
+  return lastWarningAtMs === null ||
+    nowMs - lastWarningAtMs >= QUEUE_TRUNCATION_WARNING_INTERVAL_MS;
+}
+
+export function snapshotPendingQueue(
+  results: MuninQueryResult[],
+  paginationTruncated: boolean,
+): PendingQueueSnapshot {
+  const pending = results.filter((result) => result.key === "status");
+  let oldestPendingCreatedAt: string | undefined;
+  let oldestEpochMs = Number.POSITIVE_INFINITY;
+
+  for (const result of pending) {
+    const epochMs = Date.parse(result.created_at);
+    if (!Number.isFinite(epochMs)) {
+      return {
+        pendingCount: pending.length,
+        oldestPendingCreatedAt: null,
+        paginationTruncated,
+      };
+    }
+    if (epochMs < oldestEpochMs) {
+      oldestEpochMs = epochMs;
+      oldestPendingCreatedAt = result.created_at;
+    }
+  }
+
+  return {
+    pendingCount: pending.length,
+    ...(oldestPendingCreatedAt ? { oldestPendingCreatedAt } : {}),
+    paginationTruncated,
+  };
+}
+
+export function snapshotPendingQueueAfterClaim(
+  results: MuninQueryResult[],
+  paginationTruncated: boolean,
+  claimedNamespace: string,
+): PendingQueueSnapshot {
+  return snapshotPendingQueue(
+    results.filter((result) =>
+      result.key !== "status" || result.namespace !== claimedNamespace
+    ),
+    paginationTruncated,
+  );
+}
+
+export function buildQueueObservabilityFields(
+  snapshot: PendingQueueSnapshot,
+  nowMs: number = Date.now(),
+): QueueObservabilityFields {
+  let oldestPendingAgeSeconds: number | null = 0;
+  if (snapshot.oldestPendingCreatedAt === null) {
+    oldestPendingAgeSeconds = null;
+  } else if (snapshot.oldestPendingCreatedAt !== undefined) {
+    oldestPendingAgeSeconds = Math.max(
+      0,
+      Math.floor((nowMs - Date.parse(snapshot.oldestPendingCreatedAt)) / 1000),
+    );
+  }
+
+  return {
+    queue_depth: snapshot.pendingCount,
+    queue_depth_lower_bound: snapshot.pendingCount,
+    oldest_pending_age_s: oldestPendingAgeSeconds,
+    pagination_truncated: snapshot.paginationTruncated,
+  };
+}

--- a/src/task-helpers.ts
+++ b/src/task-helpers.ts
@@ -116,7 +116,10 @@ function compareTaskClaimOrder(
 ): number {
   const aCreatedAtMs = Date.parse(a.created_at);
   const bCreatedAtMs = Date.parse(b.created_at);
-  if (Number.isFinite(aCreatedAtMs) && Number.isFinite(bCreatedAtMs)) {
+  const aCreatedAtValid = Number.isFinite(aCreatedAtMs);
+  const bCreatedAtValid = Number.isFinite(bCreatedAtMs);
+  if (aCreatedAtValid !== bCreatedAtValid) return aCreatedAtValid ? -1 : 1;
+  if (aCreatedAtValid && bCreatedAtValid) {
     if (aCreatedAtMs !== bCreatedAtMs) return aCreatedAtMs - bCreatedAtMs;
   } else if (a.created_at !== b.created_at) {
     return a.created_at < b.created_at ? -1 : 1;

--- a/src/task-helpers.ts
+++ b/src/task-helpers.ts
@@ -110,9 +110,23 @@ export function extractTaskId(namespace: string): string {
   return namespace.replace(/^tasks\//, "");
 }
 
+function compareTaskClaimOrder(
+  a: MuninQueryResult,
+  b: MuninQueryResult,
+): number {
+  const aCreatedAtMs = Date.parse(a.created_at);
+  const bCreatedAtMs = Date.parse(b.created_at);
+  if (Number.isFinite(aCreatedAtMs) && Number.isFinite(bCreatedAtMs)) {
+    if (aCreatedAtMs !== bCreatedAtMs) return aCreatedAtMs - bCreatedAtMs;
+  } else if (a.created_at !== b.created_at) {
+    return a.created_at < b.created_at ? -1 : 1;
+  }
+  return a.namespace < b.namespace ? -1 : a.namespace > b.namespace ? 1 : 0;
+}
+
 /**
  * Select the oldest pending task from a batch of query results (FIFO ordering).
- * Filters to key === "status" entries and sorts by created_at ascending.
+ * Filters to key === "status" entries and orders by (created_at, namespace).
  */
 export function pickEarliestTask(
   results: MuninQueryResult[],
@@ -120,7 +134,7 @@ export function pickEarliestTask(
   const statusEntries = results.filter((r) => r.key === "status");
   if (statusEntries.length === 0) return undefined;
   return statusEntries.reduce((earliest, r) =>
-    r.created_at < earliest.created_at ? r : earliest,
+    compareTaskClaimOrder(r, earliest) < 0 ? r : earliest,
   );
 }
 
@@ -157,13 +171,11 @@ export function selectNextTask(
   pendingTasks: MuninQueryResult[],
   runningTasks: MuninQueryResult[],
 ): MuninQueryResult | undefined {
-  // Work in FIFO order (earliest first)
+  // Work in deterministic FIFO order (earliest first, then stable task namespace)
   const statusEntries = pendingTasks.filter((r) => r.key === "status");
   if (statusEntries.length === 0) return undefined;
 
-  const sorted = [...statusEntries].sort((a, b) =>
-    a.created_at < b.created_at ? -1 : a.created_at > b.created_at ? 1 : 0,
-  );
+  const sorted = [...statusEntries].sort(compareTaskClaimOrder);
 
   for (const candidate of sorted) {
     const group = parseGroupField(candidate.content_preview);

--- a/tests/fifo-dispatch.test.ts
+++ b/tests/fifo-dispatch.test.ts
@@ -19,6 +19,14 @@ function makeResult(
   };
 }
 
+function permutations<T>(items: T[]): T[][] {
+  if (items.length <= 1) return [items];
+  return items.flatMap((item, index) =>
+    permutations(items.filter((_, candidateIndex) => candidateIndex !== index))
+      .map((rest) => [item, ...rest]),
+  );
+}
+
 describe("pickEarliestTask", () => {
   it("returns undefined for an empty result set", () => {
     expect(pickEarliestTask([])).toBeUndefined();
@@ -77,5 +85,28 @@ describe("pickEarliestTask", () => {
     const later = makeResult("tasks/b/", "2026-04-08T10:00:00.456Z");
 
     expect(pickEarliestTask([later, earlier])).toBe(earlier);
+  });
+
+  it("ranks valid timestamps before malformed timestamps across all input permutations", () => {
+    const validEarlier = makeResult(
+      "tasks/valid-earlier",
+      "2026-01-01T10:00:00+02:00",
+    );
+    const validLater = makeResult(
+      "tasks/valid-later",
+      "2026-01-01T09:00:00Z",
+    );
+    const malformedBetweenLexically = makeResult(
+      "tasks/malformed",
+      "2026-01-01T09:30:00Z invalid",
+    );
+
+    for (const ordering of permutations([
+      validEarlier,
+      validLater,
+      malformedBetweenLexically,
+    ])) {
+      expect(pickEarliestTask(ordering)).toBe(validEarlier);
+    }
   });
 });

--- a/tests/fifo-dispatch.test.ts
+++ b/tests/fifo-dispatch.test.ts
@@ -59,15 +59,17 @@ describe("pickEarliestTask", () => {
     expect(pickEarliestTask([metaEntry, newTask, oldTask])).toBe(oldTask);
   });
 
-  it("is stable: returns the first-encountered entry when timestamps are equal", () => {
+  it("breaks equal-created_at ties by stable namespace regardless of input order", () => {
     const sameTime = "2026-01-01T09:00:00Z";
-    const first = makeResult("tasks/first/", sameTime);
-    const second = makeResult("tasks/second/", sameTime);
+    const alphabeticallyFirst = makeResult("tasks/a-task", sameTime);
+    const alphabeticallySecond = makeResult("tasks/z-task", sameTime);
 
-    // When timestamps are equal the reduce keeps the first-seen entry
-    // (the `<` comparison is strict, so ties stay with the accumulator)
-    expect(pickEarliestTask([first, second])).toBe(first);
-    expect(pickEarliestTask([second, first])).toBe(second);
+    expect(pickEarliestTask([alphabeticallyFirst, alphabeticallySecond])).toBe(
+      alphabeticallyFirst,
+    );
+    expect(pickEarliestTask([alphabeticallySecond, alphabeticallyFirst])).toBe(
+      alphabeticallyFirst,
+    );
   });
 
   it("handles millisecond-precision ISO timestamps correctly", () => {

--- a/tests/munin-pagination.test.ts
+++ b/tests/munin-pagination.test.ts
@@ -118,9 +118,13 @@ describe("queryAllMuninEntries", () => {
     expect(claimedOnPoll).toBe(1);
   });
 
-  it("reports an unpageable 50-row exact timestamp bucket as truncated", async () => {
+  it("reports an overflowing timestamp bucket without skipping older visible tasks", async () => {
     const timestamp = "2026-07-12T12:00:00.000Z";
-    const rows = Array.from({ length: 60 }, (_, index) => makeTask(index, timestamp));
+    const older = makeTask(100, "2026-07-12T11:59:59.999Z");
+    const rows = [
+      ...Array.from({ length: 60 }, (_, index) => makeTask(index, timestamp)),
+      older,
+    ];
     const munin = new FilterOnlyMunin(rows);
 
     const result = await queryAllMuninEntries(munin as unknown as MuninClient, {
@@ -130,7 +134,9 @@ describe("queryAllMuninEntries", () => {
     });
 
     expect(result.truncated).toBe(true);
-    expect(result.results).toHaveLength(50);
+    expect(result.results).toHaveLength(51);
+    expect(result.results).toContain(older);
+    expect(selectNextTask(result.results, [])).toBe(older);
     expect(munin.calls).toContainEqual(expect.objectContaining({
       since: timestamp,
       until: timestamp,

--- a/tests/queue-observability.test.ts
+++ b/tests/queue-observability.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import type { MuninQueryResult } from "../src/munin-client.js";
+import {
+  buildQueueObservabilityFields,
+  QUEUE_TRUNCATION_WARNING_INTERVAL_MS,
+  shouldWarnQueueTruncation,
+  snapshotPendingQueue,
+  snapshotPendingQueueAfterClaim,
+} from "../src/queue-observability.js";
+
+function makeEntry(
+  namespace: string,
+  createdAt: string,
+  key: string = "status",
+): MuninQueryResult {
+  return {
+    id: `id-${namespace}-${key}`,
+    namespace,
+    key,
+    entry_type: "state",
+    content_preview: "must not appear in observability",
+    tags: ["pending"],
+    created_at: createdAt,
+    updated_at: createdAt,
+  };
+}
+
+describe("pending queue observability", () => {
+  it("projects content-blind pending count and advancing oldest age", () => {
+    const snapshot = snapshotPendingQueue([
+      makeEntry("tasks/newer", "2026-07-21T20:04:00.000Z"),
+      makeEntry("tasks/oldest", "2026-07-21T20:00:00.000Z"),
+      makeEntry("tasks/oldest", "2026-07-21T19:00:00.000Z", "result"),
+    ], false);
+
+    expect(buildQueueObservabilityFields(
+      snapshot,
+      Date.parse("2026-07-21T20:05:00.000Z"),
+    )).toEqual({
+      queue_depth: 2,
+      queue_depth_lower_bound: 2,
+      oldest_pending_age_s: 300,
+      pagination_truncated: false,
+    });
+  });
+
+  it("reports an empty queue with zero age", () => {
+    const snapshot = snapshotPendingQueue([], false);
+
+    expect(buildQueueObservabilityFields(snapshot, Date.now())).toEqual({
+      queue_depth: 0,
+      queue_depth_lower_bound: 0,
+      oldest_pending_age_s: 0,
+      pagination_truncated: false,
+    });
+  });
+
+  it("removes an accepted claim from the live pending count and oldest age", () => {
+    const oldest = makeEntry("tasks/oldest", "2026-07-21T20:00:00.000Z");
+    const remaining = makeEntry("tasks/remaining", "2026-07-21T20:04:00.000Z");
+
+    const snapshot = snapshotPendingQueueAfterClaim(
+      [oldest, remaining],
+      false,
+      oldest.namespace,
+    );
+
+    expect(buildQueueObservabilityFields(
+      snapshot,
+      Date.parse("2026-07-21T20:05:00.000Z"),
+    )).toMatchObject({
+      queue_depth: 1,
+      oldest_pending_age_s: 60,
+    });
+  });
+
+  it("marks the visible pending count as a lower bound when pagination truncates", () => {
+    const snapshot = snapshotPendingQueue([
+      makeEntry("tasks/visible", "2026-07-21T20:00:00.000Z"),
+    ], true);
+
+    expect(buildQueueObservabilityFields(
+      snapshot,
+      Date.parse("2026-07-21T20:00:01.000Z"),
+    )).toMatchObject({
+      queue_depth: 1,
+      queue_depth_lower_bound: 1,
+      oldest_pending_age_s: 1,
+      pagination_truncated: true,
+    });
+  });
+
+  it("rate-limits warnings while an overflowing timestamp bucket persists", () => {
+    const firstWarningAt = Date.parse("2026-07-21T20:00:00.000Z");
+
+    expect(shouldWarnQueueTruncation(true, firstWarningAt, null)).toBe(true);
+    expect(shouldWarnQueueTruncation(
+      true,
+      firstWarningAt + QUEUE_TRUNCATION_WARNING_INTERVAL_MS - 1,
+      firstWarningAt,
+    )).toBe(false);
+    expect(shouldWarnQueueTruncation(
+      true,
+      firstWarningAt + QUEUE_TRUNCATION_WARNING_INTERVAL_MS,
+      firstWarningAt,
+    )).toBe(true);
+    expect(shouldWarnQueueTruncation(false, firstWarningAt, null)).toBe(false);
+  });
+});

--- a/tests/queue-observability.test.ts
+++ b/tests/queue-observability.test.ts
@@ -6,6 +6,7 @@ import {
   shouldWarnQueueTruncation,
   snapshotPendingQueue,
   snapshotPendingQueueAfterClaim,
+  snapshotPendingQueueAfterDeparture,
 } from "../src/queue-observability.js";
 
 function makeEntry(
@@ -71,6 +72,42 @@ describe("pending queue observability", () => {
     )).toMatchObject({
       queue_depth: 1,
       oldest_pending_age_s: 60,
+    });
+  });
+
+  it("removes a cancelled task from the pending snapshot", () => {
+    const cancelled = makeEntry("tasks/cancelled", "2026-07-21T20:00:00.000Z");
+    const remaining = makeEntry("tasks/remaining", "2026-07-21T20:04:00.000Z");
+
+    const snapshot = snapshotPendingQueueAfterDeparture(
+      [cancelled, remaining],
+      false,
+      cancelled.namespace,
+    );
+
+    expect(buildQueueObservabilityFields(snapshot)).toMatchObject({
+      queue_depth: 1,
+      queue_depth_lower_bound: 1,
+    });
+  });
+
+  it("removes a task transitioned to awaiting approval from the pending snapshot", () => {
+    const awaitingApproval = makeEntry(
+      "tasks/awaiting-approval",
+      "2026-07-21T20:00:00.000Z",
+    );
+
+    const snapshot = snapshotPendingQueueAfterDeparture(
+      [awaitingApproval],
+      false,
+      awaitingApproval.namespace,
+    );
+
+    expect(buildQueueObservabilityFields(snapshot)).toEqual({
+      queue_depth: 0,
+      queue_depth_lower_bound: 0,
+      oldest_pending_age_s: 0,
+      pagination_truncated: false,
     });
   });
 

--- a/tests/select-next-task.test.ts
+++ b/tests/select-next-task.test.ts
@@ -38,6 +38,14 @@ function makeRunning(
 
 const NO_RUNNING: MuninQueryResult[] = [];
 
+function permutations<T>(items: T[]): T[][] {
+  if (items.length <= 1) return [items];
+  return items.flatMap((item, index) =>
+    permutations(items.filter((_, candidateIndex) => candidateIndex !== index))
+      .map((rest) => [item, ...rest]),
+  );
+}
+
 describe("parseGroupField", () => {
   it("returns undefined when no Group field", () => {
     expect(parseGroupField("**Runtime:** claude\n**Prompt:** do stuff")).toBeUndefined();
@@ -109,6 +117,29 @@ describe("selectNextTask", () => {
       [alphabeticallySecond, alphabeticallyFirst],
       NO_RUNNING,
     )).toBe(alphabeticallyFirst);
+  });
+
+  it("selects the earliest valid timestamp across every malformed-timestamp permutation", () => {
+    const validEarlier = makeTask(
+      "tasks/valid-earlier",
+      "2026-01-01T10:00:00+02:00",
+    );
+    const validLater = makeTask(
+      "tasks/valid-later",
+      "2026-01-01T09:00:00Z",
+    );
+    const malformedBetweenLexically = makeTask(
+      "tasks/malformed",
+      "2026-01-01T09:30:00Z invalid",
+    );
+
+    for (const ordering of permutations([
+      validEarlier,
+      validLater,
+      malformedBetweenLexically,
+    ])) {
+      expect(selectNextTask(ordering, NO_RUNNING)).toBe(validEarlier);
+    }
   });
 
   it("dispatches a grouped task with Sequence 1 when no other group members exist", () => {

--- a/tests/select-next-task.test.ts
+++ b/tests/select-next-task.test.ts
@@ -84,6 +84,33 @@ describe("selectNextTask", () => {
     expect(selectNextTask([newer, old], NO_RUNNING)).toBe(old);
   });
 
+  it("breaks equal-created_at ties by stable namespace regardless of input order", () => {
+    const sameTime = "2026-01-01T08:00:00.123Z";
+    const alphabeticallyFirst = makeTask("tasks/a-task", sameTime);
+    const alphabeticallySecond = makeTask("tasks/z-task", sameTime);
+
+    expect(selectNextTask(
+      [alphabeticallySecond, alphabeticallyFirst],
+      NO_RUNNING,
+    )).toBe(alphabeticallyFirst);
+  });
+
+  it("treats offset representations of the same millisecond as an equal-time tie", () => {
+    const alphabeticallyFirst = makeTask(
+      "tasks/a-task",
+      "2026-01-01T10:00:00.123+01:00",
+    );
+    const alphabeticallySecond = makeTask(
+      "tasks/z-task",
+      "2026-01-01T09:00:00.123Z",
+    );
+
+    expect(selectNextTask(
+      [alphabeticallySecond, alphabeticallyFirst],
+      NO_RUNNING,
+    )).toBe(alphabeticallyFirst);
+  });
+
   it("dispatches a grouped task with Sequence 1 when no other group members exist", () => {
     const content = "**Group:** batch-a\n**Sequence:** 1\n**Runtime:** claude";
     const task = makeTask("tasks/seq1/", "2026-01-01T08:00:00Z", content);


### PR DESCRIPTION
## Summary

Finishes the remaining hardening for #190 on top of the core repair merged in PR #193:

- **Deterministic equal-time ordering** — selection tuple `(created_at ASC, namespace ASC)`, including equivalence across timezone representations of the same instant.
- **Starvation observability** — content-blind pending count, lower-bound count, oldest-pending-age, and pagination-truncation flags exposed in health + heartbeat (`src/queue-observability.ts`).
- **Safe truncated-bucket behavior** — when ≥50 rows share one millisecond, the dispatcher continues into older buckets with rate-limited warnings instead of silently skipping old work; composite-cursor follow-up design documented in `docs/scheduling-fifo-hardening.md`.

## Validation

- Red/green TDD; focused suites 4 files / 36 tests; **full suite 146 files / 2,262 tests green**; TypeScript build; `git diff --check`.
- Independently re-verified in a fresh shell by mission control (24 focused tests re-run green).
- Empirical grounding: the overnight discrete-event simulation (8,800 runs, M/M/1-validated ≤2.15% error) shows the historical newest-50 policy claimed **0/500** aged tasks under continuous arrivals while complete-window FIFO claimed all 500 with zero bypasses. Full evidence: `~/mimir/research/hugin-overnight-2026-07-21/REPORT.md`.

## Deliberately not done

No Munin API redesign (composite cursor is a documented follow-up), no deployment changes, no STATUS.md changes.

Part of the 2026-07-21 overnight R&D mission. Implementation: Codex (gpt-5.6-sol); orchestration + independent verification: Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)