### PR TITLE
docs(learning): explain proposer and packager quality floors

### DIFF
--- a/docs/continuous-learning-loop.md
+++ b/docs/continuous-learning-loop.md
@@ -139,6 +139,13 @@ it does not borrow repository evidence from a separate Claude, Codex, or
 OpenCode run. Invalid, cross-task, non-admitted, provenance-incomplete, or
 managed-repository combinations fail closed and do not enter the pool.
 
+The cadence intentionally applies two different quality floors. The proposer
+includes every independently rated outcome down to `wrong`, because failures
+are necessary to detect a quality-rate difference between configurations. The
+packager then defaults to `pass` and freezes only the verifiable-quality
+subset, so a valid proposal can shrink or be refused during packaging; that is
+a trust boundary, not lost evidence.
+
 Capture is a recoverable post-terminal side effect. Eligible task status moves
 through `learning-registry:pending` to `learning-registry:captured`; startup
 and periodic reconciliation replay the natural-key-idempotent submission,

--- a/src/learning/candidate-packager.ts
+++ b/src/learning/candidate-packager.ts
@@ -8,6 +8,11 @@
  * runs, evaluates, or promotes an experiment -- it hands a frozen package to
  * the existing `LearningExperimentStore.create` surface for that.
  *
+ * Quality-floor contract: unlike the proposer, which includes failed ratings
+ * to detect a configuration signal, this packager defaults to `pass` and
+ * freezes only the verifiable-quality subset; a proposed population may
+ * therefore shrink or be refused here without contradicting the proposal.
+ *
  * Read-only guarantee: every function here either takes already-fetched
  * evidence (the pure `qualifyCandidate` / `packageExperimentCandidates`
  * core) or, in `packageAndHandOff`, only calls `listEventsForTask` (a read)

--- a/src/learning/experiment-proposer.ts
+++ b/src/learning/experiment-proposer.ts
@@ -10,6 +10,11 @@
  * an experiment -- that stays entirely inside candidate-packager.ts and
  * experiment-store.ts.
  *
+ * Quality-floor contract: the proposer deliberately includes every rated
+ * outcome down to `wrong` so failures can reveal a configuration signal; the
+ * downstream packager independently defaults to `pass` when freezing a
+ * verifiable-quality experiment package, so packaging may shrink a proposal.
+ *
  * Read-only guarantee: `proposeExperiments` is a pure function over
  * caller-supplied candidates and timelines. `proposeExperimentsFromRegistry`
  * only calls `listEventsForTask` (via `buildTaskLifecycleTimeline`, itself


### PR DESCRIPTION
## What changed

- document in the proposer header that failed ratings remain necessary to detect configuration signal
- document in the packager header that its default `pass` floor freezes only verifiable-quality evidence
- explain in the operator cadence guide why a proposal may shrink or be refused during packaging without losing evidence

## Verification

- `npm run build`
- `npm test` — 149 files / 2,316 tests
- `git diff --check`

Closes #269.