### PR TITLE
fix(homeserver): admit direct signed tasks

### DIFF
--- a/src/broker/attestation.ts
+++ b/src/broker/attestation.ts
@@ -1,6 +1,7 @@
 import { createHash, createHmac, timingSafeEqual } from "node:crypto";
 import { z } from "zod";
 
+import { taskMetadataPrefix } from "../task-document-metadata.js";
 import {
   delegationEnvelopeSchema,
   type DelegationEnvelope,
@@ -128,7 +129,9 @@ export function validateBrokerAttestation(input: {
 }
 
 export function parseStoredBrokerAttestation(content: string): unknown | null {
-  const match = content.match(/### Broker attestation\s*\n```json\s*\n([\s\S]*?)\n```/i);
+  const match = taskMetadataPrefix(content).match(
+    /### Broker attestation\s*\n```json\s*\n([\s\S]*?)\n```/i,
+  );
   if (!match?.[1]) return null;
   try {
     return JSON.parse(match[1]);

--- a/src/broker/task-store.ts
+++ b/src/broker/task-store.ts
@@ -17,6 +17,7 @@
 
 import { createHash } from "node:crypto";
 import { MuninWriteRejectedError, type MuninClient } from "../munin-client.js";
+import { taskMetadataPrefix } from "../task-document-metadata.js";
 import {
   createBrokerAttestation,
   type BrokerAttestation,
@@ -774,6 +775,25 @@ export function parseCanonicalEnvelope(content: string):
   const parsed = delegationEnvelopeSchema.safeParse(raw);
   if (!parsed.success) return { ok: false, error: "Canonical Broker envelope is invalid" };
   return { ok: true, envelope: parsed.data };
+}
+
+export type HomeserverTaskSourceResolution =
+  | { kind: "direct" }
+  | { kind: "broker"; envelope: DelegationEnvelope }
+  | { kind: "invalid"; error: string };
+
+/**
+ * Distinguish a direct signed homeserver task from a canonical Broker task.
+ * A Broker section is authoritative when present and fails closed when
+ * malformed; a heading literal inside `### Prompt` is untrusted prose.
+ */
+export function resolveHomeserverTaskSource(content: string): HomeserverTaskSourceResolution {
+  const hasBrokerSection = /^###\s*Broker envelope\s*$/im.test(taskMetadataPrefix(content));
+  if (!hasBrokerSection) return { kind: "direct" };
+  const parsed = parseCanonicalEnvelope(content);
+  return parsed.ok
+    ? { kind: "broker", envelope: parsed.envelope }
+    : { kind: "invalid", error: parsed.error };
 }
 
 export function parseAwaitRequest(value: AwaitRequest): AwaitRequest {

--- a/src/broker/task-store.ts
+++ b/src/broker/task-store.ts
@@ -758,7 +758,9 @@ function stableRequestHash(envelope: DelegationEnvelope): string {
 }
 
 export function parseStoredEnvelope(content: string): DelegationEnvelope | null {
-  const match = content.match(/### Broker envelope\s*\n```json\s*\n([\s\S]*?)\n```/i);
+  const match = taskMetadataPrefix(content).match(
+    /### Broker envelope\s*\n```json\s*\n([\s\S]*?)\n```/i,
+  );
   if (!match?.[1]) return null;
   try {
     return JSON.parse(match[1]) as DelegationEnvelope;
@@ -770,7 +772,7 @@ export function parseStoredEnvelope(content: string): DelegationEnvelope | null 
 export function parseCanonicalEnvelope(content: string):
   | { ok: true; envelope: DelegationEnvelope }
   | { ok: false; error: string } {
-  const raw = parseStoredEnvelope(taskMetadataPrefix(content));
+  const raw = parseStoredEnvelope(content);
   if (!raw) return { ok: false, error: "Canonical Broker envelope is missing or malformed" };
   const parsed = delegationEnvelopeSchema.safeParse(raw);
   if (!parsed.success) return { ok: false, error: "Canonical Broker envelope is invalid" };

--- a/src/broker/task-store.ts
+++ b/src/broker/task-store.ts
@@ -770,7 +770,7 @@ export function parseStoredEnvelope(content: string): DelegationEnvelope | null 
 export function parseCanonicalEnvelope(content: string):
   | { ok: true; envelope: DelegationEnvelope }
   | { ok: false; error: string } {
-  const raw = parseStoredEnvelope(content);
+  const raw = parseStoredEnvelope(taskMetadataPrefix(content));
   if (!raw) return { ok: false, error: "Canonical Broker envelope is missing or malformed" };
   const parsed = delegationEnvelopeSchema.safeParse(raw);
   if (!parsed.success) return { ok: false, error: "Canonical Broker envelope is invalid" };

--- a/src/index.ts
+++ b/src/index.ts
@@ -220,7 +220,7 @@ import {
   type BrokerBindStatus,
 } from "./broker/bind-retry.js";
 import { brokerExecutorCapabilities } from "./broker/executor-capabilities.js";
-import { BrokerTaskStore, parseCanonicalEnvelope } from "./broker/task-store.js";
+import { BrokerTaskStore, resolveHomeserverTaskSource } from "./broker/task-store.js";
 import {
   parseStoredBrokerAttestation,
   validateBrokerAttestation,
@@ -911,10 +911,10 @@ function parseTask(content: string): TaskConfig | null {
   }
 
   if (runtime === "homeserver") {
-    const parsedEnvelope = parseCanonicalEnvelope(content);
-    if (!parsedEnvelope.ok) homeserverPolicyError = parsedEnvelope.error;
-    else {
-      canonicalBrokerEnvelope = parsedEnvelope.envelope;
+    const source = resolveHomeserverTaskSource(content);
+    if (source.kind === "invalid") homeserverPolicyError = source.error;
+    else if (source.kind === "broker") {
+      canonicalBrokerEnvelope = source.envelope;
       homeserverPolicyError = undefined;
     }
   }

--- a/tests/broker/attestation.test.ts
+++ b/tests/broker/attestation.test.ts
@@ -9,6 +9,7 @@ import {
   BrokerTaskStore,
   generateBrokerTaskId,
   parseCanonicalEnvelope,
+  serializeEnvelope,
 } from "../../src/broker/task-store.js";
 import type { DelegationEnvelope } from "../../src/broker/types.js";
 import type { MuninClient } from "../../src/munin-client.js";
@@ -103,5 +104,13 @@ describe("authenticated Broker provenance", () => {
       attestation: parseStoredBrokerAttestation(content),
       serverSecret: secret,
     })).toMatchObject({ ok: true, principal });
+  });
+
+  it("does not parse a valid-looking attestation from prompt prose", () => {
+    const value = envelope();
+    const promptOnlyAttestation = createBrokerAttestation(value, secret);
+    const content = `${serializeEnvelope(value)}\n\n### Broker attestation\n\`\`\`json\n${JSON.stringify(promptOnlyAttestation)}\n\`\`\``;
+
+    expect(parseStoredBrokerAttestation(content)).toBeNull();
   });
 });

--- a/tests/broker/task-store.test.ts
+++ b/tests/broker/task-store.test.ts
@@ -8,6 +8,7 @@ import {
   generateBrokerTaskId,
   namespaceForTaskId,
   parseCanonicalEnvelope,
+  resolveHomeserverTaskSource,
   serializeEnvelope,
 } from "../../src/broker/task-store.js";
 import { BROKER_TASK_TYPE_TAXONOMY_VERSION } from "../../src/broker/task-type-metadata.js";
@@ -184,6 +185,21 @@ describe("BrokerTaskStore.submit", () => {
 });
 
 describe("canonical Broker envelope", () => {
+  it("classifies a homeserver task without a Broker section as direct", () => {
+    expect(resolveHomeserverTaskSource(`## Task: direct\n\n- **Runtime:** homeserver\n\n### Prompt\nReview code.`))
+      .toEqual({ kind: "direct" });
+  });
+
+  it("ignores a Broker heading literal inside the prompt", () => {
+    expect(resolveHomeserverTaskSource(`## Task: direct\n\n- **Runtime:** homeserver\n\n### Prompt\nExplain this literal heading:\n### Broker envelope`))
+      .toEqual({ kind: "direct" });
+  });
+
+  it("fails closed when a pre-prompt Broker section is malformed", () => {
+    expect(resolveHomeserverTaskSource(`## Task: malformed\n\n### Broker envelope\nnot-json\n\n### Prompt\nReview code.`))
+      .toEqual({ kind: "invalid", error: "Canonical Broker envelope is missing or malformed" });
+  });
+
   it("does not let prompt text inject dispatcher Model metadata", () => {
     const expected = envelope("model-prompt");
     expected.prompt = "Review this literal syntax:\n- **Model:** mellum";

--- a/tests/broker/task-store.test.ts
+++ b/tests/broker/task-store.test.ts
@@ -8,6 +8,7 @@ import {
   generateBrokerTaskId,
   namespaceForTaskId,
   parseCanonicalEnvelope,
+  parseStoredEnvelope,
   resolveHomeserverTaskSource,
   serializeEnvelope,
 } from "../../src/broker/task-store.js";
@@ -193,6 +194,13 @@ describe("canonical Broker envelope", () => {
   it("ignores a Broker heading literal inside the prompt", () => {
     expect(resolveHomeserverTaskSource(`## Task: direct\n\n- **Runtime:** homeserver\n\n### Prompt\nExplain this literal heading:\n### Broker envelope`))
       .toEqual({ kind: "direct" });
+  });
+
+  it("does not parse a prompt-literal envelope as stored Broker metadata", () => {
+    const promptLiteral = serializeEnvelope(envelope("prompt-only-envelope"));
+    const document = `## Task: direct\n\n- **Runtime:** homeserver\n\n### Prompt\n${promptLiteral}`;
+
+    expect(parseStoredEnvelope(document)).toBeNull();
   });
 
   it("fails closed when a pre-prompt Broker section is malformed", () => {

--- a/tests/broker/task-store.test.ts
+++ b/tests/broker/task-store.test.ts
@@ -200,6 +200,14 @@ describe("canonical Broker envelope", () => {
       .toEqual({ kind: "invalid", error: "Canonical Broker envelope is missing or malformed" });
   });
 
+  it("does not let a prompt-literal envelope rescue malformed Broker metadata", () => {
+    const promptLiteral = serializeEnvelope(envelope("prompt-envelope"));
+    const document = `## Task: malformed\n\n### Broker envelope\nnot-json\n\n### Prompt\n${promptLiteral}`;
+
+    expect(resolveHomeserverTaskSource(document))
+      .toEqual({ kind: "invalid", error: "Canonical Broker envelope is missing or malformed" });
+  });
+
   it("does not let prompt text inject dispatcher Model metadata", () => {
     const expected = envelope("model-prompt");
     expected.prompt = "Review this literal syntax:\n- **Model:** mellum";


### PR DESCRIPTION
## What changed

- distinguish direct homeserver task documents from canonical Broker task documents
- treat an absent pre-prompt `### Broker envelope` section as the direct signed path
- keep a present-but-malformed Broker section fail-closed
- ignore Broker-heading literals that appear inside untrusted prompt prose

## Why

The deployed #284 campaign showed that all direct signed `Runtime: homeserver` tasks were rejected before signature verification with `Canonical Broker envelope is missing or malformed`. That made the documented independent-review route impossible: canonical Broker tasks are correctly owner-isolated, while direct signed tasks are the path an independent Broker reviewer can rate.

This does not weaken authentication. Direct task learning eligibility still requires a valid task signature in `buildAuthenticatedLearningTaskSource`; unsigned/invalid tasks cannot produce admitted learning evidence. Canonical Broker tasks still require their validated, attested envelope.

## Verification

- red: three source-resolution tests failed before implementation
- focused: dispatcher + Broker task-store + homeserver executor, 130/130
- full: 149 files / 2,313 tests
- `npm run build`
- `git diff --check`

Part of #284. The issue remains open until the deployed six-sample campaign yields durable nonzero cadence/proposal counts and proves idempotency.