### PR TITLE
feat(results): persist sensitivity mismatch evidence

### DIFF
--- a/docs/phase5-sensitivity-classification-engineering-plan.md
+++ b/docs/phase5-sensitivity-classification-engineering-plan.md
@@ -248,7 +248,8 @@ Update [src/task-result-schema.ts](/Users/magnus/repos/hugin/src/task-result-sch
 
 - declared sensitivity when present
 - effective sensitivity
-- mismatch indicator when declared < effective
+- mismatch indicator when the detector maximum is higher than the declared
+  sensitivity (including owner overrides where declared equals effective)
 - for mismatches, the content-blind detector maximum and reason codes, plus
   owner-override evidence when one was applied
 
@@ -268,6 +269,14 @@ Reason codes describe detector sources and lattice levels only. They must never
 contain matched prompt text, context content, credentials, or customer data.
 Legacy schema-version-1 results without the additive evidence fields remain
 readable.
+
+The compact `hugin_await` summary preserves this evidence when present, while
+continuing to link to the complete durable result. Artifact-delivery recovery
+checkpoints the exact content-blind snapshot before the nonterminal
+`delivery:pending` transition and reuses it when writing the terminal result.
+Pipeline phase IR likewise retains the full assessment, and generated child
+tasks keep the phase's original declared sensitivity so execution cannot erase
+the mismatch by relabelling the declaration as the effective value.
 
 Per-phase summaries should expose effective phase sensitivity; top-level summaries should expose effective pipeline sensitivity.
 

--- a/docs/phase5-sensitivity-classification-engineering-plan.md
+++ b/docs/phase5-sensitivity-classification-engineering-plan.md
@@ -276,7 +276,10 @@ checkpoints the exact content-blind snapshot before the nonterminal
 `delivery:pending` transition and reuses it when writing the terminal result.
 Pipeline phase IR likewise retains the full assessment, and generated child
 tasks keep the phase's original declared sensitivity so execution cannot erase
-the mismatch by relabelling the declaration as the effective value.
+the mismatch by relabelling the declaration as the effective value. Phase
+execution trusts an owner override only from Hugin's separately written
+sensitivity checkpoint, bound to both the child namespace and exact task-content
+SHA-256; free-form pipeline metadata never grants override authority.
 
 Per-phase summaries should expose effective phase sensitivity; top-level summaries should expose effective pipeline sensitivity.
 

--- a/docs/phase5-sensitivity-classification-engineering-plan.md
+++ b/docs/phase5-sensitivity-classification-engineering-plan.md
@@ -279,7 +279,11 @@ tasks keep the phase's original declared sensitivity so execution cannot erase
 the mismatch by relabelling the declaration as the effective value. Phase
 execution trusts an owner override only from Hugin's separately written
 sensitivity checkpoint, bound to both the child namespace and exact task-content
-SHA-256; free-form pipeline metadata never grants override authority.
+SHA-256 and authenticated with a domain-separated HMAC. The Hugin service must
+set a dedicated, randomly generated `HUGIN_SENSITIVITY_CHECKPOINT_SECRET` of at
+least 32 characters; it must not reuse the Munin API key because Munin writers
+are inside the threat model. Missing or invalid authentication fails closed,
+and free-form pipeline metadata never grants override authority.
 
 Per-phase summaries should expose effective phase sensitivity; top-level summaries should expose effective pipeline sensitivity.
 

--- a/docs/phase5-sensitivity-classification-engineering-plan.md
+++ b/docs/phase5-sensitivity-classification-engineering-plan.md
@@ -249,6 +249,8 @@ Update [src/task-result-schema.ts](/Users/magnus/repos/hugin/src/task-result-sch
 - declared sensitivity when present
 - effective sensitivity
 - mismatch indicator when declared < effective
+- for mismatches, the content-blind detector maximum and reason codes, plus
+  owner-override evidence when one was applied
 
 Use a compact structured shape, for example:
 
@@ -256,9 +258,16 @@ Use a compact structured shape, for example:
 {
   "declared": "public",
   "effective": "private",
-  "mismatch": true
+  "mismatch": true,
+  "detectorMax": "private",
+  "reasons": ["declared:public", "prompt:private"]
 }
 ```
+
+Reason codes describe detector sources and lattice levels only. They must never
+contain matched prompt text, context content, credentials, or customer data.
+Legacy schema-version-1 results without the additive evidence fields remain
+readable.
 
 Per-phase summaries should expose effective phase sensitivity; top-level summaries should expose effective pipeline sensitivity.
 

--- a/docs/phase5-sensitivity-classification-engineering-plan.md
+++ b/docs/phase5-sensitivity-classification-engineering-plan.md
@@ -282,8 +282,10 @@ sensitivity checkpoint, bound to both the child namespace and exact task-content
 SHA-256 and authenticated with a domain-separated HMAC. The Hugin service must
 set a dedicated, randomly generated `HUGIN_SENSITIVITY_CHECKPOINT_SECRET` of at
 least 32 characters; it must not reuse the Munin API key because Munin writers
-are inside the threat model. Missing or invalid authentication fails closed,
-and free-form pipeline metadata never grants override authority.
+are inside the threat model. The dispatcher scrubs this variable from every
+spawned model and operational subprocess environment. Missing or invalid
+authentication fails closed, and free-form pipeline metadata never grants
+override authority.
 
 Per-phase summaries should expose effective phase sensitivity; top-level summaries should expose effective pipeline sensitivity.
 

--- a/src/artifact-delivery.ts
+++ b/src/artifact-delivery.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import * as fs from "node:fs";
 import { createHash } from "node:crypto";
 import { z } from "zod";
+import { buildTaskSubprocessEnv } from "./task-subprocess-env.js";
 
 // Runtime-owned artefact delivery (issue #68). The task declares an
 // `### Artifacts` JSON manifest; the agent only writes content to the declared
@@ -420,8 +421,8 @@ function runSpawn(
   return new Promise((resolve) => {
     // Force HOME so systemd-user SSH finds keys/known_hosts (the git helper
     // already learned this lesson — see task-helpers.ts runGitFetch).
-    const env: Record<string, string> = {
-      ...(process.env as Record<string, string>),
+    const env: NodeJS.ProcessEnv = {
+      ...buildTaskSubprocessEnv(),
       HOME: process.env.HOME || "/home/magnus",
     };
     const child = spawnFn(cmd, args, {

--- a/src/codex-sandbox.ts
+++ b/src/codex-sandbox.ts
@@ -17,6 +17,7 @@ import {
   buildFrictionTags,
 } from "./friction/munin-key.js";
 import type { ReportFrictionInput } from "./friction/schema.js";
+import { buildTaskSubprocessEnv } from "./task-subprocess-env.js";
 
 export const CODEX_SANDBOX_FAILURE_KIND = "CODEX_SANDBOX_UNAVAILABLE";
 export const CODEX_SANDBOX_FAILURE_TAG = "failure:infra";
@@ -57,7 +58,7 @@ export function probeCodexSandbox(
         encoding: "utf8",
         timeout: timeoutMs,
         maxBuffer: 16 * 1024,
-        env: process.env,
+        env: buildTaskSubprocessEnv(),
       },
       (error: ExecFileException | null, stdout: string, stderr: string) => {
         const checkedAt = now().toISOString();

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,6 +162,7 @@ import { runHarnessLaneSampledAttempt, type LaneAttemptOutcome } from "./harness
 import { decideHarnessLane, isHarnessLaneEligibleTaskType } from "./harness-lane-sampler.js";
 import { sanitizeProviderTokenCount } from "./m5-provenance.js";
 import {
+  buildTaskSensitivitySnapshot,
   buildStructuredTaskResult,
   type DispatcherRuntime,
   type StructuredTaskResult,
@@ -1055,17 +1056,6 @@ function buildLearningTaskSource(
     brokerAttestedNamespace: task.brokerAttestedNamespace,
     brokerAttestationError: task.brokerAttestationError,
   });
-}
-
-function buildTaskSensitivitySnapshot(
-  assessment: SensitivityAssessment | undefined,
-): TaskExecutionSensitivity | undefined {
-  if (!assessment) return undefined;
-  return {
-    declared: assessment.declared,
-    effective: assessment.effective,
-    mismatch: assessment.mismatch,
-  };
 }
 
 function getDeclaredSensitivityFromContent(

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,10 @@ import {
   type CodexSandboxProbeResult,
 } from "./codex-sandbox.js";
 import {
+  buildTaskSubprocessEnv,
+  SENSITIVITY_CHECKPOINT_SECRET_ENV,
+} from "./task-subprocess-env.js";
+import {
   decideAuthAlarm,
   alertDeliveryCommitsTransition,
   hydratePersistedAuthAlarmState,
@@ -369,7 +373,7 @@ const config = {
   // Munin credential: other agents can legitimately write tasks/* and must
   // not be able to mint phase authority.
   sensitivityCheckpointSecret:
-    process.env.HUGIN_SENSITIVITY_CHECKPOINT_SECRET?.trim() || "",
+    process.env[SENSITIVITY_CHECKPOINT_SECRET_ENV]?.trim() || "",
   pollIntervalMs: parseBoundedPositiveInt(
     process.env.HUGIN_POLL_INTERVAL_MS,
     30_000,
@@ -2224,7 +2228,7 @@ function spawnRuntime(
       cwd: task.workingDir,
       stdio: ["ignore", "pipe", "pipe"],
       env: {
-        ...process.env,
+        ...buildTaskSubprocessEnv(),
         HOME: "/home/magnus",
         HUGIN_TASK_ID: taskId,
         HUGIN_TASK_NAMESPACE: ctx.taskNs,
@@ -2604,7 +2608,7 @@ async function writeSensitivityCheckpoint(
   client: MuninClient,
   classification?: string,
 ): Promise<void> {
-  if (!sensitivity || !config.sensitivityCheckpointSecret) return;
+  if (!sensitivity || config.sensitivityCheckpointSecret.length < 32) return;
   await client.write(
     taskNs,
     SENSITIVITY_CHECKPOINT_KEY,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2523,7 +2523,10 @@ async function killOrphanDispatchers(): Promise<void> {
     const myPid = process.pid;
     const cwd = process.cwd();
     const { stdout } = await new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
-      const child = spawn("pgrep", ["-f", "node dist/index.js"], { stdio: ["ignore", "pipe", "pipe"] });
+      const child = spawn("pgrep", ["-f", "node dist/index.js"], {
+        stdio: ["ignore", "pipe", "pipe"],
+        env: buildTaskSubprocessEnv(),
+      });
       let stdout = "";
       let stderr = "";
       child.stdout?.on("data", (d: Buffer) => (stdout += d.toString()));

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,7 +164,6 @@ import { sanitizeProviderTokenCount } from "./m5-provenance.js";
 import {
   buildTaskSensitivitySnapshot,
   buildStructuredTaskResult,
-  taskExecutionSensitivitySchema,
   type DispatcherRuntime,
   type StructuredTaskResult,
   type TaskExecutionApprovalMetadata,
@@ -174,6 +173,12 @@ import {
   type TaskExecutionSensitivity,
   type SkillRoute,
 } from "./task-result-schema.js";
+import {
+  buildSensitivityCheckpoint,
+  parseSensitivityCheckpoint,
+  SENSITIVITY_CHECKPOINT_KEY,
+  SENSITIVITY_CHECKPOINT_TAGS,
+} from "./sensitivity-checkpoint.js";
 import {
   buildSensitivityAssessment,
   buildSensitivityPolicyError,
@@ -729,6 +734,7 @@ interface TaskConfig {
   declaredSensitivity?: Sensitivity;
   effectiveSensitivity?: Sensitivity;
   sensitivityAssessment?: SensitivityAssessment;
+  sensitivitySnapshot?: TaskExecutionSensitivity;
   contextResolution?: Awaited<ReturnType<typeof resolveContextRefs>>;
   pipeline?: TaskExecutionPipelineContext;
   capabilities?: RuntimeCapability[];
@@ -1098,7 +1104,7 @@ function getTaskSensitivityAssessment(task: TaskConfig): SensitivityAssessment {
   const refsSensitivity = task.contextResolution?.maxSensitivity;
   return buildSensitivityAssessment({
     declared,
-    baseline: "internal",
+    baseline: task.pipeline?.sensitivity ?? "internal",
     context: contextSensitivity,
     prompt: promptDetection.sensitivity,
     refs: refsSensitivity,
@@ -1107,12 +1113,10 @@ function getTaskSensitivityAssessment(task: TaskConfig): SensitivityAssessment {
     // dependency-driven mismatches remain useful to content-blind mining.
     inherited: task.pipeline?.sensitivity,
     hardPrivate: promptDetection.hardPrivate,
-    // Generated phase tasks are submitted by Hugin itself, but override
-    // authority belongs to the original pipeline submitter. Otherwise every
-    // generated phase would accidentally inherit Hugin's owner privilege.
-    allowOwnerOverride: isOwnerSubmitter(
-      task.pipeline?.submittedBy ?? task.submittedBy,
-    ),
+    // Pipeline-phase authority is accepted only through the separate,
+    // content-hash-bound Hugin checkpoint. Free-form pipeline metadata must
+    // never upgrade a task's owner privileges, even when Submitted-by is hugin.
+    allowOwnerOverride: !task.pipeline && isOwnerSubmitter(task.submittedBy),
   });
 }
 
@@ -1121,7 +1125,10 @@ function getTaskRuntimeLabel(task: TaskConfig): string {
   return task.ollamaHost ? `ollama:${task.ollamaHost}` : "ollama";
 }
 
-async function assessTaskSecurity(task: TaskConfig): Promise<SensitivityAssessment> {
+async function assessTaskSecurity(
+  task: TaskConfig,
+  trustedSnapshot?: TaskExecutionSensitivity,
+): Promise<SensitivityAssessment> {
   if (task.contextRefs?.length) {
     task.contextResolution = await resolveContextRefs(
       task.contextRefs,
@@ -1131,9 +1138,19 @@ async function assessTaskSecurity(task: TaskConfig): Promise<SensitivityAssessme
     );
   }
 
-  const assessment = getTaskSensitivityAssessment(task);
+  const assessment = trustedSnapshot
+    ? {
+        declared: trustedSnapshot.declared,
+        effective: trustedSnapshot.effective,
+        detectorMax: trustedSnapshot.detectorMax ?? trustedSnapshot.effective,
+        mismatch: trustedSnapshot.mismatch,
+        reasons: trustedSnapshot.reasons ?? [],
+        override: trustedSnapshot.override,
+      }
+    : getTaskSensitivityAssessment(task);
   task.effectiveSensitivity = assessment.effective;
   task.sensitivityAssessment = assessment;
+  task.sensitivitySnapshot = trustedSnapshot;
 
   if (assessment.override?.applied) {
     // Owner override is visible in logs so we can mine false positives and
@@ -2569,10 +2586,9 @@ async function writeDeliveryRetryMeta(
   );
 }
 
-const SENSITIVITY_CHECKPOINT_KEY = "sensitivity-checkpoint";
-
 async function writeSensitivityCheckpoint(
   taskNs: string,
+  taskContent: string,
   sensitivity: TaskExecutionSensitivity | undefined,
   client: MuninClient,
   classification?: string,
@@ -2581,8 +2597,8 @@ async function writeSensitivityCheckpoint(
   await client.write(
     taskNs,
     SENSITIVITY_CHECKPOINT_KEY,
-    JSON.stringify(sensitivity),
-    ["type:task-sensitivity-checkpoint"],
+    buildSensitivityCheckpoint(taskNs, taskContent, sensitivity),
+    [...SENSITIVITY_CHECKPOINT_TAGS],
     undefined,
     classification,
   );
@@ -2590,15 +2606,13 @@ async function writeSensitivityCheckpoint(
 
 async function readSensitivityCheckpoint(
   taskNs: string,
+  taskContent: string,
   client: MuninClient,
 ): Promise<TaskExecutionSensitivity | undefined> {
   try {
     const entry = await client.read(taskNs, SENSITIVITY_CHECKPOINT_KEY);
     if (!entry?.content) return undefined;
-    const parsed = taskExecutionSensitivitySchema.safeParse(
-      JSON.parse(entry.content),
-    );
-    return parsed.success ? parsed.data : undefined;
+    return parseSensitivityCheckpoint(entry.content, taskNs, taskContent);
   } catch {
     return undefined;
   }
@@ -2629,7 +2643,7 @@ async function reconcileDeliveryPending(
     "",
   ) as DispatcherRuntime;
   const recoverySensitivity =
-    await readSensitivityCheckpoint(taskNs, client) ??
+    await readSensitivityCheckpoint(taskNs, entry.content, client) ??
     (task
       ? buildTaskSensitivitySnapshot(getTaskSensitivityAssessment(task))
       : undefined);
@@ -4376,7 +4390,14 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
   }
 
   if (declaredRuntime !== "pipeline" && parsedTask) {
-    const sensitivityAssessment = await assessTaskSecurity(parsedTask);
+    const trustedPipelineSensitivity =
+      parsedTask.pipeline && entry.tags.includes("type:pipeline-phase")
+        ? await readSensitivityCheckpoint(taskNs, entry.content, munin)
+        : undefined;
+    const sensitivityAssessment = await assessTaskSecurity(
+      parsedTask,
+      trustedPipelineSensitivity,
+    );
 
     // Local-skill lane pre-step (issue #84), GUARDED by HUGIN_SKILL_LANE.
     // Default OFF ⇒ consultSkillLane returns null ⇒ a true no-op: the dispatcher
@@ -4756,9 +4777,8 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
 
     currentTaskConfig = task;
     const taskClassification = getTaskArtifactClassification(task);
-    const taskSensitivitySnapshot = buildTaskSensitivitySnapshot(
-      task.sensitivityAssessment,
-    );
+    const taskSensitivitySnapshot = task.sensitivitySnapshot ??
+      buildTaskSensitivitySnapshot(task.sensitivityAssessment);
     let approvalMetadata: TaskExecutionApprovalMetadata | undefined;
     if (task.pipeline?.authority === "gated") {
       const [approvalRequestEntry, approvalDecisionEntry] = await Promise.all([
@@ -5883,6 +5903,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
       );
       await writeSensitivityCheckpoint(
         taskNs,
+        checkpointContent,
         taskSensitivitySnapshot,
         munin,
         taskClassification,

--- a/src/index.ts
+++ b/src/index.ts
@@ -365,6 +365,11 @@ const config = {
   host: process.env.HUGIN_HOST || "127.0.0.1",
   muninUrl: process.env.MUNIN_URL || "http://localhost:3030",
   muninApiKey: process.env.MUNIN_API_KEY || "",
+  // Hugin-only producer key for sensitivity checkpoints. This must not be a
+  // Munin credential: other agents can legitimately write tasks/* and must
+  // not be able to mint phase authority.
+  sensitivityCheckpointSecret:
+    process.env.HUGIN_SENSITIVITY_CHECKPOINT_SECRET?.trim() || "",
   pollIntervalMs: parseBoundedPositiveInt(
     process.env.HUGIN_POLL_INTERVAL_MS,
     30_000,
@@ -512,6 +517,13 @@ if (config.signingPolicy !== "off") {
       "HUGIN_SIGNING_POLICY=require but no keys configured (set HUGIN_SUBMITTER_KEYS or HUGIN_SUBMITTER_KEYS_FILE). All tasks will be rejected.",
     );
   }
+}
+
+if (config.sensitivityCheckpointSecret.length < 32) {
+  console.warn(
+    "HUGIN_SENSITIVITY_CHECKPOINT_SECRET is missing or shorter than 32 characters; " +
+      "pipeline decomposition will fail closed and delivery recovery will recompute sensitivity",
+  );
 }
 
 const legacyClaudeExecutor = process.env.HUGIN_CLAUDE_EXECUTOR?.trim().toLowerCase();
@@ -1104,14 +1116,13 @@ function getTaskSensitivityAssessment(task: TaskConfig): SensitivityAssessment {
   const refsSensitivity = task.contextResolution?.maxSensitivity;
   return buildSensitivityAssessment({
     declared,
-    baseline: task.pipeline?.sensitivity ?? "internal",
+    // Any authentic pipeline classification arrives through the HMAC-bound
+    // checkpoint and bypasses this fallback. Free-form pipeline fields are
+    // untrusted here and must never lower the ordinary internal floor.
+    baseline: "internal",
     context: contextSensitivity,
     prompt: promptDetection.sensitivity,
     refs: refsSensitivity,
-    // A pipeline phase inherits the compiler's effective classification. Keep
-    // it as an explicit reason rather than an unexplained elevated baseline so
-    // dependency-driven mismatches remain useful to content-blind mining.
-    inherited: task.pipeline?.sensitivity,
     hardPrivate: promptDetection.hardPrivate,
     // Pipeline-phase authority is accepted only through the separate,
     // content-hash-bound Hugin checkpoint. Free-form pipeline metadata must
@@ -2593,11 +2604,16 @@ async function writeSensitivityCheckpoint(
   client: MuninClient,
   classification?: string,
 ): Promise<void> {
-  if (!sensitivity) return;
+  if (!sensitivity || !config.sensitivityCheckpointSecret) return;
   await client.write(
     taskNs,
     SENSITIVITY_CHECKPOINT_KEY,
-    buildSensitivityCheckpoint(taskNs, taskContent, sensitivity),
+    buildSensitivityCheckpoint(
+      taskNs,
+      taskContent,
+      sensitivity,
+      config.sensitivityCheckpointSecret,
+    ),
     [...SENSITIVITY_CHECKPOINT_TAGS],
     undefined,
     classification,
@@ -2612,7 +2628,12 @@ async function readSensitivityCheckpoint(
   try {
     const entry = await client.read(taskNs, SENSITIVITY_CHECKPOINT_KEY);
     if (!entry?.content) return undefined;
-    return parseSensitivityCheckpoint(entry.content, taskNs, taskContent);
+    return parseSensitivityCheckpoint(
+      entry.content,
+      taskNs,
+      taskContent,
+      config.sensitivityCheckpointSecret,
+    );
   } catch {
     return undefined;
   }
@@ -4703,7 +4724,10 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         entry,
         queueDepth,
         await probeAllHosts(),
-        { allowOwnerOverride: isOwnerSubmitter(submittedBy) },
+        {
+          allowOwnerOverride: isOwnerSubmitter(submittedBy),
+          sensitivityCheckpointSecret: config.sensitivityCheckpointSecret,
+        },
       );
       stopLeaseRenewal();
       stopCancellationWatch();

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,6 +164,7 @@ import { sanitizeProviderTokenCount } from "./m5-provenance.js";
 import {
   buildTaskSensitivitySnapshot,
   buildStructuredTaskResult,
+  taskExecutionSensitivitySchema,
   type DispatcherRuntime,
   type StructuredTaskResult,
   type TaskExecutionApprovalMetadata,
@@ -1092,18 +1093,26 @@ function isOwnerSubmitter(submittedBy: string | undefined): boolean {
 
 function getTaskSensitivityAssessment(task: TaskConfig): SensitivityAssessment {
   const declared = task.declaredSensitivity;
-  const baseline = task.pipeline?.sensitivity || "internal";
   const contextSensitivity = classifyContextSensitivity(task.context, task.workingDir);
   const promptDetection = detectPromptSensitivity(task.prompt);
   const refsSensitivity = task.contextResolution?.maxSensitivity;
   return buildSensitivityAssessment({
     declared,
-    baseline,
+    baseline: "internal",
     context: contextSensitivity,
     prompt: promptDetection.sensitivity,
     refs: refsSensitivity,
+    // A pipeline phase inherits the compiler's effective classification. Keep
+    // it as an explicit reason rather than an unexplained elevated baseline so
+    // dependency-driven mismatches remain useful to content-blind mining.
+    inherited: task.pipeline?.sensitivity,
     hardPrivate: promptDetection.hardPrivate,
-    allowOwnerOverride: isOwnerSubmitter(task.submittedBy),
+    // Generated phase tasks are submitted by Hugin itself, but override
+    // authority belongs to the original pipeline submitter. Otherwise every
+    // generated phase would accidentally inherit Hugin's owner privilege.
+    allowOwnerOverride: isOwnerSubmitter(
+      task.pipeline?.submittedBy ?? task.submittedBy,
+    ),
   });
 }
 
@@ -2560,6 +2569,41 @@ async function writeDeliveryRetryMeta(
   );
 }
 
+const SENSITIVITY_CHECKPOINT_KEY = "sensitivity-checkpoint";
+
+async function writeSensitivityCheckpoint(
+  taskNs: string,
+  sensitivity: TaskExecutionSensitivity | undefined,
+  client: MuninClient,
+  classification?: string,
+): Promise<void> {
+  if (!sensitivity) return;
+  await client.write(
+    taskNs,
+    SENSITIVITY_CHECKPOINT_KEY,
+    JSON.stringify(sensitivity),
+    ["type:task-sensitivity-checkpoint"],
+    undefined,
+    classification,
+  );
+}
+
+async function readSensitivityCheckpoint(
+  taskNs: string,
+  client: MuninClient,
+): Promise<TaskExecutionSensitivity | undefined> {
+  try {
+    const entry = await client.read(taskNs, SENSITIVITY_CHECKPOINT_KEY);
+    if (!entry?.content) return undefined;
+    const parsed = taskExecutionSensitivitySchema.safeParse(
+      JSON.parse(entry.content),
+    );
+    return parsed.success ? parsed.data : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 // Runtime-owned artefact delivery (issue #68 / #77): a `running +
 // delivery:pending` checkpoint means the agent content is durably preserved in
 // `result` but delivery did not finalize (crash/restart mid-delivery).
@@ -2584,6 +2628,11 @@ async function reconcileDeliveryPending(
     /^runtime:/,
     "",
   ) as DispatcherRuntime;
+  const recoverySensitivity =
+    await readSensitivityCheckpoint(taskNs, client) ??
+    (task
+      ? buildTaskSensitivitySnapshot(getTaskSensitivityAssessment(task))
+      : undefined);
 
   // Single CAS ownership: reclaim with a fresh lease, keep delivery:pending.
   const reclaimTags = buildClaimTags(
@@ -2773,6 +2822,7 @@ async function reconcileDeliveryPending(
       bodyKind: "response",
       bodyText: "",
       errorMessage: ok ? undefined : delivery.error ?? "delivery failed",
+      sensitivity: recoverySensitivity,
       artifactDelivery: {
         ok: delivery.ok,
         failureKind: delivery.failureKind,
@@ -5829,6 +5879,12 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         }),
         exfilOutcome.resultTags,
         undefined,
+        taskClassification,
+      );
+      await writeSensitivityCheckpoint(
+        taskNs,
+        taskSensitivitySnapshot,
+        munin,
         taskClassification,
       );
       const checkpointWrite = await munin.write(

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -265,7 +265,14 @@ function summarizeAwaitResponse(response: unknown, taskId: string): unknown {
     const sensitivity = asRecord(result.sensitivity);
     if (sensitivity) {
       const projectedSensitivity: Record<string, unknown> = {};
-      for (const key of ["declared", "effective", "mismatch"] as const) {
+      for (const key of [
+        "declared",
+        "effective",
+        "mismatch",
+        "detectorMax",
+        "reasons",
+        "override",
+      ] as const) {
         if (sensitivity[key] !== undefined) projectedSensitivity[key] = sensitivity[key];
       }
       if (Object.keys(projectedSensitivity).length > 0) {

--- a/src/opencode-executor.ts
+++ b/src/opencode-executor.ts
@@ -4,6 +4,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 import { isSovereignGatewayHost } from "./orchestrator/provider-config.js";
+import { buildTaskSubprocessEnv } from "./task-subprocess-env.js";
 
 export type OpencodePermissionProfile = "read-only" | "trusted-code";
 
@@ -485,7 +486,7 @@ export async function executeOpencodeTask(
       cwd: task.workingDir,
       stdio: ["ignore", "pipe", "pipe"],
       env: {
-        ...process.env,
+        ...buildTaskSubprocessEnv(),
         OPENCODE_CONFIG_DIR: configDir,
         [PROVIDER_API_KEY_ENV]: task.apiKey,
         HUGIN_TASK_ID: taskId,

--- a/src/orchestrator/worker-executor.ts
+++ b/src/orchestrator/worker-executor.ts
@@ -23,6 +23,7 @@ import { extractM5Provenance, sanitizeProviderTokenCount } from "../m5-provenanc
 import type { M5DelegationProvenance } from "../m5-provenance.js";
 import { estimateCostUsd } from "../model-pricing.js";
 import { getRegistryEntryById } from "../runtime-registry.js";
+import { buildTaskSubprocessEnv } from "../task-subprocess-env.js";
 import {
   getProviderConfig,
   resolveGatewayRootUrl,
@@ -949,6 +950,7 @@ export class PiHarnessExecutor implements WorkerExecutor {
       try {
         child = spawn(entry.harnessCmd ?? "pi", args, {
           stdio: ["ignore", "pipe", "pipe"],
+          env: buildTaskSubprocessEnv(),
         });
       } catch (spawnErr) {
         resolve({

--- a/src/pipeline-compiler.ts
+++ b/src/pipeline-compiler.ts
@@ -28,6 +28,7 @@ import {
   maxSensitivity,
   parseSensitivity,
   sensitivityToTag,
+  type SensitivityAssessment,
 } from "./sensitivity.js";
 import { MAX_DEPENDENCIES } from "./task-graph.js";
 import type { OllamaHost } from "./ollama-hosts.js";
@@ -376,17 +377,17 @@ function validateAuthority(
   throw new Error(`Phase "${phaseName}" uses unsupported authority "${authority}"`);
 }
 
-function computePhaseEffectiveSensitivities(
+function computePhaseSensitivityAssessments(
   phases: ParsedPipelinePhase[],
   pipelineSensitivity: PipelineSensitivity,
   options?: { allowOwnerOverride?: boolean },
-): Map<string, PipelineSensitivity> {
+): Map<string, SensitivityAssessment> {
   const byName = new Map(phases.map((phase) => [phase.name, phase]));
-  const computed = new Map<string, PipelineSensitivity>();
+  const computed = new Map<string, SensitivityAssessment>();
 
   const visit = (phaseName: string): PipelineSensitivity => {
     const cached = computed.get(phaseName);
-    if (cached) return cached;
+    if (cached) return cached.effective;
 
     const phase = byName.get(phaseName);
     if (!phase) {
@@ -418,7 +419,7 @@ function computePhaseEffectiveSensitivities(
       );
     }
 
-    computed.set(phaseName, assessment.effective);
+    computed.set(phaseName, assessment);
     return assessment.effective;
   };
 
@@ -459,7 +460,7 @@ export function compilePipelineTask(
   for (const phase of parsed.phases) {
     phaseIdByName.set(phase.name, `${pipelineId}-${slugifyPhaseName(phase.name)}`);
   }
-  const phaseSensitivities = computePhaseEffectiveSensitivities(
+  const phaseAssessments = computePhaseSensitivityAssessments(
     parsed.phases,
     parsed.sensitivity,
     { allowOwnerOverride: options?.allowOwnerOverride },
@@ -474,7 +475,8 @@ export function compilePipelineTask(
     const sideEffects = validateSideEffects(phase.name, phase.sideEffects);
     const authority = validateAuthority(phase.name, phase.authority, sideEffects);
     const declaredSensitivity = parseSensitivity(phase.sensitivity);
-    const effectiveSensitivity = phaseSensitivities.get(phase.name) || parsed.sensitivity;
+    const sensitivityAssessment = phaseAssessments.get(phase.name);
+    const effectiveSensitivity = sensitivityAssessment?.effective || parsed.sensitivity;
 
     let resolvedRuntimeId: PipelineRuntimeId;
     let autoRouted: boolean | undefined;
@@ -558,6 +560,7 @@ export function compilePipelineTask(
       sideEffects,
       declaredSensitivity,
       effectiveSensitivity,
+      sensitivityAssessment,
       autoRouted,
       routingReason,
     };
@@ -600,7 +603,7 @@ function buildPhaseTaskContent(
     `- **Pipeline:** ${pipeline.id}`,
     `- **Pipeline phase:** ${phase.name}`,
     `- **Pipeline submitted by:** ${pipeline.submittedBy}`,
-    `- **Sensitivity:** ${phase.effectiveSensitivity}`,
+    `- **Sensitivity:** ${phase.declaredSensitivity ?? phase.effectiveSensitivity}`,
     `- **Pipeline sensitivity:** ${phase.effectiveSensitivity}`,
     `- **Pipeline authority:** ${phase.authority}`,
     ...(phase.sideEffects.length > 0

--- a/src/pipeline-compiler.ts
+++ b/src/pipeline-compiler.ts
@@ -641,6 +641,7 @@ export function buildPhaseTaskDrafts(pipeline: PipelineIR): PipelinePhaseTaskDra
       content: buildPhaseTaskContent(pipeline, phase, index),
       tags,
       classification: phase.effectiveSensitivity,
+      sensitivityAssessment: phase.sensitivityAssessment,
     };
   });
 }

--- a/src/pipeline-dispatch.ts
+++ b/src/pipeline-dispatch.ts
@@ -3,7 +3,7 @@ import {
   buildPipelineDecompositionResult,
   compilePipelineTask,
 } from "./pipeline-compiler.js";
-import type { PipelineIR, PipelineSensitivity } from "./pipeline-ir.js";
+import type { PipelineIR, PipelinePhaseTaskDraft } from "./pipeline-ir.js";
 import type { MuninEntry, MuninReadRequest, MuninReadResult } from "./munin-client.js";
 import type { OllamaHost } from "./ollama-hosts.js";
 import { getFoundBatchEntry, extractTaskId } from "./task-helpers.js";
@@ -13,9 +13,15 @@ import {
   buildTerminalStatusTags,
 } from "./task-status-tags.js";
 import {
+  buildTaskSensitivitySnapshot,
   buildStructuredTaskResult,
   type StructuredTaskResult,
 } from "./task-result-schema.js";
+import {
+  buildSensitivityCheckpoint,
+  SENSITIVITY_CHECKPOINT_KEY,
+  SENSITIVITY_CHECKPOINT_TAGS,
+} from "./sensitivity-checkpoint.js";
 
 export interface PipelineDispatchClient {
   readBatch(reads: MuninReadRequest[]): Promise<MuninReadResult[]>;
@@ -50,12 +56,7 @@ export interface PipelineDispatchHooks {
 async function cancelCreatedChildren(
   client: PipelineDispatchClient,
   hooks: PipelineDispatchHooks,
-  createdDrafts: Array<{
-    namespace: string;
-    content: string;
-    tags: string[];
-    classification: PipelineSensitivity;
-  }>
+  createdDrafts: PipelinePhaseTaskDraft[],
 ): Promise<void> {
   for (const draft of createdDrafts) {
     try {
@@ -93,6 +94,7 @@ async function cancelCreatedChildren(
           bodyKind: "error",
           bodyText: "Pipeline decomposition aborted before parent commit",
           errorMessage: "Pipeline decomposition aborted before parent commit",
+          sensitivity: buildTaskSensitivitySnapshot(draft.sensitivityAssessment),
         }),
         sensitivityToMuninClassification(draft.classification),
       );
@@ -163,6 +165,23 @@ export async function handlePipelineTask(
     );
 
     for (const draft of phaseDrafts) {
+      const sensitivity = buildTaskSensitivitySnapshot(
+        draft.sensitivityAssessment,
+      );
+      if (sensitivity) {
+        await client.write(
+          draft.namespace,
+          SENSITIVITY_CHECKPOINT_KEY,
+          buildSensitivityCheckpoint(
+            draft.namespace,
+            draft.content,
+            sensitivity,
+          ),
+          [...SENSITIVITY_CHECKPOINT_TAGS],
+          undefined,
+          sensitivityToMuninClassification(draft.classification),
+        );
+      }
       await client.write(
         draft.namespace,
         "status",

--- a/src/pipeline-dispatch.ts
+++ b/src/pipeline-dispatch.ts
@@ -115,7 +115,10 @@ export async function handlePipelineTask(
   entry: MuninEntry & { found: true },
   queueDepth: number,
   ollamaHosts?: OllamaHost[],
-  options?: { allowOwnerOverride?: boolean },
+  options?: {
+    allowOwnerOverride?: boolean;
+    sensitivityCheckpointSecret?: string;
+  },
 ): Promise<{ hadTask: boolean; queueDepth: number }> {
   const pipelineId = extractTaskId(taskNs);
   let pipeline: PipelineIR;
@@ -176,6 +179,7 @@ export async function handlePipelineTask(
             draft.namespace,
             draft.content,
             sensitivity,
+            options?.sensitivityCheckpointSecret ?? "",
           ),
           [...SENSITIVITY_CHECKPOINT_TAGS],
           undefined,

--- a/src/pipeline-ir.ts
+++ b/src/pipeline-ir.ts
@@ -3,6 +3,7 @@ import {
   sensitivityAssessmentSchema,
   sensitivitySchema,
   type Sensitivity,
+  type SensitivityAssessment,
 } from "./sensitivity.js";
 
 export const pipelineSensitivitySchema = sensitivitySchema;
@@ -85,4 +86,5 @@ export interface PipelinePhaseTaskDraft {
   content: string;
   tags: string[];
   classification: PipelineSensitivity;
+  sensitivityAssessment?: SensitivityAssessment;
 }

--- a/src/pipeline-ir.ts
+++ b/src/pipeline-ir.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
-import { sensitivitySchema, type Sensitivity } from "./sensitivity.js";
+import {
+  sensitivityAssessmentSchema,
+  sensitivitySchema,
+  type Sensitivity,
+} from "./sensitivity.js";
 
 export const pipelineSensitivitySchema = sensitivitySchema;
 export type PipelineSensitivity = Sensitivity;
@@ -51,6 +55,7 @@ export const pipelinePhaseIRSchema = z.object({
   sideEffects: z.array(pipelineSideEffectIdSchema).default([]),
   declaredSensitivity: pipelineSensitivitySchema.optional(),
   effectiveSensitivity: pipelineSensitivitySchema,
+  sensitivityAssessment: sensitivityAssessmentSchema.optional(),
   autoRouted: z.boolean().optional(),
   routingReason: z.string().min(1).optional(),
 });

--- a/src/sdk-executor.ts
+++ b/src/sdk-executor.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 import { query, type Query } from "@anthropic-ai/claude-agent-sdk";
+import { buildTaskSubprocessEnv } from "./task-subprocess-env.js";
 
 type HttpMcpServer = { type: "http"; url: string; headers?: Record<string, string> };
 type StdioMcpServer = { type: "stdio"; command: string; args: string[]; env: Record<string, string> };
@@ -276,7 +277,7 @@ export async function executeSdkTask(
         ...(task.model ? { model: task.model } : {}),
         ...(Object.keys(mcpServers).length > 0 ? { mcpServers } : {}),
         env: {
-          ...process.env,
+          ...buildTaskSubprocessEnv(),
           HOME: "/home/magnus",
           HUGIN_TASK_ID: taskId,
         },

--- a/src/sensitivity-checkpoint.ts
+++ b/src/sensitivity-checkpoint.ts
@@ -1,0 +1,55 @@
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import {
+  taskExecutionSensitivitySchema,
+  type TaskExecutionSensitivity,
+} from "./task-result-schema.js";
+
+export const SENSITIVITY_CHECKPOINT_KEY = "sensitivity-checkpoint";
+export const SENSITIVITY_CHECKPOINT_TAGS = [
+  "type:task-sensitivity-checkpoint",
+] as const;
+
+const sensitivityCheckpointSchema = z.object({
+  schemaVersion: z.literal(1),
+  taskNamespace: z.string().min(1),
+  taskContentSha256: z.string().regex(/^[a-f0-9]{64}$/),
+  sensitivity: taskExecutionSensitivitySchema,
+}).strict();
+
+function hashTaskContent(taskContent: string): string {
+  return createHash("sha256").update(taskContent, "utf8").digest("hex");
+}
+
+export function buildSensitivityCheckpoint(
+  taskNamespace: string,
+  taskContent: string,
+  sensitivity: TaskExecutionSensitivity,
+): string {
+  return JSON.stringify(
+    sensitivityCheckpointSchema.parse({
+      schemaVersion: 1,
+      taskNamespace,
+      taskContentSha256: hashTaskContent(taskContent),
+      sensitivity,
+    }),
+  );
+}
+
+export function parseSensitivityCheckpoint(
+  content: string,
+  expectedTaskNamespace: string,
+  expectedTaskContent: string,
+): TaskExecutionSensitivity | undefined {
+  try {
+    const parsed = sensitivityCheckpointSchema.safeParse(JSON.parse(content));
+    if (!parsed.success) return undefined;
+    if (parsed.data.taskNamespace !== expectedTaskNamespace) return undefined;
+    if (parsed.data.taskContentSha256 !== hashTaskContent(expectedTaskContent)) {
+      return undefined;
+    }
+    return parsed.data.sensitivity;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/sensitivity-checkpoint.ts
+++ b/src/sensitivity-checkpoint.ts
@@ -1,4 +1,4 @@
-import { createHash } from "node:crypto";
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
 import { z } from "zod";
 import {
   taskExecutionSensitivitySchema,
@@ -9,29 +9,73 @@ export const SENSITIVITY_CHECKPOINT_KEY = "sensitivity-checkpoint";
 export const SENSITIVITY_CHECKPOINT_TAGS = [
   "type:task-sensitivity-checkpoint",
 ] as const;
+export const SENSITIVITY_CHECKPOINT_VERSION =
+  "hugin-sensitivity-checkpoint/v1" as const;
+
+const sha256Schema = z.string().regex(/^[a-f0-9]{64}$/);
 
 const sensitivityCheckpointSchema = z.object({
-  schemaVersion: z.literal(1),
+  version: z.literal(SENSITIVITY_CHECKPOINT_VERSION),
   taskNamespace: z.string().min(1),
-  taskContentSha256: z.string().regex(/^[a-f0-9]{64}$/),
+  taskContentSha256: sha256Schema,
   sensitivity: taskExecutionSensitivitySchema,
+  hmacSha256: sha256Schema,
 }).strict();
 
 function hashTaskContent(taskContent: string): string {
   return createHash("sha256").update(taskContent, "utf8").digest("hex");
 }
 
+function canonicalize(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalize).join(",")}]`;
+  if (value !== null && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record).filter((key) => record[key] !== undefined).sort().map((key) => {
+      const child = record[key];
+      return `${JSON.stringify(key)}:${canonicalize(child)}`;
+    }).join(",")}}`;
+  }
+  if (value === null || typeof value === "string" || typeof value === "boolean") {
+    return JSON.stringify(value);
+  }
+  throw new Error("sensitivity checkpoint accepts only JSON objects, arrays, strings, booleans, and null");
+}
+
+function checkpointKey(secret: string): Buffer {
+  if (secret.length < 32) {
+    throw new Error("sensitivity checkpoint secret must contain at least 32 characters");
+  }
+  return createHmac("sha256", secret)
+    .update("hugin-sensitivity-checkpoint/server-key/v1", "utf8")
+    .digest();
+}
+
+function unsignedCheckpoint(
+  taskNamespace: string,
+  taskContent: string,
+  sensitivity: TaskExecutionSensitivity,
+) {
+  return {
+    version: SENSITIVITY_CHECKPOINT_VERSION,
+    taskNamespace,
+    taskContentSha256: hashTaskContent(taskContent),
+    sensitivity: taskExecutionSensitivitySchema.parse(sensitivity),
+  };
+}
+
 export function buildSensitivityCheckpoint(
   taskNamespace: string,
   taskContent: string,
   sensitivity: TaskExecutionSensitivity,
+  secret: string,
 ): string {
+  const unsigned = unsignedCheckpoint(taskNamespace, taskContent, sensitivity);
   return JSON.stringify(
     sensitivityCheckpointSchema.parse({
-      schemaVersion: 1,
-      taskNamespace,
-      taskContentSha256: hashTaskContent(taskContent),
-      sensitivity,
+      ...unsigned,
+      hmacSha256: createHmac("sha256", checkpointKey(secret))
+        .update(canonicalize(unsigned), "utf8")
+        .digest("hex"),
     }),
   );
 }
@@ -40,12 +84,32 @@ export function parseSensitivityCheckpoint(
   content: string,
   expectedTaskNamespace: string,
   expectedTaskContent: string,
+  secret: string,
 ): TaskExecutionSensitivity | undefined {
   try {
+    if (!secret) return undefined;
     const parsed = sensitivityCheckpointSchema.safeParse(JSON.parse(content));
     if (!parsed.success) return undefined;
     if (parsed.data.taskNamespace !== expectedTaskNamespace) return undefined;
     if (parsed.data.taskContentSha256 !== hashTaskContent(expectedTaskContent)) {
+      return undefined;
+    }
+    const unsigned = unsignedCheckpoint(
+      parsed.data.taskNamespace,
+      expectedTaskContent,
+      parsed.data.sensitivity,
+    );
+    const expectedMac = Buffer.from(
+      createHmac("sha256", checkpointKey(secret))
+        .update(canonicalize(unsigned), "utf8")
+        .digest("hex"),
+      "hex",
+    );
+    const actualMac = Buffer.from(parsed.data.hmacSha256, "hex");
+    if (
+      expectedMac.length !== actualMac.length ||
+      !timingSafeEqual(expectedMac, actualMac)
+    ) {
       return undefined;
     }
     return parsed.data.sensitivity;

--- a/src/sensitivity.ts
+++ b/src/sensitivity.ts
@@ -174,11 +174,21 @@ const INTERNAL_PATH_PREFIXES = [
   "/home/magnus/scratch",
 ];
 
-export interface SensitivityAssessment {
-  declared?: Sensitivity;
-  effective: Sensitivity;
+export const sensitivityReasonSchema = z.string().regex(
+  /^(?:(?:declared|context|prompt|context-refs|inherited):(public|internal|private)|owner-override:(public|internal|private)<(public|internal|private)|owner-override-blocked:hard-private)$/,
+  "sensitivity reasons must use the content-blind detector vocabulary",
+);
+
+export const sensitivityOverrideSchema = z.object({
+  applied: z.literal(true),
+  detectorMax: sensitivitySchema,
+}).strict();
+
+export const sensitivityAssessmentSchema = z.object({
+  declared: sensitivitySchema.optional(),
+  effective: sensitivitySchema,
   /** Highest classification produced by detector inputs before declaration/override. */
-  detectorMax: Sensitivity;
+  detectorMax: sensitivitySchema,
   /**
    * True when the detector signals were strictly higher than the declared
    * sensitivity. This is audit-facing: owner overrides still set `mismatch`
@@ -186,8 +196,8 @@ export interface SensitivityAssessment {
    * {@link override} to check whether the effective value was actually
    * lowered by an owner override.
    */
-  mismatch: boolean;
-  reasons: string[];
+  mismatch: z.boolean(),
+  reasons: z.array(sensitivityReasonSchema).max(8),
   /**
    * Present only when an owner override was applied — the effective value
    * was clamped DOWN to `declared` because the detector's signals were
@@ -195,11 +205,10 @@ export interface SensitivityAssessment {
    * `detectorMax` field records what the detector would have returned
    * without the override, so audit logs can surface the false positive.
    */
-  override?: {
-    applied: true;
-    detectorMax: Sensitivity;
-  };
-}
+  override: sensitivityOverrideSchema.optional(),
+}).strict();
+
+export type SensitivityAssessment = z.infer<typeof sensitivityAssessmentSchema>;
 
 export function compareSensitivity(a: Sensitivity, b: Sensitivity): number {
   return SENSITIVITY_ORDER[a] - SENSITIVITY_ORDER[b];

--- a/src/sensitivity.ts
+++ b/src/sensitivity.ts
@@ -177,6 +177,8 @@ const INTERNAL_PATH_PREFIXES = [
 export interface SensitivityAssessment {
   declared?: Sensitivity;
   effective: Sensitivity;
+  /** Highest classification produced by detector inputs before declaration/override. */
+  detectorMax: Sensitivity;
   /**
    * True when the detector signals were strictly higher than the declared
    * sensitivity. This is audit-facing: owner overrides still set `mismatch`
@@ -545,6 +547,7 @@ export function buildSensitivityAssessment(input: {
   const assessment: SensitivityAssessment = {
     declared: input.declared,
     effective,
+    detectorMax,
     // Mismatch reflects the *detector's* disagreement with `declared`,
     // regardless of whether the override was honored. This keeps the
     // audit trail surfacing every false-positive we tune against.

--- a/src/task-helpers.ts
+++ b/src/task-helpers.ts
@@ -766,6 +766,7 @@ export async function checkoutTaskBranch(
     const child = spawn("git", ["rev-parse", "--git-dir"], {
       cwd: workingDir,
       stdio: "ignore",
+      env: buildTaskSubprocessEnv(),
     });
     child.on("close", (code) => resolve(code === 0));
     child.on("error", () => resolve(false));
@@ -777,6 +778,7 @@ export async function checkoutTaskBranch(
     const child = spawn("git", ["remote", "get-url", "origin"], {
       cwd: workingDir,
       stdio: "ignore",
+      env: buildTaskSubprocessEnv(),
     });
     child.on("close", (code) => resolve(code === 0));
     child.on("error", () => resolve(false));

--- a/src/task-helpers.ts
+++ b/src/task-helpers.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import * as path from "node:path";
 import type { MuninEntry, MuninQueryResult, MuninReadResult } from "./munin-client.js";
+import { buildTaskSubprocessEnv } from "./task-subprocess-env.js";
 
 /**
  * Task-workspace roots (issue #139).
@@ -703,7 +704,10 @@ async function runGitFetch(
   bypassSystemSshConfig: boolean,
 ): Promise<{ ok: boolean; exitCode: number | null; output: string }> {
   const home = "/home/magnus";
-  const env: Record<string, string> = { ...process.env as Record<string, string>, HOME: home };
+  const env: Record<string, string> = {
+    ...buildTaskSubprocessEnv() as Record<string, string>,
+    HOME: home,
+  };
   if (bypassSystemSshConfig) {
     env.GIT_SSH_COMMAND = `ssh -F ${home}/.ssh/config`;
   }
@@ -840,7 +844,7 @@ export async function checkoutTaskBranch(
     const child = spawn("git", ["checkout", "-b", branchName, baseRef], {
       cwd: workingDir,
       stdio: ["ignore", "pipe", "pipe"],
-      env: { ...process.env, HOME: "/home/magnus" },
+      env: { ...buildTaskSubprocessEnv(), HOME: "/home/magnus" },
     });
     let output = "";
     child.stdout?.on("data", (d: Buffer) => (output += d.toString()));
@@ -911,7 +915,7 @@ export async function finalizeTaskBranch(
     const child = spawn("git", ["status", "--porcelain"], {
       cwd: workingDir,
       stdio: ["ignore", "pipe", "pipe"],
-      env: { ...process.env, HOME: "/home/magnus" },
+      env: { ...buildTaskSubprocessEnv(), HOME: "/home/magnus" },
     });
     let out = "";
     child.stdout?.on("data", (d: Buffer) => (out += d.toString()));
@@ -924,7 +928,7 @@ export async function finalizeTaskBranch(
       const child = spawn("git", ["add", "-A"], {
         cwd: workingDir,
         stdio: "ignore",
-        env: { ...process.env, HOME: "/home/magnus" },
+        env: { ...buildTaskSubprocessEnv(), HOME: "/home/magnus" },
       });
       child.on("close", (code) => resolve(code === 0));
       child.on("error", () => resolve(false));
@@ -938,7 +942,7 @@ export async function finalizeTaskBranch(
           {
             cwd: workingDir,
             stdio: "ignore",
-            env: { ...process.env, HOME: "/home/magnus" },
+            env: { ...buildTaskSubprocessEnv(), HOME: "/home/magnus" },
           },
         );
         child.on("close", () => resolve());
@@ -952,7 +956,7 @@ export async function finalizeTaskBranch(
     const child = spawn("git", ["rev-list", "--count", `${comparisonBase}..HEAD`], {
       cwd: workingDir,
       stdio: ["ignore", "pipe", "pipe"],
-      env: { ...process.env, HOME: "/home/magnus" },
+      env: { ...buildTaskSubprocessEnv(), HOME: "/home/magnus" },
     });
     let out = "";
     child.stdout?.on("data", (d: Buffer) => (out += d.toString()));
@@ -1005,7 +1009,7 @@ export async function finalizeTaskBranch(
     const child = spawn("git", ["remote", "get-url", "--push", "origin"], {
       cwd: workingDir,
       stdio: ["ignore", "pipe", "ignore"],
-      env: { ...process.env, HOME: "/home/magnus" },
+      env: { ...buildTaskSubprocessEnv(), HOME: "/home/magnus" },
     });
     let out = "";
     child.stdout?.on("data", (d: Buffer) => (out += d.toString()));
@@ -1029,7 +1033,7 @@ export async function finalizeTaskBranch(
     const child = spawn("git", ["push", "-u", "origin", branchName], {
       cwd: workingDir,
       stdio: ["ignore", "pipe", "pipe"],
-      env: { ...process.env, HOME: "/home/magnus" },
+      env: { ...buildTaskSubprocessEnv(), HOME: "/home/magnus" },
     });
     let output = "";
     child.stdout?.on("data", (d: Buffer) => (output += d.toString()));
@@ -1090,7 +1094,7 @@ async function runGitCapture(
     const child = spawn("git", args, {
       cwd: workingDir,
       stdio: ["ignore", "pipe", "pipe"],
-      env: { ...process.env, HOME: "/home/magnus" },
+      env: { ...buildTaskSubprocessEnv(), HOME: "/home/magnus" },
     });
     const stdout: Buffer[] = [];
     let stderr = "";
@@ -1167,7 +1171,7 @@ async function cleanupLocalBranch(
     const child = spawn("git", ["checkout", "--detach", detachTarget], {
       cwd: workingDir,
       stdio: "ignore",
-      env: { ...process.env, HOME: "/home/magnus" },
+      env: { ...buildTaskSubprocessEnv(), HOME: "/home/magnus" },
     });
     child.on("close", () => resolve());
     child.on("error", () => resolve());
@@ -1177,7 +1181,7 @@ async function cleanupLocalBranch(
     const child = spawn("git", ["branch", "-d", branchName], {
       cwd: workingDir,
       stdio: "ignore",
-      env: { ...process.env, HOME: "/home/magnus" },
+      env: { ...buildTaskSubprocessEnv(), HOME: "/home/magnus" },
     });
     child.on("close", () => resolve());
     child.on("error", () => resolve());
@@ -1204,7 +1208,7 @@ async function createPullRequest(
       {
         cwd: workingDir,
         stdio: ["ignore", "pipe", "pipe"],
-        env: { ...process.env, HOME: "/home/magnus" },
+        env: { ...buildTaskSubprocessEnv(), HOME: "/home/magnus" },
       },
     );
     let out = "";
@@ -1384,7 +1388,7 @@ async function runGitVoid(workingDir: string, args: string[]): Promise<{ ok: boo
     const child = spawn("git", args, {
       cwd: workingDir,
       stdio: ["ignore", "pipe", "pipe"],
-      env: { ...process.env, HOME: "/home/magnus" },
+      env: { ...buildTaskSubprocessEnv(), HOME: "/home/magnus" },
     });
     let output = "";
     child.stdout?.on("data", (d: Buffer) => (output += d.toString()));
@@ -1663,7 +1667,7 @@ async function findExistingPullRequest(
       {
         cwd: workingDir,
         stdio: ["ignore", "pipe", "pipe"],
-        env: { ...process.env, HOME: "/home/magnus" },
+        env: { ...buildTaskSubprocessEnv(), HOME: "/home/magnus" },
       },
     );
     let out = "";
@@ -1765,7 +1769,7 @@ export async function recoverPublication(
     const child = spawn("git", ["remote", "get-url", "--push", "origin"], {
       cwd: record.workingDir,
       stdio: ["ignore", "pipe", "ignore"],
-      env: { ...process.env, HOME: "/home/magnus" },
+      env: { ...buildTaskSubprocessEnv(), HOME: "/home/magnus" },
     });
     let out = "";
     child.stdout?.on("data", (d: Buffer) => (out += d.toString()));
@@ -1790,7 +1794,7 @@ export async function recoverPublication(
       const child = spawn("git", ["push", "-u", "origin", record.branchName], {
         cwd: record.workingDir,
         stdio: ["ignore", "pipe", "pipe"],
-        env: { ...process.env, HOME: "/home/magnus" },
+        env: { ...buildTaskSubprocessEnv(), HOME: "/home/magnus" },
       });
       child.on("close", (code) => resolve(code === 0));
       child.on("error", () => resolve(false));

--- a/src/task-result-schema.ts
+++ b/src/task-result-schema.ts
@@ -6,6 +6,8 @@ import {
 } from "./pipeline-ir.js";
 import { M5_OUTCOMES } from "./m5-provenance.js";
 import {
+  sensitivityOverrideSchema,
+  sensitivityReasonSchema,
   sensitivitySchema,
   type SensitivityAssessment,
 } from "./sensitivity.js";
@@ -174,11 +176,6 @@ export type TaskExecutionRuntimeMetadata = z.infer<
   typeof taskExecutionRuntimeMetadataSchema
 >;
 
-const taskExecutionSensitivityReasonSchema = z.string().regex(
-  /^(?:(?:declared|context|prompt|context-refs|inherited):(public|internal|private)|owner-override:(public|internal|private)<(public|internal|private)|owner-override-blocked:hard-private)$/,
-  "sensitivity reasons must use the content-blind detector vocabulary",
-);
-
 export const taskExecutionSensitivitySchema = z.object({
   declared: sensitivitySchema.optional(),
   effective: sensitivitySchema,
@@ -186,11 +183,8 @@ export const taskExecutionSensitivitySchema = z.object({
   // Optional for schema-v1 compatibility. New producers emit this complete
   // content-blind evidence bundle whenever mismatch=true (#280).
   detectorMax: sensitivitySchema.optional(),
-  reasons: z.array(taskExecutionSensitivityReasonSchema).min(1).max(8).optional(),
-  override: z.object({
-    applied: z.literal(true),
-    detectorMax: sensitivitySchema,
-  }).strict().optional(),
+  reasons: z.array(sensitivityReasonSchema).min(1).max(8).optional(),
+  override: sensitivityOverrideSchema.optional(),
 }).superRefine((value, ctx) => {
   const hasEvidence = value.detectorMax !== undefined
     || value.reasons !== undefined

--- a/src/task-result-schema.ts
+++ b/src/task-result-schema.ts
@@ -5,7 +5,10 @@ import {
   pipelineSensitivitySchema,
 } from "./pipeline-ir.js";
 import { M5_OUTCOMES } from "./m5-provenance.js";
-import { sensitivitySchema } from "./sensitivity.js";
+import {
+  sensitivitySchema,
+  type SensitivityAssessment,
+} from "./sensitivity.js";
 import {
   SIGNING_POLICIES,
   TASK_SIGNATURE_STATUSES,
@@ -171,14 +174,69 @@ export type TaskExecutionRuntimeMetadata = z.infer<
   typeof taskExecutionRuntimeMetadataSchema
 >;
 
+const taskExecutionSensitivityReasonSchema = z.string().regex(
+  /^(?:(?:declared|context|prompt|context-refs|inherited):(public|internal|private)|owner-override:(public|internal|private)<(public|internal|private)|owner-override-blocked:hard-private)$/,
+  "sensitivity reasons must use the content-blind detector vocabulary",
+);
+
 export const taskExecutionSensitivitySchema = z.object({
   declared: sensitivitySchema.optional(),
   effective: sensitivitySchema,
   mismatch: z.boolean().default(false),
+  // Optional for schema-v1 compatibility. New producers emit this complete
+  // content-blind evidence bundle whenever mismatch=true (#280).
+  detectorMax: sensitivitySchema.optional(),
+  reasons: z.array(taskExecutionSensitivityReasonSchema).min(1).max(8).optional(),
+  override: z.object({
+    applied: z.literal(true),
+    detectorMax: sensitivitySchema,
+  }).strict().optional(),
+}).superRefine((value, ctx) => {
+  const hasEvidence = value.detectorMax !== undefined
+    || value.reasons !== undefined
+    || value.override !== undefined;
+  if (hasEvidence && (!value.detectorMax || !value.reasons)) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["detectorMax"],
+      message: "sensitivity mismatch evidence requires detectorMax and reasons together",
+    });
+  }
+  if (hasEvidence && !value.mismatch) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["mismatch"],
+      message: "sensitivity mismatch evidence requires mismatch=true",
+    });
+  }
+  if (value.override && value.detectorMax !== value.override.detectorMax) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["override", "detectorMax"],
+      message: "override detectorMax must match the sensitivity detectorMax",
+    });
+  }
 });
 export type TaskExecutionSensitivity = z.infer<
   typeof taskExecutionSensitivitySchema
 >;
+
+export function buildTaskSensitivitySnapshot(
+  assessment: SensitivityAssessment | undefined,
+): TaskExecutionSensitivity | undefined {
+  if (!assessment) return undefined;
+  const snapshot: TaskExecutionSensitivity = {
+    declared: assessment.declared,
+    effective: assessment.effective,
+    mismatch: assessment.mismatch,
+  };
+  if (assessment.mismatch) {
+    snapshot.detectorMax = assessment.detectorMax;
+    snapshot.reasons = [...assessment.reasons];
+    if (assessment.override) snapshot.override = { ...assessment.override };
+  }
+  return taskExecutionSensitivitySchema.parse(snapshot);
+}
 
 // Optional runtime-owned artefact delivery state (issue #68). Added under
 // schemaVersion 1 WITHOUT a version bump or `outcome` enum widening: Codex's

--- a/src/task-subprocess-env.ts
+++ b/src/task-subprocess-env.ts
@@ -1,0 +1,18 @@
+/** Environment values that belong to the dispatcher trust boundary only. */
+export const SENSITIVITY_CHECKPOINT_SECRET_ENV =
+  "HUGIN_SENSITIVITY_CHECKPOINT_SECRET" as const;
+
+/**
+ * Build an environment for any child process spawned by Hugin.
+ *
+ * Model runtimes can execute task-controlled code, and even operational
+ * subprocesses can traverse repository hooks or helpers. Never let either
+ * inherit dispatcher-only producer credentials.
+ */
+export function buildTaskSubprocessEnv(
+  source: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  const env = { ...source };
+  delete env[SENSITIVITY_CHECKPOINT_SECRET_ENV];
+  return env;
+}

--- a/tests/artifact-delivery.test.ts
+++ b/tests/artifact-delivery.test.ts
@@ -15,7 +15,11 @@ import { buildTaskResultDocument } from "../src/result-format.js";
 
 // --- spawn mock (FIFO behaviors) -------------------------------------------
 
-const spawnCalls: Array<{ cmd: string; args: string[] }> = [];
+const spawnCalls: Array<{
+  cmd: string;
+  args: string[];
+  options?: { env?: NodeJS.ProcessEnv };
+}> = [];
 let spawnBehaviors: Array<{ code: number; stdout?: string; stderr?: string }> =
   [];
 let spawnIdx = 0;
@@ -28,8 +32,12 @@ class MockChild extends EventEmitter {
   }
 }
 
-const mockSpawn = ((cmd: string, args: string[]) => {
-  spawnCalls.push({ cmd, args });
+const mockSpawn = ((
+  cmd: string,
+  args: string[],
+  options?: { env?: NodeJS.ProcessEnv },
+) => {
+  spawnCalls.push({ cmd, args, options });
   const child = new MockChild();
   const behavior = spawnBehaviors[spawnIdx] ?? { code: 0 };
   spawnIdx++;
@@ -289,6 +297,39 @@ const manifestOf = parseArtifactManifest(
 ).manifest!;
 
 describe("deliverArtifacts", () => {
+  it("does not expose the dispatcher checkpoint secret to delivery subprocesses", async () => {
+    const previousSecret = process.env.HUGIN_SENSITIVITY_CHECKPOINT_SECRET;
+    process.env.HUGIN_SENSITIVITY_CHECKPOINT_SECRET = "dispatcher-only-secret";
+    spawnBehaviors = [
+      { code: 0 },
+      { code: 0 },
+      { code: 0, stdout: "abc123  file\n" },
+      { code: 0 },
+    ];
+
+    try {
+      await deliverArtifacts({
+        manifest: manifestOf,
+        appendLog: () => {},
+        spawnFn: mockSpawn,
+        statFn: () => ({ size: 42 }),
+        hashFn: () => "abc123",
+      });
+      expect(spawnCalls.length).toBeGreaterThan(0);
+      for (const call of spawnCalls) {
+        expect(call.options?.env).not.toHaveProperty(
+          "HUGIN_SENSITIVITY_CHECKPOINT_SECRET",
+        );
+      }
+    } finally {
+      if (previousSecret === undefined) {
+        delete process.env.HUGIN_SENSITIVITY_CHECKPOINT_SECRET;
+      } else {
+        process.env.HUGIN_SENSITIVITY_CHECKPOINT_SECRET = previousSecret;
+      }
+    }
+  });
+
   it("succeeds: stat -> mkdir -> rsync -> sha match -> mv", async () => {
     spawnBehaviors = [
       { code: 0 }, // ssh mkdir -p

--- a/tests/codex-sandbox.test.ts
+++ b/tests/codex-sandbox.test.ts
@@ -31,16 +31,29 @@ function fakeExec(
 
 describe("probeCodexSandbox", () => {
   it("runs Codex's zero-token sandbox command", async () => {
+    const key = "HUGIN_SENSITIVITY_CHECKPOINT_SECRET";
+    const previous = process.env[key];
+    process.env[key] = "dispatcher-only-secret-at-least-32-chars";
     const execFileImpl = fakeExec((callback) => callback(null, "", ""));
-    const result = await probeCodexSandbox({
-      execFileImpl,
-      now: () => new Date("2026-07-15T09:00:00.000Z"),
-    });
+    let result;
+    try {
+      result = await probeCodexSandbox({
+        execFileImpl,
+        now: () => new Date("2026-07-15T09:00:00.000Z"),
+      });
+    } finally {
+      if (previous === undefined) delete process.env[key];
+      else process.env[key] = previous;
+    }
 
     expect(execFileImpl).toHaveBeenCalledWith(
       "codex",
       ["sandbox", "--", "/bin/true"],
-      expect.objectContaining({ timeout: 10_000, encoding: "utf8" }),
+      expect.objectContaining({
+        timeout: 10_000,
+        encoding: "utf8",
+        env: expect.not.objectContaining({ [key]: expect.anything() }),
+      }),
       expect.any(Function),
     );
     expect(result).toEqual({

--- a/tests/delivery-sensitivity-recovery.test.ts
+++ b/tests/delivery-sensitivity-recovery.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import * as path from "node:path";
+
+// Delivery recovery lives inside the dispatcher module and is not independently
+// exported. Guard the two durability seams together: the live path must persist
+// the already-computed content-blind snapshot before marking delivery pending,
+// and reconciliation must reuse that exact snapshot in the terminal result.
+const SRC = readFileSync(
+  path.join(__dirname, "..", "src", "index.ts"),
+  "utf8",
+);
+
+function sliceBetween(startMarker: string, endMarker: string): string {
+  const start = SRC.indexOf(startMarker);
+  const end = SRC.indexOf(endMarker, start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return SRC.slice(start, end);
+}
+
+describe("delivery recovery preserves sensitivity evidence (#280)", () => {
+  it("checkpoints the exact sensitivity snapshot before delivery can crash", () => {
+    const liveDelivery = sliceBetween(
+      "if (deliveryEligible && task.artifactManifest)",
+      "// 2. Deliver + verify.",
+    );
+    expect(liveDelivery).toContain("writeSensitivityCheckpoint(");
+    expect(liveDelivery).toContain("taskSensitivitySnapshot");
+  });
+
+  it("reuses the checkpoint in delivery reconciliation's terminal result", () => {
+    const recovery = sliceBetween(
+      "async function reconcileDeliveryPending(",
+      "async function recoverStaleTasks(",
+    );
+    expect(recovery).toContain("readSensitivityCheckpoint(");
+    expect(recovery).toContain("sensitivity: recoverySensitivity");
+  });
+});

--- a/tests/delivery-sensitivity-recovery.test.ts
+++ b/tests/delivery-sensitivity-recovery.test.ts
@@ -27,6 +27,9 @@ describe("delivery recovery preserves sensitivity evidence (#280)", () => {
     );
     expect(liveDelivery).toContain("writeSensitivityCheckpoint(");
     expect(liveDelivery).toContain("taskSensitivitySnapshot");
+    expect(SRC).toContain(
+      "config.sensitivityCheckpointSecret.length < 32",
+    );
   });
 
   it("reuses the checkpoint in delivery reconciliation's terminal result", () => {

--- a/tests/mcp/tools.test.ts
+++ b/tests/mcp/tools.test.ts
@@ -470,6 +470,54 @@ describe("buildTools — hugin_await", () => {
     });
   });
 
+  it("preserves content-blind mismatch evidence in a compact terminal summary", async () => {
+    const await_ = vi.fn(async () => ({
+      status: "completed",
+      result: {
+        outcome: "completed",
+        exitCode: 0,
+        bodyText: "done",
+        sensitivity: {
+          declared: "internal",
+          effective: "internal",
+          mismatch: true,
+          detectorMax: "private",
+          reasons: [
+            "declared:internal",
+            "prompt:private",
+            "owner-override:internal<private",
+          ],
+          override: { applied: true, detectorMax: "private" },
+        },
+      },
+    }));
+    const tools = buildTools({
+      broker: fakeBroker({ await_ }),
+      sessionId: "sess",
+      submitter: "claude-code",
+    });
+
+    const result = await tools.await_.handler({
+      task_id: "t-mismatch",
+      verbosity: "summary",
+    });
+
+    expect(parseResult(result)).toMatchObject({
+      sensitivity: {
+        declared: "internal",
+        effective: "internal",
+        mismatch: true,
+        detectorMax: "private",
+        reasons: [
+          "declared:internal",
+          "prompt:private",
+          "owner-override:internal<private",
+        ],
+        override: { applied: true, detectorMax: "private" },
+      },
+    });
+  });
+
   it("keeps polling evidence in a compact running summary", async () => {
     const await_ = vi.fn(async () => ({
       status: "running",

--- a/tests/opencode-executor.test.ts
+++ b/tests/opencode-executor.test.ts
@@ -203,7 +203,8 @@ fs.writeFileSync(path.join(process.cwd(), "observed.json"), JSON.stringify({
   argv: process.argv.slice(2),
   configDir,
   config: JSON.parse(fs.readFileSync(path.join(configDir, "opencode.json"), "utf8")),
-  apiKey: process.env.HUGIN_OPENCODE_PROVIDER_API_KEY
+  apiKey: process.env.HUGIN_OPENCODE_PROVIDER_API_KEY,
+  checkpointSecret: process.env.HUGIN_SENSITIVITY_CHECKPOINT_SECRET
 }));
 console.log(JSON.stringify({ type: "tool_use", part: { type: "tool", tool: "bash", state: { status: "completed", input: { command: "npm test 2>&1" }, metadata: { exit: 0 } } } }));
 console.log(JSON.stringify({ type: "tool_use", part: { type: "tool", tool: "edit", state: { status: "completed", metadata: { filediff: { file: path.join(process.cwd(), "math.js"), additions: 1, deletions: 1 }, diff: "@@ diff" } } } }));
@@ -212,15 +213,24 @@ console.log(JSON.stringify({ type: "text", part: { text: "Fixed math.js and test
       { mode: 0o755 },
     );
 
-    const result = await executeOpencodeTask(
-      makeTask({
-        workingDir: repoDir,
-        apiKey: "owner-key",
-        opencodeCommand: fakeOpencode,
-      }),
-      "opencode-ok",
-      logDir,
-    );
+    const checkpointKey = "HUGIN_SENSITIVITY_CHECKPOINT_SECRET";
+    const previousCheckpointSecret = process.env[checkpointKey];
+    process.env[checkpointKey] = "dispatcher-only-secret-at-least-32-chars";
+    let result;
+    try {
+      result = await executeOpencodeTask(
+        makeTask({
+          workingDir: repoDir,
+          apiKey: "owner-key",
+          opencodeCommand: fakeOpencode,
+        }),
+        "opencode-ok",
+        logDir,
+      );
+    } finally {
+      if (previousCheckpointSecret === undefined) delete process.env[checkpointKey];
+      else process.env[checkpointKey] = previousCheckpointSecret;
+    }
 
     expect(result.exitCode).toBe(0);
     expect(result.resultText).toContain("Fixed math.js");
@@ -245,6 +255,7 @@ console.log(JSON.stringify({ type: "text", part: { text: "Fixed math.js and test
       "json",
       "Fix the failing test.",
     ]);
+    expect(observed.checkpointSecret).toBeUndefined();
     expect(observed.config.permission).toEqual({ edit: "allow", bash: "allow" });
     expect(observed.apiKey).toBe("owner-key");
   });

--- a/tests/orchestrator/worker-executor.test.ts
+++ b/tests/orchestrator/worker-executor.test.ts
@@ -23,7 +23,11 @@ interface SpawnBehavior {
   delayMs?: number;
 }
 
-const spawnCalls: Array<{ cmd: string; args: string[] }> = [];
+const spawnCalls: Array<{
+  cmd: string;
+  args: string[];
+  options?: { env?: NodeJS.ProcessEnv };
+}> = [];
 let spawnBehaviors: SpawnBehavior[] = [];
 let spawnCallIndex = 0;
 
@@ -39,8 +43,8 @@ class MockChildProcess extends EventEmitter {
 }
 
 vi.mock("node:child_process", () => ({
-  spawn: (cmd: string, args: string[]) => {
-    spawnCalls.push({ cmd, args });
+  spawn: (cmd: string, args: string[], options?: { env?: NodeJS.ProcessEnv }) => {
+    spawnCalls.push({ cmd, args, options });
     const child = new MockChildProcess();
     const behavior = spawnBehaviors[spawnCallIndex] ?? { exitCode: 0 };
     spawnCallIndex++;
@@ -1516,6 +1520,26 @@ describe("PiHarnessExecutor — success path", () => {
     // prompt flag
     expect(args).toContain("-p");
     expect(args).toContain("hello");
+  });
+
+  it("does not expose the dispatcher checkpoint secret to the Pi harness", async () => {
+    vi.stubEnv("HUGIN_SENSITIVITY_CHECKPOINT_SECRET", "dispatcher-only-secret");
+    vi.stubEnv("HUGIN_ORDINARY_CHILD_VALUE", "preserved");
+    spawnBehaviors = [{ exitCode: 0, stdout: PI_JSONL_SUCCESS }];
+
+    await new PiHarnessExecutor().run({
+      provider: "pi-harness",
+      model: "qwen/qwen3-coder-next",
+      prompt: "hello",
+      timeoutMs: 5000,
+    });
+
+    expect(spawnCalls[0]?.options?.env).not.toHaveProperty(
+      "HUGIN_SENSITIVITY_CHECKPOINT_SECRET",
+    );
+    expect(spawnCalls[0]?.options?.env?.HUGIN_ORDINARY_CHILD_VALUE).toBe(
+      "preserved",
+    );
   });
 
   it("uses alternate_tokens field if content field absent (text field)", async () => {

--- a/tests/pipeline-compiler.test.ts
+++ b/tests/pipeline-compiler.test.ts
@@ -291,6 +291,79 @@ Phase: review
     expect(pipeline.phases[0]?.runtime).toBe("ollama-pi");
   });
 
+  it("preserves a detected phase mismatch in IR and the generated child task", () => {
+    const pipeline = makePipeline(`## Task: Phase sensitivity audit
+
+- **Runtime:** pipeline
+- **Sensitivity:** internal
+- **Submitted by:** claude-code
+
+### Pipeline
+
+Phase: review
+  Runtime: ollama-pi
+  Sensitivity: internal
+  Prompt: |
+    Review the medical notes.
+`);
+
+    expect(pipeline.phases[0]?.sensitivityAssessment).toEqual({
+      declared: "internal",
+      effective: "private",
+      detectorMax: "private",
+      mismatch: true,
+      reasons: ["declared:internal", "prompt:private"],
+    });
+
+    const [draft] = buildPhaseTaskDrafts(pipeline);
+    expect(draft?.content).toContain("- **Submitted by:** hugin");
+    expect(draft?.content).toContain("- **Pipeline submitted by:** claude-code");
+    expect(draft?.content).toContain("- **Sensitivity:** internal");
+    expect(draft?.content).toContain("- **Pipeline sensitivity:** private");
+  });
+
+  it("preserves owner-override evidence and original submitter provenance in a child task", () => {
+    const pipeline = compilePipelineTask(
+      "20260402-owner-override",
+      "tasks/20260402-owner-override",
+      `## Task: Owner-reviewed phase
+
+- **Runtime:** pipeline
+- **Sensitivity:** internal
+- **Submitted by:** claude-code
+
+### Pipeline
+
+Phase: review
+  Runtime: ollama-pi
+  Sensitivity: internal
+  Prompt: |
+    Review the invoice.
+`,
+      defaultOllamaHosts,
+      { allowOwnerOverride: true },
+    );
+
+    expect(pipeline.phases[0]?.sensitivityAssessment).toEqual({
+      declared: "internal",
+      effective: "internal",
+      detectorMax: "private",
+      mismatch: true,
+      reasons: [
+        "declared:internal",
+        "prompt:private",
+        "owner-override:internal<private",
+      ],
+      override: { applied: true, detectorMax: "private" },
+    });
+
+    const [draft] = buildPhaseTaskDrafts(pipeline);
+    expect(draft?.content).toContain("- **Submitted by:** hugin");
+    expect(draft?.content).toContain("- **Pipeline submitted by:** claude-code");
+    expect(draft?.content).toContain("- **Sensitivity:** internal");
+    expect(draft?.content).toContain("- **Pipeline sensitivity:** internal");
+  });
+
   it("renders parent routing metadata in the decomposition result", () => {
     const pipeline = makePipeline(`## Task: Improve Munin UX
 

--- a/tests/pipeline-dispatch.test.ts
+++ b/tests/pipeline-dispatch.test.ts
@@ -9,6 +9,10 @@ import {
 } from "../src/pipeline-summary.js";
 import { buildTerminalStatusTags } from "../src/task-status-tags.js";
 import type { MuninEntry, MuninReadRequest, MuninReadResult } from "../src/munin-client.js";
+import {
+  parseSensitivityCheckpoint,
+  SENSITIVITY_CHECKPOINT_KEY,
+} from "../src/sensitivity-checkpoint.js";
 
 type StoredEntry = MuninEntry & { found: true };
 
@@ -268,6 +272,21 @@ describe("handlePipelineTask", () => {
       "sensitivity:internal",
     ]);
     expect(exploreStatus?.content).toContain("- **Pipeline:** 20260403-valid-pipeline");
+    const exploreSensitivity = client.get(
+      "tasks/20260403-valid-pipeline-explore",
+      SENSITIVITY_CHECKPOINT_KEY,
+    );
+    expect(exploreSensitivity?.tags).toEqual(["type:task-sensitivity-checkpoint"]);
+    expect(
+      parseSensitivityCheckpoint(
+        exploreSensitivity?.content ?? "",
+        "tasks/20260403-valid-pipeline-explore",
+        exploreStatus?.content ?? "",
+      ),
+    ).toEqual({
+      effective: "internal",
+      mismatch: false,
+    });
 
     const synthesizeStatus = client.get(
       "tasks/20260403-valid-pipeline-synthesize",
@@ -307,6 +326,44 @@ describe("handlePipelineTask", () => {
       namespace: taskNs,
       content: "Pipeline compiled and decomposed into 2 phase task(s)",
       tags: [],
+    });
+  });
+
+  it("checkpoints an explicitly public phase without introducing an internal mismatch", async () => {
+    const client = new FakePipelineDispatchClient();
+    const { hooks } = createPipelineHooks(client);
+    const taskNs = "tasks/20260403-public-pipeline";
+    const parentEntry = client.seed({
+      namespace: taskNs,
+      key: "status",
+      content: `## Task: Public research
+
+- **Runtime:** pipeline
+- **Submitted by:** ratatoskr
+- **Sensitivity:** public
+
+### Pipeline
+Phase: Explore
+  Runtime: claude-sdk
+  Prompt: |
+    Gather public sources.`,
+      tags: ["running", "runtime:pipeline"],
+    });
+
+    await handlePipelineTask(client, hooks, taskNs, parentEntry, 0);
+
+    const childNs = "tasks/20260403-public-pipeline-explore";
+    const childStatus = client.get(childNs, "status");
+    const checkpoint = client.get(childNs, SENSITIVITY_CHECKPOINT_KEY);
+    expect(
+      parseSensitivityCheckpoint(
+        checkpoint?.content ?? "",
+        childNs,
+        childStatus?.content ?? "",
+      ),
+    ).toEqual({
+      effective: "public",
+      mismatch: false,
     });
   });
 

--- a/tests/pipeline-dispatch.test.ts
+++ b/tests/pipeline-dispatch.test.ts
@@ -15,6 +15,10 @@ import {
 } from "../src/sensitivity-checkpoint.js";
 
 type StoredEntry = MuninEntry & { found: true };
+const CHECKPOINT_SECRET = "test-only-hugin-checkpoint-secret";
+const PIPELINE_OPTIONS = {
+  sensitivityCheckpointSecret: CHECKPOINT_SECRET,
+} as const;
 
 class FakePipelineDispatchClient implements PipelineDispatchClient {
   private entries = new Map<string, StoredEntry>();
@@ -224,7 +228,15 @@ describe("handlePipelineTask", () => {
       tags: ["running", "runtime:pipeline", "type:research", "type:evaluation"],
     });
 
-    const result = await handlePipelineTask(client, hooks, taskNs, parentEntry, 4);
+    const result = await handlePipelineTask(
+      client,
+      hooks,
+      taskNs,
+      parentEntry,
+      4,
+      undefined,
+      PIPELINE_OPTIONS,
+    );
 
     expect(result).toEqual({ hadTask: true, queueDepth: 4 });
 
@@ -282,6 +294,7 @@ describe("handlePipelineTask", () => {
         exploreSensitivity?.content ?? "",
         "tasks/20260403-valid-pipeline-explore",
         exploreStatus?.content ?? "",
+        CHECKPOINT_SECRET,
       ),
     ).toEqual({
       effective: "internal",
@@ -350,7 +363,15 @@ Phase: Explore
       tags: ["running", "runtime:pipeline"],
     });
 
-    await handlePipelineTask(client, hooks, taskNs, parentEntry, 0);
+    await handlePipelineTask(
+      client,
+      hooks,
+      taskNs,
+      parentEntry,
+      0,
+      undefined,
+      PIPELINE_OPTIONS,
+    );
 
     const childNs = "tasks/20260403-public-pipeline-explore";
     const childStatus = client.get(childNs, "status");
@@ -360,11 +381,32 @@ Phase: Explore
         checkpoint?.content ?? "",
         childNs,
         childStatus?.content ?? "",
+        CHECKPOINT_SECRET,
       ),
     ).toEqual({
       effective: "public",
       mismatch: false,
     });
+  });
+
+  it("fails closed before creating a child when the Hugin checkpoint secret is absent", async () => {
+    const client = new FakePipelineDispatchClient();
+    const { hooks } = createPipelineHooks(client);
+    const taskNs = "tasks/20260403-no-checkpoint-secret";
+    const parentEntry = client.seed({
+      namespace: taskNs,
+      key: "status",
+      content: makeValidPipelineContent(),
+      tags: ["running", "runtime:pipeline"],
+    });
+
+    await handlePipelineTask(client, hooks, taskNs, parentEntry, 0);
+
+    expect(client.get(taskNs, "status")?.tags).toContain("failed");
+    expect(client.get(taskNs, "result")?.content).toContain(
+      "sensitivity checkpoint secret must contain at least 32 characters",
+    );
+    expect(client.get("tasks/20260403-no-checkpoint-secret-explore", "status")).toBeNull();
   });
 
   it("fails the parent task cleanly when pipeline compile validation fails", async () => {
@@ -387,7 +429,7 @@ Phase: Explore
       tags: ["running", "runtime:pipeline", "type:research"],
     });
 
-    await handlePipelineTask(client, hooks, taskNs, parentEntry, 1);
+    await handlePipelineTask(client, hooks, taskNs, parentEntry, 1, undefined, PIPELINE_OPTIONS);
 
     expect(client.get(taskNs, "spec")).toBeNull();
     expect(client.listByNamespace(`${taskNs}-`)).toHaveLength(0);
@@ -435,7 +477,7 @@ Phase: Explore
       tags: ["pending", "runtime:claude"],
     });
 
-    await handlePipelineTask(client, hooks, taskNs, parentEntry, 2);
+    await handlePipelineTask(client, hooks, taskNs, parentEntry, 2, undefined, PIPELINE_OPTIONS);
 
     expect(client.get(taskNs, "spec")).toBeNull();
     expect(client.get(compiled.phases[1]!.taskNamespace, "status")).toBeNull();
@@ -481,7 +523,7 @@ Phase: Explore
       "simulated child write failure"
     );
 
-    await handlePipelineTask(client, hooks, taskNs, parentEntry, 3);
+    await handlePipelineTask(client, hooks, taskNs, parentEntry, 3, undefined, PIPELINE_OPTIONS);
 
     const rolledBackChild = client.get(compiled.phases[0]!.taskNamespace, "status");
     expect(rolledBackChild?.tags).toEqual([

--- a/tests/publication-recovery.test.ts
+++ b/tests/publication-recovery.test.ts
@@ -157,6 +157,18 @@ function seededStatus(tags: string[]): Record<string, Record<string, FakeEntry>>
           completedAt: "2026-07-15T09:40:00.000Z",
           bodyKind: "response",
           bodyText: "done",
+          sensitivity: {
+            declared: "internal",
+            effective: "internal",
+            mismatch: true,
+            detectorMax: "private",
+            reasons: [
+              "declared:internal",
+              "prompt:private",
+              "owner-override:internal<private",
+            ],
+            override: { applied: true, detectorMax: "private" },
+          },
           repositoryOutcome: { state: "publication-failed", baseBranch: "master", baseCommit: "a".repeat(40) },
           repositoryChange: {
             baseBranch: "master",
@@ -249,6 +261,18 @@ describe("recoverPublicationForTask", () => {
     const resultStructured = JSON.parse(store.get(NS)!.get("result-structured")!.content);
     expect(resultStructured.repositoryOutcome.state).toBe("publication-recovered");
     expect(resultStructured.prUrl).toBe("https://github.com/Magnus-Gille/cassette/pull/28");
+    expect(resultStructured.sensitivity).toEqual({
+      declared: "internal",
+      effective: "internal",
+      mismatch: true,
+      detectorMax: "private",
+      reasons: [
+        "declared:internal",
+        "prompt:private",
+        "owner-override:internal<private",
+      ],
+      override: { applied: true, detectorMax: "private" },
+    });
 
     const resultDoc = store.get(NS)!.get("result")!.content;
     expect(resultDoc).toContain("### Publication Recovery");

--- a/tests/sdk-executor.test.ts
+++ b/tests/sdk-executor.test.ts
@@ -139,6 +139,25 @@ afterEach(() => {
 });
 
 describe("SDK executor", () => {
+  it("does not expose the Hugin sensitivity checkpoint secret to Claude", async () => {
+    const key = "HUGIN_SENSITIVITY_CHECKPOINT_SECRET";
+    const previous = process.env[key];
+    process.env[key] = "dispatcher-only-secret-at-least-32-chars";
+    try {
+      mockedQuery.mockReturnValue(
+        createMockQuery([createMockResultSuccess("done")]) as ReturnType<typeof query>,
+      );
+      await executeSdkTask(makeTaskConfig(), "test-secret-scrub", tmpLogDir);
+      const call = mockedQuery.mock.calls[0]?.[0] as {
+        options?: { env?: Record<string, string | undefined> };
+      };
+      expect(call.options?.env?.[key]).toBeUndefined();
+    } finally {
+      if (previous === undefined) delete process.env[key];
+      else process.env[key] = previous;
+    }
+  });
+
   it("builds read-only Claude permission options by default", () => {
     const options = buildClaudePermissionOptions();
 

--- a/tests/sensitivity-checkpoint.test.ts
+++ b/tests/sensitivity-checkpoint.test.ts
@@ -18,6 +18,7 @@ const childContent = `## Task: generated phase
 ### Prompt
 Review the invoice.`;
 const childNamespace = "tasks/parent-1-review";
+const checkpointSecret = "test-only-hugin-checkpoint-secret";
 
 const mismatch = {
   declared: "internal" as const,
@@ -33,19 +34,53 @@ describe("trusted sensitivity checkpoints", () => {
       childNamespace,
       childContent,
       mismatch,
+      checkpointSecret,
     );
     expect(
-      parseSensitivityCheckpoint(checkpoint, childNamespace, childContent),
+      parseSensitivityCheckpoint(
+        checkpoint,
+        childNamespace,
+        childContent,
+        checkpointSecret,
+      ),
     ).toEqual(mismatch);
     expect(
       parseSensitivityCheckpoint(
         checkpoint,
         childNamespace,
         childContent.replace("ratatoskr", "claude-code"),
+        checkpointSecret,
+      ),
+    ).toBeUndefined();
+    const attackerCheckpoint = buildSensitivityCheckpoint(
+      childNamespace,
+      childContent,
+      { ...mismatch, effective: "public" },
+      "attacker-controlled-secret-at-least-32-chars",
+    );
+    expect(
+      parseSensitivityCheckpoint(
+        attackerCheckpoint,
+        childNamespace,
+        childContent,
+        checkpointSecret,
       ),
     ).toBeUndefined();
     expect(
-      parseSensitivityCheckpoint(checkpoint, "tasks/replayed", childContent),
+      parseSensitivityCheckpoint(
+        checkpoint,
+        "tasks/replayed",
+        childContent,
+        checkpointSecret,
+      ),
+    ).toBeUndefined();
+    expect(
+      parseSensitivityCheckpoint(
+        checkpoint,
+        childNamespace,
+        childContent,
+        "attacker-controlled-secret",
+      ),
     ).toBeUndefined();
   });
 
@@ -55,10 +90,16 @@ describe("trusted sensitivity checkpoints", () => {
         JSON.stringify(mismatch),
         childNamespace,
         childContent,
+        checkpointSecret,
       ),
     ).toBeUndefined();
     expect(
-      parseSensitivityCheckpoint("not-json", childNamespace, childContent),
+      parseSensitivityCheckpoint(
+        "not-json",
+        childNamespace,
+        childContent,
+        checkpointSecret,
+      ),
     ).toBeUndefined();
   });
 

--- a/tests/sensitivity-checkpoint.test.ts
+++ b/tests/sensitivity-checkpoint.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import * as path from "node:path";
+import {
+  buildSensitivityCheckpoint,
+  parseSensitivityCheckpoint,
+} from "../src/sensitivity-checkpoint.js";
+
+const childContent = `## Task: generated phase
+
+- **Runtime:** ollama
+- **Submitted by:** hugin
+- **Pipeline:** parent-1
+- **Pipeline phase:** review
+- **Pipeline submitted by:** ratatoskr
+- **Sensitivity:** internal
+
+### Prompt
+Review the invoice.`;
+const childNamespace = "tasks/parent-1-review";
+
+const mismatch = {
+  declared: "internal" as const,
+  effective: "private" as const,
+  mismatch: true,
+  detectorMax: "private" as const,
+  reasons: ["declared:internal", "prompt:private"],
+};
+
+describe("trusted sensitivity checkpoints", () => {
+  it("round-trips only for the exact generated task content", () => {
+    const checkpoint = buildSensitivityCheckpoint(
+      childNamespace,
+      childContent,
+      mismatch,
+    );
+    expect(
+      parseSensitivityCheckpoint(checkpoint, childNamespace, childContent),
+    ).toEqual(mismatch);
+    expect(
+      parseSensitivityCheckpoint(
+        checkpoint,
+        childNamespace,
+        childContent.replace("ratatoskr", "claude-code"),
+      ),
+    ).toBeUndefined();
+    expect(
+      parseSensitivityCheckpoint(checkpoint, "tasks/replayed", childContent),
+    ).toBeUndefined();
+  });
+
+  it("rejects free-form task prose without a Hugin checkpoint envelope", () => {
+    expect(
+      parseSensitivityCheckpoint(
+        JSON.stringify(mismatch),
+        childNamespace,
+        childContent,
+      ),
+    ).toBeUndefined();
+    expect(
+      parseSensitivityCheckpoint("not-json", childNamespace, childContent),
+    ).toBeUndefined();
+  });
+
+  it("never grants owner override authority from parsed pipeline prose", () => {
+    const dispatcher = readFileSync(
+      path.join(__dirname, "..", "src", "index.ts"),
+      "utf8",
+    );
+    const start = dispatcher.indexOf("function getTaskSensitivityAssessment(");
+    const end = dispatcher.indexOf("function getTaskRuntimeLabel(", start);
+    const assessment = dispatcher.slice(start, end);
+    expect(assessment).toContain(
+      "allowOwnerOverride: !task.pipeline && isOwnerSubmitter(task.submittedBy)",
+    );
+    expect(assessment).not.toContain("task.pipeline?.submittedBy");
+  });
+});

--- a/tests/sensitivity.test.ts
+++ b/tests/sensitivity.test.ts
@@ -312,6 +312,7 @@ describe("sensitivity helpers", () => {
 
     expect(assessment.effective).toBe("private");
     expect(assessment.mismatch).toBe(true);
+    expect(assessment.detectorMax).toBe("private");
     expect(assessment.reasons).toContain("declared:public");
     expect(assessment.reasons).toContain("context-refs:private");
   });

--- a/tests/task-result-schema.test.ts
+++ b/tests/task-result-schema.test.ts
@@ -1,7 +1,127 @@
 import { describe, expect, it } from "vitest";
-import { buildStructuredTaskResult } from "../src/task-result-schema.js";
+import {
+  buildStructuredTaskResult,
+  buildTaskSensitivitySnapshot,
+} from "../src/task-result-schema.js";
+import { buildSensitivityAssessment } from "../src/sensitivity.js";
 
 describe("structured task result schema", () => {
+  it("builds mismatch evidence from the detector assessment without content (#280)", () => {
+    const assessment = buildSensitivityAssessment({
+      declared: "internal",
+      baseline: "internal",
+      prompt: "private",
+      allowOwnerOverride: true,
+    });
+
+    expect(buildTaskSensitivitySnapshot(assessment)).toEqual({
+      declared: "internal",
+      effective: "internal",
+      mismatch: true,
+      detectorMax: "private",
+      reasons: [
+        "declared:internal",
+        "prompt:private",
+        "owner-override:internal<private",
+      ],
+      override: { applied: true, detectorMax: "private" },
+    });
+  });
+
+  it("preserves content-blind sensitivity mismatch evidence (#280)", () => {
+    const result = buildStructuredTaskResult({
+      schemaVersion: 1,
+      taskId: "sensitivity-1",
+      taskNamespace: "tasks/sensitivity-1",
+      lifecycle: "completed",
+      outcome: "completed",
+      runtime: "homeserver",
+      executor: "homeserver-delegate",
+      resultSource: "homeserver-delegate",
+      exitCode: 0,
+      completedAt: "2026-07-22T12:00:00Z",
+      bodyKind: "response",
+      bodyText: "ok",
+      sensitivity: {
+        declared: "internal",
+        effective: "internal",
+        mismatch: true,
+        detectorMax: "private",
+        reasons: [
+          "declared:internal",
+          "prompt:private",
+          "owner-override:internal<private",
+        ],
+        override: { applied: true, detectorMax: "private" },
+      },
+    });
+
+    expect(result.sensitivity).toEqual({
+      declared: "internal",
+      effective: "internal",
+      mismatch: true,
+      detectorMax: "private",
+      reasons: [
+        "declared:internal",
+        "prompt:private",
+        "owner-override:internal<private",
+      ],
+      override: { applied: true, detectorMax: "private" },
+    });
+  });
+
+  it("rejects prompt-derived prose in sensitivity reasons (#280)", () => {
+    expect(() => buildStructuredTaskResult({
+      schemaVersion: 1,
+      taskId: "sensitivity-unsafe",
+      taskNamespace: "tasks/sensitivity-unsafe",
+      lifecycle: "completed",
+      outcome: "completed",
+      runtime: "homeserver",
+      executor: "homeserver-delegate",
+      resultSource: "homeserver-delegate",
+      exitCode: 0,
+      completedAt: "2026-07-22T12:00:00Z",
+      bodyKind: "response",
+      bodyText: "ok",
+      sensitivity: {
+        declared: "internal",
+        effective: "internal",
+        mismatch: true,
+        detectorMax: "private",
+        reasons: ["prompt:private:Faktura F-2214"],
+      },
+    })).toThrow();
+  });
+
+  it("keeps legacy mismatch results readable without the additive evidence (#280)", () => {
+    const result = buildStructuredTaskResult({
+      schemaVersion: 1,
+      taskId: "sensitivity-legacy",
+      taskNamespace: "tasks/sensitivity-legacy",
+      lifecycle: "completed",
+      outcome: "completed",
+      runtime: "claude",
+      executor: "claude-sdk",
+      resultSource: "sdk-result",
+      exitCode: 0,
+      completedAt: "2026-07-22T12:00:00Z",
+      bodyKind: "response",
+      bodyText: "ok",
+      sensitivity: {
+        declared: "internal",
+        effective: "private",
+        mismatch: true,
+      },
+    });
+
+    expect(result.sensitivity).toEqual({
+      declared: "internal",
+      effective: "private",
+      mismatch: true,
+    });
+  });
+
   it("preserves exact content-blind repository change evidence", () => {
     const result = buildStructuredTaskResult({
       schemaVersion: 1, taskId: "daily-1", taskNamespace: "tasks/daily-1",

--- a/tests/task-subprocess-env.test.ts
+++ b/tests/task-subprocess-env.test.ts
@@ -25,4 +25,28 @@ describe("task subprocess environment", () => {
     expect(spawnRuntime).toContain("...buildTaskSubprocessEnv()");
     expect(spawnRuntime).not.toContain("...process.env");
   });
+
+  it("scrubs the secret from the Pi harness and operational subprocesses", () => {
+    const sources = [
+      "src/artifact-delivery.ts",
+      "src/orchestrator/worker-executor.ts",
+      "src/task-helpers.ts",
+    ].map((relativePath) =>
+      readFileSync(path.join(__dirname, "..", relativePath), "utf8"),
+    );
+
+    for (const source of sources) {
+      expect(source).toContain("buildTaskSubprocessEnv()");
+    }
+
+    const indexSource = readFileSync(
+      path.join(__dirname, "..", "src", "index.ts"),
+      "utf8",
+    );
+    const pgrepStart = indexSource.indexOf('spawn("pgrep"');
+    const pgrepEnd = indexSource.indexOf("});", pgrepStart);
+    expect(indexSource.slice(pgrepStart, pgrepEnd)).toContain(
+      "env: buildTaskSubprocessEnv()",
+    );
+  });
 });

--- a/tests/task-subprocess-env.test.ts
+++ b/tests/task-subprocess-env.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  buildTaskSubprocessEnv,
+  SENSITIVITY_CHECKPOINT_SECRET_ENV,
+} from "../src/task-subprocess-env.js";
+
+describe("task subprocess environment", () => {
+  it("removes the dispatcher-only checkpoint secret and preserves ordinary values", () => {
+    expect(buildTaskSubprocessEnv({
+      PATH: "/usr/bin",
+      [SENSITIVITY_CHECKPOINT_SECRET_ENV]: "hugin-only-secret",
+    } as NodeJS.ProcessEnv)).toEqual({ PATH: "/usr/bin" });
+  });
+
+  it("the Codex task spawn uses the scrubbed environment helper", () => {
+    const source = readFileSync(
+      path.join(__dirname, "..", "src", "index.ts"),
+      "utf8",
+    );
+    const start = source.indexOf("function spawnRuntime(");
+    const end = source.indexOf("async function", start);
+    const spawnRuntime = source.slice(start, end);
+    expect(spawnRuntime).toContain("...buildTaskSubprocessEnv()");
+    expect(spawnRuntime).not.toContain("...process.env");
+  });
+});


### PR DESCRIPTION
Closes #280

Persists a content-blind mismatch evidence bundle in structured task results: detector maximum, schema-whitelisted reason codes, and owner-override evidence. Legacy schema-v1 results remain readable, while publication recovery preserves the additive fields.

Pipeline child sensitivity authority is carried by an HMAC-authenticated, task-bound checkpoint. The dedicated producer secret is scrubbed from every spawned task and operational subprocess.

Verification:
- npm run build
- npm test (152 files, 2341 tests)
- focused runtime, delivery, checkout, and subprocess isolation tests (217 tests)
- git diff --check
- GitHub CI build-test