### PR TITLE
Persist claim-to-release shadow scheduling outcomes

### DIFF
--- a/docs/scheduling-shadow-lanes.md
+++ b/docs/scheduling-shadow-lanes.md
@@ -1,7 +1,7 @@
 # Scheduling shadow lanes and work-minute admission
 
-**Status:** prediction persistence active in shadow; recovery preservation
-deferred; no scheduling behavior change
+**Status:** prediction and in-process terminal-outcome persistence active in
+shadow; recovery preservation deferred; no scheduling behavior change
 
 **Issue:** [#282](https://github.com/Magnus-Gille/hugin/issues/282)
 
@@ -204,6 +204,19 @@ first writer was Hugin or that the pointer came from the successful claim CAS.
 Recovery preservation therefore requires a future immutable, authenticated
 claim-instance binding; mutable status tags plus create-only evidence are not
 sufficient authority.
+
+For a terminal result written by the live in-process claim owner, Hugin retains
+the exact serialized `result-structured` SHA-256 and Munin revision returned by
+that successful write. After synchronous delivery/publication, learning
+capture, dependent promotion, pipeline refresh, quota sampling, and invocation
+journaling finish, Hugin records the release boundary, clears `currentTask`, and
+queues a create-only outcome on the same isolated telemetry client. The outcome
+write is therefore outside the dispatch critical path. If Munin did not return
+the exact claim-CAS timestamp, the outcome records an incomplete
+`claim-boundary-unavailable` clock instead of borrowing the older pending
+timestamp. A release timestamp preceding the claim timestamp is likewise
+incomplete rather than coerced. The initial `longJob` threshold is the same
+explicit 1,800-second bound used by the shadow overdue policy.
 
 Prediction and outcome use separate retry comparisons. A prediction retry
 must match the claim-bound prediction digest. An outcome is deterministically

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { type Server } from "node:http";
 import * as fs from "node:fs";
 import { createRequire } from "node:module";
@@ -158,11 +158,14 @@ import {
   stripSchedulerDecisionPointers,
 } from "./task-status-tags.js";
 import {
+  buildSchedulerDecisionOutcomeFromTerminalResult,
   hashSchedulerPrediction,
   schedulerDecisionPredictionSchema,
   type SchedulerDecisionPrediction,
+  type SchedulerTerminalResultRevision,
 } from "./scheduler-evidence.js";
 import {
+  persistSchedulerOutcome,
   persistSchedulerPrediction,
 } from "./scheduler-evidence-store.js";
 import { LearningLoopCollector } from "./learning-loop-collector.js";
@@ -1429,12 +1432,14 @@ async function writeStructuredTaskResult(
   result: StructuredTaskResult,
   classification?: string,
   client: MuninClient = munin,
-): Promise<void> {
+): Promise<(SchedulerTerminalResultRevision & { result: StructuredTaskResult }) | null> {
   const provenance = result.provenance ?? await resolveTaskProvenance(taskNs, client);
-  await client.write(
+  const durableResult = buildStructuredTaskResult({ ...result, provenance });
+  const content = JSON.stringify(durableResult, null, 2);
+  const writeResult = await client.write(
     taskNs,
     "result-structured",
-    JSON.stringify(buildStructuredTaskResult({ ...result, provenance }), null, 2),
+    content,
     ["type:task-result", "type:task-result-structured"],
     undefined,
     classification,
@@ -1448,6 +1453,15 @@ async function writeStructuredTaskResult(
       err instanceof Error ? err.message : String(err),
     );
   }
+  return typeof writeResult.updated_at === "string"
+    ? {
+        namespace: taskNs,
+        key: "result-structured",
+        updatedAt: writeResult.updated_at,
+        sha256: createHash("sha256").update(content, "utf8").digest("hex"),
+        result: durableResult,
+      }
+    : null;
 }
 
 async function refreshPipelineSummary(
@@ -2432,6 +2446,49 @@ function stripLeaseTags(tags: string[]): string[] {
   return tags.filter(
     (t) => !t.startsWith("claimed_by:") && !t.startsWith("lease_expires:")
   );
+}
+
+function releaseCurrentClaimWithSchedulerOutcome(input: {
+  taskNamespace: string;
+  prediction: SchedulerDecisionPrediction | null;
+  claimedAt: string | null;
+  requestedRuntime: DispatcherRuntime;
+  effectiveRuntime: DispatcherRuntime;
+  terminalResult: (SchedulerTerminalResultRevision & { result: StructuredTaskResult }) | null;
+  taskType?: string;
+  harness?: string;
+  model?: string;
+}): void {
+  const releasedAt = new Date().toISOString();
+  currentTask = null;
+  currentTaskConfig = null;
+  if (!input.prediction || !input.terminalResult) return;
+
+  try {
+    const outcome = buildSchedulerDecisionOutcomeFromTerminalResult({
+      prediction: input.prediction,
+      claimedAt: input.claimedAt,
+      releasedAt,
+      requestedRuntime: input.requestedRuntime,
+      effectiveRuntime: input.effectiveRuntime,
+      terminalResult: input.terminalResult,
+      taskType: input.taskType,
+      harness: input.harness,
+      model: input.model,
+    });
+    void persistSchedulerOutcome(schedulerEvidenceMunin, outcome)
+      .catch((err: unknown) => {
+        console.warn(
+          `Scheduler shadow outcome persistence failed for ${input.taskNamespace} ` +
+            `(${outcome.decisionId}): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+  } catch (err) {
+    console.warn(
+      `Scheduler shadow outcome construction failed for ${input.taskNamespace}: ` +
+        (err instanceof Error ? err.message : String(err)),
+    );
+  }
 }
 
 /** Start periodic lease renewal for the current task. */
@@ -4210,7 +4267,7 @@ async function failTaskWithMessage(
   errorMessage: string,
   runtimeTagOverride?: string,
   preserveClaimedSchedulerPointer = false,
-): Promise<void> {
+): Promise<(SchedulerTerminalResultRevision & { result: StructuredTaskResult }) | null> {
   const runtime = (
     runtimeTagOverride ||
     entry.tags.find((tag) => tag.startsWith("runtime:")) ||
@@ -4240,7 +4297,7 @@ async function failTaskWithMessage(
     undefined,
     classification
   );
-  await writeStructuredTaskResult(
+  return writeStructuredTaskResult(
     taskNs,
     createFailureStructuredResult(taskNs, runtime, errorMessage, {
       executor: "dispatcher",
@@ -4760,6 +4817,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
   // session-flow analysis). A fresh ID is set again in the finally block below.
   munin.setSessionId(randomUUID());
   let claimAcceptedAt = entry.updated_at;
+  let schedulerClaimedAt: string | null = null;
   try {
     const claimResult = await munin.write(
       taskNs,
@@ -4772,6 +4830,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     if (typeof claimResult.updated_at === "string") {
       entry.updated_at = claimResult.updated_at;
       claimAcceptedAt = claimResult.updated_at;
+      schedulerClaimedAt = claimResult.updated_at;
     }
     // From this point onward the winning claim tags are authoritative. In
     // particular, dispatcher-owned scheduler pointers added to the claim CAS
@@ -4821,14 +4880,32 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
   try {
     if (declaredRuntime === "pipeline") {
       currentTaskConfig = null;
+      let pipelineTerminalResult:
+        | (SchedulerTerminalResultRevision & { result: StructuredTaskResult })
+        | null = null;
       const pipelineResult = await dispatchPipelineTask(
         munin,
         {
-          failTaskWithMessage: (namespace, claimedEntry, message, runtimeTag) =>
-            failTaskWithMessage(namespace, claimedEntry, message, runtimeTag, true),
+          failTaskWithMessage: async (namespace, claimedEntry, message, runtimeTag) => {
+            const revision = await failTaskWithMessage(
+              namespace,
+              claimedEntry,
+              message,
+              runtimeTag,
+              true,
+            );
+            if (namespace === taskNs) pipelineTerminalResult = revision;
+          },
           promoteDependents,
           refreshPipelineSummary,
-          writeStructuredResult: writeStructuredTaskResult,
+          writeStructuredResult: async (namespace, result, classification) => {
+            const revision = await writeStructuredTaskResult(
+              namespace,
+              result,
+              classification,
+            );
+            if (namespace === taskNs) pipelineTerminalResult = revision;
+          },
         },
         taskNs,
         entry,
@@ -4841,8 +4918,14 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
       );
       stopLeaseRenewal();
       stopCancellationWatch();
-      currentTask = null;
-      currentTaskConfig = null;
+      releaseCurrentClaimWithSchedulerOutcome({
+        taskNamespace: taskNs,
+        prediction: schedulerPrediction,
+        claimedAt: schedulerClaimedAt,
+        requestedRuntime: "pipeline",
+        effectiveRuntime: "pipeline",
+        terminalResult: pipelineTerminalResult,
+      });
       return pipelineResult;
     }
 
@@ -6406,6 +6489,9 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
       : deliveryAwareFinalizeTags;
 
     let terminalStructuredResultOk = false;
+    let terminalStructuredResult:
+      | (SchedulerTerminalResultRevision & { result: StructuredTaskResult })
+      | null = null;
     if (isCancelled && cancellation) {
       await munin.write(
         taskNs,
@@ -6438,28 +6524,30 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         // the task never entered delivery this is undefined → no CAS, same as
         // the prior behaviour.
         expectedUpdatedAt: deliveryCheckpointUpdatedAt,
-        writeStructuredResult: () => writeStructuredTaskResult(
-          taskNs,
-          createCancelledStructuredResult(taskNs, task.runtime, cancellation.reason, {
-            executor: effectiveExecutor,
-            resultSource,
-            startedAt,
-            completedAt,
-            durationSeconds: Math.round(durationMs / 1000),
-            logFile: `~/.hugin/logs/${taskId}.log`,
-            replyTo: task.replyTo,
-            replyFormat: task.replyFormat,
-            group: task.group,
-            sequence: task.sequence,
-            pipeline: task.pipeline,
-            runtimeMetadata,
-            approval: approvalMetadata,
-            bodyKind: structuredBodyKind,
-            bodyText: structuredBodyText,
-            sensitivity: taskSensitivitySnapshot,
-          }),
-          taskClassification,
-        ),
+        writeStructuredResult: async () => {
+          terminalStructuredResult = await writeStructuredTaskResult(
+            taskNs,
+            createCancelledStructuredResult(taskNs, task.runtime, cancellation.reason, {
+              executor: effectiveExecutor,
+              resultSource,
+              startedAt,
+              completedAt,
+              durationSeconds: Math.round(durationMs / 1000),
+              logFile: `~/.hugin/logs/${taskId}.log`,
+              replyTo: task.replyTo,
+              replyFormat: task.replyFormat,
+              group: task.group,
+              sequence: task.sequence,
+              pipeline: task.pipeline,
+              runtimeMetadata,
+              approval: approvalMetadata,
+              bodyKind: structuredBodyKind,
+              bodyText: structuredBodyText,
+              sensitivity: taskSensitivitySnapshot,
+            }),
+            taskClassification,
+          );
+        },
         logMessage: `Task cancelled in ${Math.round(durationMs / 1000)}s (reason: ${cancellation.reason}, executor: ${executorLabel})`,
       });
       if (cancelledFinalize.statusCasLost) {
@@ -6498,62 +6586,64 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         // reconciler reclaimed the checkpoint while we were delivering, this
         // CAS is rejected and we must NOT finalize — the new owner stands.
         expectedUpdatedAt: deliveryCheckpointUpdatedAt,
-        writeStructuredResult: () => writeStructuredTaskResult(
-          taskNs,
-          buildStructuredTaskResult({
-            schemaVersion: 1,
-            taskId,
-            taskNamespace: taskNs,
-            lifecycle: ok ? "completed" : "failed",
-            outcome: ok ? "completed" : isTimeout ? "timed_out" : "failed",
-            runtime: task.runtime,
-            executor: effectiveExecutor,
-            resultSource,
-            exitCode,
-            startedAt,
-            completedAt,
-            durationSeconds: Math.round(durationMs / 1000),
-            logFile: `~/.hugin/logs/${taskId}.log`,
-            replyTo: task.replyTo,
-            replyFormat: task.replyFormat,
-            group: task.group,
-            sequence: task.sequence,
-            costUsd: costUsd ?? undefined,
-            prUrl,
-            repositoryOutcome,
-            repositoryChange,
-            bodyKind: structuredBodyKind,
-            bodyText: structuredBodyText,
-            errorMessage: ok
-              ? undefined
-              : failureClassification
-                ? failureClassification.reason
-                : deliveryResult && !deliveryResult.ok
-                  ? deliveryResult.error ?? structuredBodyText
-                  : structuredBodyText,
-            runtimeMetadata,
-            pipeline: task.pipeline,
-            approval: approvalMetadata,
-            sensitivity: taskSensitivitySnapshot,
-            artifactDelivery: deliveryResult
-              ? {
-                  ok: deliveryResult.ok,
-                  failureKind: deliveryResult.failureKind,
-                  artifacts: deliveryResult.records.map((r) => ({
-                    id: r.id,
-                    status: r.status,
-                    remote: r.remote,
-                    bytes: r.bytes,
-                    sha256: r.sha256,
-                    error: r.error,
-                  })),
-                }
-              : undefined,
-            orchestratorOutcomes,
-            savings: savingsResult,
-          }),
-          taskClassification,
-        ),
+        writeStructuredResult: async () => {
+          terminalStructuredResult = await writeStructuredTaskResult(
+            taskNs,
+            buildStructuredTaskResult({
+              schemaVersion: 1,
+              taskId,
+              taskNamespace: taskNs,
+              lifecycle: ok ? "completed" : "failed",
+              outcome: ok ? "completed" : isTimeout ? "timed_out" : "failed",
+              runtime: task.runtime,
+              executor: effectiveExecutor,
+              resultSource,
+              exitCode,
+              startedAt,
+              completedAt,
+              durationSeconds: Math.round(durationMs / 1000),
+              logFile: `~/.hugin/logs/${taskId}.log`,
+              replyTo: task.replyTo,
+              replyFormat: task.replyFormat,
+              group: task.group,
+              sequence: task.sequence,
+              costUsd: costUsd ?? undefined,
+              prUrl,
+              repositoryOutcome,
+              repositoryChange,
+              bodyKind: structuredBodyKind,
+              bodyText: structuredBodyText,
+              errorMessage: ok
+                ? undefined
+                : failureClassification
+                  ? failureClassification.reason
+                  : deliveryResult && !deliveryResult.ok
+                    ? deliveryResult.error ?? structuredBodyText
+                    : structuredBodyText,
+              runtimeMetadata,
+              pipeline: task.pipeline,
+              approval: approvalMetadata,
+              sensitivity: taskSensitivitySnapshot,
+              artifactDelivery: deliveryResult
+                ? {
+                    ok: deliveryResult.ok,
+                    failureKind: deliveryResult.failureKind,
+                    artifacts: deliveryResult.records.map((r) => ({
+                      id: r.id,
+                      status: r.status,
+                      remote: r.remote,
+                      bytes: r.bytes,
+                      sha256: r.sha256,
+                      error: r.error,
+                    })),
+                  }
+                : undefined,
+              orchestratorOutcomes,
+              savings: savingsResult,
+            }),
+            taskClassification,
+          );
+        },
         logMessage: `Task ${ok ? "completed" : isTimeout ? "timed out" : "failed"} in ${Math.round(durationMs / 1000)}s (exit ${exitCode}, executor: ${executorLabel}${costUsd !== null ? `, cost: $${costUsd.toFixed(4)}` : ""})`,
       });
       if (finalizeOutcome.statusCasLost) {
@@ -6659,8 +6749,26 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
       ...opencodeJournalExtras,
     });
 
-    currentTask = null;
-    currentTaskConfig = null;
+    const effectiveSchedulerRuntime: DispatcherRuntime = sampledHarnessLane
+      ? "opencode"
+      : fallbackTriggered
+        ? "claude"
+        : task.runtime;
+    const effectiveSchedulerModel = opencodeResult?.model
+      ?? (isOllama && !fallbackTriggered
+        ? task.model || config.ollamaDefaultModel
+        : undefined);
+    releaseCurrentClaimWithSchedulerOutcome({
+      taskNamespace: taskNs,
+      prediction: schedulerPrediction,
+      claimedAt: schedulerClaimedAt,
+      requestedRuntime: declaredRuntime as DispatcherRuntime,
+      effectiveRuntime: effectiveSchedulerRuntime,
+      terminalResult: terminalStructuredResultOk ? terminalStructuredResult : null,
+      taskType: task.homeserverTaskType,
+      harness: sampledHarnessLane ? "opencode-sampled" : undefined,
+      model: effectiveSchedulerModel,
+    });
     return { hadTask: true, queueDepth };
   } finally {
     stopLeaseRenewal();

--- a/src/scheduler-evidence-store.ts
+++ b/src/scheduler-evidence-store.ts
@@ -3,12 +3,16 @@ import {
   type MuninEntry,
 } from "./munin-client.js";
 import {
+  hashSchedulerOutcome,
   hashSchedulerPrediction,
+  schedulerDecisionOutcomeSchema,
   schedulerDecisionPredictionSchema,
 } from "./scheduler-evidence.js";
 
 const PREDICTION_KEY = "prediction";
 const PREDICTION_TAGS = ["type:scheduler-decision-prediction", "scheduler-shadow:v1"];
+const OUTCOME_KEY = "outcome";
+const OUTCOME_TAGS = ["type:scheduler-decision-outcome", "scheduler-shadow:v1"];
 
 export interface SchedulerEvidenceStoreClient {
   read(
@@ -30,6 +34,13 @@ export class SchedulerPredictionConflictError extends Error {
   constructor(decisionId: string) {
     super(`scheduler decision ${decisionId} already contains a different prediction`);
     this.name = "SchedulerPredictionConflictError";
+  }
+}
+
+export class SchedulerOutcomeConflictError extends Error {
+  constructor(decisionId: string) {
+    super(`scheduler decision ${decisionId} already contains a different outcome`);
+    this.name = "SchedulerOutcomeConflictError";
   }
 }
 
@@ -76,6 +87,49 @@ export async function persistSchedulerPrediction(
     const stored = existing ? parseStoredPrediction(existing.content) : null;
     if (!stored || hashSchedulerPrediction(stored) !== hashSchedulerPrediction(prediction)) {
       throw new SchedulerPredictionConflictError(prediction.decisionId);
+    }
+    return { status: "exact-existing" };
+  }
+}
+
+export async function persistSchedulerOutcome(
+  munin: SchedulerEvidenceStoreClient,
+  input: unknown,
+): Promise<{ status: "created" | "exact-existing" }> {
+  const outcome = schedulerDecisionOutcomeSchema.parse(input);
+  const namespace = schedulerDecisionNamespace(outcome.decisionId);
+  try {
+    const result = await munin.write(
+      namespace,
+      OUTCOME_KEY,
+      JSON.stringify(outcome),
+      OUTCOME_TAGS,
+      undefined,
+      "internal",
+      true,
+    );
+    if (result.status !== "created") {
+      throw new Error(
+        `scheduler outcome write returned non-created status for ${namespace}/${OUTCOME_KEY}`,
+      );
+    }
+    return { status: "created" };
+  } catch (error) {
+    if (!(error instanceof MuninWriteRejectedError)
+      || error.conflictReason !== "already_exists") {
+      throw error;
+    }
+    const existing = await munin.read(namespace, OUTCOME_KEY);
+    let stored: unknown = null;
+    try {
+      stored = existing
+        ? schedulerDecisionOutcomeSchema.parse(JSON.parse(existing.content))
+        : null;
+    } catch {
+      stored = null;
+    }
+    if (!stored || hashSchedulerOutcome(stored) !== hashSchedulerOutcome(outcome)) {
+      throw new SchedulerOutcomeConflictError(outcome.decisionId);
     }
     return { status: "exact-existing" };
   }

--- a/src/scheduler-evidence.ts
+++ b/src/scheduler-evidence.ts
@@ -1,10 +1,15 @@
 import { createHash } from "node:crypto";
 import { z } from "zod";
 import { canonicalizeJcs } from "./jcs.js";
-import { dispatcherRuntimeSchema } from "./task-result-schema.js";
+import {
+  dispatcherRuntimeSchema,
+  structuredTaskResultSchema,
+  type DispatcherRuntime,
+} from "./task-result-schema.js";
 
 export const SCHEDULER_ESTIMATOR_VERSION = "scheduler-duration-v1" as const;
 export const SCHEDULER_SERVICE_CLOCK = "claim-to-release-v1" as const;
+export const SCHEDULER_LONG_JOB_SECONDS = 1800 as const;
 
 const isoTimestampSchema = z.string().datetime({ offset: true });
 const taskNamespaceSchema = z.string().regex(/^tasks\/[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/);
@@ -256,6 +261,93 @@ export const schedulerDecisionOutcomeSchema = z.object({
   }
 });
 export type SchedulerDecisionOutcome = z.infer<typeof schedulerDecisionOutcomeSchema>;
+
+export interface SchedulerTerminalResultRevision {
+  namespace: string;
+  key: "result-structured";
+  updatedAt: string;
+  sha256: string;
+  result: unknown;
+}
+
+export interface BuildSchedulerDecisionOutcomeInput {
+  prediction: unknown;
+  claimedAt: string | null;
+  releasedAt: string;
+  requestedRuntime: DispatcherRuntime;
+  effectiveRuntime: DispatcherRuntime;
+  terminalResult: SchedulerTerminalResultRevision;
+  taskType?: string;
+  harness?: string;
+  model?: string;
+}
+
+function boundedIdentity(value: string | undefined, pattern: RegExp): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && pattern.test(trimmed) ? trimmed : undefined;
+}
+
+/** Build one content-blind outcome from the exact durable terminal result revision. */
+export function buildSchedulerDecisionOutcomeFromTerminalResult(
+  input: BuildSchedulerDecisionOutcomeInput,
+): SchedulerDecisionOutcome {
+  const prediction = schedulerDecisionPredictionSchema.parse(input.prediction);
+  const terminal = structuredTaskResultSchema.parse(input.terminalResult.result);
+  if (input.terminalResult.namespace !== prediction.champion.taskRef.namespace
+    || terminal.taskNamespace !== prediction.champion.taskRef.namespace) {
+    throw new Error("terminal result does not bind the champion task");
+  }
+  if (input.terminalResult.key !== "result-structured") {
+    throw new Error("scheduler outcome requires result-structured evidence");
+  }
+
+  const claimedAt = input.claimedAt && isoTimestampSchema.safeParse(input.claimedAt).success
+    ? input.claimedAt
+    : null;
+  const releaseBoundaryValid = isoTimestampSchema.safeParse(input.releasedAt).success
+    && (!claimedAt || Date.parse(input.releasedAt) >= Date.parse(claimedAt));
+  const clock: SchedulerServiceClockEvidence = claimedAt && releaseBoundaryValid
+    ? buildCompleteSchedulerServiceClock(claimedAt, input.releasedAt)
+    : schedulerServiceClockEvidenceSchema.parse({
+        serviceClock: SCHEDULER_SERVICE_CLOCK,
+        clockComplete: false,
+        ...(claimedAt ? { claimedAt } : {}),
+        releasedAt: input.releasedAt,
+        incompleteReason: claimedAt
+          ? "release-boundary-unavailable"
+          : "claim-boundary-unavailable",
+      });
+  const championEstimateSeconds = prediction.champion.serviceEstimate?.seconds ?? null;
+  const absolutePredictionErrorSeconds = clock.clockComplete
+    && championEstimateSeconds !== null
+    ? Math.abs(clock.schedulerServiceSeconds - championEstimateSeconds)
+    : null;
+  const terminalClass = terminal.outcome === "timed_out" ? "timed-out" : terminal.outcome;
+
+  return schedulerDecisionOutcomeSchema.parse({
+    schemaVersion: 1,
+    decisionId: prediction.decisionId,
+    taskRef: prediction.champion.taskRef,
+    terminalClass,
+    clock,
+    requestedRuntime: input.requestedRuntime,
+    effectiveRuntime: input.effectiveRuntime,
+    taskType: boundedIdentity(input.taskType, /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/),
+    harness: boundedIdentity(input.harness, /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/),
+    model: boundedIdentity(input.model, /^[A-Za-z0-9][A-Za-z0-9._:/-]{0,159}$/),
+    championEstimateSeconds,
+    absolutePredictionErrorSeconds,
+    longJob: clock.clockComplete
+      ? clock.schedulerServiceSeconds >= SCHEDULER_LONG_JOB_SECONDS
+      : false,
+    terminalResult: {
+      namespace: input.terminalResult.namespace,
+      key: input.terminalResult.key,
+      updatedAt: input.terminalResult.updatedAt,
+      sha256: sha256Schema.parse(input.terminalResult.sha256),
+    },
+  });
+}
 
 function hashSchedulerEvidence(value: unknown): string {
   return createHash("sha256").update(canonicalizeJcs(value), "utf8").digest("hex");

--- a/tests/scheduler-evidence-store.test.ts
+++ b/tests/scheduler-evidence-store.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { MuninWriteRejectedError, type MuninEntry } from "../src/munin-client.js";
 import {
+  persistSchedulerOutcome,
   persistSchedulerPrediction,
   type SchedulerEvidenceStoreClient,
 } from "../src/scheduler-evidence-store.js";
@@ -103,6 +104,46 @@ describe("scheduler evidence store", () => {
     await expect(persistSchedulerPrediction(munin, prediction({
       observedAt: "2026-07-22T22:16:00.000Z",
     }))).rejects.toThrow(/different prediction/);
+  });
+
+  it("creates outcomes separately and refuses a conflicting immutable replay", async () => {
+    const munin = new FakeMunin();
+    const value = {
+      schemaVersion: 1,
+      decisionId,
+      taskRef: { namespace: taskNamespace, key: "status" },
+      terminalClass: "completed",
+      clock: {
+        serviceClock: "claim-to-release-v1",
+        clockComplete: true,
+        claimedAt: "2026-07-22T22:15:00.000Z",
+        releasedAt: "2026-07-22T22:16:00.000Z",
+        schedulerServiceSeconds: 60,
+      },
+      requestedRuntime: "codex",
+      effectiveRuntime: "codex",
+      championEstimateSeconds: null,
+      absolutePredictionErrorSeconds: null,
+      longJob: false,
+      terminalResult: {
+        namespace: taskNamespace,
+        key: "result-structured",
+        updatedAt: "2026-07-22T22:15:59.000Z",
+        sha256: "a".repeat(64),
+      },
+    };
+
+    expect(await persistSchedulerOutcome(munin, value)).toEqual({ status: "created" });
+    expect(munin.writes[0]).toEqual({
+      namespace: `scheduler/decisions/${decisionId}`,
+      key: "outcome",
+      createIfAbsent: true,
+    });
+    expect(await persistSchedulerOutcome(munin, value)).toEqual({ status: "exact-existing" });
+    await expect(persistSchedulerOutcome(munin, {
+      ...value,
+      terminalClass: "failed",
+    })).rejects.toThrow(/different outcome/);
   });
 
 });

--- a/tests/scheduler-evidence.test.ts
+++ b/tests/scheduler-evidence.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildSchedulerDecisionOutcomeFromTerminalResult,
   buildRollingMedianDurationEstimate,
   buildCompleteSchedulerServiceClock,
   hashSchedulerOutcome,
@@ -8,6 +9,7 @@ import {
   schedulerDecisionPredictionSchema,
   schedulerServiceClockEvidenceSchema,
 } from "../src/scheduler-evidence.js";
+import { createHash } from "node:crypto";
 
 const taskRef = { namespace: "tasks/20260722-230000-abcd", key: "status" as const };
 const decisionId = "34f2d430-6c31-47de-860a-8b22bc97f4d4";
@@ -292,5 +294,139 @@ describe("scheduler evidence", () => {
     });
     expect(parsed.terminalResult.sha256).toHaveLength(64);
     expect(hashSchedulerOutcome(parsed)).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("derives a complete long-job outcome from the exact durable terminal result", () => {
+    const terminalContent = JSON.stringify({
+      schemaVersion: 1,
+      taskId: "20260722-230000-abcd",
+      taskNamespace: taskRef.namespace,
+      lifecycle: "failed",
+      outcome: "timed_out",
+      runtime: "codex",
+      executor: "codex",
+      resultSource: "codex",
+      exitCode: "TIMEOUT",
+      completedAt: "2026-07-22T21:31:41.000Z",
+      bodyKind: "error",
+      bodyText: "timed out",
+    });
+    const prediction = schedulerDecisionPredictionSchema.parse({
+      schemaVersion: 1,
+      decisionId,
+      observedAt: "2026-07-22T21:00:00.000Z",
+      champion: { policy: "complete-fifo-v1", taskRef, serviceEstimate: null },
+      challenger: {
+        policy: "bounded-sejf-v1",
+        overdueThresholdSeconds: 1800,
+        taskRef: null,
+        reason: "insufficient-evidence",
+        evidenceReasons: ["estimate-missing"],
+        serviceEstimate: null,
+      },
+      window: {
+        eligibleTasks: 1,
+        pendingEnumerationComplete: true,
+        runningEnumerationComplete: true,
+        eligibilityAuthority: "legacy-unbound-group-sequence",
+        estimatedWorkMinutes: null,
+        missingEstimates: 1,
+      },
+      estimatorVersion: "scheduler-duration-v1",
+    });
+
+    expect(buildSchedulerDecisionOutcomeFromTerminalResult({
+      prediction,
+      claimedAt: "2026-07-22T21:00:00.000Z",
+      releasedAt: "2026-07-22T21:31:41.000Z",
+      requestedRuntime: "codex",
+      effectiveRuntime: "codex",
+      taskType: "code-fix",
+      terminalResult: {
+        namespace: taskRef.namespace,
+        key: "result-structured",
+        updatedAt: "2026-07-22T21:31:40.000Z",
+        sha256: createHash("sha256").update(terminalContent, "utf8").digest("hex"),
+        result: JSON.parse(terminalContent),
+      },
+    })).toMatchObject({
+      decisionId,
+      terminalClass: "timed-out",
+      clock: { clockComplete: true, schedulerServiceSeconds: 1901 },
+      longJob: true,
+      terminalResult: {
+        sha256: createHash("sha256").update(terminalContent, "utf8").digest("hex"),
+      },
+    });
+  });
+
+  it("marks a missing exact claim boundary incomplete and rejects cross-task results", () => {
+    const prediction = schedulerDecisionPredictionSchema.parse({
+      schemaVersion: 1,
+      decisionId,
+      observedAt: "2026-07-22T21:00:00.000Z",
+      champion: { policy: "complete-fifo-v1", taskRef, serviceEstimate: null },
+      challenger: {
+        policy: "bounded-sejf-v1",
+        overdueThresholdSeconds: 1800,
+        taskRef: null,
+        reason: "insufficient-evidence",
+        evidenceReasons: ["estimate-missing"],
+        serviceEstimate: null,
+      },
+      window: {
+        eligibleTasks: 1,
+        pendingEnumerationComplete: true,
+        runningEnumerationComplete: true,
+        eligibilityAuthority: "legacy-unbound-group-sequence",
+        estimatedWorkMinutes: null,
+        missingEstimates: 1,
+      },
+      estimatorVersion: "scheduler-duration-v1",
+    });
+    const terminal = {
+      schemaVersion: 1,
+      taskId: "20260722-230000-abcd",
+      taskNamespace: taskRef.namespace,
+      lifecycle: "completed",
+      outcome: "completed",
+      runtime: "codex",
+      executor: "codex",
+      resultSource: "codex",
+      exitCode: 0,
+      completedAt: "2026-07-22T21:01:00.000Z",
+      bodyKind: "response",
+      bodyText: "ok",
+    };
+    const input = {
+      prediction,
+      claimedAt: null,
+      releasedAt: "2026-07-22T21:01:01.000Z",
+      requestedRuntime: "codex" as const,
+      effectiveRuntime: "codex" as const,
+      terminalResult: {
+        namespace: taskRef.namespace,
+        key: "result-structured" as const,
+        updatedAt: "2026-07-22T21:01:00.000Z",
+        sha256: createHash("sha256").update(JSON.stringify(terminal), "utf8").digest("hex"),
+        result: terminal,
+      },
+    };
+    expect(buildSchedulerDecisionOutcomeFromTerminalResult(input)).toMatchObject({
+      clock: { clockComplete: false, incompleteReason: "claim-boundary-unavailable" },
+      longJob: false,
+      absolutePredictionErrorSeconds: null,
+    });
+    expect(buildSchedulerDecisionOutcomeFromTerminalResult({
+      ...input,
+      claimedAt: "2026-07-22T21:02:00.000Z",
+    })).toMatchObject({
+      clock: { clockComplete: false, incompleteReason: "release-boundary-unavailable" },
+      longJob: false,
+    });
+    expect(() => buildSchedulerDecisionOutcomeFromTerminalResult({
+      ...input,
+      terminalResult: { ...input.terminalResult, namespace: "tasks/other" },
+    })).toThrow(/champion task/);
   });
 });


### PR DESCRIPTION
## Summary

- retain the exact serialized `result-structured` SHA-256 and Munin revision returned by Hugin's successful terminal write
- capture the claim-CAS-to-`currentTask`-release service clock after all synchronous slot-holding post-processing
- persist a separate internal create-only outcome on the isolated scheduler evidence client
- preserve requested/effective runtime, bounded task/harness/model identity, terminal class, long-job classification, and exact prediction error when available
- record missing or invalid exact boundaries as incomplete instead of substituting pending timestamps

FIFO remains the only enforced scheduler. Recovery/reaper paths still strip scheduler pointers and do not emit outcomes.

## Verification

- red/green scheduler builder and immutable store tests
- `npm run build`
- focused lifecycle/scheduler suite — 63 tests
- `npm test` — 154 files, 2,364 tests
- `bash scripts/deploy-pi.test.sh`
- `git diff --check`

Continues #282.