### PR TITLE
Fix cadence user-unit startup and deployment acceptance

### DIFF
--- a/scripts/deploy-pi.sh
+++ b/scripts/deploy-pi.sh
@@ -256,6 +256,12 @@ ssh "$REMOTE" "
   /usr/bin/node -e 'const m=JSON.parse(require(\"node:fs\").readFileSync(process.argv[1],\"utf8\")); if(m.schemaVersion!==2) throw new Error(\"daily exam manifest must be schema v2\"); if(m.candidates.some((c)=>c.lane===\"provisional-holdout\"&&c.crossClientExposure?.state!==\"unseen-covered\")) throw new Error(\"provisional candidate lacks complete cross-client exposure coverage\"); const states=Object.fromEntries([\"not-checked\",\"seen\",\"unseen-covered\",\"incomplete\",\"error\"].map((s)=>[s,m.candidates.filter((c)=>c.crossClientExposure?.state===s).length])); process.stdout.write(JSON.stringify({schemaVersion:m.schemaVersion,generatedAt:m.generatedAt,inspectedTasks:m.inspectedTasks,historyComplete:m.historyComplete,counts:m.counts,crossClientExposureStates:states})+\"\\n\")' /home/$DEPLOY_USER/.hugin/daily-exam-candidates/latest.json
 "
 
+echo "==> Experiment cadence acceptance..."
+# A successful tick durably logs even when the candidate pool is empty. This
+# catches user-unit credential/sandbox failures before an accepted deployment
+# can wait until the next morning to reveal them.
+ssh "$REMOTE" "XDG_RUNTIME_DIR=/run/user/1000 systemctl --user start hugin-experiment-cadence.service"
+
 echo ""
 echo "Acceptance gates passed; finalizing deployment."
 echo "Health check: curl http://$PI_HOST:3032/health"

--- a/scripts/deploy-pi.test.sh
+++ b/scripts/deploy-pi.test.sh
@@ -260,12 +260,15 @@ assert_contains "$full_calls" "health.codex_sandbox?.available !== true" "deploy
 assert_contains "$full_calls" "in-service Codex sandbox self-test unavailable after 15 attempts" "deployment waits for a definitive in-service probe result"
 assert_contains "$full_calls" "codex sandbox -- /bin/true" "deployment host preflight exercises Codex's zero-token sandbox entry point"
 assert_contains "$full_calls" "enable --now hugin-daily-exam-factory.timer" "deployment enables the automatic daily factory"
+assert_contains "$full_calls" "enable --now hugin-experiment-cadence.timer" "deployment enables the automatic experiment cadence"
 assert_contains "$full_calls" "start hugin-daily-exam-factory.service" "deployment runs a factory acceptance sweep"
+assert_contains "$full_calls" "start hugin-experiment-cadence.service" "deployment runs a cadence acceptance tick"
 assert_contains "$full_calls" "daily exam manifest must be schema v2" "deployment requires the cross-client exposure manifest contract"
 assert_contains "$full_calls" "provisional candidate lacks complete cross-client exposure coverage" "deployment rejects an unjoined provisional candidate"
 assert_contains "$full_calls" "$full_sha" "deployment stamps the exact local full SHA"
 assert_order "$full_calls" "curl -fsS http://127.0.0.1:3032/health" "mv '/home/magnus/repos/hugin/.deployed-commit.tmp' '/home/magnus/repos/hugin/.deployed-commit'" "health acceptance precedes atomic marker stamp"
 assert_order "$full_calls" "start hugin-daily-exam-factory.service" "mv '/home/magnus/repos/hugin/.deployed-commit.tmp' '/home/magnus/repos/hugin/.deployed-commit'" "factory acceptance precedes atomic marker stamp"
+assert_order "$full_calls" "start hugin-experiment-cadence.service" "mv '/home/magnus/repos/hugin/.deployed-commit.tmp' '/home/magnus/repos/hugin/.deployed-commit'" "cadence acceptance precedes atomic marker stamp"
 
 # If the marker cannot be invalidated, the script must not begin payload sync.
 : >"$CALL_LOG"
@@ -310,6 +313,21 @@ export FAKE_SSH_FAIL_MATCH=""
 factory_fail_calls="$(cat "$CALL_LOG")"
 assert_contains "$factory_fail_calls" "start hugin-daily-exam-factory.service" "factory failure reaches the new acceptance gate"
 assert_not_contains "$factory_fail_calls" "mv '/home/magnus/repos/hugin/.deployed-commit.tmp' '/home/magnus/repos/hugin/.deployed-commit'" "failed factory acceptance remains markerless"
+
+# The cadence is also a deployed production mechanism. Its service must start
+# successfully before the exact revision can be marked accepted.
+: >"$CALL_LOG"
+export FAKE_SSH_FAIL_MATCH="start hugin-experiment-cadence.service"
+export FAKE_SSH_FAIL_RC=71
+set +e
+(cd "$FULL_SOURCE" && bash "$DEPLOY_SCRIPT" testhost >/dev/null 2>&1)
+cadence_fail_rc=$?
+set -e
+export FAKE_SSH_FAIL_MATCH=""
+[[ "$cadence_fail_rc" -ne 0 ]] || fail "failed cadence acceptance must fail deployment"
+cadence_fail_calls="$(cat "$CALL_LOG")"
+assert_contains "$cadence_fail_calls" "start hugin-experiment-cadence.service" "cadence failure reaches the acceptance gate"
+assert_not_contains "$cadence_fail_calls" "mv '/home/magnus/repos/hugin/.deployed-commit.tmp' '/home/magnus/repos/hugin/.deployed-commit'" "failed cadence acceptance remains markerless"
 
 if [[ "$failures" -gt 0 ]]; then
   echo "$failures assertion(s) failed" >&2

--- a/systemd/hugin-daily-analysis.service
+++ b/systemd/hugin-daily-analysis.service
@@ -5,7 +5,6 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
-User=magnus
 WorkingDirectory=/home/magnus/repos/hugin
 ExecStart=/usr/bin/bash scripts/submit-daily-analysis.sh
 EnvironmentFile=/home/magnus/repos/hugin/.env

--- a/systemd/hugin-daily-analysis.service
+++ b/systemd/hugin-daily-analysis.service
@@ -5,6 +5,7 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
+User=magnus
 WorkingDirectory=/home/magnus/repos/hugin
 ExecStart=/usr/bin/bash scripts/submit-daily-analysis.sh
 EnvironmentFile=/home/magnus/repos/hugin/.env

--- a/systemd/hugin-experiment-cadence.service
+++ b/systemd/hugin-experiment-cadence.service
@@ -5,7 +5,6 @@ Wants=network-online.target
 
 [Service]
 Type=oneshot
-User=magnus
 WorkingDirectory=/home/magnus/repos/hugin
 # hugin#272: no --candidates flag -- the default production candidate-pool
 # assembler scans the #232 registry itself. A leftover

--- a/tests/systemd-user-units.test.ts
+++ b/tests/systemd-user-units.test.ts
@@ -22,6 +22,6 @@ describe("systemd user services", () => {
   it.each(SYSTEM_UNITS)("%s declares a non-root runtime identity", (unitPath) => {
     const unit = readFileSync(resolve(unitPath), "utf8");
 
-    expect(unit).toMatch(/^User=\S+$/m);
+    expect(unit).toMatch(/^User=magnus$/m);
   });
 });

--- a/tests/systemd-user-units.test.ts
+++ b/tests/systemd-user-units.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const USER_UNITS = [
+  "hugin.service",
+  "systemd/hugin-daily-analysis.service",
+  "systemd/hugin-daily-exam-factory.service",
+  "systemd/hugin-experiment-cadence.service",
+];
+
+describe("systemd user services", () => {
+  it.each(USER_UNITS)("%s inherits the user manager identity", (unitPath) => {
+    const unit = readFileSync(resolve(unitPath), "utf8");
+
+    expect(unit).not.toMatch(/^User=/m);
+    expect(unit).not.toMatch(/^Group=/m);
+    expect(unit).not.toMatch(/^SupplementaryGroups=/m);
+  });
+});

--- a/tests/systemd-user-units.test.ts
+++ b/tests/systemd-user-units.test.ts
@@ -4,10 +4,11 @@ import { describe, expect, it } from "vitest";
 
 const USER_UNITS = [
   "hugin.service",
-  "systemd/hugin-daily-analysis.service",
   "systemd/hugin-daily-exam-factory.service",
   "systemd/hugin-experiment-cadence.service",
 ];
+
+const SYSTEM_UNITS = ["systemd/hugin-daily-analysis.service"];
 
 describe("systemd user services", () => {
   it.each(USER_UNITS)("%s inherits the user manager identity", (unitPath) => {
@@ -16,5 +17,11 @@ describe("systemd user services", () => {
     expect(unit).not.toMatch(/^User=/m);
     expect(unit).not.toMatch(/^Group=/m);
     expect(unit).not.toMatch(/^SupplementaryGroups=/m);
+  });
+
+  it.each(SYSTEM_UNITS)("%s declares a non-root runtime identity", (unitPath) => {
+    const unit = readFileSync(resolve(unitPath), "utf8");
+
+    expect(unit).toMatch(/^User=\S+$/m);
   });
 });


### PR DESCRIPTION
## What changed

- remove explicit identity directives from Hugin systemd user services so they inherit the user manager identity
- add a regression test covering all repository user-service units
- run a real experiment-cadence tick during deployment acceptance before stamping `.deployed-commit`
- extend deployment tests so cadence startup failures remain markerless

## Root cause

The scheduled cadence timer fired, but its service never reached Node. The unit is installed under `systemctl --user` while also declaring `User=magnus`; under its confinement, systemd failed while determining supplementary groups and exited with `216/GROUP`. That left no durable Munin tick log and the pre-reboot journal was later lost.

## Impact

The cadence service can start as the owning user again. Future deployments fail before acceptance if the cadence unit, credentials, sandbox, or durable tick-log write is broken, including an empty-candidate no-op tick.

## Validation

- `npm run build`
- `npm test` — 146 files, 2,259 tests
- `bash scripts/deploy-pi.test.sh`
- `git diff --check`
- production reproduction: `status=216/GROUP` before `ExecStart`

## Review note

A pre-PR independent M5 Qwen3-Coder-Next review ran. Its proposed findings were checked against the repository and declined: the deploy script already uses `set -euo pipefail`, SSH propagates the `systemctl` failure, the fake failure covers any nonzero exit, and systemd user units inherit the non-root user-manager identity.