### PR TITLE
feat(learning): bounded exact idempotent recovery after ambiguous stamped M5 responses (#246)

### DIFF
--- a/docs/learning-task-handshake.md
+++ b/docs/learning-task-handshake.md
@@ -111,6 +111,18 @@ reported as outcome-persistence failure without an `attemptOutcomeRef`; startup
 continues with the ordinary failed task result rather than pointing at an
 unusable row.
 
+After an eligible stamped request gets an ambiguous transport failure or a
+non-backpressure 5xx without an authoritative echo, Hugin also makes one
+immediate, short-timeout probe through this same stored-row validation path.
+The probe reuses the byte-identical classified replay payload and every original
+task, attempt, request, idempotency, principal, namespace, and stamp identity.
+Only an authenticated exact stored-admission recovery may improve the admission
+join. Missing, malformed, mismatched, unavailable, or fresh/non-recovery
+responses leave the original `transport-not-admitted` evidence unchanged.
+This improves evidence coverage only: the ambiguous task remains failed, and
+neither the ambiguous response nor the recovery response supplies trusted task
+output or provenance. Normal 429/503 backpressure never enters this probe path.
+
 This contract does not create the learning registry, choose a model, or promote
 evidence. Those remain Hugin #232 and Gille policy/capture responsibilities.
 

--- a/src/homeserver-executor.ts
+++ b/src/homeserver-executor.ts
@@ -34,6 +34,7 @@ import {
   learningTaskExecutionEvidenceSchema,
   requestStampDigest,
   validateLearningTaskGatewayEcho,
+  validatePreparedLearningTaskOutcome,
   validateLearningTaskReplayPayload,
   type LearningTaskExecutionEvidence,
   type LearningTaskPreparation,
@@ -137,6 +138,14 @@ export interface HomeserverExecutorResult {
 
 export interface HomeserverExecutorOptions {
   abortController?: AbortController;
+  /**
+   * Storage-aware, success-only probe for a stamped request whose admission is
+   * ambiguous. Implementations must return null unless exact recovery proves
+   * admission; failures leave the original transport evidence untouched.
+   */
+  recoverAmbiguousLearningTask?: (
+    failureEvidence: LearningTaskExecutionEvidence,
+  ) => Promise<LearningTaskExecutionEvidence | null>;
 }
 
 export interface HomeserverGatewayConfig {
@@ -413,6 +422,33 @@ export async function executeHomeserverTask(
   const headers: Record<string, string> = { "Content-Type": "application/json" };
   if (task.apiKey) headers.Authorization = `Bearer ${task.apiKey}`;
 
+  const recoverAmbiguousLearningTask = async (): Promise<void> => {
+    const original = result.learningTask;
+    if (!options?.recoverAmbiguousLearningTask
+      || !original
+      || original.state !== "m5-not-admitted"
+      || original.evidenceAccepted
+      || original.failureCode !== "transport-not-admitted"
+      || task.learningTask?.kind !== "ready") {
+      return;
+    }
+    try {
+      const recovered = await options.recoverAmbiguousLearningTask(original);
+      if (!recovered
+        || recovered.state !== "m5-admitted"
+        || !recovered.evidenceAccepted) {
+        return;
+      }
+      result.learningTask = validatePreparedLearningTaskOutcome(
+        task.learningTask.preparedDispatch,
+        learningTaskExecutionEvidenceSchema.parse(recovered),
+      );
+    } catch {
+      // Recovery is evidence enrichment only. Its absence or rejection must
+      // not replace the truthful failure recorded for the original request.
+    }
+  };
+
   try {
     if (task.path === "delegate" && task.learningTask?.kind === "preflight-failed") {
       const { attempt, attemptStartRef, failureReason } = task.learningTask;
@@ -513,8 +549,37 @@ export async function executeHomeserverTask(
 
     if (!res.ok) {
       const errText = await res.text().catch(() => "");
-      appendOutput(`[Gateway HTTP ${res.status}] ${errText}\n`);
       result.exitCode = res.status; // surface 401/403/400 as the exit code
+      const eligibleStamped5xx = res.status >= 500
+        && task.path === "delegate"
+        && task.learningTask?.kind === "ready";
+      if (eligibleStamped5xx) {
+        let authoritativeEchoAccepted = false;
+        try {
+          const raw = JSON.parse(errText) as { learningTaskGatewayEcho?: unknown };
+          const gatewayEcho = validateLearningTaskGatewayEcho(
+            raw.learningTaskGatewayEcho,
+            body.learningTaskStamp!,
+          );
+          result.learningTask = learningTaskExecutionEvidenceSchema.parse({
+            ...result.learningTask!,
+            state: "m5-admitted",
+            evidenceAccepted: true,
+            gatewayEcho,
+            gatewayEchoDigest: gatewayEchoDigest(gatewayEcho),
+            failureCode: undefined,
+            failureReason: undefined,
+          });
+          authoritativeEchoAccepted = true;
+        } catch {
+          // Missing/malformed/mismatched 5xx evidence is the ambiguity that
+          // the single exact-recovery probe is allowed to investigate.
+        }
+        if (!authoritativeEchoAccepted) await recoverAmbiguousLearningTask();
+        appendOutput(`[Gateway HTTP ${res.status}]\n`);
+      } else {
+        appendOutput(`[Gateway HTTP ${res.status}] ${errText}\n`);
+      }
       return finish();
     }
 
@@ -524,7 +589,23 @@ export async function executeHomeserverTask(
       // anything out of contract, so a buggy or hostile gateway value cannot
       // throw inside the downstream buildStructuredTaskResult .parse() and lose
       // the result of an already-paid run.
-      const raw: unknown = await res.json();
+      let raw: unknown;
+      try {
+        raw = await res.json();
+      } catch (error) {
+        if (task.learningTask?.kind !== "ready" || !(error instanceof SyntaxError)) throw error;
+        const reason = "gateway returned malformed JSON without an exact admission echo";
+        result.learningTask = learningTaskExecutionEvidenceSchema.parse({
+          ...result.learningTask!,
+          state: "join-failed",
+          evidenceAccepted: false,
+          failureCode: "gateway-echo-invalid",
+          failureReason: reason,
+        });
+        appendOutput(`[LearningTaskContract join rejected: ${reason}]\n`);
+        result.exitCode = 1;
+        return finish();
+      }
       if (task.learningTask?.kind === "ready") {
         const stamp = body.learningTaskStamp!;
         let gatewayEcho;
@@ -666,6 +747,7 @@ export async function executeHomeserverTask(
           ? "gateway request timed out before an exact admission echo"
           : "gateway request failed before an exact admission echo",
       });
+      await recoverAmbiguousLearningTask();
     }
     if (err instanceof Error && err.name === "AbortError") {
       result.exitCode = "TIMEOUT";

--- a/src/homeserver-executor.ts
+++ b/src/homeserver-executor.ts
@@ -425,6 +425,7 @@ export async function executeHomeserverTask(
   const recoverAmbiguousLearningTask = async (): Promise<void> => {
     const original = result.learningTask;
     if (!options?.recoverAmbiguousLearningTask
+      || options.abortController?.signal.aborted
       || !original
       || original.state !== "m5-not-admitted"
       || original.evidenceAccepted

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,7 @@ import {
   type LearningTaskSource,
 } from "./learning-task-handshake.js";
 import {
+  recoverAmbiguousStoredLearningTaskCandidate,
   recoverLatestStoredLearningTaskAttempt,
   type RecoveredStoredLearningTask,
 } from "./learning-task-recovery.js";
@@ -5218,7 +5219,22 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
       homeserverResult = await executeHomeserverTask({
         ...homeserverTaskConfig,
         learningTask: preparedLearningTask?.preparation ?? { kind: "ineligible" },
-      }, taskId, LOG_DIR, { abortController: homeserverAbort });
+      }, taskId, LOG_DIR, {
+        abortController: homeserverAbort,
+        recoverAmbiguousLearningTask: async (failureEvidence) => {
+          const preparation = preparedLearningTask?.preparation;
+          if (preparation?.kind !== "ready") return null;
+          const recovered = await recoverAmbiguousStoredLearningTaskCandidate({
+            munin,
+            taskNamespace: taskNs,
+            taskClassification,
+            preparedDispatchRef: preparation.preparedDispatch.preparedDispatchRef,
+            failureEvidence,
+            gateway,
+          });
+          return recovered?.evidence ?? null;
+        },
+      });
       if (homeserverResult.learningTask && learningAttemptKey) {
         const outcomeKey = `${learningAttemptKey}-outcome`;
         const attemptOutcomeRef = { namespace: taskNs, key: outcomeKey };

--- a/src/index.ts
+++ b/src/index.ts
@@ -5223,7 +5223,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         abortController: homeserverAbort,
         recoverAmbiguousLearningTask: async (failureEvidence) => {
           const preparation = preparedLearningTask?.preparation;
-          if (preparation?.kind !== "ready") return null;
+          if (homeserverAbort.signal.aborted || preparation?.kind !== "ready") return null;
           const recovered = await recoverAmbiguousStoredLearningTaskCandidate({
             munin,
             taskNamespace: taskNs,
@@ -5231,6 +5231,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
             preparedDispatchRef: preparation.preparedDispatch.preparedDispatchRef,
             failureEvidence,
             gateway,
+            signal: homeserverAbort.signal,
           });
           return recovered?.evidence ?? null;
         },

--- a/src/learning-task-handshake.ts
+++ b/src/learning-task-handshake.ts
@@ -1174,6 +1174,8 @@ export async function recoverPreparedLearningTaskDispatch(input: {
   replayPayload: unknown;
   gatewayBaseUrl: string;
   apiKey: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
   fetchImpl?: typeof fetch;
 }): Promise<LearningTaskExecutionEvidence> {
   const prepared = preparedLearningTaskDispatchSchema.parse(input.prepared);
@@ -1190,7 +1192,8 @@ export async function recoverPreparedLearningTaskDispatch(input: {
         ...(input.apiKey ? { Authorization: `Bearer ${input.apiKey}` } : {}),
       },
       body: JSON.stringify(replay.requestBody),
-      signal: AbortSignal.timeout(30_000),
+      signal: input.signal
+        ?? AbortSignal.timeout(Math.min(30_000, Math.max(1, input.timeoutMs ?? 30_000))),
     });
     if (!response.ok) {
       return learningTaskRecoveryFailure(

--- a/src/learning-task-recovery.ts
+++ b/src/learning-task-recovery.ts
@@ -23,6 +23,8 @@ export interface RecoveredStoredLearningTask {
   classification?: string;
 }
 
+export const IMMEDIATE_LEARNING_TASK_RECOVERY_TIMEOUT_MS = 5_000;
+
 function sameClassification(actual: string | undefined, expected: string | undefined): boolean {
   return actual === expected;
 }
@@ -30,6 +32,179 @@ function sameClassification(actual: string | undefined, expected: string | undef
 function parseJson(content: string): unknown {
   try {
     return JSON.parse(content);
+  } catch {
+    return null;
+  }
+}
+
+async function readLearningEntryBeforeDeadline(
+  munin: MuninClient,
+  namespace: string,
+  key: string,
+  signal: AbortSignal,
+): Promise<MuninEntry | null> {
+  if (signal.aborted) return null;
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (entry: MuninEntry | null): void => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener("abort", onAbort);
+      resolve(entry);
+    };
+    const onAbort = (): void => finish(null);
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    munin.read(namespace, key, { signal, maxRetries: 0 }).then(finish, () => finish(null));
+  });
+}
+
+/**
+ * Probe one exact prepared attempt immediately after an ambiguous transport
+ * result. This deliberately performs no writes: only a fully admitted exact
+ * recovery is returned, so a failed probe cannot replace the original
+ * transport-not-admitted outcome before normal outcome persistence.
+ */
+export async function recoverAmbiguousStoredLearningTaskCandidate(input: {
+  munin: MuninClient;
+  taskNamespace: string;
+  taskClassification?: string;
+  preparedDispatchRef: { namespace: string; key: string };
+  failureEvidence: LearningTaskExecutionEvidence;
+  gateway: { baseUrl: string; apiKey: string } | null;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}): Promise<RecoveredStoredLearningTask | null> {
+  const failure = learningTaskExecutionEvidenceSchema.safeParse(input.failureEvidence);
+  if (!failure.success
+    || failure.data.state !== "m5-not-admitted"
+    || failure.data.evidenceAccepted
+    || failure.data.failureCode !== "transport-not-admitted"
+    || !input.gateway
+    || !failure.data.preparedDispatchRef
+    || input.preparedDispatchRef.namespace !== input.taskNamespace
+    || input.preparedDispatchRef.namespace !== failure.data.preparedDispatchRef.namespace
+    || input.preparedDispatchRef.key !== failure.data.preparedDispatchRef.key) {
+    return null;
+  }
+  const timeoutMs = Math.min(
+    IMMEDIATE_LEARNING_TASK_RECOVERY_TIMEOUT_MS,
+    Math.max(1, input.timeoutMs ?? IMMEDIATE_LEARNING_TASK_RECOVERY_TIMEOUT_MS),
+  );
+  const signal = AbortSignal.timeout(timeoutMs);
+  const preparedEntry = await readLearningEntryBeforeDeadline(
+    input.munin,
+    input.preparedDispatchRef.namespace,
+    input.preparedDispatchRef.key,
+    signal,
+  );
+  if (!preparedEntry
+    || signal.aborted
+    || !sameClassification(preparedEntry.classification, input.taskClassification)) {
+    return null;
+  }
+  const parsedPrepared = preparedLearningTaskDispatchSchema.safeParse(
+    parseJson(preparedEntry.content),
+  );
+  if (!parsedPrepared.success) return null;
+  const prepared = parsedPrepared.data;
+  if (prepared.taskId !== input.taskNamespace.replace(/^tasks\//, "")
+    || prepared.preparedDispatchRef.namespace !== preparedEntry.namespace
+    || prepared.preparedDispatchRef.key !== preparedEntry.key) {
+    return null;
+  }
+
+  const attemptStartEntry = await readLearningEntryBeforeDeadline(
+    input.munin,
+    prepared.attemptStartRef.namespace,
+    prepared.attemptStartRef.key,
+    signal,
+  );
+  if (!attemptStartEntry
+    || signal.aborted
+    || !sameClassification(attemptStartEntry.classification, input.taskClassification)) {
+    return null;
+  }
+  let attemptStart: DurableLearningTaskAttemptStart;
+  try {
+    attemptStart = validatePreparedLearningTaskAttemptStart(
+      prepared,
+      parseJson(attemptStartEntry.content),
+    );
+  } catch {
+    return null;
+  }
+
+  const replayEntry = await readLearningEntryBeforeDeadline(
+    input.munin,
+    prepared.replayPayloadRef.namespace,
+    prepared.replayPayloadRef.key,
+    signal,
+  );
+  if (!replayEntry
+    || signal.aborted
+    || !sameClassification(replayEntry.classification, input.taskClassification)) {
+    return null;
+  }
+  let replay: ReturnType<typeof validatePreparedLearningTaskReplayPayload>;
+  try {
+    replay = validatePreparedLearningTaskReplayPayload(
+      prepared,
+      parseJson(replayEntry.content),
+      attemptStart,
+    );
+    const boundFailure = failure.data.attemptOutcomeRef
+      ? failure.data
+      : { ...failure.data, attemptOutcomeRef: prepared.attemptOutcomeRef };
+    validatePreparedLearningTaskOutcome(prepared, boundFailure);
+  } catch {
+    return null;
+  }
+
+  const existingOutcome = await readLearningEntryBeforeDeadline(
+    input.munin,
+    prepared.attemptOutcomeRef.namespace,
+    prepared.attemptOutcomeRef.key,
+    signal,
+  );
+  if (signal.aborted) return null;
+  if (existingOutcome) {
+    if (!sameClassification(existingOutcome.classification, input.taskClassification)) return null;
+    try {
+      const evidence = validatePreparedLearningTaskOutcome(
+        prepared,
+        learningTaskExecutionEvidenceSchema.parse(parseJson(existingOutcome.content)),
+      );
+      return evidence.state === "m5-admitted" && evidence.evidenceAccepted
+        ? {
+            evidence,
+            huginTaskIdentity: attemptStart.huginTaskIdentity,
+            classification: input.taskClassification,
+          }
+        : null;
+    } catch {
+      return null;
+    }
+  }
+
+  const evidence = await recoverPreparedLearningTaskDispatch({
+    prepared,
+    replayPayload: replay,
+    gatewayBaseUrl: input.gateway.baseUrl,
+    apiKey: input.gateway.apiKey,
+    signal,
+    fetchImpl: input.fetchImpl,
+  });
+  if (evidence.state !== "m5-admitted" || !evidence.evidenceAccepted) return null;
+  try {
+    return {
+      evidence: validatePreparedLearningTaskOutcome(prepared, evidence),
+      huginTaskIdentity: attemptStart.huginTaskIdentity,
+      classification: input.taskClassification,
+    };
   } catch {
     return null;
   }

--- a/src/learning-task-recovery.ts
+++ b/src/learning-task-recovery.ts
@@ -1,4 +1,4 @@
-import type { MuninClient, MuninEntry } from "./munin-client.js";
+import { composeAbortSignals, type MuninClient, type MuninEntry } from "./munin-client.js";
 import type { HuginTaskIdentity } from "./task-identity.js";
 import {
   learningTaskExecutionEvidenceSchema,
@@ -75,9 +75,11 @@ export async function recoverAmbiguousStoredLearningTaskCandidate(input: {
   preparedDispatchRef: { namespace: string; key: string };
   failureEvidence: LearningTaskExecutionEvidence;
   gateway: { baseUrl: string; apiKey: string } | null;
+  signal?: AbortSignal;
   timeoutMs?: number;
   fetchImpl?: typeof fetch;
 }): Promise<RecoveredStoredLearningTask | null> {
+  if (input.signal?.aborted) return null;
   const failure = learningTaskExecutionEvidenceSchema.safeParse(input.failureEvidence);
   if (!failure.success
     || failure.data.state !== "m5-not-admitted"
@@ -94,7 +96,12 @@ export async function recoverAmbiguousStoredLearningTaskCandidate(input: {
     IMMEDIATE_LEARNING_TASK_RECOVERY_TIMEOUT_MS,
     Math.max(1, input.timeoutMs ?? IMMEDIATE_LEARNING_TASK_RECOVERY_TIMEOUT_MS),
   );
-  const signal = AbortSignal.timeout(timeoutMs);
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const recoveryAbort = input.signal
+    ? composeAbortSignals([input.signal, timeoutSignal])
+    : { signal: timeoutSignal, cleanup: () => {} };
+  const signal = recoveryAbort.signal;
+  try {
   const preparedEntry = await readLearningEntryBeforeDeadline(
     input.munin,
     input.preparedDispatchRef.namespace,
@@ -207,6 +214,9 @@ export async function recoverAmbiguousStoredLearningTaskCandidate(input: {
     };
   } catch {
     return null;
+  }
+  } finally {
+    recoveryAbort.cleanup();
   }
 }
 

--- a/src/munin-client.ts
+++ b/src/munin-client.ts
@@ -41,6 +41,12 @@ export interface MuninReadRequest {
   key: string;
 }
 
+export interface MuninRequestOptions {
+  signal?: AbortSignal;
+  requestTimeoutMs?: number;
+  maxRetries?: number;
+}
+
 export type MuninReadResult =
   | (MuninEntry & { found: true })
   | { namespace: string; key: string; found: false };
@@ -78,8 +84,50 @@ export class MuninWriteRejectedError extends Error {
 
 let rpcId = 0;
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function abortReason(signal: AbortSignal): Error {
+  if (signal.reason instanceof Error) return signal.reason;
+  const error = new Error("Munin request aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  if (!signal) return new Promise((resolve) => setTimeout(resolve, ms));
+  if (signal.aborted) return Promise.reject(abortReason(signal));
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      reject(abortReason(signal));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+async function waitForRequestSlot(
+  previous: Promise<void>,
+  signal: AbortSignal,
+): Promise<boolean> {
+  if (signal.aborted) return false;
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (acquired: boolean): void => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener("abort", onAbort);
+      resolve(acquired);
+    };
+    const onAbort = (): void => finish(false);
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    previous.then(() => finish(true));
+  });
 }
 
 function parseRetryAfterMs(headerValue: string | null): number | null {
@@ -157,19 +205,29 @@ export class MuninClient {
     return this.retryBaseDelayMs * 2 ** attempt;
   }
 
-  private async withRequestSlot<T>(fn: () => Promise<T>): Promise<T> {
+  private async withRequestSlot<T>(
+    fn: () => Promise<T>,
+    signal?: AbortSignal,
+  ): Promise<T> {
     const previous = this.requestQueue;
     let release!: () => void;
     this.requestQueue = new Promise<void>((resolve) => {
       release = resolve;
     });
 
-    await previous;
+    let acquired = true;
+    if (signal) acquired = await waitForRequestSlot(previous, signal);
+    else await previous;
+    if (!acquired) {
+      // Preserve queue ordering even though this canceled caller returns now.
+      void previous.then(release);
+      throw abortReason(signal!);
+    }
 
     try {
       const waitMs = this.nextRequestAt - Date.now();
       if (waitMs > 0) {
-        await sleep(waitMs);
+        await sleep(waitMs, signal);
       }
       return await fn();
     } finally {
@@ -180,7 +238,8 @@ export class MuninClient {
 
   private async callTool(
     name: string,
-    args: Record<string, unknown>
+    args: Record<string, unknown>,
+    options: MuninRequestOptions = {},
   ): Promise<unknown> {
     return this.withRequestSlot(async () => {
       const body = {
@@ -191,9 +250,13 @@ export class MuninClient {
       };
 
       let attempt = 0;
+      const maxRetries = options.maxRetries ?? this.maxRetries;
+      const requestTimeoutMs = options.requestTimeoutMs ?? this.requestTimeoutMs;
 
       while (true) {
         try {
+          if (options.signal?.aborted) throw abortReason(options.signal);
+          const timeoutSignal = AbortSignal.timeout(requestTimeoutMs);
           const res = await fetch(`${this.baseUrl}/mcp`, {
             method: "POST",
             headers: {
@@ -203,21 +266,23 @@ export class MuninClient {
               "mcp-session-id": this.sessionId,
             },
             body: JSON.stringify(body),
-            signal: AbortSignal.timeout(this.requestTimeoutMs),
+            signal: options.signal
+              ? AbortSignal.any([options.signal, timeoutSignal])
+              : timeoutSignal,
           });
 
           if (!res.ok) {
             const text = await res.text().catch(() => "");
             const shouldRetry =
               (res.status === 429 || res.status >= 500) &&
-              attempt < this.maxRetries;
+              attempt < maxRetries;
             if (shouldRetry) {
               const retryDelayMs = this.getRetryDelayMs(
                 attempt,
                 res.headers.get("retry-after")
               );
               this.deferNextRequest(retryDelayMs);
-              await sleep(retryDelayMs);
+              await sleep(retryDelayMs, options.signal);
               attempt++;
               continue;
             }
@@ -253,30 +318,32 @@ export class MuninClient {
           }
           return rpc.result;
         } catch (err) {
-          if (attempt < this.maxRetries && isRetryableFetchError(err)) {
+          if (options.signal?.aborted) throw abortReason(options.signal);
+          if (attempt < maxRetries && isRetryableFetchError(err)) {
             const retryDelayMs = this.getRetryDelayMs(attempt, null);
             this.deferNextRequest(retryDelayMs);
-            await sleep(retryDelayMs);
+            await sleep(retryDelayMs, options.signal);
             attempt++;
             continue;
           }
           if (err instanceof Error && (err.name === "AbortError" || err.name === "TimeoutError")) {
-            throw new Error(`Munin request timed out after ${this.requestTimeoutMs}ms`);
+            throw new Error(`Munin request timed out after ${requestTimeoutMs}ms`);
           }
           throw err;
         }
       }
-    });
+    }, options.signal);
   }
 
   async read(
     namespace: string,
-    key: string
+    key: string,
+    options: MuninRequestOptions = {},
   ): Promise<(MuninEntry & { found: true }) | null> {
     const result = (await this.callTool("memory_read", {
       namespace,
       key,
-    })) as { found: boolean } & MuninEntry;
+    }, options)) as { found: boolean } & MuninEntry;
     return result.found ? (result as MuninEntry & { found: true }) : null;
   }
 

--- a/src/munin-client.ts
+++ b/src/munin-client.ts
@@ -91,6 +91,40 @@ function abortReason(signal: AbortSignal): Error {
   return error;
 }
 
+export function composeAbortSignals(signals: readonly AbortSignal[]): {
+  signal: AbortSignal;
+  cleanup: () => void;
+} {
+  if (typeof AbortSignal.any === "function") {
+    return { signal: AbortSignal.any([...signals]), cleanup: () => {} };
+  }
+
+  const controller = new AbortController();
+  const listeners: Array<{ signal: AbortSignal; listener: () => void }> = [];
+  const cleanup = (): void => {
+    for (const { signal, listener } of listeners) {
+      signal.removeEventListener("abort", listener);
+    }
+    listeners.length = 0;
+  };
+
+  for (const signal of signals) {
+    if (signal.aborted) {
+      controller.abort(signal.reason);
+      cleanup();
+      break;
+    }
+    const listener = (): void => {
+      controller.abort(signal.reason);
+      cleanup();
+    };
+    listeners.push({ signal, listener });
+    signal.addEventListener("abort", listener, { once: true });
+  }
+
+  return { signal: controller.signal, cleanup };
+}
+
 function sleep(ms: number, signal?: AbortSignal): Promise<void> {
   if (!signal) return new Promise((resolve) => setTimeout(resolve, ms));
   if (signal.aborted) return Promise.reject(abortReason(signal));
@@ -254,9 +288,14 @@ export class MuninClient {
       const requestTimeoutMs = options.requestTimeoutMs ?? this.requestTimeoutMs;
 
       while (true) {
+        let cleanupRequestSignal = (): void => {};
         try {
           if (options.signal?.aborted) throw abortReason(options.signal);
           const timeoutSignal = AbortSignal.timeout(requestTimeoutMs);
+          const requestAbort = options.signal
+            ? composeAbortSignals([options.signal, timeoutSignal])
+            : { signal: timeoutSignal, cleanup: () => {} };
+          cleanupRequestSignal = requestAbort.cleanup;
           const res = await fetch(`${this.baseUrl}/mcp`, {
             method: "POST",
             headers: {
@@ -266,9 +305,7 @@ export class MuninClient {
               "mcp-session-id": this.sessionId,
             },
             body: JSON.stringify(body),
-            signal: options.signal
-              ? AbortSignal.any([options.signal, timeoutSignal])
-              : timeoutSignal,
+            signal: requestAbort.signal,
           });
 
           if (!res.ok) {
@@ -330,6 +367,8 @@ export class MuninClient {
             throw new Error(`Munin request timed out after ${requestTimeoutMs}ms`);
           }
           throw err;
+        } finally {
+          cleanupRequestSignal();
         }
       }
     }, options.signal);

--- a/tests/homeserver-executor.test.ts
+++ b/tests/homeserver-executor.test.ts
@@ -552,6 +552,34 @@ describe("executeHomeserverTask — delegate path", () => {
     });
   });
 
+  it("does not invoke immediate recovery after the external abort controller fires", async () => {
+    const task = withLearningTaskContext(
+      makeTaskConfig({ path: "delegate", taskType: "extract" }),
+      "delegate-cancelled-before-recovery",
+    );
+    const externalAbort = new AbortController();
+    vi.spyOn(globalThis, "fetch").mockImplementationOnce(async (_url, init) => {
+      externalAbort.abort(new Error("operator cancelled task"));
+      const signal = (init as RequestInit).signal!;
+      throw signal.reason;
+    });
+    const recovery = vi.fn(async () => null);
+
+    const result = await executeHomeserverTask(
+      task,
+      "delegate-cancelled-before-recovery",
+      tmpLogDir,
+      { abortController: externalAbort, recoverAmbiguousLearningTask: recovery },
+    );
+
+    expect(recovery).not.toHaveBeenCalled();
+    expect(result.learningTask).toMatchObject({
+      state: "m5-not-admitted",
+      evidenceAccepted: false,
+      failureCode: "transport-not-admitted",
+    });
+  });
+
   it("keeps the truthful transport failure when immediate recovery is mismatched", async () => {
     const task = withLearningTaskContext(
       makeTaskConfig({ path: "delegate", taskType: "extract" }),

--- a/tests/homeserver-executor.test.ts
+++ b/tests/homeserver-executor.test.ts
@@ -8,6 +8,7 @@ import {
   loadHomeserverGatewayConfig,
   type HomeserverTaskConfig,
 } from "../src/homeserver-executor.js";
+import { recoverPreparedLearningTaskDispatch } from "../src/learning-task-handshake.js";
 import {
   withLearningTaskContext,
   withLearningTaskGatewayEcho,
@@ -50,6 +51,25 @@ function streamResponse(chunks: string[]): Response {
     },
   });
   return new Response(stream, { status: 200, headers: { "Content-Type": "text/event-stream" } });
+}
+
+function immediateRecoveryOptions(task: HomeserverTaskConfig) {
+  if (task.learningTask?.kind !== "ready") throw new Error("fixture is not learning-ready");
+  const { preparedDispatch, replayPayload } = task.learningTask;
+  return {
+    recoverAmbiguousLearningTask: async () => {
+      const recovered = await recoverPreparedLearningTaskDispatch({
+        prepared: preparedDispatch,
+        replayPayload,
+        gatewayBaseUrl: task.gatewayBaseUrl,
+        apiKey: task.apiKey,
+        timeoutMs: 5_000,
+      });
+      return recovered.state === "m5-admitted" && recovered.evidenceAccepted
+        ? recovered
+        : null;
+    },
+  };
 }
 
 let tmpLogDir: string;
@@ -470,6 +490,211 @@ describe("executeHomeserverTask — delegate path", () => {
     expect(result.output).not.toContain("must not be accepted");
   });
 
+  it("rejects malformed 2xx JSON without treating it as transport ambiguity", async () => {
+    const task = withLearningTaskContext(
+      makeTaskConfig({ path: "delegate", taskType: "extract" }),
+      "delegate-malformed-200",
+    );
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      new Response("{not-json", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const recovery = vi.fn(immediateRecoveryOptions(task).recoverAmbiguousLearningTask);
+
+    const result = await executeHomeserverTask(
+      task,
+      "delegate-malformed-200",
+      tmpLogDir,
+      { recoverAmbiguousLearningTask: recovery },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(recovery).not.toHaveBeenCalled();
+    expect(result.learningTask).toMatchObject({
+      state: "join-failed",
+      evidenceAccepted: false,
+      failureCode: "gateway-echo-invalid",
+    });
+  });
+
+  it("immediately recovers one exact stored admission after an ambiguous transport failure", async () => {
+    const task = withLearningTaskContext(
+      makeTaskConfig({ path: "delegate", taskType: "extract" }),
+      "delegate-immediate-recovery",
+    );
+    const recoveredResponse = withLearningTaskGatewayEcho(task, "delegate-immediate-recovery", {
+      learningTaskAdmission: { recovered: true, outcomeAvailable: false },
+      output: "recovery output must not be accepted",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(new TypeError("socket closed after admission"))
+      .mockResolvedValueOnce(jsonResponse(recoveredResponse));
+
+    const result = await executeHomeserverTask(
+      task,
+      "delegate-immediate-recovery",
+      tmpLogDir,
+      immediateRecoveryOptions(task),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect((fetchMock.mock.calls[1]?.[1] as RequestInit).body)
+      .toBe((fetchMock.mock.calls[0]?.[1] as RequestInit).body);
+    expect(result.exitCode).toBe(1);
+    expect(result.resultText).toBeNull();
+    expect(result.provenance).toBeNull();
+    expect(result.output).not.toContain("recovery output must not be accepted");
+    expect(result.learningTask).toMatchObject({
+      state: "m5-admitted",
+      evidenceAccepted: true,
+    });
+  });
+
+  it("keeps the truthful transport failure when immediate recovery is mismatched", async () => {
+    const task = withLearningTaskContext(
+      makeTaskConfig({ path: "delegate", taskType: "extract" }),
+      "delegate-recovery-mismatch",
+    );
+    const mismatched = withLearningTaskGatewayEcho(task, "delegate-recovery-mismatch", {
+      learningTaskAdmission: { recovered: true, outcomeAvailable: false },
+    }) as any;
+    mismatched.learningTaskGatewayEcho.echoed_request.attempt_id =
+      "hugin-attempt:99999999-9999-4999-8999-999999999999";
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(new TypeError("socket closed after admission"))
+      .mockResolvedValueOnce(jsonResponse(mismatched));
+
+    const result = await executeHomeserverTask(
+      task,
+      "delegate-recovery-mismatch",
+      tmpLogDir,
+      immediateRecoveryOptions(task),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.learningTask).toMatchObject({
+      state: "m5-not-admitted",
+      evidenceAccepted: false,
+      failureCode: "transport-not-admitted",
+      failureReason: "gateway request failed before an exact admission echo",
+    });
+  });
+
+  it("keeps the truthful transport failure when immediate recovery is unavailable", async () => {
+    const task = withLearningTaskContext(
+      makeTaskConfig({ path: "delegate", taskType: "extract" }),
+      "delegate-recovery-unavailable",
+    );
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(new TypeError("socket closed after admission"))
+      .mockRejectedValueOnce(new TypeError("recovery endpoint unavailable"));
+
+    const result = await executeHomeserverTask(
+      task,
+      "delegate-recovery-unavailable",
+      tmpLogDir,
+      immediateRecoveryOptions(task),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.learningTask).toMatchObject({
+      state: "m5-not-admitted",
+      evidenceAccepted: false,
+      failureCode: "transport-not-admitted",
+      failureReason: "gateway request failed before an exact admission echo",
+    });
+  });
+
+  it("rejects a fresh response during immediate recovery without starting a third request", async () => {
+    const task = withLearningTaskContext(
+      makeTaskConfig({ path: "delegate", taskType: "extract" }),
+      "delegate-recovery-fresh",
+    );
+    const fresh = withLearningTaskGatewayEcho(task, "delegate-recovery-fresh", {
+      outcome: "pass",
+      output: "fresh duplicate inference must not be accepted",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(new TypeError("socket closed after admission"))
+      .mockResolvedValueOnce(jsonResponse(fresh));
+
+    const result = await executeHomeserverTask(
+      task,
+      "delegate-recovery-fresh",
+      tmpLogDir,
+      immediateRecoveryOptions(task),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.resultText).toBeNull();
+    expect(result.provenance).toBeNull();
+    expect(result.output).not.toContain("fresh duplicate inference must not be accepted");
+    expect(result.learningTask).toMatchObject({
+      state: "m5-not-admitted",
+      evidenceAccepted: false,
+      failureCode: "transport-not-admitted",
+    });
+  });
+
+  it("probes one eligible 5xx without accepting either response body as output", async () => {
+    const task = withLearningTaskContext(
+      makeTaskConfig({ path: "delegate", taskType: "extract" }),
+      "delegate-recovery-500",
+    );
+    const recovered = withLearningTaskGatewayEcho(task, "delegate-recovery-500", {
+      learningTaskAdmission: { recovered: true, outcomeAvailable: false },
+      output: "recovery output must stay untrusted",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse({ output: "ambiguous 500 output" }, 500))
+      .mockResolvedValueOnce(jsonResponse(recovered));
+
+    const result = await executeHomeserverTask(
+      task,
+      "delegate-recovery-500",
+      tmpLogDir,
+      immediateRecoveryOptions(task),
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(result.exitCode).toBe(500);
+    expect(result.resultText).toBeNull();
+    expect(result.provenance).toBeNull();
+    expect(result.output).not.toContain("ambiguous 500 output");
+    expect(result.output).not.toContain("recovery output must stay untrusted");
+    expect(result.learningTask).toMatchObject({ state: "m5-admitted", evidenceAccepted: true });
+  });
+
+  it("does not probe a 5xx that already carries an authoritative exact echo", async () => {
+    const task = withLearningTaskContext(
+      makeTaskConfig({ path: "delegate", taskType: "extract" }),
+      "delegate-echo-500",
+    );
+    const responseBody = withLearningTaskGatewayEcho(task, "delegate-echo-500", {
+      output: "5xx output must stay untrusted",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(jsonResponse(responseBody, 500));
+    const recovery = vi.fn(immediateRecoveryOptions(task).recoverAmbiguousLearningTask);
+
+    const result = await executeHomeserverTask(
+      task,
+      "delegate-echo-500",
+      tmpLogDir,
+      { recoverAmbiguousLearningTask: recovery },
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(recovery).not.toHaveBeenCalled();
+    expect(result.exitCode).toBe(500);
+    expect(result.resultText).toBeNull();
+    expect(result.provenance).toBeNull();
+    expect(result.output).not.toContain("5xx output must stay untrusted");
+    expect(result.learningTask).toMatchObject({ state: "m5-admitted", evidenceAccepted: true });
+  });
+
   it("maps outcome 'fail'/'error' to a non-zero exit code, but 'unverified' to 0", async () => {
     const failTask = withLearningTaskContext(
       makeTaskConfig({ path: "delegate", taskType: "extract" }),
@@ -514,7 +739,7 @@ describe("executeHomeserverTask — delegate path", () => {
 
 describe("executeHomeserverTask — backpressure & errors", () => {
   it("flags 503 as admission backpressure and parses Retry-After", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       new Response("owner preempted the GPU", { status: 503, headers: { "Retry-After": "5" } }),
     );
 
@@ -526,8 +751,10 @@ describe("executeHomeserverTask — backpressure & errors", () => {
       task,
       "bp-503",
       tmpLogDir,
+      immediateRecoveryOptions(task),
     );
 
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(result.exitCode).toBe(1);
     expect(result.backpressure).toBe("admission");
     expect(result.retryAfterS).toBe(5);
@@ -544,12 +771,22 @@ describe("executeHomeserverTask — backpressure & errors", () => {
   });
 
   it("flags 429 as quota backpressure", async () => {
-    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+    const task = withLearningTaskContext(
+      makeTaskConfig({ path: "delegate", taskType: "extract" }),
+      "bp-429",
+    );
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       jsonResponse({ error: { message: "rpm exceeded" } }, 429),
     );
 
-    const result = await executeHomeserverTask(makeTaskConfig(), "bp-429", tmpLogDir);
+    const result = await executeHomeserverTask(
+      task,
+      "bp-429",
+      tmpLogDir,
+      immediateRecoveryOptions(task),
+    );
 
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(result.backpressure).toBe("quota");
     expect(result.exitCode).toBe(1);
   });

--- a/tests/learning-task-handshake.test.ts
+++ b/tests/learning-task-handshake.test.ts
@@ -505,6 +505,8 @@ describe("LearningTaskContract v1 producer handshake", () => {
     expect(recovered).toMatchObject({ state: "m5-admitted", evidenceAccepted: true });
     expect(validatePreparedLearningTaskOutcome(prepared.preparedDispatch, recovered))
       .toEqual(recovered);
+    expect((fetchImpl.mock.calls[0]?.[1] as RequestInit).body)
+      .toBe(JSON.stringify(prepared.replayPayload.requestBody));
     expect(JSON.parse((fetchImpl.mock.calls[0]?.[1] as RequestInit).body as string))
       .toEqual(prepared.replayPayload.requestBody);
     const crossAttempt = structuredClone(recovered);

--- a/tests/learning-task-recovery.test.ts
+++ b/tests/learning-task-recovery.test.ts
@@ -7,8 +7,11 @@ import {
   durableLearningTaskAttemptStart,
   jcsCanonicalize,
   learningTaskAttemptKey,
+  learningTaskExecutionEvidenceSchema,
+  requestStampDigest,
 } from "../src/learning-task-handshake.js";
 import {
+  recoverAmbiguousStoredLearningTaskCandidate,
   recoverLatestStoredLearningTaskAttempt,
   recoverStoredLearningTaskCandidate,
 } from "../src/learning-task-recovery.js";
@@ -55,6 +58,7 @@ function fixture() {
   const replay = task.learningTask.replayPayload;
   const entries = new Map<string, MuninEntry>([
     [prepared.attemptStartRef.key, entry(prepared.attemptStartRef.key, start)],
+    [prepared.preparedDispatchRef.key, entry(prepared.preparedDispatchRef.key, prepared)],
     [prepared.replayPayloadRef.key, entry(prepared.replayPayloadRef.key, replay)],
   ]);
   const writes: unknown[][] = [];
@@ -88,6 +92,29 @@ function fixture() {
   return { task, prepared, start, entries, writes, client, fetchImpl };
 }
 
+function transportFailure(input: ReturnType<typeof fixture>) {
+  const stamp = input.prepared.requestStamp;
+  return learningTaskExecutionEvidenceSchema.parse({
+    schemaVersion: 1,
+    contractVersion: "grimnir.learning-task/v1",
+    state: "m5-not-admitted",
+    evidenceAccepted: false,
+    taskId: input.prepared.taskId,
+    attemptId: input.prepared.attemptId,
+    attemptStartedAt: input.prepared.attemptStartedAt,
+    attemptStartRef: input.prepared.attemptStartRef,
+    preparedDispatchRef: input.prepared.preparedDispatchRef,
+    replayPayloadRef: input.prepared.replayPayloadRef,
+    replayPayloadDigest: input.prepared.replayPayloadDigest,
+    taskOutcomeRef: input.prepared.taskOutcomeRef,
+    rawFingerprint: stamp.raw_fingerprint,
+    requestStamp: stamp,
+    requestStampDigest: requestStampDigest(stamp),
+    failureCode: "transport-not-admitted",
+    failureReason: "gateway request failed before an exact admission echo",
+  });
+}
+
 async function recover(input: ReturnType<typeof fixture>) {
   return recoverStoredLearningTaskCandidate({
     munin: input.client,
@@ -103,6 +130,90 @@ async function recover(input: ReturnType<typeof fixture>) {
 }
 
 describe("stored LearningTaskContract recovery", () => {
+  it("immediately probes the exact classified stored attempt without persisting a second outcome", async () => {
+    const input = fixture();
+    const recovered = await recoverAmbiguousStoredLearningTaskCandidate({
+      munin: input.client,
+      taskNamespace: `tasks/${TASK_ID}`,
+      taskClassification: CLASSIFICATION,
+      preparedDispatchRef: input.prepared.preparedDispatchRef,
+      failureEvidence: transportFailure(input),
+      gateway: { baseUrl: "https://m5.test", apiKey: "owner-key" },
+      fetchImpl: input.fetchImpl as typeof fetch,
+    });
+
+    expect(recovered?.evidence).toMatchObject({ state: "m5-admitted", evidenceAccepted: true });
+    expect(recovered?.classification).toBe(CLASSIFICATION);
+    expect(input.fetchImpl).toHaveBeenCalledTimes(1);
+    expect((input.fetchImpl.mock.calls[0]?.[1] as RequestInit).body)
+      .toBe(JSON.stringify(input.task.learningTask!.kind === "ready"
+        ? input.task.learningTask.replayPayload.requestBody
+        : null));
+    expect(input.writes).toHaveLength(0);
+  });
+
+  it("does not probe when immediate recovery storage classification differs", async () => {
+    const input = fixture();
+    input.entries.set(
+      input.prepared.preparedDispatchRef.key,
+      entry(input.prepared.preparedDispatchRef.key, input.prepared, "internal"),
+    );
+    const recovered = await recoverAmbiguousStoredLearningTaskCandidate({
+      munin: input.client,
+      taskNamespace: `tasks/${TASK_ID}`,
+      taskClassification: CLASSIFICATION,
+      preparedDispatchRef: input.prepared.preparedDispatchRef,
+      failureEvidence: transportFailure(input),
+      gateway: { baseUrl: "https://m5.test", apiKey: "owner-key" },
+      fetchImpl: input.fetchImpl as typeof fetch,
+    });
+
+    expect(recovered).toBeNull();
+    expect(input.fetchImpl).not.toHaveBeenCalled();
+    expect(input.writes).toHaveLength(0);
+  });
+
+  it("does not probe past a differently classified existing outcome", async () => {
+    const input = fixture();
+    input.entries.set(
+      input.prepared.attemptOutcomeRef.key,
+      entry(input.prepared.attemptOutcomeRef.key, transportFailure(input), "internal"),
+    );
+    const recovered = await recoverAmbiguousStoredLearningTaskCandidate({
+      munin: input.client,
+      taskNamespace: `tasks/${TASK_ID}`,
+      taskClassification: CLASSIFICATION,
+      preparedDispatchRef: input.prepared.preparedDispatchRef,
+      failureEvidence: transportFailure(input),
+      gateway: { baseUrl: "https://m5.test", apiKey: "owner-key" },
+      fetchImpl: input.fetchImpl as typeof fetch,
+    });
+
+    expect(recovered).toBeNull();
+    expect(input.fetchImpl).not.toHaveBeenCalled();
+    expect(input.writes).toHaveLength(0);
+  });
+
+  it("bounds stalled storage lookup and never starts a late gateway probe", async () => {
+    const input = fixture();
+    const stalledClient = {
+      read: async () => new Promise<MuninEntry | null>(() => {}),
+    } as unknown as MuninClient;
+    const recovered = await recoverAmbiguousStoredLearningTaskCandidate({
+      munin: stalledClient,
+      taskNamespace: `tasks/${TASK_ID}`,
+      taskClassification: CLASSIFICATION,
+      preparedDispatchRef: input.prepared.preparedDispatchRef,
+      failureEvidence: transportFailure(input),
+      gateway: { baseUrl: "https://m5.test", apiKey: "owner-key" },
+      timeoutMs: 20,
+      fetchImpl: input.fetchImpl as typeof fetch,
+    });
+
+    expect(recovered).toBeNull();
+    expect(input.fetchImpl).not.toHaveBeenCalled();
+  });
+
   it("loads the immutable attempt start, preserves its full identity, and classifies output", async () => {
     const input = fixture();
     const recovered = await recover(input);

--- a/tests/learning-task-recovery.test.ts
+++ b/tests/learning-task-recovery.test.ts
@@ -152,6 +152,58 @@ describe("stored LearningTaskContract recovery", () => {
     expect(input.writes).toHaveLength(0);
   });
 
+  it("does not start immediate recovery when the external signal is already aborted", async () => {
+    const input = fixture();
+    const controller = new AbortController();
+    controller.abort(new Error("operator cancelled task"));
+
+    const recovered = await recoverAmbiguousStoredLearningTaskCandidate({
+      munin: input.client,
+      taskNamespace: `tasks/${TASK_ID}`,
+      taskClassification: CLASSIFICATION,
+      preparedDispatchRef: input.prepared.preparedDispatchRef,
+      failureEvidence: transportFailure(input),
+      gateway: { baseUrl: "https://m5.test", apiKey: "owner-key" },
+      signal: controller.signal,
+      fetchImpl: input.fetchImpl as typeof fetch,
+    });
+
+    expect(recovered).toBeNull();
+    expect(input.fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("aborts an in-flight immediate recovery probe when the external signal fires", async () => {
+    const input = fixture();
+    const controller = new AbortController();
+    let probeSignal: AbortSignal | null = null;
+    const fetchImpl = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      probeSignal = init?.signal as AbortSignal;
+      controller.abort(new Error("operator cancelled task"));
+      await new Promise<void>((_resolve, reject) => {
+        if (probeSignal!.aborted) reject(probeSignal!.reason);
+        else probeSignal!.addEventListener("abort", () => reject(probeSignal!.reason), { once: true });
+      });
+      throw new Error("unreachable");
+    });
+
+    const recovered = await recoverAmbiguousStoredLearningTaskCandidate({
+      munin: input.client,
+      taskNamespace: `tasks/${TASK_ID}`,
+      taskClassification: CLASSIFICATION,
+      preparedDispatchRef: input.prepared.preparedDispatchRef,
+      failureEvidence: transportFailure(input),
+      gateway: { baseUrl: "https://m5.test", apiKey: "owner-key" },
+      signal: controller.signal,
+      timeoutMs: 1_000,
+      fetchImpl: fetchImpl as typeof fetch,
+    });
+
+    expect(recovered).toBeNull();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(probeSignal?.aborted).toBe(true);
+    expect(probeSignal?.reason).toBe(controller.signal.reason);
+  });
+
   it("does not probe when immediate recovery storage classification differs", async () => {
     const input = fixture();
     input.entries.set(

--- a/tests/munin-client.test.ts
+++ b/tests/munin-client.test.ts
@@ -100,6 +100,49 @@ describe("MuninClient", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("composes cancellation without AbortSignal.any and cleans up fallback listeners", async () => {
+    const anyDescriptor = Object.getOwnPropertyDescriptor(AbortSignal, "any");
+    Object.defineProperty(AbortSignal, "any", {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+    try {
+      const controller = new AbortController();
+      const addListener = vi.spyOn(controller.signal, "addEventListener");
+      const removeListener = vi.spyOn(controller.signal, "removeEventListener");
+      let requestSignal: AbortSignal | null = null;
+      vi.spyOn(globalThis, "fetch").mockImplementationOnce(async (_url, init) => {
+        requestSignal = (init as RequestInit).signal!;
+        return new Promise<Response>((_resolve, reject) => {
+          requestSignal!.addEventListener("abort", () => reject(requestSignal!.reason), { once: true });
+        });
+      });
+      const client = new MuninClient({
+        baseUrl: "http://munin.test",
+        apiKey: "test-key",
+        minRequestSpacingMs: 0,
+      });
+
+      const read = client.read("tasks/demo", "status", {
+        signal: controller.signal,
+        maxRetries: 0,
+      });
+      await vi.waitFor(() => expect(requestSignal).not.toBeNull());
+      const reason = new Error("operator cancelled task");
+      controller.abort(reason);
+
+      await expect(read).rejects.toBe(reason);
+      expect(requestSignal).not.toBe(controller.signal);
+      expect(requestSignal?.reason).toBe(reason);
+      expect(addListener).toHaveBeenCalledWith("abort", expect.any(Function), { once: true });
+      expect(removeListener).toHaveBeenCalledWith("abort", expect.any(Function));
+    } finally {
+      if (anyDescriptor) Object.defineProperty(AbortSignal, "any", anyDescriptor);
+      else delete (AbortSignal as { any?: unknown }).any;
+    }
+  });
+
   it("supports batch reads", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       rpcResponse({

--- a/tests/munin-client.test.ts
+++ b/tests/munin-client.test.ts
@@ -74,6 +74,32 @@ describe("MuninClient", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it("cancels a deadline-bound read without retrying and releases the request queue", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockImplementationOnce(async (_url, init) => new Promise<Response>((_resolve, reject) => {
+        const signal = (init as RequestInit).signal!;
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+      }))
+      .mockResolvedValueOnce(rpcResponse({ ok: true }));
+    const client = new MuninClient({
+      baseUrl: "http://munin.test",
+      apiKey: "test-key",
+      minRequestSpacingMs: 0,
+    });
+    const controller = new AbortController();
+
+    const read = client.read("tasks/demo", "status", {
+      signal: controller.signal,
+      maxRetries: 0,
+    });
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    controller.abort(new Error("immediate recovery deadline exceeded"));
+
+    await expect(read).rejects.toThrow(/deadline exceeded|aborted/i);
+    await expect(client.write("tasks/demo", "result", "failed")).resolves.toMatchObject({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("supports batch reads", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
       rpcResponse({


### PR DESCRIPTION
## Summary

Implements #246: after an eligible stamped delegate attempt ends in an ambiguous transport failure or non-backpressure 5xx without an authoritative echo, Hugin performs **one bounded (5 s), storage-validated, fail-closed exact-recovery probe** using the byte-identical replay payload and identical task/attempt/request/idempotency/principal/namespace/stamp identity.

- Recovery accepts only an authenticated, schema-valid, admitted+accepted exact-recovery response; the same prepared-dispatch cross-binding and classification checks as startup recovery apply.
- A recovered admission echo improves join/evidence state only — **output from the ambiguous response is never trusted**; missing/malformed/mismatched responses leave the truthful failure state unchanged; no duplicate or fresh inference is possible.
- 429/503 backpressure classification and exit codes are unchanged.

## Validation

- Red/green TDD; focused 5 files / 95 tests; **full suite 145 files / 2,267 tests green**; TypeScript build; `git diff --check`; staged exact-diff adversarial self-review.
- Independently re-verified by mission control (13/13 recovery tests green in fresh shell) and Claude cross-review passed. One non-blocking review note: a 503 still triggers the (cheap, read-mostly) recovery probe against an already-loaded gateway — defensible, but deserves a code comment.
- Motivating live evidence from the same night: a broker submit timed out at 60 s transport while the server had accepted it (idempotency key bridged it), and a separate 120 s gateway abort produced exactly the `transport-not-admitted` ambiguity this PR recovers. Full evidence: `~/mimir/research/hugin-overnight-2026-07-21/REPORT.md`.

## Deliberately not done

No push/merge/deploy in the implementation session, no live M5 testing, no STATUS.md or deployment-file changes.

Part of the 2026-07-21 overnight R&D mission. Implementation: Codex (gpt-5.6-sol); orchestration + independent verification: Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)