### PR TITLE
fix(learning): normalize Gille evidence hash wire prefix

### DIFF
--- a/src/m5-ledger-attempt-binding.ts
+++ b/src/m5-ledger-attempt-binding.ts
@@ -1,12 +1,17 @@
 import { z } from "zod";
 import type { HomeserverGatewayConfig } from "./homeserver-executor.js";
 
-const sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
+const wireSha256Schema = z.string()
+  .regex(/^sha256:[a-f0-9]{64}$/)
+  .transform((value) => value.slice("sha256:".length));
 
 /** Content-blind join returned by Gille's authenticated GET /ledger/{id}. */
 export const m5LedgerAttemptBindingSchema = z.object({
   id: z.string().min(1),
-  evidenceIdentityHash: sha256Schema,
+  // Gille's ledger contract uses the explicit `sha256:` wire prefix. Hugin's
+  // durable schemas use the canonical bare digest, so normalize only after
+  // validating the exact upstream representation.
+  evidenceIdentityHash: wireSha256Schema,
   taskInstanceId: z.string().min(1),
   attemptId: z.string().min(1),
   taskType: z.string().min(1),

--- a/tests/m5-ledger-attempt-binding.test.ts
+++ b/tests/m5-ledger-attempt-binding.test.ts
@@ -12,13 +12,17 @@ const binding: M5LedgerAttemptBinding = {
   taskType: "code-edit",
   modelId: "qwen3-coder-next",
 };
+const wireBinding = {
+  ...binding,
+  evidenceIdentityHash: `sha256:${binding.evidenceIdentityHash}`,
+};
 
 afterEach(() => vi.unstubAllGlobals());
 
 describe("fetchM5LedgerAttemptBinding", () => {
   it("reads the exact authenticated, id-addressable content-blind join", async () => {
     const fetchMock = vi.fn(async () => new Response(JSON.stringify({
-      ...binding,
+      ...wireBinding,
       outcome: "pass",
       score: 1,
     }), { status: 200 }));
@@ -38,9 +42,10 @@ describe("fetchM5LedgerAttemptBinding", () => {
   });
 
   it.each([
-    ["missing evidence identity", { ...binding, evidenceIdentityHash: undefined }],
-    ["legacy unstamped row", { ...binding, taskInstanceId: null, attemptId: null }],
-    ["different ledger row", { ...binding, id: "ledger:other" }],
+    ["missing evidence identity", { ...wireBinding, evidenceIdentityHash: undefined }],
+    ["unprefixed evidence identity", binding],
+    ["legacy unstamped row", { ...wireBinding, taskInstanceId: null, attemptId: null }],
+    ["different ledger row", { ...wireBinding, id: "ledger:other" }],
   ])("fails closed for %s", async (_label, body) => {
     vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify(body), { status: 200 })));
     await expect(fetchM5LedgerAttemptBinding(


### PR DESCRIPTION
## Summary

- accept Gille’s documented `sha256:<digest>` evidence-identity wire format
- validate the prefix strictly, then normalize to Hugin’s canonical bare digest
- keep malformed, legacy, unprefixed, and cross-row responses fail-closed

## Live evidence

After PR #285 and gille-inference #62 were deployed, production task `mcp-m5-cde28030357d13354aa31890` completed with authenticated `m5-admitted` evidence and an exact ledger ID, but remained `learning-registry:pending`. Its durable log showed Hugin rejected the binding response because the deployed Gille endpoint correctly returned the documented `sha256:` prefix.

The pending tag is recoverable; deployment of this patch should capture the existing terminal task without rerunning inference.

## Verification

- red test reproduced the live prefix rejection
- focused integration suite: 3 files / 19 tests passed
- full suite: 149 files / 2,306 tests passed
- TypeScript build passed
- `git diff --check` passed

Tracks #284.