### PR TITLE
Persist content-blind shadow scheduling predictions

### DIFF
--- a/docs/scheduling-shadow-lanes.md
+++ b/docs/scheduling-shadow-lanes.md
@@ -1,6 +1,7 @@
 # Scheduling shadow lanes and work-minute admission
 
-**Status:** design contract; no scheduling behavior change
+**Status:** prediction persistence active in shadow; recovery preservation
+deferred; no scheduling behavior change
 
 **Issue:** [#282](https://github.com/Magnus-Gille/hugin/issues/282)
 
@@ -188,6 +189,21 @@ the same identity is a conflict, never an update. After a restart, a missing
 prediction remains explicitly missing because the original queue snapshot
 cannot be reconstructed; recovery must not generate a new prediction from the
 later queue state.
+
+The first live shadow slice attempts to persist an explicit `estimate-missing`
+abstention for each accepted claim because no production duration estimator
+is active yet. Evidence construction fails open to an unmodified FIFO claim
+with caller pointer tags stripped. Eligible-window collection uses indexed
+per-group minimum sequences rather than a nested scan. A dedicated Munin client
+and fire-and-forget write ensure evidence latency cannot enter the
+claim-to-execution critical path.
+
+Startup, lease-reaper, and interrupted-delivery recovery continue to strip the
+pointer. Schema and digest validation proves content integrity but not that the
+first writer was Hugin or that the pointer came from the successful claim CAS.
+Recovery preservation therefore requires a future immutable, authenticated
+claim-instance binding; mutable status tags plus create-only evidence are not
+sufficient authority.
 
 Prediction and outcome use separate retry comparisons. A prediction retry
 must match the claim-bound prediction digest. An outcome is deterministically

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ import {
   type MuninClientConfig,
   type MuninReadResult,
 } from "./munin-client.js";
-import { getFoundBatchEntry, extractTaskId, pickEarliestTask, selectNextTask, checkoutTaskBranch, finalizeTaskBranch, deriveRepositoryOutcome, prepareManagedCheckout, shouldReapExpiredLease, decideStartupRecovery, decideDeliveryRetry, finalizeTaskCompletion, resolveTaskWorkingDirectory, normalizeRoot, parseBaseBranchOverride, DEFAULT_REPOS_ROOT, MAX_TASK_OUTPUT_TOKENS, MAX_TASK_TIMEOUT_MS, parseBoundedPositiveInt, PUBLICATION_FAILED_TAG } from "./task-helpers.js";
+import { getFoundBatchEntry, extractTaskId, pickEarliestTask, listEligibleTasks, checkoutTaskBranch, finalizeTaskBranch, deriveRepositoryOutcome, prepareManagedCheckout, shouldReapExpiredLease, decideStartupRecovery, decideDeliveryRetry, finalizeTaskCompletion, resolveTaskWorkingDirectory, normalizeRoot, parseBaseBranchOverride, DEFAULT_REPOS_ROOT, MAX_TASK_OUTPUT_TOKENS, MAX_TASK_TIMEOUT_MS, parseBoundedPositiveInt, PUBLICATION_FAILED_TAG } from "./task-helpers.js";
 import { persistPublicationFailure } from "./publication-recovery.js";
 import { queryAllMuninEntries } from "./munin-pagination.js";
 import {
@@ -148,6 +148,7 @@ import {
   type DependencyState,
 } from "./task-graph.js";
 import {
+  attachSchedulerDecisionPointer,
   buildAwaitingApprovalTags,
   buildClaimedTerminalStatusTags,
   buildLeasedStatusTags,
@@ -156,6 +157,14 @@ import {
   shouldDeferCancellationToLocalOwner,
   stripSchedulerDecisionPointers,
 } from "./task-status-tags.js";
+import {
+  hashSchedulerPrediction,
+  schedulerDecisionPredictionSchema,
+  type SchedulerDecisionPrediction,
+} from "./scheduler-evidence.js";
+import {
+  persistSchedulerPrediction,
+} from "./scheduler-evidence-store.js";
 import { LearningLoopCollector } from "./learning-loop-collector.js";
 import { LearningRegistryStore } from "./learning-registry-store.js";
 import { LearningExperimentStore } from "./learning/experiment-store.js";
@@ -699,6 +708,10 @@ const learningRegistry = new LearningRegistryStore(munin);
 const leaseMunin = createMuninClient();
 const cancelWatchMunin = createMuninClient();
 const reaperMunin = createMuninClient();
+// Shadow scheduling evidence is non-authoritative telemetry. A dedicated
+// request queue plus fire-and-forget writes ensures Munin latency cannot hold
+// up execution after the claim CAS.
+const schedulerEvidenceMunin = createMuninClient();
 // Verdict-store traffic (batched record + confidence-source read, Fix #2c)
 // gets its own dedicated client, same precedent as leaseMunin/cancelWatchMunin
 // above: verdict recording is fire-and-forget background work and must never
@@ -3154,7 +3167,6 @@ async function reapExpiredLeases(): Promise<void> {
       }
       const classification = getTaskArtifactClassification(task || undefined, entry.content);
       const runtime = getRuntimeFromTags(entry.tags);
-
       try {
         await reaperMunin.write(
           result.namespace,
@@ -4306,8 +4318,10 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
   );
   const queueDepth = lastPendingQueueSnapshot.pendingCount;
 
-  // Select the next eligible task respecting Group/Sequence ordering (FIFO within eligible set)
-  const taskResult = selectNextTask(dispatchableResults, runningResults);
+  // Enumerate the same eligible FIFO window used for selection. Shadow
+  // scheduling records this content-blind window but does not alter its order.
+  const eligibleTasks = listEligibleTasks(dispatchableResults, runningResults);
+  const taskResult = eligibleTasks[0];
   if (!taskResult) return { hadTask: false, queueDepth };
 
   const taskNs = taskResult.namespace;
@@ -4691,11 +4705,54 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         .map((t) => (t === "runtime:auto" ? `runtime:${parsedTask!.runtime}` : t))
         .concat("routing:auto")
     : entry.tags;
-  // Until the dispatcher adds its own schema-valid prediction in the next
-  // slice, never carry caller-supplied scheduler identities into a winning
-  // claim. attachSchedulerDecisionPointer performs the same replacement when
-  // prediction persistence is wired.
-  const tagsForClaim = stripSchedulerDecisionPointers(claimInputTags);
+  let schedulerPrediction: SchedulerDecisionPrediction | null = null;
+  let tagsForClaim = stripSchedulerDecisionPointers(claimInputTags);
+  try {
+    const candidatePrediction = schedulerDecisionPredictionSchema.parse({
+      schemaVersion: 1,
+      decisionId: randomUUID(),
+      observedAt: new Date().toISOString(),
+      champion: {
+        policy: pendingPage.truncated || runningPage.truncated
+          ? "visible-window-fifo-v1"
+          : "complete-fifo-v1",
+        taskRef: { namespace: taskNs, key: "status" },
+        serviceEstimate: null,
+      },
+      challenger: {
+        policy: "bounded-sejf-v1",
+        overdueThresholdSeconds: 1800,
+        taskRef: null,
+        reason: "insufficient-evidence",
+        evidenceReasons: [
+          ...(pendingPage.truncated || runningPage.truncated ? ["window-truncated"] : []),
+          "estimate-missing",
+        ],
+        serviceEstimate: null,
+      },
+      window: {
+        eligibleTasks: eligibleTasks.length,
+        pendingEnumerationComplete: !pendingPage.truncated,
+        runningEnumerationComplete: !runningPage.truncated,
+        eligibilityAuthority: "legacy-unbound-group-sequence",
+        estimatedWorkMinutes: null,
+        missingEstimates: eligibleTasks.length,
+      },
+      estimatorVersion: "scheduler-duration-v1",
+    });
+    schedulerPrediction = candidatePrediction;
+    tagsForClaim = attachSchedulerDecisionPointer(claimInputTags, {
+      decisionId: candidatePrediction.decisionId,
+      predictionDigest: hashSchedulerPrediction(candidatePrediction),
+    });
+  } catch (err) {
+    // Shadow evidence can fail closed without becoming dispatch authority.
+    // Caller-controlled pointer tags remain stripped in this fallback.
+    console.warn(
+      `Scheduler shadow prediction construction failed for ${taskNs}: ` +
+        (err instanceof Error ? err.message : String(err)),
+    );
+  }
   const claimTags = buildClaimTags(tagsForClaim, "running", true);
 
   // Rotate the mcp-session-id so all MCP calls for this task execution share
@@ -4728,6 +4785,20 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     taskProvenance.delete(taskNs);
     console.log(`Failed to claim ${taskNs} (concurrent claim?):`, err);
     return { hadTask: false, queueDepth };
+  }
+
+  // The claim is the scheduling authority. Prediction persistence happens
+  // only after that CAS and is deliberately best-effort: telemetry must never
+  // delay, fail, or reorder a production dispatch.
+  if (schedulerPrediction) {
+    const acceptedPrediction = schedulerPrediction;
+    void persistSchedulerPrediction(schedulerEvidenceMunin, acceptedPrediction)
+      .catch((err: unknown) => {
+        console.warn(
+          `Scheduler shadow prediction persistence failed for ${taskNs} (${acceptedPrediction.decisionId}): ` +
+            (err instanceof Error ? err.message : String(err)),
+        );
+      });
   }
 
   // The selected status is now running. Keep /health accurate while the task

--- a/src/scheduler-evidence-store.ts
+++ b/src/scheduler-evidence-store.ts
@@ -1,0 +1,82 @@
+import {
+  MuninWriteRejectedError,
+  type MuninEntry,
+} from "./munin-client.js";
+import {
+  hashSchedulerPrediction,
+  schedulerDecisionPredictionSchema,
+} from "./scheduler-evidence.js";
+
+const PREDICTION_KEY = "prediction";
+const PREDICTION_TAGS = ["type:scheduler-decision-prediction", "scheduler-shadow:v1"];
+
+export interface SchedulerEvidenceStoreClient {
+  read(
+    namespace: string,
+    key: string,
+  ): Promise<(MuninEntry & { found: true }) | null>;
+  write(
+    namespace: string,
+    key: string,
+    content: string,
+    tags?: string[],
+    expectedUpdatedAt?: string,
+    classification?: string,
+    createIfAbsent?: boolean,
+  ): Promise<Record<string, unknown>>;
+}
+
+export class SchedulerPredictionConflictError extends Error {
+  constructor(decisionId: string) {
+    super(`scheduler decision ${decisionId} already contains a different prediction`);
+    this.name = "SchedulerPredictionConflictError";
+  }
+}
+
+export function schedulerDecisionNamespace(decisionId: string): string {
+  return `scheduler/decisions/${decisionId}`;
+}
+
+function parseStoredPrediction(content: string) {
+  try {
+    return schedulerDecisionPredictionSchema.parse(JSON.parse(content));
+  } catch {
+    return null;
+  }
+}
+
+export async function persistSchedulerPrediction(
+  munin: SchedulerEvidenceStoreClient,
+  input: unknown,
+): Promise<{ status: "created" | "exact-existing" }> {
+  const prediction = schedulerDecisionPredictionSchema.parse(input);
+  const namespace = schedulerDecisionNamespace(prediction.decisionId);
+  try {
+    const result = await munin.write(
+      namespace,
+      PREDICTION_KEY,
+      JSON.stringify(prediction),
+      PREDICTION_TAGS,
+      undefined,
+      "internal",
+      true,
+    );
+    if (result.status !== "created") {
+      throw new Error(
+        `scheduler prediction write returned non-created status for ${namespace}/${PREDICTION_KEY}`,
+      );
+    }
+    return { status: "created" };
+  } catch (error) {
+    if (!(error instanceof MuninWriteRejectedError)
+      || error.conflictReason !== "already_exists") {
+      throw error;
+    }
+    const existing = await munin.read(namespace, PREDICTION_KEY);
+    const stored = existing ? parseStoredPrediction(existing.content) : null;
+    if (!stored || hashSchedulerPrediction(stored) !== hashSchedulerPrediction(prediction)) {
+      throw new SchedulerPredictionConflictError(prediction.decisionId);
+    }
+    return { status: "exact-existing" };
+  }
+}

--- a/src/task-helpers.ts
+++ b/src/task-helpers.ts
@@ -171,54 +171,54 @@ export function parseSequenceField(content: string): number | undefined {
  * Both pendingTasks and runningTasks are arrays of MuninQueryResult; Group and
  * Sequence are parsed from content_preview which contains the task metadata.
  */
-export function selectNextTask(
+export function listEligibleTasks(
   pendingTasks: MuninQueryResult[],
   runningTasks: MuninQueryResult[],
-): MuninQueryResult | undefined {
+): MuninQueryResult[] {
   // Work in deterministic FIFO order (earliest first, then stable task namespace)
   const statusEntries = pendingTasks.filter((r) => r.key === "status");
-  if (statusEntries.length === 0) return undefined;
+  if (statusEntries.length === 0) return [];
 
   const sorted = [...statusEntries].sort(compareTaskClaimOrder);
+  const minimumSequenceByGroup = (
+    tasks: MuninQueryResult[],
+  ): Map<string, number> => {
+    const minimums = new Map<string, number>();
+    for (const task of tasks) {
+      const group = parseGroupField(task.content_preview);
+      const sequence = parseSequenceField(task.content_preview);
+      if (!group || sequence === undefined) continue;
+      const current = minimums.get(group);
+      if (current === undefined || sequence < current) minimums.set(group, sequence);
+    }
+    return minimums;
+  };
+  const pendingMinimums = minimumSequenceByGroup(statusEntries);
+  const runningMinimums = minimumSequenceByGroup(runningTasks);
 
-  for (const candidate of sorted) {
+  return sorted.filter((candidate) => {
     const group = parseGroupField(candidate.content_preview);
     if (!group) {
       // No group field — always eligible
-      return candidate;
+      return true;
     }
 
     const sequence = parseSequenceField(candidate.content_preview);
     if (sequence === undefined) {
       // Has group but no sequence — treat as eligible (no ordering constraint)
-      return candidate;
+      return true;
     }
 
-    // Check if any lower-sequence sibling exists in pending tasks
-    const blockedByPending = statusEntries.some((other) => {
-      if (other === candidate) return false;
-      const otherGroup = parseGroupField(other.content_preview);
-      if (otherGroup !== group) return false;
-      const otherSeq = parseSequenceField(other.content_preview);
-      return otherSeq !== undefined && otherSeq < sequence;
-    });
+    return (pendingMinimums.get(group) ?? sequence) >= sequence
+      && (runningMinimums.get(group) ?? sequence) >= sequence;
+  });
+}
 
-    if (blockedByPending) continue;
-
-    // Check if any lower-sequence sibling is currently running
-    const blockedByRunning = runningTasks.some((r) => {
-      const otherGroup = parseGroupField(r.content_preview);
-      if (otherGroup !== group) return false;
-      const otherSeq = parseSequenceField(r.content_preview);
-      return otherSeq !== undefined && otherSeq < sequence;
-    });
-
-    if (blockedByRunning) continue;
-
-    return candidate;
-  }
-
-  return undefined;
+export function selectNextTask(
+  pendingTasks: MuninQueryResult[],
+  runningTasks: MuninQueryResult[],
+): MuninQueryResult | undefined {
+  return listEligibleTasks(pendingTasks, runningTasks)[0];
 }
 
 // --- Lease reaping (#38) ---

--- a/tests/scheduler-evidence-store.test.ts
+++ b/tests/scheduler-evidence-store.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import { MuninWriteRejectedError, type MuninEntry } from "../src/munin-client.js";
+import {
+  persistSchedulerPrediction,
+  type SchedulerEvidenceStoreClient,
+} from "../src/scheduler-evidence-store.js";
+
+const taskNamespace = "tasks/20260723-001500-abcd";
+const decisionId = "34f2d430-6c31-47de-860a-8b22bc97f4d4";
+
+function prediction(overrides: Record<string, unknown> = {}) {
+  return {
+    schemaVersion: 1,
+    decisionId,
+    observedAt: "2026-07-22T22:15:00.000Z",
+    champion: {
+      policy: "complete-fifo-v1",
+      taskRef: { namespace: taskNamespace, key: "status" },
+      serviceEstimate: null,
+    },
+    challenger: {
+      policy: "bounded-sejf-v1",
+      overdueThresholdSeconds: 1800,
+      taskRef: null,
+      reason: "insufficient-evidence",
+      evidenceReasons: ["estimate-missing"],
+      serviceEstimate: null,
+    },
+    window: {
+      eligibleTasks: 2,
+      pendingEnumerationComplete: true,
+      runningEnumerationComplete: true,
+      eligibilityAuthority: "legacy-unbound-group-sequence",
+      estimatedWorkMinutes: null,
+      missingEstimates: 2,
+    },
+    estimatorVersion: "scheduler-duration-v1",
+    ...overrides,
+  };
+}
+
+class FakeMunin implements SchedulerEvidenceStoreClient {
+  readonly rows = new Map<string, MuninEntry & { found: true }>();
+  readonly writes: Array<{ namespace: string; key: string; createIfAbsent?: boolean }> = [];
+
+  async read(namespace: string, key: string): Promise<(MuninEntry & { found: true }) | null> {
+    return this.rows.get(`${namespace}/${key}`) ?? null;
+  }
+
+  async write(
+    namespace: string,
+    key: string,
+    content: string,
+    tags?: string[],
+    _expectedUpdatedAt?: string,
+    classification?: string,
+    createIfAbsent?: boolean,
+  ): Promise<Record<string, unknown>> {
+    this.writes.push({ namespace, key, createIfAbsent });
+    const rowKey = `${namespace}/${key}`;
+    if (createIfAbsent && this.rows.has(rowKey)) {
+      throw new MuninWriteRejectedError(namespace, key, {
+        error: "conflict",
+        conflict_reason: "already_exists",
+      });
+    }
+    this.rows.set(rowKey, {
+      found: true,
+      id: rowKey,
+      namespace,
+      key,
+      content,
+      tags: tags ?? [],
+      classification,
+      created_at: "2026-07-22T22:15:01.000Z",
+      updated_at: "2026-07-22T22:15:01.000Z",
+    });
+    return { ok: true, status: createIfAbsent ? "created" : "updated" };
+  }
+}
+
+describe("scheduler evidence store", () => {
+  it("atomically creates a content-blind prediction", async () => {
+    const munin = new FakeMunin();
+    const value = prediction();
+
+    expect(await persistSchedulerPrediction(munin, value)).toEqual({ status: "created" });
+    expect(munin.writes[0]).toEqual({
+      namespace: `scheduler/decisions/${decisionId}`,
+      key: "prediction",
+      createIfAbsent: true,
+    });
+
+    expect([...munin.rows.values()][0]?.classification).toBe("internal");
+  });
+
+  it("treats an exact immutable replay as reusable but refuses conflicting content", async () => {
+    const munin = new FakeMunin();
+    const value = prediction();
+    await persistSchedulerPrediction(munin, value);
+
+    expect(await persistSchedulerPrediction(munin, value)).toEqual({ status: "exact-existing" });
+    await expect(persistSchedulerPrediction(munin, prediction({
+      observedAt: "2026-07-22T22:16:00.000Z",
+    }))).rejects.toThrow(/different prediction/);
+  });
+
+});

--- a/tests/select-next-task.test.ts
+++ b/tests/select-next-task.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { selectNextTask, parseGroupField, parseSequenceField } from "../src/task-helpers.js";
+import {
+  listEligibleTasks,
+  selectNextTask,
+  parseGroupField,
+  parseSequenceField,
+} from "../src/task-helpers.js";
 import type { MuninQueryResult } from "../src/munin-client.js";
 
 function makeTask(
@@ -253,5 +258,30 @@ describe("selectNextTask", () => {
       "**Group:** batch-a\n**Runtime:** claude",
     );
     expect(selectNextTask([noSeqGroupTask], NO_RUNNING)).toBe(noSeqGroupTask);
+  });
+
+  it("exposes the complete FIFO-ordered eligible window without changing the champion", () => {
+    const blocked = makeTask(
+      "tasks/a-blocked",
+      "2026-01-01T07:00:00Z",
+      "**Group:** batch-a\n**Sequence:** 2",
+    );
+    const oldestEligible = makeTask("tasks/b-oldest", "2026-01-01T08:00:00Z");
+    const newestEligible = makeTask("tasks/c-newest", "2026-01-01T09:00:00Z");
+    const runningSeq1 = makeRunning(
+      "tasks/a-running",
+      "**Group:** batch-a\n**Sequence:** 1",
+    );
+
+    const eligible = listEligibleTasks(
+      [newestEligible, blocked, oldestEligible],
+      [runningSeq1],
+    );
+
+    expect(eligible).toEqual([oldestEligible, newestEligible]);
+    expect(selectNextTask(
+      [newestEligible, blocked, oldestEligible],
+      [runningSeq1],
+    )).toBe(eligible[0]);
   });
 });


### PR DESCRIPTION
## Summary

- attach a dispatcher-owned decision UUID and prediction digest to each successful FIFO claim
- atomically persist the content-blind abstaining prediction after the claim on an isolated, fire-and-forget Munin client
- enumerate the full eligible FIFO window with indexed per-group minima, preserving existing selection semantics without a quadratic scan
- continue stripping scheduler pointers on every recovery path until an authenticated claim-instance binding exists

Scheduling behavior remains FIFO. Missing estimates produce an explicit challenger abstention. Recovery does not treat create-only evidence as dispatcher provenance.

## Verification

- `npm run build`
- `npm test` — 154 files, 2,361 tests
- focused scheduler/store/FIFO/tag suite — 48 tests
- `bash scripts/deploy-pi.test.sh`
- `git diff --check`

Closes part of #282.