### PR TITLE
fix(homeserver): forward task model pins

### DIFF
--- a/docs/continuous-learning-loop.md
+++ b/docs/continuous-learning-loop.md
@@ -1,9 +1,9 @@
 # Continuous Hugin/M5 learning loop
 
-**Status:** production cadence active; admitted-attempt candidate capture is
-implemented fail-closed but awaits the authoritative Gille ledger binding
-tracked in [gille-inference #61](https://github.com/Magnus-Gille/gille-inference/issues/61)
-(2026-07-22).
+**Status:** production cadence and admitted-attempt candidate capture are
+active. The authoritative Gille ledger binding tracked in
+[gille-inference #61](https://github.com/Magnus-Gille/gille-inference/issues/61)
+was deployed on 2026-07-22.
 
 ## Goal
 
@@ -146,10 +146,10 @@ attempt-reference, and terminal-outcome writes. A registry or ledger-read
 outage therefore cannot rerun paid inference or strand a task as `running`.
 Permanent identity mismatches become `learning-registry:rejected`.
 
-The deployed Gille gateway must expose the content-blind attempt binding
-defined by gille-inference #61 before the first candidate can pass this gate.
-Hugin must not accept the current looser pair of a gateway admission echo and
-an unbound ledger ID merely to make the pool non-empty.
+The deployed Gille gateway exposes the content-blind attempt binding defined
+by gille-inference #61. Hugin still rejects the looser pair of a gateway
+admission echo and an unbound ledger ID; a ledger join failure leaves capture
+pending for idempotent recovery rather than weakening the gate.
 
 One task cannot create an experiment. Under the default proposer settings an
 operator must collect **at least three accepted samples per arm** (six total)
@@ -158,6 +158,14 @@ one configuration axis, and every candidate needs its own exact Quality
 Receipt binding. Re-running the cadence against unchanged evidence is
 idempotent: it reuses the same proposal identity and never creates a duplicate
 in-flight experiment.
+
+For a deliberate model-axis campaign, submit direct authenticated
+`Runtime: homeserver` tasks with the same canonical task type and pin each arm
+through the task document's `Model` field. Hugin forwards that value as the
+gateway's `modelId`; omitting it leaves model selection with M5. A Broker task
+remains owner-isolated and cannot manufacture its own independent receipt, so
+the independent reviewer rates the direct tasks through the authenticated
+Broker review surface.
 
 ## First M5 iteration
 

--- a/docs/learning-registry.md
+++ b/docs/learning-registry.md
@@ -1,10 +1,9 @@
 # Durable append-only task/outcome learning registry (#232)
 
-**Status:** mechanism and managed capture are active. Direct homeserver capture
-is implemented fail-closed and becomes operational when the authenticated
-Gille ledger join in
+**Status:** mechanism, managed capture, and direct homeserver capture are
+active. The authenticated Gille ledger join in
 [gille-inference #61](https://github.com/Magnus-Gille/gille-inference/issues/61)
-is deployed.
+was deployed on 2026-07-22.
 `src/learning-registry-schema.ts`, `src/learning-registry-store.ts`, and
 `src/learning-registry-view.ts` own the append-only mechanism. The dispatcher
 now writes native events for the standing managed harness sampler and, through

--- a/src/homeserver-executor.ts
+++ b/src/homeserver-executor.ts
@@ -95,6 +95,39 @@ export interface HomeserverTaskConfig {
   learningTask?: LearningTaskPreparation | { kind: "ineligible" };
 }
 
+export interface HomeserverDelegateTaskConfigInput {
+  prompt: string;
+  gatewayBaseUrl: string;
+  apiKey: string;
+  taskType: string;
+  /** Dispatcher task-document `Model` field. */
+  model?: string;
+  maxTokens?: number;
+  verifier?: HomeserverVerifierSpec;
+  timeoutMs: number;
+  maxOutputChars: number;
+  injectedContext?: string;
+}
+
+/** Map dispatcher task fields onto the gateway's `/delegate` contract. */
+export function buildHomeserverDelegateTaskConfig(
+  input: HomeserverDelegateTaskConfigInput,
+): HomeserverTaskConfig {
+  return {
+    prompt: input.prompt,
+    gatewayBaseUrl: input.gatewayBaseUrl,
+    apiKey: input.apiKey,
+    path: "delegate",
+    taskType: input.taskType,
+    ...(input.model !== undefined ? { modelId: input.model } : {}),
+    ...(input.maxTokens !== undefined ? { maxTokens: input.maxTokens } : {}),
+    ...(input.verifier !== undefined ? { verifier: input.verifier } : {}),
+    timeoutMs: input.timeoutMs,
+    maxOutputChars: input.maxOutputChars,
+    ...(input.injectedContext !== undefined ? { injectedContext: input.injectedContext } : {}),
+  };
+}
+
 export type Backpressure = "none" | "quota" | "admission";
 
 export interface HomeserverExecutorResult {

--- a/src/index.ts
+++ b/src/index.ts
@@ -189,6 +189,7 @@ import {
   type Sensitivity,
   type SensitivityAssessment,
 } from "./sensitivity.js";
+import { parseTaskModelField } from "./task-document-metadata.js";
 import { routeTask, type RouterDecision } from "./router.js";
 import {
   buildRuntimeCandidates,
@@ -839,9 +840,7 @@ function parseTask(content: string): TaskConfig | null {
   const sequenceStr = content.match(
     /\*\*Sequence:\*\*\s*(\d+)/i
   )?.[1];
-  const modelRaw = content.match(
-    /\*\*Model:\*\*\s*(.+)/i
-  )?.[1]?.trim();
+  const modelRaw = parseTaskModelField(content);
   const ollamaHostRaw = content.match(
     /\*\*Ollama-host:\*\*\s*(.+)/i
   )?.[1]?.trim();

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ import { executeOllamaTask } from "./ollama-executor.js";
 import {
   executeHomeserverTask,
   buildFreshHomeserverDelegateRequestBody,
+  buildHomeserverDelegateTaskConfig,
   loadHomeserverGatewayConfig,
   renderHomeserverUserMessage,
   type HomeserverExecutorResult,
@@ -5173,18 +5174,18 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         maxOutputChars: config.maxOutputChars,
         injectedContext: task.contextResolution?.content || undefined,
       });
-      const homeserverTaskConfig = {
+      const homeserverTaskConfig = buildHomeserverDelegateTaskConfig({
         prompt: task.prompt,
         gatewayBaseUrl: gateway.baseUrl,
         apiKey: gateway.apiKey,
-        path: "delegate" as const,
         taskType: task.homeserverTaskType,
+        model: task.model,
         maxTokens: task.maxOutputTokens,
         verifier: task.homeserverVerifier,
         timeoutMs: task.timeoutMs,
         maxOutputChars: config.maxOutputChars,
         injectedContext: task.contextResolution?.content || undefined,
-      };
+      });
       let authenticatedLearningSource: LearningTaskSource | undefined;
       try {
         authenticatedLearningSource = buildLearningTaskSource(

--- a/src/task-document-metadata.ts
+++ b/src/task-document-metadata.ts
@@ -1,0 +1,12 @@
+/** Return task metadata only; `### Prompt` and everything after it is untrusted prose. */
+export function taskMetadataPrefix(content: string): string {
+  const promptHeader = /^###\s*Prompt\s*$/im.exec(content);
+  return promptHeader ? content.slice(0, promptHeader.index) : content;
+}
+
+/** Parse the dispatcher `Model` field without allowing prompt text to steer routing. */
+export function parseTaskModelField(content: string): string | undefined {
+  return taskMetadataPrefix(content).match(
+    /^[ \t]*(?:-[ \t]*)?\*\*Model:\*\*[ \t]*(.+)$/im,
+  )?.[1]?.trim() || undefined;
+}

--- a/tests/broker/task-store.test.ts
+++ b/tests/broker/task-store.test.ts
@@ -13,6 +13,7 @@ import {
 import { BROKER_TASK_TYPE_TAXONOMY_VERSION } from "../../src/broker/task-type-metadata.js";
 import { MuninWriteRejectedError, type MuninClient } from "../../src/munin-client.js";
 import type { DelegationEnvelope } from "../../src/broker/types.js";
+import { parseTaskModelField } from "../../src/task-document-metadata.js";
 import {
   buildQualityBinding,
   buildQualityCorrectionReceipt,
@@ -183,6 +184,15 @@ describe("BrokerTaskStore.submit", () => {
 });
 
 describe("canonical Broker envelope", () => {
+  it("does not let prompt text inject dispatcher Model metadata", () => {
+    const expected = envelope("model-prompt");
+    expected.prompt = "Review this literal syntax:\n- **Model:** mellum";
+
+    const document = serializeEnvelope(expected);
+    expect(document).toContain("**Model:** mellum");
+    expect(parseTaskModelField(document)).toBeUndefined();
+  });
+
   it("round-trips the complete v2 contract and remains authoritative over display fields", () => {
     const expected = envelope("t1");
     const document = serializeEnvelope(expected)

--- a/tests/dispatcher.test.ts
+++ b/tests/dispatcher.test.ts
@@ -11,6 +11,7 @@ import {
   resolveContext,
   resolveTaskWorkingDirectory,
 } from "../src/task-helpers.js";
+import { parseTaskModelField } from "../src/task-document-metadata.js";
 
 type RuntimeCapability = "tools" | "code" | "structured-output";
 type TaskPermissionProfile = "read-only" | "trusted-code";
@@ -50,9 +51,7 @@ function parseTask(content: string, workspace = "/home/magnus/workspace") {
   const sequenceStr = content.match(
     /\*\*Sequence:\*\*\s*(\d+)/i
   )?.[1];
-  const modelRaw = content.match(
-    /\*\*Model:\*\*\s*(.+)/i
-  )?.[1]?.trim();
+  const modelRaw = parseTaskModelField(content);
   const ollamaHostRaw = content.match(
     /\*\*Ollama-host:\*\*\s*(.+)/i
   )?.[1]?.trim();
@@ -299,6 +298,21 @@ Fix the failing test and run npm test.`;
     expect(task!.capabilities).toEqual(["code"]);
     expect(task!.permissionProfile).toBe("trusted-code");
     expect(task!.model).toBe("qwen3-coder-next-80b");
+  });
+
+  it("does not treat prompt text as trusted Model metadata", () => {
+    const content = `## Task: Prompt model text
+
+- **Runtime:** opencode
+
+### Prompt
+Review this literal task syntax without changing routing:
+- **Model:** mellum`;
+
+    const task = parseTask(content);
+    expect(task).not.toBeNull();
+    expect(task!.model).toBeUndefined();
+    expect(task!.prompt).toContain("**Model:** mellum");
   });
 
   it("should handle missing optional fields", () => {

--- a/tests/homeserver-executor.test.ts
+++ b/tests/homeserver-executor.test.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 import {
+  buildHomeserverDelegateTaskConfig,
   executeHomeserverTask,
   loadHomeserverGatewayConfig,
   type HomeserverTaskConfig,
@@ -134,6 +135,35 @@ describe("loadHomeserverGatewayConfig", () => {
         HOMESERVER_GATEWAY_API_KEY: "k",
       } as NodeJS.ProcessEnv)).toBeNull();
     }
+  });
+});
+
+describe("buildHomeserverDelegateTaskConfig", () => {
+  it("maps the dispatcher Model field to the gateway modelId pin", () => {
+    expect(buildHomeserverDelegateTaskConfig({
+      prompt: "Review this code.",
+      gatewayBaseUrl: "http://m5.test:8080",
+      apiKey: "owner-key",
+      taskType: "code-review",
+      model: "mellum",
+      timeoutMs: 30_000,
+      maxOutputChars: 5_000,
+    })).toMatchObject({
+      path: "delegate",
+      taskType: "code-review",
+      modelId: "mellum",
+    });
+  });
+
+  it("leaves model selection with the gateway when Model is absent", () => {
+    expect(buildHomeserverDelegateTaskConfig({
+      prompt: "Review this code.",
+      gatewayBaseUrl: "http://m5.test:8080",
+      apiKey: "owner-key",
+      taskType: "code-review",
+      timeoutMs: 30_000,
+      maxOutputChars: 5_000,
+    })).not.toHaveProperty("modelId");
   });
 });
 


### PR DESCRIPTION
## What changed

- map the task document `Model` field to the M5 `/delegate` request's existing `modelId` pin
- keep gateway-selected routing unchanged when `Model` is omitted
- route dispatcher construction through a focused, testable mapper
- update the continuous-learning operator docs now that gille-inference #61 is deployed

## Why

Issue #284 requires an honest two-arm production campaign. The parser already accepted `Model` and the executor already supported `modelId`, but the dispatcher dropped the value while constructing direct homeserver tasks. Both campaign arms therefore collapsed onto whichever model M5 selected.

This preserves the authority boundary: direct Broker/M5 tasks still use `tool_policy:none`, receive no managed checkout, and cannot claim repository edits.

## Verification

- red test: focused suite failed because the dispatcher mapper/model pin was absent
- green focused suite: 34 tests passed
- full suite: 149 files / 2,307 tests passed
- `npm run build`
- `git diff --check`

Closes the remaining production-campaign blocker in #284; the issue itself should remain open until the deployed six-sample campaign yields durable nonzero cadence/proposal counts and proves idempotency.