### PR TITLE
fix(broker): bound list and submit latency

### DIFF
--- a/docs/mcp-durable-m5-lifecycle.md
+++ b/docs/mcp-durable-m5-lifecycle.md
@@ -24,13 +24,24 @@ Retries compare the normalized behavior payload stored at that namespace;
 rotating the MCP session ID does not create a collision. The same key and
 payload returns the original task, including after Broker restart. The same key
 with a different behavior payload is rejected. An in-process reservation closes
-the concurrent-submit race before the first Munin write completes. Both the
+the concurrent-submit race before the first Munin write completes. The fresh
+path uses one atomic `create_if_absent` write rather than a preflight read plus
+write. If that create loses to an existing durable task, the Broker reads and
+compares the stored envelope before returning reuse or collision. Both the
 durable identity and that reservation are scoped by authenticated principal.
 
 Await and list are principal-isolated. A Broker key cannot discover or read
 another principal's canonical results. Rate remains owner-only for Broker
 tasks; the same authenticated endpoint can also review an ordinary terminal
 Hugin task, which has no Broker owner.
+
+Each of list discovery's two unioned channels walks a bounded 1,000-candidate
+Munin history budget. The response reports `truncated: true` whenever either
+budget or an ambiguous timestamp boundary may omit matches. Discovered status
+entries are fetched through Munin's batch-read surface. Do not replace that
+batch with nominally concurrent individual reads: the Munin client deliberately
+serializes and spaces requests, and the resulting queue can exceed the MCP
+transport deadline and delay unrelated submissions.
 
 `hugin_await` preserves its canonical full response by default and when called
 with `verbosity: "full"`. Callers that only need the actionable outcome can use

--- a/src/broker/handlers.ts
+++ b/src/broker/handlers.ts
@@ -250,8 +250,8 @@ export function createSubmitHandler(deps: BrokerHandlerDependencies) {
         err.conflictReason === "already_exists"
       ) {
         const persisted = await deps.taskStore.readStatus(taskId).catch(() => null);
-        deps.idempotency.release(reservationKey);
         if (!persisted) {
+          deps.idempotency.release(reservationKey);
           res.status(500).json({
             error: "internal",
             message: "idempotency task exists but its canonical envelope is unavailable",
@@ -260,6 +260,7 @@ export function createSubmitHandler(deps: BrokerHandlerDependencies) {
         }
         const persistedEnvelopeResult = parseCanonicalEnvelope(persisted.content);
         if (!persistedEnvelopeResult.ok) {
+          deps.idempotency.release(reservationKey);
           res.status(409).json({
             error: "policy_rejected",
             message: "idempotency task exists but its canonical envelope is unreadable",
@@ -270,6 +271,7 @@ export function createSubmitHandler(deps: BrokerHandlerDependencies) {
         const persistedEnvelope = persistedEnvelopeResult.envelope;
         const persistedRequestResult = delegationRequestSchema.safeParse(persistedEnvelope);
         if (!persistedRequestResult.success) {
+          deps.idempotency.release(reservationKey);
           res.status(409).json({
             error: "policy_rejected",
             message: "idempotency task exists but its request contract is invalid",
@@ -278,6 +280,7 @@ export function createSubmitHandler(deps: BrokerHandlerDependencies) {
           return;
         }
         if (hashPayload(persistedRequestResult.data) !== hashPayload(request)) {
+          deps.idempotency.release(reservationKey);
           res.status(409).json({
             error: "policy_rejected",
             message: "idempotency_key reused with a different payload",

--- a/src/broker/handlers.ts
+++ b/src/broker/handlers.ts
@@ -54,6 +54,7 @@ import {
   buildQualityReceipt,
 } from "../quality-receipt.js";
 import { structuredTaskResultSchema } from "../task-result-schema.js";
+import { MuninWriteRejectedError } from "../munin-client.js";
 
 const brokerFrictionInputSchema = reportFrictionInputSchema.extend({
   event_id: z.string().uuid(),
@@ -204,45 +205,6 @@ export function createSubmitHandler(deps: BrokerHandlerDependencies) {
     }
 
     const taskId = generateBrokerTaskId(principal, request.idempotency_key);
-    const persisted = await deps.taskStore.readStatus(taskId);
-    if (persisted) {
-      const persistedEnvelopeResult = parseCanonicalEnvelope(persisted.content);
-      if (!persistedEnvelopeResult.ok) {
-        res.status(409).json({
-          error: "policy_rejected",
-          message: "idempotency task exists but its canonical envelope is unreadable",
-          existing_task_id: taskId,
-        });
-        return;
-      }
-      const persistedEnvelope = persistedEnvelopeResult.envelope;
-      const persistedRequestResult = delegationRequestSchema.safeParse(persistedEnvelope);
-      if (!persistedRequestResult.success) {
-        res.status(409).json({
-          error: "policy_rejected",
-          message: "idempotency task exists but its request contract is invalid",
-          existing_task_id: taskId,
-        });
-        return;
-      }
-      const persistedRequest = persistedRequestResult.data;
-      if (hashPayload(persistedRequest) !== hashPayload(request)) {
-        res.status(409).json({
-          error: "policy_rejected",
-          message: "idempotency_key reused with a different payload",
-          existing_task_id: taskId,
-        });
-        return;
-      }
-      res.status(200).json({
-        task_id: taskId,
-        received_at: persistedEnvelope.received_at,
-        reused_idempotency: true,
-        ...(submitWarnings.length > 0 ? { warnings: submitWarnings } : {}),
-      });
-      return;
-    }
-
     const reservationKey = scopedIdempotencyKey(principal, request.idempotency_key);
     const idemOutcome = deps.idempotency.reserve(reservationKey, request);
     if (idemOutcome.kind === "retry") {
@@ -283,6 +245,55 @@ export function createSubmitHandler(deps: BrokerHandlerDependencies) {
     try {
       await deps.taskStore.submit({ envelope });
     } catch (err) {
+      if (
+        err instanceof MuninWriteRejectedError &&
+        err.conflictReason === "already_exists"
+      ) {
+        const persisted = await deps.taskStore.readStatus(taskId).catch(() => null);
+        deps.idempotency.release(reservationKey);
+        if (!persisted) {
+          res.status(500).json({
+            error: "internal",
+            message: "idempotency task exists but its canonical envelope is unavailable",
+          });
+          return;
+        }
+        const persistedEnvelopeResult = parseCanonicalEnvelope(persisted.content);
+        if (!persistedEnvelopeResult.ok) {
+          res.status(409).json({
+            error: "policy_rejected",
+            message: "idempotency task exists but its canonical envelope is unreadable",
+            existing_task_id: taskId,
+          });
+          return;
+        }
+        const persistedEnvelope = persistedEnvelopeResult.envelope;
+        const persistedRequestResult = delegationRequestSchema.safeParse(persistedEnvelope);
+        if (!persistedRequestResult.success) {
+          res.status(409).json({
+            error: "policy_rejected",
+            message: "idempotency task exists but its request contract is invalid",
+            existing_task_id: taskId,
+          });
+          return;
+        }
+        if (hashPayload(persistedRequestResult.data) !== hashPayload(request)) {
+          res.status(409).json({
+            error: "policy_rejected",
+            message: "idempotency_key reused with a different payload",
+            existing_task_id: taskId,
+          });
+          return;
+        }
+        deps.idempotency.record(reservationKey, request, taskId);
+        res.status(200).json({
+          task_id: taskId,
+          received_at: persistedEnvelope.received_at,
+          reused_idempotency: true,
+          ...(submitWarnings.length > 0 ? { warnings: submitWarnings } : {}),
+        });
+        return;
+      }
       deps.idempotency.release(reservationKey);
       res.status(500).json({
         error: "internal",

--- a/src/broker/task-store.ts
+++ b/src/broker/task-store.ts
@@ -65,7 +65,6 @@ export const RESULT_ERROR_KEY = "result-error";
 /** Durable-handoff evidence for the #165 trial (#164). */
 export const AWAIT_OBSERVATION_KEY = "await-observation";
 const CANONICAL_HISTORY_SCAN_BUDGET = { maxPages: 20, maxResults: 1_000 } as const;
-const CANONICAL_HISTORY_READ_CONCURRENCY = 25;
 export interface TaskStoreConfig {
   munin: MuninClient;
 }
@@ -198,14 +197,20 @@ export class BrokerTaskStore {
       ? createBrokerAttestation(params.envelope, secret)
       : undefined;
     const content = serializeEnvelope(params.envelope, attestation);
-    await this.munin.write(
+    const result = await this.munin.write(
       ns,
       STATUS_KEY,
       content,
       tags,
       undefined,
       params.envelope.sensitivity === "private" ? "client-restricted" : "internal",
+      true,
     );
+    if (result.status !== "created") {
+      throw new Error(
+        "Munin create_if_absent did not return status created; refusing to acknowledge submit",
+      );
+    }
   }
 
   /**
@@ -511,8 +516,10 @@ export class BrokerTaskStore {
    * matched (any key, either tag) only to learn the task's *namespace*, union
    * with a `runtime:homeserver` tag query (carried only by `status` entries,
    * so it is immune to feedback/await-observation pollution), then read each
-   * unique namespace's `status` entry directly rather than relying on it
-   * having survived inside the raw query window.
+   * unique namespace's `status` entry in bounded Munin batches rather than
+   * relying on it having survived inside the raw query window. A batch is
+   * load-bearing here: Munin serializes and spaces requests, so one read per
+   * namespace can exceed the Broker transport deadline even when idle (#278).
    *
    * Candidate discovery uses the shared capped-window paginator (#183). It
    * selects Munin's temporally ordered filter-only mode, walks backward by
@@ -546,22 +553,11 @@ export class BrokerTaskStore {
     }
 
     const namespaceList = [...namespaces];
-    const entries = [];
-    for (
-      let offset = 0;
-      offset < namespaceList.length;
-      offset += CANONICAL_HISTORY_READ_CONCURRENCY
-    ) {
-      const chunk = namespaceList.slice(
-        offset,
-        offset + CANONICAL_HISTORY_READ_CONCURRENCY,
-      );
-      entries.push(
-        ...(await Promise.all(
-          chunk.map((namespace) => this.munin.read(namespace, STATUS_KEY)),
-        )),
-      );
-    }
+    const entries = namespaceList.length === 0
+      ? []
+      : (await this.munin.readBatch(
+          namespaceList.map((namespace) => ({ namespace, key: STATUS_KEY })),
+        )).filter((entry) => entry.found);
 
     const rows = [];
     for (const entry of entries) {

--- a/tests/broker/handlers.test.ts
+++ b/tests/broker/handlers.test.ts
@@ -8,7 +8,7 @@ import { BrokerTaskStore, ORCH_V1_TAG } from "../../src/broker/task-store.js";
 import { DelegationJournal } from "../../src/broker/journal.js";
 import { IdempotencyIndex } from "../../src/broker/idempotency.js";
 import { brokerExecutorCapabilities } from "../../src/broker/executor-capabilities.js";
-import type { MuninClient } from "../../src/munin-client.js";
+import { MuninWriteRejectedError, type MuninClient } from "../../src/munin-client.js";
 import {
   buildStructuredTaskResult,
   type StructuredTaskResult,
@@ -36,9 +36,12 @@ class FakeMunin {
     content: string;
     tags?: string[];
     classification?: string;
+    createIfAbsent?: boolean;
   }> = [];
   reads: Record<string, unknown> = {};
   queryCalls = 0;
+  readCalls = 0;
+  readBatchCalls = 0;
   queryReturn: { results: unknown[]; total: number } = { results: [], total: 0 };
   async write(
     namespace: string,
@@ -49,7 +52,13 @@ class FakeMunin {
     classification?: string,
     createIfAbsent?: boolean,
   ): Promise<Record<string, unknown>> {
-    this.writes.push({ namespace, key, content, tags, classification });
+    if (createIfAbsent && this.reads[`${namespace}/${key}`]) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        conflict_reason: "already_exists",
+      });
+    }
+    this.writes.push({ namespace, key, content, tags, classification, createIfAbsent });
     this.reads[`${namespace}/${key}`] = {
       namespace, key, content, tags: tags ?? [],
       classification,
@@ -59,7 +68,17 @@ class FakeMunin {
     return { ok: true, status: createIfAbsent ? "created" : "updated" };
   }
   async read(namespace: string, key: string): Promise<unknown> {
+    this.readCalls += 1;
     return this.reads[`${namespace}/${key}`] ?? null;
+  }
+  async readBatch(reads: Array<{ namespace: string; key: string }>) {
+    this.readBatchCalls += 1;
+    return reads.map(({ namespace, key }) => {
+      const entry = this.reads[`${namespace}/${key}`] as Record<string, unknown> | undefined;
+      return entry
+        ? { namespace, key, found: true, ...entry }
+        : { namespace, key, found: false };
+    });
   }
   async query(): Promise<{ results: unknown[]; total: number }> {
     this.queryCalls += 1;
@@ -362,6 +381,19 @@ describe("POST /v1/delegate/submit", () => {
     expect(harness.munin.writes).toHaveLength(1);
     expect(harness.munin.writes[0]!.tags).toContain("broker:mcp-v2");
     expect(harness.munin.writes[0]!.tags).not.toContain("orch-v1");
+  });
+
+  it("persists a fresh submit atomically without a preflight Munin read", async () => {
+    const res = await fetch(`${harness.url}/v1/delegate/submit`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify(validRequest()),
+    });
+
+    expect(res.status).toBe(202);
+    expect(harness.munin.readCalls).toBe(0);
+    expect((harness.munin.writes[0] as { createIfAbsent?: boolean })?.createIfAbsent)
+      .toBe(true);
   });
 
   it("returns 200 reused_idempotency on retry with same payload", async () => {

--- a/tests/broker/task-store.test.ts
+++ b/tests/broker/task-store.test.ts
@@ -39,6 +39,8 @@ class FakeMunin {
   queries: Parameters<MuninClient["query"]>[0][] = [];
   readReturn: Record<string, unknown> = {};
   queryReturn: { results: unknown[]; total: number } = { results: [], total: 0 };
+  readBatchCalls: Array<Array<{ namespace: string; key: string }>> = [];
+  createStatus: string = "created";
   queryOverride?: (
     opts: Parameters<MuninClient["query"]>[0],
   ) => { results: unknown[]; total: number };
@@ -65,11 +67,22 @@ class FakeMunin {
       classification,
       createIfAbsent,
     });
-    return { ok: true, status: createIfAbsent ? "created" : "updated" };
+    return { ok: true, status: createIfAbsent ? this.createStatus : "updated" };
   }
   async read(namespace: string, key: string): Promise<unknown> {
     this.reads.push({ namespace, key });
     return this.readReturn[`${namespace}/${key}`] ?? null;
+  }
+  async readBatch(reads: Array<{ namespace: string; key: string }>) {
+    this.readBatchCalls.push(reads);
+    return reads.map(({ namespace, key }) => {
+      const entry = this.readReturn[`${namespace}/${key}`] as
+        | Record<string, unknown>
+        | undefined;
+      return entry
+        ? { namespace, key, found: true, ...entry }
+        : { namespace, key, found: false };
+    });
   }
   async query(opts: Parameters<MuninClient["query"]>[0]) {
     this.queries.push(opts);
@@ -174,6 +187,7 @@ describe("BrokerTaskStore.submit", () => {
     expect(w.content).toContain("**Runtime:** homeserver");
     expect(w.content).toContain("### Broker envelope");
     expect(w.classification).toBe("internal");
+    expect(w.createIfAbsent).toBe(true);
   });
 
   it("stores private task content at the restricted classification floor", async () => {
@@ -182,6 +196,15 @@ describe("BrokerTaskStore.submit", () => {
     privateEnvelope.sensitivity = "private";
     await new BrokerTaskStore(munin as unknown as MuninClient).submit({ envelope: privateEnvelope });
     expect(munin.writes[0]?.classification).toBe("client-restricted");
+  });
+
+  it("does not acknowledge a create_if_absent write without atomic-create confirmation", async () => {
+    const munin = new FakeMunin();
+    munin.createStatus = "updated";
+
+    await expect(
+      new BrokerTaskStore(munin as unknown as MuninClient).submit({ envelope: envelope("t1") }),
+    ).rejects.toThrow(/did not return status created/);
   });
 });
 
@@ -377,6 +400,9 @@ describe("BrokerTaskStore.listCanonical", () => {
     expect(result.truncated).toBe(false);
     expect(munin.queries.length).toBeGreaterThan(2);
     expect(munin.queries.every((query) => query.query === undefined)).toBe(true);
+    expect(munin.readBatchCalls).toHaveLength(1);
+    expect(munin.readBatchCalls[0]).toHaveLength(130);
+    expect(munin.reads).toHaveLength(0);
   });
 
   // Codex review of #181/PR182: a caller-requested small output limit must

--- a/tests/broker/task-type-harvest.test.ts
+++ b/tests/broker/task-type-harvest.test.ts
@@ -16,6 +16,7 @@ class PersistingMunin {
     tags: string[] = [],
     _expectedUpdatedAt?: string,
     classification = "internal",
+    createIfAbsent?: boolean,
   ): Promise<Record<string, unknown>> {
     if (key === "status") {
       this.status = {
@@ -29,7 +30,7 @@ class PersistingMunin {
         updated_at: "2026-07-18T10:00:00.000Z",
       };
     }
-    return { ok: true };
+    return { ok: true, status: createIfAbsent ? "created" : "updated" };
   }
 }
 


### PR DESCRIPTION
Closes #278

## What changed

- batch canonical status reads after the two bounded Munin discovery queries instead of issuing one serialized read per task
- make fresh submit a single atomic `create_if_absent` write and acknowledge only a confirmed `created` result
- recover deterministic idempotent retries from the persisted envelope after an atomic conflict, while preserving principal isolation and collision detection
- retain the in-memory reservation throughout durable conflict validation
- document the load-bearing batching and atomic-create contracts

## Why

The Munin client serializes and spaces requests. Broker list could therefore perform hundreds of individual reads and exceed 60 seconds, while fresh submit performed a preflight read plus a write and could queue behind list traffic. This change bounds list round trips via the existing batch API and removes the submit preflight race without weakening durability.

## Verification

- `npm run build`
- focused Broker suite: 5 files, 152 tests passed
- final focused suite after race adjustment: 3 files, 117 tests passed
- full suite: 152 files, 2343 tests passed
- `bash scripts/deploy-pi.test.sh`
- `bash scripts/lib/claude-config-bootstrap.test.sh`
- `git diff --check`