### PR TITLE
fix(learning): bridge admitted M5 attempts into cadence

### DIFF
--- a/docs/continuous-learning-loop.md
+++ b/docs/continuous-learning-loop.md
@@ -1,6 +1,9 @@
 # Continuous Hugin/M5 learning loop
 
-**Status:** first production-safe slice (2026-07-13)
+**Status:** production cadence active; admitted-attempt candidate capture is
+implemented fail-closed but awaits the authoritative Gille ledger binding
+tracked in [gille-inference #61](https://github.com/Magnus-Gille/gille-inference/issues/61)
+(2026-07-22).
 
 ## Goal
 
@@ -116,6 +119,45 @@ Automated runners normally record `product_outcome: unrated` as soon as protecte
 and optional review time. This is a one-way, audited transition: an existing rating cannot be
 overwritten. An experiment that requires product coverage therefore remains in `gathering` until
 enough runs have been rated.
+
+## Production candidate cadence
+
+The default cadence candidate pool is assembled from native learning-registry
+terminal outcomes. A direct `Runtime: homeserver` task becomes eligible only
+when all of these independently bind to the same task and attempt:
+
+- an authenticated, accepted LearningTaskContract M5 admission;
+- an authenticated `GET /ledger/{id}` row whose evidence-identity hash,
+  admitted task/attempt IDs, model, and canonical task type all match;
+- the durable task result plus an effective independently bound Quality Receipt; and
+- repository outcome `not-managed`.
+
+The final condition is an authority ceiling, not a missing feature. Direct
+Broker/M5 one-shot tasks keep `tool_policy:none`, receive no managed checkout,
+and cannot claim file edits. Hugin records them as the M5 one-shot population;
+it does not borrow repository evidence from a separate Claude, Codex, or
+OpenCode run. Invalid, cross-task, non-admitted, provenance-incomplete, or
+managed-repository combinations fail closed and do not enter the pool.
+
+Capture is a recoverable post-terminal side effect. Eligible task status moves
+through `learning-registry:pending` to `learning-registry:captured`; startup
+and periodic reconciliation replay the natural-key-idempotent submission,
+attempt-reference, and terminal-outcome writes. A registry or ledger-read
+outage therefore cannot rerun paid inference or strand a task as `running`.
+Permanent identity mismatches become `learning-registry:rejected`.
+
+The deployed Gille gateway must expose the content-blind attempt binding
+defined by gille-inference #61 before the first candidate can pass this gate.
+Hugin must not accept the current looser pair of a gateway admission echo and
+an unbound ledger ID merely to make the pool non-empty.
+
+One task cannot create an experiment. Under the default proposer settings an
+operator must collect **at least three accepted samples per arm** (six total)
+for the same canonical task type. The two populations must differ on exactly
+one configuration axis, and every candidate needs its own exact Quality
+Receipt binding. Re-running the cadence against unchanged evidence is
+idempotent: it reuses the same proposal identity and never creates a duplicate
+in-flight experiment.
 
 ## First M5 iteration
 

--- a/docs/harness-lane-standing-sampler.md
+++ b/docs/harness-lane-standing-sampler.md
@@ -1,18 +1,14 @@
 # Standing harness-lane sampler (#267)
 
-**Status:** mechanism implemented; not yet wired into the live dispatch loop.
+**Status:** wired into the live managed Claude/Codex mutation-task seam.
 `src/harness-lane-sampler.ts`, `src/harness-lane-executor.ts`, and
-`src/harness-lane-comparison-report.ts` are a self-contained, tested library —
-same "ship the mechanism first" shape as `docs/learning-registry.md` (#232)
-and `docs/external-receipt-intake.md` (#237). `runHarnessLaneSampledAttempt`
-takes both lane executors as injected callbacks rather than calling any real
-runtime itself, per #267's explicit instruction not to build a new executor.
-Wiring real callbacks (the Broker `/delegate` one-shot path and
-`src/opencode-executor.ts` / `src/learning/m5-code-loop-*` for harness) into
-`src/index.ts`'s dispatch loop is deliberately left to a follow-up so this
-ships as an independently testable, zero-blast-radius library — exactly like
-#232 did. The env default (`0%`) means that even once wired, the lane stays
-fully shadowed until a human deliberately raises it.
+`src/harness-lane-comparison-report.ts` remain independently tested, while
+`src/index.ts` supplies the existing direct executor and OpenCode harness
+callbacks after checkout and runtime preflight. The env default (`0%`) keeps
+the harness lane shadowed until a human deliberately raises it. Direct
+Broker/M5 one-shot capture is a separate path in
+`src/homeserver-learning-registry-bridge.ts`; it never enters this managed
+sampler or gains its checkout authority.
 
 ## Why a standing lane, not another campaign
 

--- a/docs/learning-registry.md
+++ b/docs/learning-registry.md
@@ -1,11 +1,24 @@
 # Durable append-only task/outcome learning registry (#232)
 
-**Status:** mechanism implemented; not yet wired into the dispatcher's normal
-task lifecycle. `src/learning-registry-schema.ts`, `src/learning-registry-store.ts`,
-and `src/learning-registry-view.ts` are a self-contained, tested library. Wiring
-calls into `src/index.ts`/`src/broker/handlers.ts` is deliberately left to the
-tickets that actually need it (#233), to avoid broadening this PR's blast
-radius across in-flight sibling work on `src/broker/handlers.ts` (#250/#251).
+**Status:** mechanism and managed capture are active. Direct homeserver capture
+is implemented fail-closed and becomes operational when the authenticated
+Gille ledger join in
+[gille-inference #61](https://github.com/Magnus-Gille/gille-inference/issues/61)
+is deployed.
+`src/learning-registry-schema.ts`, `src/learning-registry-store.ts`, and
+`src/learning-registry-view.ts` own the append-only mechanism. The dispatcher
+now writes native events for the standing managed harness sampler and, through
+`src/homeserver-learning-registry-bridge.ts`, authenticated direct
+homeserver/M5 attempts. The latter is deliberately restricted to
+`repositoryOutcome: not-managed`; it does not grant Broker tasks a checkout or
+file-edit authority.
+The dispatcher first terminalizes the task and writes `result-structured`,
+then resolves the held `ledgerId` through authenticated `GET /ledger/{id}`.
+The returned evidence-identity hash, task ID, attempt ID, model, and task type
+must all be present and match before registry writes begin. Status tag
+`learning-registry:pending` is the durable retry checkpoint; idempotent replay
+advances it to `learning-registry:captured`, while a permanent mismatch becomes
+`learning-registry:rejected`.
 External Codex/Pi receipt ingestion (#237) is now implemented on top of this
 mechanism — see `docs/external-receipt-intake.md`; it widened
 `submissionEventSchema.payload.originComponent` from `z.literal("hugin")` to
@@ -191,6 +204,6 @@ on.
 - Ingesting external Codex/Pi receipts — implemented in #237 as a consumer of
   this mechanism (`docs/external-receipt-intake.md`), not inside it.
 - Candidate packaging/promotion — #233.
-- Wiring `record*` calls into the live dispatcher lifecycle in
-  `src/index.ts`/`src/broker/handlers.ts` — left to the consuming tickets so
-  this PR stays a self-contained, independently testable library.
+- Adding new live producer paths beyond the managed sampler and admitted
+  direct homeserver bridge. Every new writer must define its authority and
+  evidence bindings explicitly rather than copying another attempt's refs.

--- a/src/homeserver-learning-registry-bridge.ts
+++ b/src/homeserver-learning-registry-bridge.ts
@@ -1,0 +1,177 @@
+/**
+ * Native registry bridge for direct homeserver/M5 attempts (hugin#284).
+ *
+ * Direct `Runtime: homeserver` is the one production path that already owns
+ * an authenticated LearningTaskContract admission and exact M5 execution
+ * provenance. It deliberately owns no checkout or file-edit authority. This
+ * bridge records that existing attempt in the learning registry without
+ * changing either boundary: only admitted evidence is accepted, and the
+ * repository outcome must remain exactly `not-managed`.
+ *
+ * Validation failures are ordinary learning ineligibility and produce no
+ * writes. Storage failures still throw so the caller can report the recovery
+ * fault after the primary task has been durably terminalized.
+ */
+
+import { taskTypeSchema } from "./broker/task-type-metadata.js";
+import type { AppendResult, LearningRegistryStore } from "./learning-registry-store.js";
+import type {
+  AttemptReferenceEvent,
+  SubmissionEvent,
+  TerminalOutcomeEvent,
+} from "./learning-registry-schema.js";
+import { learningTaskExecutionEvidenceSchema } from "./learning-task-handshake.js";
+import { delegationProvenanceSchema } from "./task-result-schema.js";
+import type { ResolveM5LedgerAttemptBinding } from "./m5-ledger-attempt-binding.js";
+
+export type HomeserverLearningRegistrySkipReason =
+  | "invalid-learning-task-evidence"
+  | "not-admitted"
+  | "task-identity-mismatch"
+  | "task-type-mismatch"
+  | "missing-delegation-identity"
+  | "delegation-binding-mismatch"
+  | "repository-authority-mismatch";
+
+export interface AdmittedHomeserverAttemptInput {
+  taskId: string;
+  taskType: string;
+  occurredAt: string;
+  outcome: TerminalOutcomeEvent["payload"]["outcome"];
+  /** Kept wider than the registry enum so newly-added dispatcher states fail
+   * closed here instead of silently becoming learning-eligible. */
+  repositoryOutcomeState: string;
+  learningTask: unknown;
+  provenance: unknown;
+}
+
+export type AdmittedHomeserverAttemptResult =
+  | {
+      status: "skipped";
+      reason: HomeserverLearningRegistrySkipReason;
+    }
+  | {
+      status: "recorded";
+      attemptId: string;
+      registry: {
+        submission: AppendResult<SubmissionEvent>;
+        attemptReference: AppendResult<AttemptReferenceEvent>;
+        terminalOutcome: AppendResult<TerminalOutcomeEvent>;
+      };
+    };
+
+type RegistryDeps = Pick<
+  LearningRegistryStore,
+  "recordSubmission" | "recordAttemptReference" | "recordTerminalOutcome"
+>;
+
+export interface HomeserverLearningRegistryBridgeDeps {
+  registry: RegistryDeps;
+  resolveLedgerAttemptBinding: ResolveM5LedgerAttemptBinding;
+}
+
+export function isPotentialAdmittedHomeserverAttempt(
+  learningTask: unknown,
+  provenance: unknown,
+): boolean {
+  const evidence = learningTaskExecutionEvidenceSchema.safeParse(learningTask);
+  const delegation = delegationProvenanceSchema.safeParse(provenance);
+  return evidence.success
+    && evidence.data.state === "m5-admitted"
+    && evidence.data.evidenceAccepted
+    && delegation.success
+    && Boolean(delegation.data.ledgerId && delegation.data.modelId && delegation.data.taskType);
+}
+
+export async function recordAdmittedHomeserverAttempt(
+  deps: HomeserverLearningRegistryBridgeDeps,
+  input: AdmittedHomeserverAttemptInput,
+): Promise<AdmittedHomeserverAttemptResult> {
+  // This is the authority boundary, not merely metadata. If the dispatcher
+  // ever gives homeserver tasks a checkout, this bridge stops until that new
+  // execution model receives an explicit design and review.
+  if (input.repositoryOutcomeState !== "not-managed") {
+    return { status: "skipped", reason: "repository-authority-mismatch" };
+  }
+
+  const taskType = taskTypeSchema.safeParse(input.taskType);
+  const evidence = learningTaskExecutionEvidenceSchema.safeParse(input.learningTask);
+  if (!evidence.success) {
+    return { status: "skipped", reason: "invalid-learning-task-evidence" };
+  }
+  if (evidence.data.state !== "m5-admitted" || !evidence.data.evidenceAccepted) {
+    return { status: "skipped", reason: "not-admitted" };
+  }
+  if (evidence.data.taskId !== input.taskId) {
+    return { status: "skipped", reason: "task-identity-mismatch" };
+  }
+
+  const stampedTaskType = evidence.data.requestStamp?.task_type.id;
+  if (!taskType.success || stampedTaskType !== taskType.data) {
+    return { status: "skipped", reason: "task-type-mismatch" };
+  }
+
+  const provenance = delegationProvenanceSchema.safeParse(input.provenance);
+  if (!provenance.success
+    || !provenance.data.ledgerId
+    || !provenance.data.modelId) {
+    return { status: "skipped", reason: "missing-delegation-identity" };
+  }
+  if (provenance.data.taskType !== taskType.data) {
+    return { status: "skipped", reason: "task-type-mismatch" };
+  }
+
+  const authoritative = await deps.resolveLedgerAttemptBinding(provenance.data.ledgerId);
+  if (authoritative.id !== provenance.data.ledgerId
+    || authoritative.taskInstanceId !== input.taskId
+    || authoritative.attemptId !== evidence.data.attemptId
+    || authoritative.taskType !== taskType.data
+    || authoritative.modelId !== provenance.data.modelId) {
+    return { status: "skipped", reason: "delegation-binding-mismatch" };
+  }
+
+  // Admitted evidence is schema-bound to all of these refs. The explicit
+  // guards keep the bridge total even if the evidence schema later gains a
+  // different admitted state with optional references.
+  const attemptStartRef = evidence.data.attemptStartRef;
+  const attemptOutcomeRef = evidence.data.attemptOutcomeRef;
+  if (!attemptStartRef || !attemptOutcomeRef) {
+    return { status: "skipped", reason: "invalid-learning-task-evidence" };
+  }
+
+  const delegation = delegationProvenanceSchema.parse({
+    ...provenance.data,
+    taskType: taskType.data,
+    lane: "one-shot",
+    evidenceIdentityHash: authoritative.evidenceIdentityHash,
+  });
+  const taskOutcomeRef = evidence.data.taskOutcomeRef;
+  const submission = await deps.registry.recordSubmission({
+    taskId: input.taskId,
+    taskOutcomeRef,
+    occurredAt: input.occurredAt,
+  });
+  const attemptReference = await deps.registry.recordAttemptReference({
+    taskId: input.taskId,
+    attemptId: evidence.data.attemptId,
+    attemptStartRef,
+    taskOutcomeRef,
+    occurredAt: input.occurredAt,
+  });
+  const terminalOutcome = await deps.registry.recordTerminalOutcome({
+    taskId: input.taskId,
+    attemptId: evidence.data.attemptId,
+    outcome: input.outcome,
+    repositoryOutcomeState: "not-managed",
+    taskOutcomeRef,
+    attemptOutcomeRef,
+    delegation,
+    occurredAt: input.occurredAt,
+  });
+
+  return {
+    status: "recorded",
+    attemptId: evidence.data.attemptId,
+    registry: { submission, attemptReference, terminalOutcome },
+  };
+}

--- a/src/homeserver-learning-registry-recovery.ts
+++ b/src/homeserver-learning-registry-recovery.ts
@@ -1,0 +1,131 @@
+import type { MuninClient, MuninQueryResult } from "./munin-client.js";
+import { queryAllMuninEntries, type MuninPaginationBudget } from "./munin-pagination.js";
+import type { LearningRegistryStore } from "./learning-registry-store.js";
+import {
+  recordAdmittedHomeserverAttempt,
+  type HomeserverLearningRegistrySkipReason,
+} from "./homeserver-learning-registry-bridge.js";
+import type { ResolveM5LedgerAttemptBinding } from "./m5-ledger-attempt-binding.js";
+import { structuredTaskResultSchema } from "./task-result-schema.js";
+
+export const LEARNING_REGISTRY_PENDING_TAG = "learning-registry:pending";
+export const LEARNING_REGISTRY_CAPTURED_TAG = "learning-registry:captured";
+export const LEARNING_REGISTRY_REJECTED_TAG = "learning-registry:rejected";
+
+type RecoveryMunin = Pick<MuninClient, "read" | "write" | "query" | "log">;
+
+export interface HomeserverLearningRegistryRecoveryDeps {
+  munin: RecoveryMunin;
+  registry: LearningRegistryStore;
+  resolveLedgerAttemptBinding: ResolveM5LedgerAttemptBinding;
+}
+
+export type CapturePendingHomeserverLearningResult =
+  | { status: "not-pending" }
+  | { status: "captured"; attemptId: string }
+  | { status: "rejected"; reason: HomeserverLearningRegistrySkipReason };
+
+function replaceCaptureTag(tags: string[], replacement: string): string[] {
+  return [...tags.filter((tag) => !tag.startsWith("learning-registry:")), replacement];
+}
+
+async function writeCaptureStatus(
+  munin: RecoveryMunin,
+  taskNamespace: string,
+  status: NonNullable<Awaited<ReturnType<RecoveryMunin["read"]>>>,
+  tag: string,
+): Promise<void> {
+  await munin.write(
+    taskNamespace,
+    "status",
+    status.content,
+    replaceCaptureTag(status.tags, tag),
+    status.updated_at,
+    status.classification,
+  );
+}
+
+/** Replays only durable terminal evidence; all registry writes are natural-key idempotent. */
+export async function capturePendingHomeserverLearningTask(
+  deps: HomeserverLearningRegistryRecoveryDeps,
+  taskNamespace: string,
+): Promise<CapturePendingHomeserverLearningResult> {
+  const status = await deps.munin.read(taskNamespace, "status");
+  if (!status?.tags.includes(LEARNING_REGISTRY_PENDING_TAG)) return { status: "not-pending" };
+  const resultEntry = await deps.munin.read(taskNamespace, "result-structured");
+  if (!resultEntry) throw new Error(`${taskNamespace} has pending learning capture but no result-structured`);
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(resultEntry.content);
+  } catch {
+    throw new Error(`${taskNamespace} has invalid pending result-structured JSON`);
+  }
+  const result = structuredTaskResultSchema.parse(raw);
+  const learningTask = result.runtimeMetadata?.learningTask;
+  const provenance = result.runtimeMetadata?.delegation;
+  const taskType = provenance?.taskType;
+  if (result.runtime !== "homeserver" || !learningTask || !provenance || !taskType) {
+    await writeCaptureStatus(deps.munin, taskNamespace, status, LEARNING_REGISTRY_REJECTED_TAG);
+    return { status: "rejected", reason: "missing-delegation-identity" };
+  }
+
+  const capture = await recordAdmittedHomeserverAttempt({
+    registry: deps.registry,
+    resolveLedgerAttemptBinding: deps.resolveLedgerAttemptBinding,
+  }, {
+    taskId: result.taskId,
+    taskType,
+    occurredAt: result.startedAt ?? result.completedAt,
+    outcome: result.outcome,
+    repositoryOutcomeState: result.repositoryOutcome?.state ?? "missing",
+    learningTask,
+    provenance,
+  });
+  if (capture.status === "skipped") {
+    await writeCaptureStatus(deps.munin, taskNamespace, status, LEARNING_REGISTRY_REJECTED_TAG);
+    await deps.munin.log(taskNamespace, `Learning registry capture rejected: ${capture.reason}`).catch(() => {});
+    return { status: "rejected", reason: capture.reason };
+  }
+  await writeCaptureStatus(deps.munin, taskNamespace, status, LEARNING_REGISTRY_CAPTURED_TAG);
+  await deps.munin.log(
+    taskNamespace,
+    `Learning registry captured admitted homeserver attempt ${capture.attemptId}`,
+  ).catch(() => {});
+  return { status: "captured", attemptId: capture.attemptId };
+}
+
+export interface ReconcileHomeserverLearningResult {
+  scanned: number;
+  captured: number;
+  rejected: number;
+  failed: number;
+  truncated: boolean;
+}
+
+export async function reconcilePendingHomeserverLearningTasks(
+  deps: HomeserverLearningRegistryRecoveryDeps,
+  budget: MuninPaginationBudget = { maxPages: 20, maxResults: 1_000 },
+): Promise<ReconcileHomeserverLearningResult> {
+  const query = await queryAllMuninEntries(
+    deps.munin,
+    { namespace: "tasks/", tags: [LEARNING_REGISTRY_PENDING_TAG], entry_type: "state" },
+    budget,
+  );
+  const statuses = query.results.filter((entry: MuninQueryResult) => entry.key === "status");
+  let captured = 0;
+  let rejected = 0;
+  let failed = 0;
+  for (const status of statuses) {
+    try {
+      const result = await capturePendingHomeserverLearningTask(deps, status.namespace);
+      if (result.status === "captured") captured += 1;
+      if (result.status === "rejected") rejected += 1;
+    } catch (error) {
+      failed += 1;
+      const detail = error instanceof Error ? error.message : String(error);
+      await deps.munin.log(status.namespace, `Learning registry capture retry failed: ${detail}`).catch(() => {});
+    }
+  }
+  return { scanned: statuses.length, captured, rejected, failed, truncated: query.truncated };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -150,6 +150,13 @@ import {
 import { LearningLoopCollector } from "./learning-loop-collector.js";
 import { LearningRegistryStore } from "./learning-registry-store.js";
 import { LearningExperimentStore } from "./learning/experiment-store.js";
+import { isPotentialAdmittedHomeserverAttempt } from "./homeserver-learning-registry-bridge.js";
+import {
+  LEARNING_REGISTRY_PENDING_TAG,
+  capturePendingHomeserverLearningTask,
+  reconcilePendingHomeserverLearningTasks,
+} from "./homeserver-learning-registry-recovery.js";
+import { fetchM5LedgerAttemptBinding } from "./m5-ledger-attempt-binding.js";
 import { runHarnessLaneSampledAttempt, type LaneAttemptOutcome } from "./harness-lane-executor.js";
 import { decideHarnessLane, isHarnessLaneEligibleTaskType } from "./harness-lane-sampler.js";
 import { sanitizeProviderTokenCount } from "./m5-provenance.js";
@@ -6173,13 +6180,26 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     // set so downstream consumers + startup reconciliation see a consistent
     // terminal delivery state. Shared by the cancelled and normal branches —
     // a cancel mid-delivery still set terminalDeliveryTag = "delivery:failed".
-    const finalizeBaseTags = terminalDeliveryTag
+    const deliveryAwareFinalizeTags = terminalDeliveryTag
       ? [
           ...entry.tags.filter((t) => !t.startsWith("delivery:")),
           terminalDeliveryTag,
         ]
       : entry.tags;
+    const learningCapturePending = isHomeserver
+      && repositoryOutcome.state === "not-managed"
+      && isPotentialAdmittedHomeserverAttempt(
+        homeserverResult?.learningTask,
+        runtimeMetadata?.delegation,
+      );
+    const finalizeBaseTags = learningCapturePending
+      ? [
+          ...deliveryAwareFinalizeTags.filter((tag) => !tag.startsWith("learning-registry:")),
+          LEARNING_REGISTRY_PENDING_TAG,
+        ]
+      : deliveryAwareFinalizeTags;
 
+    let terminalStructuredResultOk = false;
     if (isCancelled && cancellation) {
       await munin.write(
         taskNs,
@@ -6247,6 +6267,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         currentTaskConfig = null;
         return { hadTask: true, queueDepth };
       }
+      terminalStructuredResultOk = cancelledFinalize.structuredResultOk;
     } else {
       // Append the distinct failure tag (issue #129) and the publication
       // failure tag (issue #225) AFTER buildTerminalStatusTags, whose
@@ -6340,6 +6361,33 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         currentTaskConfig = null;
         return { hadTask: true, queueDepth };
       }
+      terminalStructuredResultOk = finalizeOutcome.structuredResultOk;
+    }
+
+    // hugin#284: capture from the DURABLE terminal result, never from mutable
+    // executor locals. A pending status survives partial registry writes and
+    // is replayed idempotently by startup/periodic reconciliation. The M5
+    // ledger read must independently bind ledger/model/task to this exact
+    // admitted task+attempt before the first registry event is accepted.
+    if (terminalStructuredResultOk && learningCapturePending) {
+      try {
+        const gateway = loadHomeserverGatewayConfig(process.env);
+        if (!gateway) throw new Error("homeserver gateway unavailable for authoritative ledger binding");
+        await capturePendingHomeserverLearningTask({
+          munin,
+          registry: learningRegistry,
+          resolveLedgerAttemptBinding: (ledgerId) => fetchM5LedgerAttemptBinding(gateway, ledgerId),
+        }, taskNs);
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        console.error(`Learning registry capture pending for ${taskNs}: ${detail}`);
+        await munin.log(
+          taskNs,
+          `Learning registry capture pending after terminalization: ${detail}`,
+        ).catch((logError) => {
+          console.error(`Learning registry failure log also failed for ${taskNs}:`, logError);
+        });
+      }
     }
 
     const shouldPromoteDependents =
@@ -6424,6 +6472,26 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
   }
 }
 
+async function runHomeserverLearningRegistryReconciliation(): Promise<void> {
+  const gateway = loadHomeserverGatewayConfig(process.env);
+  if (!gateway) return;
+  try {
+    const result = await reconcilePendingHomeserverLearningTasks({
+      munin,
+      registry: learningRegistry,
+      resolveLedgerAttemptBinding: (ledgerId) => fetchM5LedgerAttemptBinding(gateway, ledgerId),
+    });
+    if (result.scanned > 0 || result.truncated) {
+      console.log(
+        `Learning registry reconciliation: scanned=${result.scanned} captured=${result.captured} `
+        + `rejected=${result.rejected} failed=${result.failed} truncated=${result.truncated}`,
+      );
+    }
+  } catch (error) {
+    console.error("Learning registry reconciliation failed:", error);
+  }
+}
+
 async function pollLoop(): Promise<void> {
   console.log(
     `Hugin dispatcher started (poll interval: ${config.pollIntervalMs}ms)`
@@ -6435,6 +6503,7 @@ async function pollLoop(): Promise<void> {
   // Recover any tasks left running from a previous crash
   await recoverStaleTasks();
   await reconcileBlockedTasks();
+  await runHomeserverLearningRegistryReconciliation();
   await primeTrackedPipelineSummaries();
   await reconcileTrackedPipelineSummaries();
 
@@ -6484,6 +6553,9 @@ async function pollLoop(): Promise<void> {
       const poll = await pollOnce();
       if (pollCount % 5 === 0) {
         await reconcileBlockedTasks();
+      }
+      if (pollCount % 60 === 0) {
+        await runHomeserverLearningRegistryReconciliation();
       }
       lastBlockedTaskCount = await countTasksWithLifecycle("blocked");
       // Fire-and-forget heartbeat

--- a/src/learning/candidate-packager-schema.ts
+++ b/src/learning/candidate-packager-schema.ts
@@ -146,6 +146,7 @@ export type CandidateRejectionReason =
   | { code: "outcome-not-completed"; outcome: string }
   | { code: "quality-receipt-task-mismatch" }
   | { code: "quality-receipt-attempt-mismatch" }
+  | { code: "quality-receipt-not-independent"; independence: "self" | "unknown" }
   | { code: "quality-rating-insufficient"; rating: PackagerQualityRating };
 
 export interface RejectedCandidate {

--- a/src/learning/candidate-packager.ts
+++ b/src/learning/candidate-packager.ts
@@ -138,6 +138,12 @@ export function qualifyCandidate(
   if (receipt.schemaVersion === 2 && receipt.attemptId !== candidate.attemptId) {
     reasons.push({ code: "quality-receipt-attempt-mismatch" });
   }
+  if (receipt.reviewer.independence !== "independent") {
+    reasons.push({
+      code: "quality-receipt-not-independent",
+      independence: receipt.reviewer.independence,
+    });
+  }
   const minRating = options.minQualityRating ?? DEFAULT_MIN_QUALITY_RATING;
   if (RATING_RANK[receipt.rating] < RATING_RANK[minRating]) {
     reasons.push({ code: "quality-rating-insufficient", rating: receipt.rating });

--- a/src/learning/candidate-pool-assembler.ts
+++ b/src/learning/candidate-pool-assembler.ts
@@ -36,10 +36,10 @@
  *
  *   1. `payload.outcome !== "completed"` -> excluded ("outcome-not-completed").
  *   2. `payload.delegation?.modelId` absent -> excluded
- *      ("missing-model-identity"). Hugin's own registry only durably records a
- *      real model identity via the standing harness-lane sampler's (#267)
- *      `delegation` field; a terminal outcome the sampler never touched
- *      carries no model identity Hugin can honestly attribute.
+ *      ("missing-model-identity"). Hugin's native registry producers durably
+ *      record real model identity in the shared `delegation` field. The
+ *      admitted direct-homeserver bridge (#284) additionally requires its M5
+ *      ledger join before it writes that field.
  *   3. `payload.delegation?.taskType` absent or not a valid Broker task type
  *      -> excluded ("missing-or-invalid-task-type").
  *   4. `payload.attemptOutcomeRef` absent, or it does not resolve to an
@@ -57,8 +57,8 @@
  *          `.harness` (id/version + the config document's own sha256 digest;
  *          `harness.toolPolicyVersion` from `origin_config.tool_policy.version`).
  *        - `model` from `delegation.modelId`, with `provider`/`runtime`
- *          naming the one dispatch surface Hugin's own registry can honestly
- *          attribute today (the M5 gateway's `/delegate` lane); `config: {}`
+ *          naming the dispatch surface the admitted attempt proves (the M5
+ *          gateway's `/delegate` lane); `config: {}`
  *          because Hugin does not durably record per-task model-config detail
  *          (quantization/temperature/etc) -- left empty rather than guessed.
  *        - `logging`/`testHarness`/`routing`: Hugin does not yet durably
@@ -117,8 +117,8 @@ import type { LearningTaskExecutionEvidence } from "../learning-task-handshake.j
 
 const DEFAULT_LOOKBACK_MONTHS = 2;
 
-/** The one dispatch surface Hugin's own registry can honestly attribute a
- * model identity through today -- the M5 gateway's `/delegate` endpoint (see
+/** The dispatch surface an admitted candidate can honestly attribute today --
+ * the M5 gateway's `/delegate` endpoint (see
  * `m5-provenance.ts` and `learning-task-handshake.ts`'s
  * `HARNESS_CONFIG_DOCUMENT.settings.adapter`). Never a guess at the
  * underlying model's own real provider/runtime, which Hugin does not own
@@ -182,6 +182,7 @@ export interface AssembleCandidatePoolOptions {
 export type SkippedCandidateReason =
   | "outcome-not-completed"
   | "missing-model-identity"
+  | "missing-evidence-identity"
   | "missing-or-invalid-task-type"
   | "missing-attempt-outcome-ref"
   | "attempt-outcome-not-admitted"
@@ -267,6 +268,14 @@ async function resolveCandidate(
   if (!modelId) {
     return { skip: { taskId, attemptId, reason: "missing-model-identity" } };
   }
+  const evidenceIdentityHash = event.payload.delegation?.evidenceIdentityHash;
+  if (!evidenceIdentityHash) {
+    return { skip: { taskId, attemptId, reason: "missing-evidence-identity" } };
+  }
+  // Presence proves the registry writer completed the authoritative Gille
+  // ledger join. Do not use the full hash as a configuration axis: Gille's
+  // evidence identity intentionally includes logical-task/prompt identity, so
+  // it differs across matched samples even when their configuration is equal.
 
   const rawTaskType = event.payload.delegation?.taskType;
   const taskTypeParsed = rawTaskType ? taskTypeSchema.safeParse(rawTaskType) : undefined;

--- a/src/learning/quality-receipt-resolution.ts
+++ b/src/learning/quality-receipt-resolution.ts
@@ -32,8 +32,10 @@ import {
 /**
  * `null` when the task's status/result documents are missing (nothing to
  * bind against), the feedback ledger is missing/unreadable/unparseable, no
- * receipt is bound to the CURRENT task content, or no bound receipt survives
- * as the effective one for this exact attempt. Never fabricates or guesses.
+ * receipt is bound to the CURRENT task content, or no independently-reviewed
+ * bound receipt survives as the effective one for this exact attempt. Never
+ * fabricates or guesses. A self/unknown correction still supersedes its
+ * predecessor; it does not resurrect an older independent verdict.
  *
  * A schemaVersion-2 (attempt-bound) effective receipt naming this exact
  * `attemptId` wins. Otherwise a legacy schemaVersion-1 (task-level, no
@@ -86,12 +88,15 @@ export async function resolveEffectiveQualityReceipt(
   if (effective.length === 0) return null;
 
   const attemptBound = effective
-    .filter((receipt) => receipt.schemaVersion === 2 && receipt.attemptId === attemptId)
+    .filter((receipt) => receipt.schemaVersion === 2
+      && receipt.attemptId === attemptId
+      && receipt.reviewer.independence === "independent")
     .sort((a, b) => b.ratedAt.localeCompare(a.ratedAt));
   if (attemptBound.length > 0) return attemptBound[0]!;
 
   const taskLevel = effective
-    .filter((receipt) => receipt.schemaVersion === 1)
+    .filter((receipt) => receipt.schemaVersion === 1
+      && receipt.reviewer.independence === "independent")
     .sort((a, b) => b.ratedAt.localeCompare(a.ratedAt));
   return taskLevel[0] ?? null;
 }

--- a/src/m5-ledger-attempt-binding.ts
+++ b/src/m5-ledger-attempt-binding.ts
@@ -1,0 +1,70 @@
+import { z } from "zod";
+import type { HomeserverGatewayConfig } from "./homeserver-executor.js";
+
+const sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
+
+/** Content-blind join returned by Gille's authenticated GET /ledger/{id}. */
+export const m5LedgerAttemptBindingSchema = z.object({
+  id: z.string().min(1),
+  evidenceIdentityHash: sha256Schema,
+  taskInstanceId: z.string().min(1),
+  attemptId: z.string().min(1),
+  taskType: z.string().min(1),
+  modelId: z.string().min(1),
+}).strip();
+
+export type M5LedgerAttemptBinding = z.infer<typeof m5LedgerAttemptBindingSchema>;
+export type ResolveM5LedgerAttemptBinding = (
+  ledgerId: string,
+) => Promise<M5LedgerAttemptBinding>;
+
+const MAX_LEDGER_RESPONSE_BYTES = 64 * 1024;
+const LEDGER_LOOKUP_TIMEOUT_MS = 5_000;
+
+async function readBoundedResponseBody(response: Response): Promise<string> {
+  if (!response.body) throw new Error("M5 ledger binding response had no body");
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let bytes = 0;
+  let text = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    bytes += value.byteLength;
+    if (bytes > MAX_LEDGER_RESPONSE_BYTES) {
+      await reader.cancel().catch(() => {});
+      throw new Error("M5 ledger binding response exceeded the size limit");
+    }
+    text += decoder.decode(value, { stream: true });
+  }
+  return text + decoder.decode();
+}
+
+export async function fetchM5LedgerAttemptBinding(
+  gateway: HomeserverGatewayConfig,
+  ledgerId: string,
+  signal?: AbortSignal,
+): Promise<M5LedgerAttemptBinding> {
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (gateway.apiKey) headers.Authorization = `Bearer ${gateway.apiKey}`;
+  const response = await fetch(`${gateway.baseUrl}/ledger/${encodeURIComponent(ledgerId)}`, {
+    method: "GET",
+    headers,
+    signal: signal ?? AbortSignal.timeout(LEDGER_LOOKUP_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new Error(`M5 ledger binding lookup failed with HTTP ${response.status}`);
+  }
+  const text = await readBoundedResponseBody(response);
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch {
+    throw new Error("M5 ledger binding response was not valid JSON");
+  }
+  const parsed = m5LedgerAttemptBindingSchema.safeParse(raw);
+  if (!parsed.success || parsed.data.id !== ledgerId) {
+    throw new Error("M5 ledger binding response did not match the requested authoritative row");
+  }
+  return parsed.data;
+}

--- a/src/task-result-schema.ts
+++ b/src/task-result-schema.ts
@@ -118,6 +118,10 @@ export const delegationProvenanceSchema = z.object({
   nodeId: z.string().min(1).optional(),
   modelId: z.string().min(1).optional(),
   taskType: z.string().min(1).optional(),
+  // Authoritative Gille evidence-identity hash for registry/cadence
+  // candidates. Direct gateway responses do not self-assert this value;
+  // Hugin adds it only after authenticated GET /ledger/{id} verification.
+  evidenceIdentityHash: z.string().regex(/^[a-f0-9]{64}$/).optional(),
   // Standing harness-lane sampler (hugin#267). Distinguishes a one-shot
   // delegation from one additionally sampled through the harness (code_loop /
   // opencode) lane, so the SAME #163 evidence-identity shape carries the

--- a/src/task-status-tags.ts
+++ b/src/task-status-tags.ts
@@ -26,6 +26,9 @@ const DELIVERY_PREFIX = "delivery:";
 // (`publication:failed` -> `publication:recovered`/`publication:abandoned`)
 // so `buildTerminalStatusTags` does not silently drop it mid-transition.
 const PUBLICATION_PREFIX = "publication:";
+// Durable post-terminal learning capture. `pending` survives restart until
+// the authoritative M5 ledger join and all idempotent registry writes finish.
+const LEARNING_REGISTRY_PREFIX = "learning-registry:";
 
 function dedupeTags(tags: string[]): string[] {
   const seen = new Set<string>();
@@ -56,6 +59,7 @@ export function getPersistentStatusTags(
   const routingTags = tags.filter((tag) => tag.startsWith(ROUTING_PREFIX));
   const deliveryTags = tags.filter((tag) => tag.startsWith(DELIVERY_PREFIX));
   const publicationTags = tags.filter((tag) => tag.startsWith(PUBLICATION_PREFIX));
+  const learningRegistryTags = tags.filter((tag) => tag.startsWith(LEARNING_REGISTRY_PREFIX));
   const brokerTags = tags.filter((tag) => tag.startsWith(BROKER_PREFIX));
   const aliasTags = tags.filter((tag) => tag.startsWith(ALIAS_PREFIX));
   const taskTypeTags = tags.filter((tag) => tag.startsWith(TASK_TYPE_PREFIX));
@@ -72,6 +76,7 @@ export function getPersistentStatusTags(
     ...routingTags,
     ...deliveryTags,
     ...publicationTags,
+    ...learningRegistryTags,
     ...brokerTags,
     ...aliasTags,
     ...taskTypeTags,

--- a/tests/candidate-packager.test.ts
+++ b/tests/candidate-packager.test.ts
@@ -278,6 +278,20 @@ describe("qualifyCandidate", () => {
     if (!result.ok) expect(result.reasons).toContainEqual({ code: "quality-receipt-task-mismatch" });
   });
 
+  it("rejects a candidate whose quality receipt is not independently reviewed", async () => {
+    const store = new LearningRegistryStore(munin());
+    await registerQualifiedAttempt(store, { taskId: "t1", attemptId: "a1", occurredAt: "2026-07-19T00:00:00.000Z" });
+    const timeline = await buildTaskLifecycleTimeline(store, "t1");
+    const candidate = candidateFor("t1", "a1", "champion", "agent-prompt", {
+      reviewerIndependence: "self",
+    });
+    const result = qualifyCandidate(candidate, timeline);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reasons).toContainEqual({ code: "quality-receipt-not-independent", independence: "self" });
+    }
+  });
+
   it("rejects a candidate whose receipt rating is below the required threshold", async () => {
     const store = new LearningRegistryStore(munin());
     await registerQualifiedAttempt(store, { taskId: "t1", attemptId: "a1", occurredAt: "2026-07-19T00:00:00.000Z" });

--- a/tests/candidate-pool-assembler.test.ts
+++ b/tests/candidate-pool-assembler.test.ts
@@ -124,7 +124,14 @@ const PERIOD = "2026-07";
 async function seedResolvableCandidate(
   m: InMemoryMunin & MuninClient,
   store: LearningRegistryStore,
-  input: { taskId: string; taskType: string; modelId: string; rating: "pass" | "partial" | "redo" | "wrong"; occurredAt: string },
+  input: {
+    taskId: string;
+    taskType: string;
+    modelId: string;
+    rating: "pass" | "partial" | "redo" | "wrong";
+    occurredAt: string;
+    reviewerIndependence?: "independent" | "self" | "unknown";
+  },
 ): Promise<{ attemptId: string }> {
   const { attemptId, attemptOutcomeRef, evidence } = buildFixtureAdmittedAttempt({
     taskId: input.taskId,
@@ -147,7 +154,12 @@ async function seedResolvableCandidate(
     outcome: "completed",
     taskOutcomeRef,
     attemptOutcomeRef,
-    delegation: { modelId: input.modelId, taskType: input.taskType, lane: "harness" },
+    delegation: {
+      modelId: input.modelId,
+      taskType: input.taskType,
+      lane: "harness",
+      evidenceIdentityHash: hash(`evidence:${input.taskId}`),
+    },
     occurredAt: input.occurredAt,
   });
 
@@ -160,7 +172,7 @@ async function seedResolvableCandidate(
   const receipt = buildQualityReceipt({
     taskId: input.taskId,
     reviewerPrincipal: "codex",
-    reviewerIndependence: "independent",
+    reviewerIndependence: input.reviewerIndependence ?? "independent",
     rating: input.rating,
     ratingReason: `SECRET-RAW-EVIDENCE-TEXT-${input.taskId}`,
     verificationOutcome: input.rating === "pass" ? "accepted_unchanged" : "major_rewrite",
@@ -245,7 +257,7 @@ describe("assembleCandidatePool", () => {
     });
     await store.recordTerminalOutcome({
       taskId, attemptId, outcome: "failed", taskOutcomeRef, attemptOutcomeRef,
-      delegation: { modelId: "model-a", taskType: "code-edit" },
+      delegation: { modelId: "model-a", taskType: "code-edit", evidenceIdentityHash: hash("failed") },
       occurredAt: "2026-07-05T00:00:00.000Z",
     });
 
@@ -275,6 +287,28 @@ describe("assembleCandidatePool", () => {
     expect(result.skipped).toEqual([{ taskId, attemptId, reason: "missing-model-identity" }]);
   });
 
+  it("skips a completed outcome whose model lacks an authoritative evidence identity", async () => {
+    const m = munin();
+    const store = new LearningRegistryStore(m);
+    const taskId = "task-no-evidence-identity";
+    const attemptId = "some-attempt-id";
+    const taskOutcomeRef = ref(`tasks/${taskId}`, "result-structured");
+    await store.recordSubmission({ taskId, taskOutcomeRef, occurredAt: "2026-07-05T00:00:00.000Z" });
+    await store.recordAttemptReference({
+      taskId, attemptId, attemptStartRef: ref(`tasks/${taskId}`, `learning-attempt-${attemptId}`), taskOutcomeRef,
+      occurredAt: "2026-07-05T00:00:00.000Z",
+    });
+    await store.recordTerminalOutcome({
+      taskId, attemptId, outcome: "completed", taskOutcomeRef,
+      delegation: { modelId: "model-a", taskType: "code-edit" },
+      occurredAt: "2026-07-05T00:00:00.000Z",
+    });
+
+    const result = await assembleCandidatePool({ registry: store, munin: m }, { periods: [PERIOD] });
+    expect(result.candidates).toEqual([]);
+    expect(result.skipped).toEqual([{ taskId, attemptId, reason: "missing-evidence-identity" }]);
+  });
+
   it("skips a completed outcome missing an attempt-outcome ref", async () => {
     const m = munin();
     const store = new LearningRegistryStore(m);
@@ -288,7 +322,7 @@ describe("assembleCandidatePool", () => {
     });
     await store.recordTerminalOutcome({
       taskId, attemptId, outcome: "completed", taskOutcomeRef,
-      delegation: { modelId: "model-a", taskType: "code-edit" },
+      delegation: { modelId: "model-a", taskType: "code-edit", evidenceIdentityHash: hash("no-ref") },
       occurredAt: "2026-07-05T00:00:00.000Z",
     });
 
@@ -323,7 +357,7 @@ describe("assembleCandidatePool", () => {
     });
     await store.recordTerminalOutcome({
       taskId, attemptId, outcome: "completed", taskOutcomeRef, attemptOutcomeRef,
-      delegation: { modelId: "model-a", taskType: "code-edit" },
+      delegation: { modelId: "model-a", taskType: "code-edit", evidenceIdentityHash: hash("not-admitted") },
       occurredAt: "2026-07-05T00:00:00.000Z",
     });
 
@@ -346,10 +380,28 @@ describe("assembleCandidatePool", () => {
     });
     await store.recordTerminalOutcome({
       taskId, attemptId, outcome: "completed", taskOutcomeRef, attemptOutcomeRef,
-      delegation: { modelId: "model-a", taskType: "code-edit" },
+      delegation: { modelId: "model-a", taskType: "code-edit", evidenceIdentityHash: hash("no-receipt") },
       occurredAt: "2026-07-05T00:00:00.000Z",
     });
     // No status/result-structured/feedback docs written -- nothing to bind a receipt against.
+
+    const result = await assembleCandidatePool({ registry: store, munin: m }, { periods: [PERIOD] });
+    expect(result.candidates).toEqual([]);
+    expect(result.skipped).toEqual([{ taskId, attemptId, reason: "missing-quality-receipt" }]);
+  });
+
+  it("skips an exact-bound receipt when the reviewer is not independent", async () => {
+    const m = munin();
+    const store = new LearningRegistryStore(m);
+    const taskId = "task-self-reviewed";
+    const { attemptId } = await seedResolvableCandidate(m, store, {
+      taskId,
+      taskType: "code-edit",
+      modelId: "model-a",
+      rating: "pass",
+      occurredAt: "2026-07-05T00:00:00.000Z",
+      reviewerIndependence: "self",
+    });
 
     const result = await assembleCandidatePool({ registry: store, munin: m }, { periods: [PERIOD] });
     expect(result.candidates).toEqual([]);

--- a/tests/experiment-cadence-with-assembler.test.ts
+++ b/tests/experiment-cadence-with-assembler.test.ts
@@ -3,6 +3,7 @@ import { once } from "node:events";
 import { describe, expect, it, afterEach } from "vitest";
 import { MuninWriteRejectedError, type MuninClient } from "../src/munin-client.js";
 import { LearningRegistryStore } from "../src/learning-registry-store.js";
+import { recordAdmittedHomeserverAttempt } from "../src/homeserver-learning-registry-bridge.js";
 import { LearningExperimentStore } from "../src/learning/experiment-store.js";
 import { buildQualityBinding, buildQualityReceipt } from "../src/quality-receipt.js";
 import { createCandidatePoolAssembler } from "../src/learning/candidate-pool-assembler.js";
@@ -128,17 +129,34 @@ async function seedResolvableCandidate(
   });
   await m.write(attemptOutcomeRef.namespace, attemptOutcomeRef.key, JSON.stringify(evidence), []);
 
-  const taskOutcomeRef = ref(`tasks/${input.taskId}`, "result-structured");
-  await store.recordSubmission({ taskId: input.taskId, taskOutcomeRef, occurredAt: input.occurredAt });
-  await store.recordAttemptReference({
-    taskId: input.taskId, attemptId, attemptStartRef: ref(`tasks/${input.taskId}`, `learning-attempt-${attemptId}`),
-    taskOutcomeRef, occurredAt: input.occurredAt,
-  });
-  await store.recordTerminalOutcome({
-    taskId: input.taskId, attemptId, outcome: "completed", taskOutcomeRef, attemptOutcomeRef,
-    delegation: { modelId: input.modelId, taskType: input.taskType, nodeId: "m5" },
+  const ledgerId = `ledger:${input.taskId}`;
+  const bridge = await recordAdmittedHomeserverAttempt({
+    registry: store,
+    resolveLedgerAttemptBinding: async () => ({
+      id: ledgerId,
+      evidenceIdentityHash: "a".repeat(64),
+      taskInstanceId: input.taskId,
+      attemptId,
+      taskType: input.taskType,
+      modelId: input.modelId,
+    }),
+  }, {
+    taskId: input.taskId,
+    taskType: input.taskType,
     occurredAt: input.occurredAt,
+    outcome: "completed",
+    repositoryOutcomeState: "not-managed",
+    learningTask: evidence,
+    provenance: {
+      ledgerId,
+      modelId: input.modelId,
+      taskType: input.taskType,
+      nodeId: "m5",
+      outcome: input.rating === "pass" ? "pass" : "fail",
+      delegated: true,
+    },
   });
+  expect(bridge.status).toBe("recorded");
 
   const statusContent = buildFixtureStatusDocument(input.taskId, `prompt for ${input.taskId}`);
   const resultContent = buildFixtureResultStructuredDocument(input.taskId);
@@ -163,16 +181,20 @@ async function seedResolvableCandidate(
 async function seedOneAxisPopulation(
   m: InMemoryMunin & MuninClient,
   store: LearningRegistryStore,
-  input: { taskType: string; idPrefix: string; startIso: string },
+  input: { taskType: string; idPrefix: string; startIso: string; samplesPerArm?: number },
 ): Promise<void> {
-  const championRatings: Array<"pass" | "wrong"> = ["pass", "pass", "wrong", "wrong"];
-  for (let i = 0; i < 4; i += 1) {
+  const samplesPerArm = input.samplesPerArm ?? 4;
+  const championRatings: Array<"pass" | "wrong"> = Array.from(
+    { length: samplesPerArm },
+    (_, index) => index < 2 ? "pass" : "wrong",
+  );
+  for (let i = 0; i < samplesPerArm; i += 1) {
     await seedResolvableCandidate(m, store, {
       taskId: `${input.idPrefix}-champ-${i}`, taskType: input.taskType, modelId: `${input.idPrefix}-champion-model`,
       rating: championRatings[i]!, occurredAt: new Date(Date.parse(input.startIso) + i * 86_400_000).toISOString(),
     });
   }
-  for (let i = 0; i < 4; i += 1) {
+  for (let i = 0; i < samplesPerArm; i += 1) {
     await seedResolvableCandidate(m, store, {
       taskId: `${input.idPrefix}-chall-${i}`, taskType: input.taskType, modelId: `${input.idPrefix}-challenger-model`,
       rating: "pass", occurredAt: new Date(Date.parse(input.startIso) + (5 + i) * 86_400_000).toISOString(),
@@ -232,6 +254,27 @@ function baseDeps(
 }
 
 describe("runExperimentCadenceTick with the production candidate-pool assembler", () => {
+  it("proposes from the documented minimum campaign of three admitted samples per arm", async () => {
+    const m = munin();
+    const registry = new LearningRegistryStore(m);
+    const experimentStore = new LearningExperimentStore(m);
+    await seedOneAxisPopulation(m, registry, {
+      taskType: "code-edit",
+      idPrefix: "cadence-minimum",
+      startIso: "2026-07-01T00:00:00.000Z",
+      samplesPerArm: 3,
+    });
+
+    const tick = await runExperimentCadenceTick(
+      baseDeps(m, registry, experimentStore, "service:test-cadence-minimum"),
+    );
+
+    expect(tick.errors).toEqual([]);
+    expect(tick.candidatesLoaded).toBe(6);
+    expect(tick.proposalsConsidered).toBe(1);
+    expect(tick.packaged).not.toBeNull();
+  });
+
   it("proposes and packages exactly one experiment from real registry/receipt/evidence state, idempotently", async () => {
     const m = munin();
     const registry = new LearningRegistryStore(m);

--- a/tests/homeserver-learning-registry-bridge.test.ts
+++ b/tests/homeserver-learning-registry-bridge.test.ts
@@ -1,0 +1,407 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { MuninWriteRejectedError, type MuninClient } from "../src/munin-client.js";
+import { LearningRegistryStore } from "../src/learning-registry-store.js";
+import { recordAdmittedHomeserverAttempt } from "../src/homeserver-learning-registry-bridge.js";
+import {
+  LEARNING_REGISTRY_CAPTURED_TAG,
+  LEARNING_REGISTRY_PENDING_TAG,
+  reconcilePendingHomeserverLearningTasks,
+} from "../src/homeserver-learning-registry-recovery.js";
+import type { M5LedgerAttemptBinding } from "../src/m5-ledger-attempt-binding.js";
+import { buildStructuredTaskResult } from "../src/task-result-schema.js";
+import { finalizeTaskCompletion } from "../src/task-helpers.js";
+import { assembleCandidatePool } from "../src/learning/candidate-pool-assembler.js";
+import { buildQualityBinding, buildQualityReceipt } from "../src/quality-receipt.js";
+import {
+  buildFixtureAdmittedAttempt,
+  buildFixtureResultStructuredDocument,
+  buildFixtureStatusDocument,
+} from "./helpers/candidate-evidence-fixtures.js";
+
+interface StoredEntry {
+  namespace: string;
+  key: string;
+  content: string;
+  tags: string[];
+  classification?: string;
+  created_at: string;
+  updated_at: string;
+}
+
+const hash = (value: string): string => createHash("sha256").update(value).digest("hex");
+
+class InMemoryMunin {
+  private readonly entries: StoredEntry[] = [];
+  private seq = 0;
+
+  private clock(): string {
+    this.seq += 1;
+    return new Date(Date.UTC(2026, 6, 1) + this.seq).toISOString();
+  }
+
+  private find(namespace: string, key: string): StoredEntry | undefined {
+    return this.entries.find((entry) => entry.namespace === namespace && entry.key === key);
+  }
+
+  async read(namespace: string, key: string) {
+    const entry = this.find(namespace, key);
+    return entry ? { ...entry, found: true as const } : null;
+  }
+
+  async write(
+    namespace: string,
+    key: string,
+    content: string,
+    tags?: string[],
+    expectedUpdatedAt?: string,
+    classification?: string,
+    createIfAbsent?: boolean,
+  ) {
+    const existing = this.find(namespace, key);
+    if (createIfAbsent && existing) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        message: "Entry already exists.",
+        conflict_reason: "already_exists",
+        current_updated_at: existing.updated_at,
+      });
+    }
+    if (expectedUpdatedAt !== undefined && existing?.updated_at !== expectedUpdatedAt) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        message: "Entry version changed.",
+        conflict_reason: "version_mismatch",
+        current_updated_at: existing?.updated_at,
+      });
+    }
+    const updated_at = this.clock();
+    const next: StoredEntry = {
+      namespace,
+      key,
+      content,
+      tags: tags ?? [],
+      classification,
+      created_at: existing?.created_at ?? updated_at,
+      updated_at,
+    };
+    if (existing) Object.assign(existing, next);
+    else this.entries.push(next);
+    return { ok: true, status: existing ? "updated" : "created", updated_at };
+  }
+
+  async query(opts: { namespace?: string; tags?: string[]; limit?: number }) {
+    const rows = this.entries.filter((entry) =>
+      (!opts.namespace || entry.namespace.startsWith(opts.namespace))
+      && (opts.tags ?? []).every((tag) => entry.tags.includes(tag)));
+    const limited = rows.slice(0, opts.limit ?? 50);
+    return {
+      results: limited.map((entry) => ({
+        id: `${entry.namespace}/${entry.key}`,
+        namespace: entry.namespace,
+        key: entry.key,
+        entry_type: "state",
+        content_preview: entry.content.slice(0, 80),
+        tags: entry.tags,
+        classification: entry.classification,
+        created_at: entry.created_at,
+        updated_at: entry.updated_at,
+      })),
+      total: rows.length,
+    };
+  }
+
+  async log() {}
+}
+
+function setup() {
+  const munin = new InMemoryMunin() as unknown as InMemoryMunin & MuninClient;
+  return { munin, registry: new LearningRegistryStore(munin) };
+}
+
+function admittedInput(taskId = "broker-learning-1") {
+  const admitted = buildFixtureAdmittedAttempt({ taskId, taskType: "code-edit" });
+  const binding: M5LedgerAttemptBinding = {
+    id: `ledger:${taskId}`,
+    evidenceIdentityHash: hash(`evidence:${taskId}`),
+    taskInstanceId: taskId,
+    attemptId: admitted.attemptId,
+    taskType: "code-edit",
+    modelId: "qwen3-coder-next",
+  };
+  return {
+    admitted,
+    binding,
+    input: {
+      taskId,
+      taskType: "code-edit",
+      occurredAt: "2026-07-22T12:00:00.000Z",
+      outcome: "completed" as const,
+      repositoryOutcomeState: "not-managed" as const,
+      learningTask: admitted.evidence,
+      provenance: {
+        ledgerId: `ledger:${taskId}`,
+        nodeId: "m5",
+        modelId: "qwen3-coder-next",
+        taskType: "code-edit",
+        outcome: "pass" as const,
+        delegated: true,
+      },
+    },
+  };
+}
+
+function bridgeDeps(
+  registry: LearningRegistryStore,
+  binding: M5LedgerAttemptBinding,
+) {
+  return {
+    registry,
+    resolveLedgerAttemptBinding: async () => binding,
+  };
+}
+
+describe("recordAdmittedHomeserverAttempt", () => {
+  it("records one real admitted Broker/M5 attempt with an explicit non-managed authority ceiling", async () => {
+    const { munin, registry } = setup();
+    const { admitted, binding, input } = admittedInput();
+    await munin.write(
+      admitted.attemptOutcomeRef.namespace,
+      admitted.attemptOutcomeRef.key,
+      JSON.stringify(admitted.evidence),
+      ["learning-task-attempt", "attempt:admitted"],
+    );
+
+    const result = await recordAdmittedHomeserverAttempt(bridgeDeps(registry, binding), input);
+
+    expect(result.status).toBe("recorded");
+    if (result.status !== "recorded") throw new Error("expected recorded result");
+    expect(result.attemptId).toBe(admitted.attemptId);
+    expect(result.registry.attemptReference.event.payload.attemptStartRef)
+      .toEqual(admitted.evidence.attemptStartRef);
+    expect(result.registry.terminalOutcome.event.payload).toMatchObject({
+      outcome: "completed",
+      repositoryOutcomeState: "not-managed",
+      attemptOutcomeRef: admitted.attemptOutcomeRef,
+      delegation: {
+        lane: "one-shot",
+        ledgerId: "ledger:broker-learning-1",
+        modelId: "qwen3-coder-next",
+        taskType: "code-edit",
+        evidenceIdentityHash: binding.evidenceIdentityHash,
+      },
+    });
+
+    const statusContent = buildFixtureStatusDocument(input.taskId, "production-shaped Broker prompt");
+    const structuredResultContent = buildFixtureResultStructuredDocument(input.taskId);
+    await munin.write(`tasks/${input.taskId}`, "status", statusContent, ["completed"]);
+    await munin.write(`tasks/${input.taskId}`, "result-structured", structuredResultContent, ["result"]);
+    const receipt = buildQualityReceipt({
+      taskId: input.taskId,
+      reviewerPrincipal: "codex",
+      reviewerIndependence: "independent",
+      rating: "pass",
+      ratingReason: "Bound independent review accepted the one-shot result.",
+      verificationOutcome: "accepted_unchanged",
+      ratedAt: input.occurredAt,
+      bindingAttestation: "server-bound",
+      binding: buildQualityBinding({ statusContent, structuredResultContent }),
+    });
+    await munin.write(
+      `tasks/${input.taskId}`,
+      "feedback",
+      JSON.stringify({ schemaVersion: 1, taskId: input.taskId, receipts: [receipt] }),
+      ["feedback"],
+    );
+
+    const pool = await assembleCandidatePool(
+      { registry, munin },
+      { periods: ["2026-07"] },
+    );
+    expect(pool.skipped).toEqual([]);
+    expect(pool.candidates).toEqual([
+      expect.objectContaining({
+        taskId: input.taskId,
+        attemptId: admitted.attemptId,
+        taskType: "code-edit",
+        configuration: expect.objectContaining({
+          model: expect.objectContaining({ id: "qwen3-coder-next" }),
+        }),
+      }),
+    ]);
+  });
+
+  it("is idempotent for an exact replay of the same admitted attempt", async () => {
+    const { registry } = setup();
+    const { binding, input } = admittedInput("broker-learning-replay");
+
+    const first = await recordAdmittedHomeserverAttempt(bridgeDeps(registry, binding), input);
+    const second = await recordAdmittedHomeserverAttempt(bridgeDeps(registry, binding), input);
+
+    expect(first.status).toBe("recorded");
+    expect(second.status).toBe("recorded");
+    if (second.status !== "recorded") throw new Error("expected recorded result");
+    expect(second.registry.submission.status).toBe("exact-existing");
+    expect(second.registry.attemptReference.status).toBe("exact-existing");
+    expect(second.registry.terminalOutcome.status).toBe("exact-existing");
+  });
+
+  it.each([
+    ["not-admitted", (input: ReturnType<typeof admittedInput>["input"]) => ({
+      ...input,
+      learningTask: { ...input.learningTask, state: "m5-not-admitted", evidenceAccepted: false },
+    })],
+    ["task-identity-mismatch", (input: ReturnType<typeof admittedInput>["input"]) => ({
+      ...input,
+      taskId: "different-task",
+    })],
+    ["task-type-mismatch", (input: ReturnType<typeof admittedInput>["input"]) => ({
+      ...input,
+      provenance: { ...input.provenance, taskType: "summarize" },
+    })],
+    ["missing-delegation-identity", (input: ReturnType<typeof admittedInput>["input"]) => ({
+      ...input,
+      provenance: { taskType: input.taskType },
+    })],
+    ["repository-authority-mismatch", (input: ReturnType<typeof admittedInput>["input"]) => ({
+      ...input,
+      repositoryOutcomeState: "changes-present" as const,
+    })],
+  ])("fails closed without registry writes for %s", async (reason, mutate) => {
+    const { registry } = setup();
+    const { binding, input } = admittedInput(`broker-learning-${reason}`);
+
+    const result = await recordAdmittedHomeserverAttempt(bridgeDeps(registry, binding), mutate(input));
+
+    expect(result).toEqual({ status: "skipped", reason });
+    expect((await registry.listEventsForTask(input.taskId)).events).toEqual([]);
+  });
+
+  it("rejects a stale ledger row bound to another admitted attempt", async () => {
+    const { registry } = setup();
+    const { binding, input } = admittedInput("broker-learning-stale-ledger");
+    const result = await recordAdmittedHomeserverAttempt(
+      bridgeDeps(registry, { ...binding, attemptId: "hugin-attempt:00000000-0000-4000-8000-000000000000" }),
+      input,
+    );
+    expect(result).toEqual({ status: "skipped", reason: "delegation-binding-mismatch" });
+    expect((await registry.listEventsForTask(input.taskId)).events).toEqual([]);
+  });
+
+  it("recovers a partial post-terminal registry write without re-running the task", async () => {
+    const { munin, registry } = setup();
+    const { admitted, binding, input } = admittedInput("broker-learning-recovery");
+    const taskNamespace = `tasks/${input.taskId}`;
+    await munin.write(
+      admitted.attemptOutcomeRef.namespace,
+      admitted.attemptOutcomeRef.key,
+      JSON.stringify(admitted.evidence),
+      ["learning-task-attempt", "attempt:admitted"],
+    );
+    const structured = buildStructuredTaskResult({
+      schemaVersion: 1,
+      taskId: input.taskId,
+      taskNamespace,
+      lifecycle: "completed",
+      outcome: "completed",
+      runtime: "homeserver",
+      executor: "homeserver/M5",
+      resultSource: "homeserver",
+      exitCode: 0,
+      startedAt: input.occurredAt,
+      completedAt: "2026-07-22T12:01:00.000Z",
+      bodyKind: "response",
+      bodyText: "fixture output",
+      repositoryOutcome: { state: "not-managed" },
+      runtimeMetadata: {
+        effectiveModel: input.provenance.modelId,
+        effectiveHost: "m5",
+        delegation: input.provenance,
+        huginTaskIdentity: {
+          schemaVersion: 1,
+          producer: "hugin",
+          taskId: input.taskId,
+          rawTaskFingerprint: admitted.evidence.rawFingerprint,
+          renderedPromptFingerprint: {
+            algorithm: "sha256",
+            version: "hugin-delegate-prompt-utf8-sha256-v1",
+            digest: hash("rendered-prompt"),
+            utf8Bytes: 15,
+          },
+        },
+        learningTask: admitted.evidence,
+      },
+    });
+    const statusContent = buildFixtureStatusDocument(input.taskId, "production-shaped Broker prompt");
+    await finalizeTaskCompletion(munin, taskNamespace, {
+      statusContent,
+      terminalTags: ["completed", "runtime:homeserver", LEARNING_REGISTRY_PENDING_TAG],
+      classification: "internal",
+      writeStructuredResult: () => munin.write(
+        taskNamespace,
+        "result-structured",
+        JSON.stringify(structured),
+        ["result"],
+        undefined,
+        "internal",
+      ).then(() => undefined),
+      logMessage: "task completed",
+    });
+
+    let failTerminalOnce = true;
+    const partialRegistry = {
+      recordSubmission: registry.recordSubmission.bind(registry),
+      recordAttemptReference: registry.recordAttemptReference.bind(registry),
+      recordTerminalOutcome: async (...args: Parameters<LearningRegistryStore["recordTerminalOutcome"]>) => {
+        if (failTerminalOnce) {
+          failTerminalOnce = false;
+          throw new Error("injected terminal registry outage");
+        }
+        return registry.recordTerminalOutcome(...args);
+      },
+    } as LearningRegistryStore;
+    const first = await reconcilePendingHomeserverLearningTasks({
+      munin,
+      registry: partialRegistry,
+      resolveLedgerAttemptBinding: async () => binding,
+    });
+    expect(first).toMatchObject({ scanned: 1, captured: 0, failed: 1 });
+    expect((await registry.listEventsForTask(input.taskId)).events.map((event) => event.recordKind).sort())
+      .toEqual(["attempt-reference", "submission"]);
+    expect((await munin.read(taskNamespace, "status"))?.tags).toContain(LEARNING_REGISTRY_PENDING_TAG);
+
+    const second = await reconcilePendingHomeserverLearningTasks({
+      munin,
+      registry,
+      resolveLedgerAttemptBinding: async () => binding,
+    });
+    expect(second).toMatchObject({ scanned: 1, captured: 1, failed: 0 });
+    expect((await registry.listEventsForTask(input.taskId)).events.map((event) => event.recordKind).sort())
+      .toEqual(["attempt-reference", "submission", "terminal-outcome"]);
+    expect((await munin.read(taskNamespace, "status"))?.tags).toContain(LEARNING_REGISTRY_CAPTURED_TAG);
+
+    const receipt = buildQualityReceipt({
+      taskId: input.taskId,
+      reviewerPrincipal: "codex-independent",
+      reviewerIndependence: "independent",
+      rating: "pass",
+      ratingReason: "Independent review accepted the recovered candidate.",
+      verificationOutcome: "accepted_unchanged",
+      ratedAt: "2026-07-22T12:02:00.000Z",
+      bindingAttestation: "server-bound",
+      binding: buildQualityBinding({
+        statusContent,
+        structuredResultContent: JSON.stringify(structured),
+      }),
+    });
+    await munin.write(
+      taskNamespace,
+      "feedback",
+      JSON.stringify({ schemaVersion: 1, taskId: input.taskId, receipts: [receipt] }),
+      ["feedback"],
+    );
+    const pool = await assembleCandidatePool({ registry, munin }, { periods: ["2026-07"] });
+    expect(pool.skipped).toEqual([]);
+    expect(pool.candidates.map((candidate) => candidate.taskId)).toEqual([input.taskId]);
+  });
+});

--- a/tests/m5-ledger-attempt-binding.test.ts
+++ b/tests/m5-ledger-attempt-binding.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchM5LedgerAttemptBinding,
+  type M5LedgerAttemptBinding,
+} from "../src/m5-ledger-attempt-binding.js";
+
+const binding: M5LedgerAttemptBinding = {
+  id: "ledger:attempt-1",
+  evidenceIdentityHash: "a".repeat(64),
+  taskInstanceId: "task-1",
+  attemptId: "hugin-attempt:11111111-1111-4111-8111-111111111111",
+  taskType: "code-edit",
+  modelId: "qwen3-coder-next",
+};
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("fetchM5LedgerAttemptBinding", () => {
+  it("reads the exact authenticated, id-addressable content-blind join", async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      ...binding,
+      outcome: "pass",
+      score: 1,
+    }), { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(fetchM5LedgerAttemptBinding(
+      { baseUrl: "http://m5.internal:8080", apiKey: "test-owner-key" },
+      binding.id,
+    )).resolves.toEqual(binding);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://m5.internal:8080/ledger/ledger%3Aattempt-1",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({ Authorization: "Bearer test-owner-key" }),
+      }),
+    );
+  });
+
+  it.each([
+    ["missing evidence identity", { ...binding, evidenceIdentityHash: undefined }],
+    ["legacy unstamped row", { ...binding, taskInstanceId: null, attemptId: null }],
+    ["different ledger row", { ...binding, id: "ledger:other" }],
+  ])("fails closed for %s", async (_label, body) => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify(body), { status: 200 })));
+    await expect(fetchM5LedgerAttemptBinding(
+      { baseUrl: "http://m5.internal:8080", apiKey: "test-owner-key" },
+      binding.id,
+    )).rejects.toThrow(/binding response/);
+  });
+
+  it("bounds an untrusted gateway response while reading it", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("x".repeat(65 * 1024), { status: 200 })));
+    await expect(fetchM5LedgerAttemptBinding(
+      { baseUrl: "http://m5.internal:8080", apiKey: "test-owner-key" },
+      binding.id,
+    )).rejects.toThrow(/size limit/);
+  });
+});

--- a/tests/task-status-tags.test.ts
+++ b/tests/task-status-tags.test.ts
@@ -57,6 +57,18 @@ describe("task status tag helpers", () => {
     ).toEqual(["completed", "runtime:codex", "publication:recovered"]);
   });
 
+  it("preserves learning-registry recovery state across terminal rewrites", () => {
+    expect(buildTerminalStatusTags("completed", [
+      "completed",
+      "runtime:homeserver",
+      "learning-registry:pending",
+    ])).toEqual([
+      "completed",
+      "runtime:homeserver",
+      "learning-registry:pending",
+    ]);
+  });
+
   it.each(["draft", "conversation"])(
     "preserves the additive M5 task type %s through terminalization",
     (taskType) => {


### PR DESCRIPTION
Tracks #284

## Summary

- captures authenticated direct homeserver/M5 attempts in the native learning registry only after primary terminalization
- independently resolves `GET /ledger/{id}` and requires its evidence-identity hash, task ID, attempt ID, model, and canonical task type to match the admitted attempt
- persists `learning-registry:pending` and reconciles partial submission/attempt/outcome writes idempotently to `captured` or permanent `rejected`
- requires the candidate pool and packager to use an exact-bound, independently reviewed Quality Receipt
- proves the default minimum campaign of three samples per arm creates one proposal
- documents the real authority boundary, recovery behavior, and six-sample minimum

## Safety

- Broker/M5 tasks remain outside managed checkout and retain their existing no-file-tool ceiling
- registry and ledger-read failures happen after terminal result persistence, cannot strand paid work, and never trigger a second inference run
- stale/cross-attempt ledger substitution and missing evidence identities fail closed
- gateway response reads are authenticated, time-bounded, size-bounded, and content-blind

## Cross-repository dependency

This PR intentionally remains draft until [gille-inference #61](https://github.com/Magnus-Gille/gille-inference/issues/61) exposes the authoritative content-blind ledger/attempt binding. Current Gille omits those fields, so Hugin will leave eligible captures pending rather than weaken provenance. After that dependency is deployed, #284 still requires a real deployed cadence tick with durable candidate/proposal counts before closure.

## Verification

- `npm test`: 149 files, 2,305 tests passed on exact head
- `npm run build`
- `bash scripts/deploy-pi.test.sh`
- `git diff --check`
