### PR TITLE
feat(mcp): add compact hugin_await summaries

### DIFF
--- a/docs/mcp-durable-m5-lifecycle.md
+++ b/docs/mcp-durable-m5-lifecycle.md
@@ -32,6 +32,29 @@ another principal's canonical results. Rate remains owner-only for Broker
 tasks; the same authenticated endpoint can also review an ordinary terminal
 Hugin task, which has no Broker owner.
 
+`hugin_await` preserves its canonical full response by default and when called
+with `verbosity: "full"`. Callers that only need the actionable outcome can use
+`verbosity: "summary"`. The compact response retains the status, polling lease
+and orphan evidence, error, outcome, exit code, body text, effective model and
+host, delegation decision, and declared/effective/mismatch sensitivity fields
+when present. It replaces the inline terminal result and its potentially large
+learning provenance with Munin references:
+
+```json
+{
+  "refs": {
+    "status": { "namespace": "tasks/<task-id>", "key": "status" },
+    "fullResult": {
+      "namespace": "tasks/<task-id>",
+      "key": "result-structured"
+    }
+  }
+}
+```
+
+`fullResult` appears only when the Broker returned a structured terminal
+result. The MCP projection does not alter or rewrite the durable document.
+
 This guarantees one durable task for idempotent submission retries. It does not
 claim exactly-once network execution if the process crashes after M5 performs a
 future side effect but before Hugin stores the response. The current endpoint is

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -140,6 +140,9 @@ const submitInputSchema = z.object(submitInputShape);
 
 export const awaitInputShape = {
   task_id: z.string().min(1).describe("Task id returned by `hugin_submit`."),
+  verbosity: z.enum(["full", "summary"]).optional().describe(
+    "Response detail. Omit or use `full` for the canonical durable result; use `summary` for a compact projection with refs to the full result.",
+  ),
 };
 const awaitInputSchema = z.object(awaitInputShape);
 
@@ -211,6 +214,73 @@ function withIdempotencyKey(response: unknown, idempotencyKey: string): unknown 
     return obj;
   }
   return { response, idempotency_key: idempotencyKey };
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+/**
+ * Project the Broker's canonical await response without changing its durable
+ * representation. Terminal provenance remains available at `fullResult`;
+ * polling fields remain inline so summary callers can safely make progress.
+ */
+function summarizeAwaitResponse(response: unknown, taskId: string): unknown {
+  const source = asRecord(response);
+  if (!source) return response;
+
+  const namespace = `tasks/${taskId}`;
+  const summary: Record<string, unknown> = {
+    task_id: taskId,
+  };
+  for (const key of ["status", "reason", "error", "lease", "orphan_suspected"] as const) {
+    if (source[key] !== undefined) summary[key] = source[key];
+  }
+
+  const result = asRecord(source.result);
+  if (result) {
+    for (const key of ["outcome", "exitCode", "bodyText"] as const) {
+      if (result[key] !== undefined) summary[key] = result[key];
+    }
+
+    const runtimeMetadata = asRecord(result.runtimeMetadata);
+    if (runtimeMetadata) {
+      if (runtimeMetadata.effectiveModel !== undefined) {
+        summary.effectiveModel = runtimeMetadata.effectiveModel;
+      }
+      if (runtimeMetadata.effectiveHost !== undefined) {
+        summary.effectiveHost = runtimeMetadata.effectiveHost;
+      }
+      const delegation = asRecord(runtimeMetadata.delegation);
+      const delegationDecision = delegation?.decisionReason
+        ?? delegation?.policyReason
+        ?? runtimeMetadata.routingReason;
+      if (delegationDecision !== undefined) {
+        summary.delegationDecision = delegationDecision;
+      }
+    }
+
+    const sensitivity = asRecord(result.sensitivity);
+    if (sensitivity) {
+      const projectedSensitivity: Record<string, unknown> = {};
+      for (const key of ["declared", "effective", "mismatch"] as const) {
+        if (sensitivity[key] !== undefined) projectedSensitivity[key] = sensitivity[key];
+      }
+      if (Object.keys(projectedSensitivity).length > 0) {
+        summary.sensitivity = projectedSensitivity;
+      }
+    }
+  }
+
+  summary.refs = {
+    status: { namespace, key: "status" },
+    ...(result
+      ? { fullResult: { namespace, key: "result-structured" } }
+      : {}),
+  };
+  return summary;
 }
 
 function errorPayload(err: unknown): { error: { kind: string; message: string; http_status?: number; body?: unknown } } {
@@ -319,7 +389,7 @@ export function buildTools(deps: ToolDeps): {
     name: "hugin_await",
     title: "Read the current state of a delegated task",
     description:
-      "Idempotent read of a task's status: `running` / `completed` / `failed`. Returns immediately. While `running`, the response also carries lease info and an `orphan_suspected` flag (true once the lease has expired without completion). Safe to poll.",
+      "Idempotent read of a task's status: `running` / `completed` / `failed`. Returns immediately. While `running`, the response also carries lease info and an `orphan_suspected` flag (true once the lease has expired without completion). Use `verbosity: summary` to avoid inlining full terminal provenance; the summary includes a namespace/key ref to it. Safe to poll.",
     inputShape: awaitInputShape,
     handler: async (rawInput) => {
       try {
@@ -328,10 +398,14 @@ export function buildTools(deps: ToolDeps): {
         // broker tell a durable handoff (a LATER session collecting a result)
         // from an ordinary same-session poll. Callers never supply it.
         const response = await deps.broker.await_({
-          ...input,
+          task_id: input.task_id,
           orchestrator_session_id: deps.sessionId,
         });
-        return asResult(response);
+        return asResult(
+          input.verbosity === "summary"
+            ? summarizeAwaitResponse(response, input.task_id)
+            : response,
+        );
       } catch (err) {
         return asResult(errorPayload(err), true);
       }

--- a/tests/mcp/tools.test.ts
+++ b/tests/mcp/tools.test.ts
@@ -497,6 +497,78 @@ describe("buildTools — hugin_await", () => {
       },
     });
   });
+
+  it("keeps terminal error details while compacting a failed structured result", async () => {
+    const await_ = vi.fn(async () => ({
+      status: "failed",
+      result: {
+        outcome: "failed",
+        exitCode: 1,
+        bodyText: "executor failed",
+        runtimeMetadata: { learningTask: { durable: "full provenance" } },
+      },
+      error: {
+        task_id: "t-failed",
+        kind: "executor_failed",
+        message: "executor failed",
+        retryable: false,
+      },
+    }));
+    const tools = buildTools({
+      broker: fakeBroker({ await_ }),
+      sessionId: "sess",
+      submitter: "claude-code",
+    });
+
+    const result = await tools.await_.handler({
+      task_id: "t-failed",
+      verbosity: "summary",
+    });
+
+    expect(parseResult(result)).toEqual({
+      task_id: "t-failed",
+      status: "failed",
+      outcome: "failed",
+      exitCode: 1,
+      bodyText: "executor failed",
+      error: {
+        task_id: "t-failed",
+        kind: "executor_failed",
+        message: "executor failed",
+        retryable: false,
+      },
+      refs: {
+        status: { namespace: "tasks/t-failed", key: "status" },
+        fullResult: { namespace: "tasks/t-failed", key: "result-structured" },
+      },
+    });
+  });
+
+  it("returns a compact unknown response with only the reachable status ref", async () => {
+    const await_ = vi.fn(async () => ({
+      status: "unknown",
+      reason: "task_id_not_found",
+    }));
+    const tools = buildTools({
+      broker: fakeBroker({ await_ }),
+      sessionId: "sess",
+      submitter: "claude-code",
+    });
+
+    const result = await tools.await_.handler({
+      task_id: "t-missing",
+      verbosity: "summary",
+    });
+
+    expect(parseResult(result)).toEqual({
+      task_id: "t-missing",
+      status: "unknown",
+      reason: "task_id_not_found",
+      refs: {
+        status: { namespace: "tasks/t-missing", key: "status" },
+      },
+    });
+  });
 });
 
 describe("buildTools — hugin_rate", () => {

--- a/tests/mcp/tools.test.ts
+++ b/tests/mcp/tools.test.ts
@@ -382,6 +382,121 @@ describe("buildTools — hugin_await", () => {
     });
     expect(parseResult(result)).toEqual({ state: "completed" });
   });
+
+  it("returns the canonical response unchanged when full verbosity is explicit", async () => {
+    const canonical = {
+      status: "completed",
+      result: {
+        bodyText: "done",
+        runtimeMetadata: { learningTask: { durable: "full provenance" } },
+      },
+    };
+    const await_ = vi.fn(async () => canonical);
+    const tools = buildTools({
+      broker: fakeBroker({ await_ }),
+      sessionId: "sess",
+      submitter: "claude-code",
+    });
+
+    const result = await tools.await_.handler({ task_id: "t-full", verbosity: "full" });
+
+    expect(await_).toHaveBeenCalledWith({
+      task_id: "t-full",
+      orchestrator_session_id: "sess",
+    });
+    expect(parseResult(result)).toEqual(canonical);
+  });
+
+  it("projects a compact terminal summary without forwarding verbosity", async () => {
+    const await_ = vi.fn(async () => ({
+      status: "completed",
+      result: {
+        schemaVersion: 1,
+        taskId: "t-compact",
+        outcome: "completed",
+        exitCode: 0,
+        bodyText: "done",
+        runtimeMetadata: {
+          effectiveModel: "qwen3-coder-next-80b",
+          effectiveHost: "m5",
+          delegation: {
+            decisionReason: "Selected the strongest available local coding model.",
+            verifierNotes: "large provenance field that must not be inlined",
+          },
+          learningTask: {
+            gatewayEcho: { request: "large provenance field that must not be inlined" },
+          },
+        },
+        sensitivity: {
+          declared: "internal",
+          effective: "internal",
+          mismatch: false,
+        },
+      },
+    }));
+    const tools = buildTools({
+      broker: fakeBroker({ await_ }),
+      sessionId: "sess",
+      submitter: "claude-code",
+    });
+
+    const result = await tools.await_.handler({
+      task_id: "t-compact",
+      verbosity: "summary",
+    });
+
+    expect(await_).toHaveBeenCalledWith({
+      task_id: "t-compact",
+      orchestrator_session_id: "sess",
+    });
+    expect(parseResult(result)).toEqual({
+      task_id: "t-compact",
+      status: "completed",
+      outcome: "completed",
+      exitCode: 0,
+      bodyText: "done",
+      effectiveModel: "qwen3-coder-next-80b",
+      effectiveHost: "m5",
+      delegationDecision: "Selected the strongest available local coding model.",
+      sensitivity: {
+        declared: "internal",
+        effective: "internal",
+        mismatch: false,
+      },
+      refs: {
+        status: { namespace: "tasks/t-compact", key: "status" },
+        fullResult: { namespace: "tasks/t-compact", key: "result-structured" },
+      },
+    });
+  });
+
+  it("keeps polling evidence in a compact running summary", async () => {
+    const await_ = vi.fn(async () => ({
+      status: "running",
+      lease: { claimed_by: "worker-1", lease_expires_at: "2026-07-22T20:00:00Z" },
+      orphan_suspected: false,
+    }));
+    const tools = buildTools({
+      broker: fakeBroker({ await_ }),
+      sessionId: "sess",
+      submitter: "claude-code",
+    });
+
+    const result = await tools.await_.handler({
+      task_id: "t-running",
+      verbosity: "summary",
+    });
+
+    expect(parseResult(result)).toEqual({
+      task_id: "t-running",
+      status: "running",
+      lease: { claimed_by: "worker-1", lease_expires_at: "2026-07-22T20:00:00Z" },
+      orphan_suspected: false,
+      refs: {
+        status: { namespace: "tasks/t-running", key: "status" },
+      },
+    });
+  });
 });
 
 describe("buildTools — hugin_rate", () => {


### PR DESCRIPTION
Closes #281

Adds an explicit summary verbosity mode to hugin_await while preserving the canonical full response by default. Compact terminal responses retain actionable execution fields and exact Munin refs to status and result-structured; polling summaries retain lease and orphan evidence.

Verification:
- npm run build
- npm test (149 files, 2319 tests)
- git diff --check