### PR TITLE
feat: add bounded scheduler shadow estimates

### DIFF
--- a/docs/scheduling-shadow-lanes.md
+++ b/docs/scheduling-shadow-lanes.md
@@ -1,7 +1,8 @@
 # Scheduling shadow lanes and work-minute admission
 
-**Status:** prediction and in-process terminal-outcome persistence active in
-shadow; recovery preservation deferred; no scheduling behavior change
+**Status:** prediction, in-process terminal outcomes, and a live-process
+runtime estimator are active; bounded-SEJF comparison is opt-in shadow only;
+recovery preservation is deferred; no scheduling behavior change
 
 **Issue:** [#282](https://github.com/Magnus-Gille/hugin/issues/282)
 
@@ -131,14 +132,15 @@ recovery alone is not an exclusion. The old executor-span `durationSeconds`
 may be compared during calibration but never substituted for the new service
 clock.
 
-An estimate is a persisted, versioned value derived from a bounded historical
-window. The initial implementation should use a robust statistic such as a
-rolling median, require a minimum sample count, and record the history
+An estimate is a versioned value derived from a bounded historical window. The
+initial executable calibration groups by requested dispatcher runtime (the
+only identity mechanically known for every candidate before claim), uses a
+rolling numeric median over the newest 24 complete outcomes, requires three
+samples, and records the history
 high-water tuple used to build it. Equal release timestamps are ordered by the
 content-blind decision UUID; repeated identical outcomes are counted once and
-conflicting outcomes under one UUID fail closed. Exact window length, minimum
-sample count, and grouping keys are calibration parameters, not implicit
-constants.
+conflicting outcomes under one UUID fail closed. These grouping and window
+values are explicit calibration parameters, not a scheduler-promotion claim.
 
 Every estimate carries:
 
@@ -197,6 +199,22 @@ with caller pointer tags stripped. Eligible-window collection uses indexed
 per-group minimum sequences rather than a nested scan. A dedicated Munin client
 and fire-and-forget write ensure evidence latency cannot enter the
 claim-to-execution critical path.
+
+The next live slice admits an outcome to estimator memory only after this
+process receives `status: created` for its create-only outcome write. It never
+trains from `exact-existing` or arbitrary post-restart Munin rows: schema and a
+terminal-result hash prove content consistency, but not that Hugin owned the
+claim instance. A restart therefore cold-starts the three-sample runtime
+window and abstains until enough new exact-bound outcomes have been created.
+The cache retains at most the 24 newest complete outcomes per requested
+runtime. This is intentionally conservative until authenticated
+claim-instance provenance exists.
+
+`HUGIN_SCHEDULER_SHADOW=on` enables challenger computation. It defaults to
+`off`; the disabled state persists a bounded `shadow-disabled` abstention.
+Whether enabled or disabled, `eligibleTasks[0]` remains the exact FIFO claim
+candidate selected before evidence construction, and evidence failure falls
+open only to that same candidate with caller scheduler pointers stripped.
 
 Startup, lease-reaper, and interrupted-delivery recovery continue to strip the
 pointer. Schema and digest validation proves content integrity but not that the
@@ -285,7 +303,8 @@ reported truncation; that case always carries an abstaining challenger.
 Allowed challenger reasons are `shortest-estimate`, `oldest-overdue`, and
 `insufficient-evidence`. An abstention uses a null challenger task reference
 and one or more bounded evidence reasons such as `window-truncated`,
-`estimate-missing`, or `estimator-version-mismatch`, never free-form task
+`estimate-missing`, `estimator-version-mismatch`,
+`candidate-timestamp-invalid`, or `shadow-disabled`, never free-form task
 content.
 
 When the champion task terminalizes, the outcome record adds its realized
@@ -370,9 +389,10 @@ capacity, Hugin must say so truthfully.
 
 1. **Duration evidence:** implement the versioned historical estimator and
    prediction/outcome schemas; no alternate choice yet.
-2. **SEJF shadow:** add the 30-minute challenger behind
-   `HUGIN_SCHEDULER_SHADOW=off` by default. Prove that toggling it cannot change
-   the champion claim.
+2. **SEJF shadow:** the 30-minute challenger is implemented behind
+   `HUGIN_SCHEDULER_SHADOW=off` by default. Toggling it cannot change the
+   champion claim; it needs production observation and calibration before this
+   delivery step is complete.
 3. **Urgency authority:** add digest-bound authenticated urgency, then shadow
    low-to-normal promotion at half of the declared low-class SLA.
 4. **Work-minute shadow:** publish complete/lower-bound queued work and validate

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,9 +158,10 @@ import {
   stripSchedulerDecisionPointers,
 } from "./task-status-tags.js";
 import {
+  buildSchedulerDecisionPrediction,
   buildSchedulerDecisionOutcomeFromTerminalResult,
   hashSchedulerPrediction,
-  schedulerDecisionPredictionSchema,
+  SchedulerRuntimeEstimatorCache,
   type SchedulerDecisionPrediction,
   type SchedulerTerminalResultRevision,
 } from "./scheduler-evidence.js";
@@ -184,6 +185,7 @@ import { sanitizeProviderTokenCount } from "./m5-provenance.js";
 import {
   buildTaskSensitivitySnapshot,
   buildStructuredTaskResult,
+  dispatcherRuntimeSchema,
   type DispatcherRuntime,
   type StructuredTaskResult,
   type TaskExecutionApprovalMetadata,
@@ -487,6 +489,9 @@ const config = {
   // artifacts + a real cell that do not exist yet. Until then the orchestrator
   // fails closed to the existing cloud auto-router, so flipping this on is a no-op.
   skillLaneEnabled: process.env.HUGIN_SKILL_LANE === "on",
+  // Bounded-SEJF remains observation-only and opt-in. When off, the exact FIFO
+  // champion is still recorded with an explicit shadow-disabled abstention.
+  schedulerShadowEnabled: process.env.HUGIN_SCHEDULER_SHADOW === "on",
   // Pre-flight Claude auth check (issue #129). When `on` (default), a Claude SDK
   // task probes the Pi's Claude credential BEFORE the (paid, slot-consuming) run
   // and short-circuits to a distinctly-classified AUTH_FAILED failure if the
@@ -715,6 +720,13 @@ const reaperMunin = createMuninClient();
 // request queue plus fire-and-forget writes ensures Munin latency cannot hold
 // up execution after the claim CAS.
 const schedulerEvidenceMunin = createMuninClient();
+// Only outcomes created successfully by this live process enter estimator
+// memory. Durable rows cannot be trusted after restart until scheduler claim
+// instances have an authenticated binding, so restart intentionally cold-starts.
+const schedulerRuntimeEstimator = new SchedulerRuntimeEstimatorCache({
+  minimumSamples: 3,
+  windowSize: 24,
+});
 // Verdict-store traffic (batched record + confidence-source read, Fix #2c)
 // gets its own dedicated client, same precedent as leaseMunin/cancelWatchMunin
 // above: verdict recording is fire-and-forget background work and must never
@@ -2477,6 +2489,21 @@ function releaseCurrentClaimWithSchedulerOutcome(input: {
       model: input.model,
     });
     void persistSchedulerOutcome(schedulerEvidenceMunin, outcome)
+      .then((result) => {
+        // A `created` acknowledgement proves this live dispatcher authored the
+        // immutable row. Never train from exact-existing/replayed rows until
+        // durable claim-instance authentication is available.
+        if (result.status === "created") {
+          try {
+            schedulerRuntimeEstimator.recordCreated(outcome);
+          } catch (err) {
+            console.warn(
+              `Scheduler estimator admission failed for ${input.taskNamespace} ` +
+                `(${outcome.decisionId}): ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        }
+      })
       .catch((err: unknown) => {
         console.warn(
           `Scheduler shadow outcome persistence failed for ${input.taskNamespace} ` +
@@ -4333,6 +4360,15 @@ async function emitHeartbeat(blockedTasks: number): Promise<void> {
 
 // --- Poll loop ---
 
+function schedulerRequestedRuntimeFromTags(tags: string[]): DispatcherRuntime | null {
+  const values = tags
+    .filter((tag) => tag.startsWith("runtime:"))
+    .map((tag) => tag.slice("runtime:".length));
+  if (values.length !== 1) return null;
+  const parsed = dispatcherRuntimeSchema.safeParse(values[0]);
+  return parsed.success ? parsed.data : null;
+}
+
 /** Enumerate the complete pending window and claim the oldest eligible task. */
 async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
   const [pendingPage, runningPage] = await Promise.all([
@@ -4765,37 +4801,21 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
   let schedulerPrediction: SchedulerDecisionPrediction | null = null;
   let tagsForClaim = stripSchedulerDecisionPointers(claimInputTags);
   try {
-    const candidatePrediction = schedulerDecisionPredictionSchema.parse({
-      schemaVersion: 1,
+    const candidatePrediction = buildSchedulerDecisionPrediction({
       decisionId: randomUUID(),
       observedAt: new Date().toISOString(),
-      champion: {
-        policy: pendingPage.truncated || runningPage.truncated
-          ? "visible-window-fifo-v1"
-          : "complete-fifo-v1",
-        taskRef: { namespace: taskNs, key: "status" },
-        serviceEstimate: null,
-      },
-      challenger: {
-        policy: "bounded-sejf-v1",
-        overdueThresholdSeconds: 1800,
-        taskRef: null,
-        reason: "insufficient-evidence",
-        evidenceReasons: [
-          ...(pendingPage.truncated || runningPage.truncated ? ["window-truncated"] : []),
-          "estimate-missing",
-        ],
-        serviceEstimate: null,
-      },
-      window: {
-        eligibleTasks: eligibleTasks.length,
-        pendingEnumerationComplete: !pendingPage.truncated,
-        runningEnumerationComplete: !runningPage.truncated,
-        eligibilityAuthority: "legacy-unbound-group-sequence",
-        estimatedWorkMinutes: null,
-        missingEstimates: eligibleTasks.length,
-      },
-      estimatorVersion: "scheduler-duration-v1",
+      championTaskRef: { namespace: taskNs, key: "status" },
+      candidates: eligibleTasks.map((candidate) => {
+        const runtime = schedulerRequestedRuntimeFromTags(candidate.tags);
+        return {
+          taskRef: { namespace: candidate.namespace, key: "status" },
+          createdAt: candidate.created_at,
+          serviceEstimate: runtime ? schedulerRuntimeEstimator.get(runtime) : null,
+        };
+      }),
+      pendingEnumerationComplete: !pendingPage.truncated,
+      runningEnumerationComplete: !runningPage.truncated,
+      shadowEnabled: config.schedulerShadowEnabled,
     });
     schedulerPrediction = candidatePrediction;
     tagsForClaim = attachSchedulerDecisionPointer(claimInputTags, {

--- a/src/index.ts
+++ b/src/index.ts
@@ -161,6 +161,7 @@ import {
   buildSchedulerDecisionPrediction,
   buildSchedulerDecisionOutcomeFromTerminalResult,
   hashSchedulerPrediction,
+  resolveSchedulerRuntimeEstimates,
   SchedulerRuntimeEstimatorCache,
   type SchedulerDecisionPrediction,
   type SchedulerTerminalResultRevision,
@@ -4801,18 +4802,36 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
   let schedulerPrediction: SchedulerDecisionPrediction | null = null;
   let tagsForClaim = stripSchedulerDecisionPointers(claimInputTags);
   try {
+    const compareShadow = config.schedulerShadowEnabled
+      && !pendingPage.truncated
+      && !runningPage.truncated;
+    const schedulerCandidates = compareShadow
+      ? (() => {
+          const runtimes = eligibleTasks.map((candidate) =>
+            schedulerRequestedRuntimeFromTags(candidate.tags),
+          );
+          const estimates = resolveSchedulerRuntimeEstimates(
+            runtimes,
+            true,
+            (runtime) => schedulerRuntimeEstimator.get(runtime),
+          );
+          return eligibleTasks.map((candidate, index) => ({
+            taskRef: { namespace: candidate.namespace, key: "status" as const },
+            createdAt: candidate.created_at,
+            serviceEstimate: estimates[index] ?? null,
+          }));
+        })()
+      : [{
+          taskRef: { namespace: taskNs, key: "status" as const },
+          createdAt: taskResult.created_at,
+          serviceEstimate: null,
+        }];
     const candidatePrediction = buildSchedulerDecisionPrediction({
       decisionId: randomUUID(),
       observedAt: new Date().toISOString(),
       championTaskRef: { namespace: taskNs, key: "status" },
-      candidates: eligibleTasks.map((candidate) => {
-        const runtime = schedulerRequestedRuntimeFromTags(candidate.tags);
-        return {
-          taskRef: { namespace: candidate.namespace, key: "status" },
-          createdAt: candidate.created_at,
-          serviceEstimate: runtime ? schedulerRuntimeEstimator.get(runtime) : null,
-        };
-      }),
+      candidates: schedulerCandidates,
+      eligibleTaskCount: eligibleTasks.length,
       pendingEnumerationComplete: !pendingPage.truncated,
       runningEnumerationComplete: !runningPage.truncated,
       shadowEnabled: config.schedulerShadowEnabled,

--- a/src/scheduler-evidence.ts
+++ b/src/scheduler-evidence.ts
@@ -209,6 +209,7 @@ export interface BuildSchedulerDecisionPredictionInput {
   observedAt: string;
   championTaskRef: z.input<typeof schedulerTaskRefSchema>;
   candidates: SchedulerShadowCandidate[];
+  eligibleTaskCount?: number;
   pendingEnumerationComplete: boolean;
   runningEnumerationComplete: boolean;
   shadowEnabled: boolean;
@@ -226,10 +227,19 @@ export function buildSchedulerDecisionPrediction(
   const observedAtMs = Date.parse(input.observedAt);
   if (!Number.isFinite(observedAtMs)) throw new Error("scheduler observation time is invalid");
   if (input.candidates.length === 0) throw new Error("scheduler prediction requires candidates");
+  const windowComplete = input.pendingEnumerationComplete && input.runningEnumerationComplete;
+  const evaluateCandidates = input.shadowEnabled && windowComplete;
+  const eligibleTaskCount = input.eligibleTaskCount ?? input.candidates.length;
+  if (!Number.isInteger(eligibleTaskCount) || eligibleTaskCount < input.candidates.length) {
+    throw new Error("eligible task count cannot be smaller than supplied candidates");
+  }
+  if (evaluateCandidates && eligibleTaskCount !== input.candidates.length) {
+    throw new Error("enabled complete-window comparison requires every eligible candidate");
+  }
 
   const candidates = input.candidates.map((candidate) => {
     const taskRef = schedulerTaskRefSchema.parse(candidate.taskRef);
-    const estimateResult = candidate.serviceEstimate === null
+    const estimateResult = !evaluateCandidates || candidate.serviceEstimate === null
       ? null
       : schedulerServiceEstimateSchema.safeParse(candidate.serviceEstimate);
     const estimateValid = estimateResult?.success === true
@@ -239,17 +249,20 @@ export function buildSchedulerDecisionPrediction(
       createdAt: candidate.createdAt,
       createdAtMs: Date.parse(candidate.createdAt),
       estimate: estimateValid ? estimateResult.data : null,
-      estimateInvalid: estimateResult !== null && !estimateValid,
+      estimateInvalid: evaluateCandidates && estimateResult !== null && !estimateValid,
     };
   });
   if (candidates[0]!.taskRef.namespace !== championTaskRef.namespace) {
     throw new Error("scheduler champion must remain the first eligible FIFO task");
   }
 
-  const missingEstimates = candidates.filter((candidate) => candidate.estimate === null).length;
+  const missingEstimates = evaluateCandidates
+    ? candidates.filter((candidate) => candidate.estimate === null).length
+    : eligibleTaskCount;
   const invalidEstimate = candidates.some((candidate) => candidate.estimateInvalid);
-  const invalidTimestamp = candidates.some((candidate) => !Number.isFinite(candidate.createdAtMs));
-  const windowComplete = input.pendingEnumerationComplete && input.runningEnumerationComplete;
+  const invalidTimestamp = evaluateCandidates && candidates.some(
+    (candidate) => !Number.isFinite(candidate.createdAtMs) || candidate.createdAtMs > observedAtMs,
+  );
   const evidenceReasons: z.infer<typeof challengerEvidenceReasonSchema>[] = [];
   if (!windowComplete) evidenceReasons.push("window-truncated");
   if (missingEstimates > 0) evidenceReasons.push("estimate-missing");
@@ -298,7 +311,7 @@ export function buildSchedulerDecisionPrediction(
       serviceEstimate: chosen?.estimate ?? null,
     },
     window: {
-      eligibleTasks: candidates.length,
+      eligibleTasks: eligibleTaskCount,
       pendingEnumerationComplete: input.pendingEnumerationComplete,
       runningEnumerationComplete: input.runningEnumerationComplete,
       eligibilityAuthority: "legacy-unbound-group-sequence",
@@ -306,6 +319,21 @@ export function buildSchedulerDecisionPrediction(
       missingEstimates,
     },
     estimatorVersion: SCHEDULER_ESTIMATOR_VERSION,
+  });
+}
+
+/** Resolve at most one bounded estimate per finite requested runtime per poll. */
+export function resolveSchedulerRuntimeEstimates<T extends DispatcherRuntime>(
+  runtimes: readonly (T | null)[],
+  enabled: boolean,
+  lookup: (runtime: T) => z.infer<typeof schedulerServiceEstimateSchema> | null,
+): Array<z.infer<typeof schedulerServiceEstimateSchema> | null> {
+  if (!enabled) return runtimes.map(() => null);
+  const memoized = new Map<T, z.infer<typeof schedulerServiceEstimateSchema> | null>();
+  return runtimes.map((runtime) => {
+    if (runtime === null) return null;
+    if (!memoized.has(runtime)) memoized.set(runtime, lookup(runtime));
+    return memoized.get(runtime) ?? null;
   });
 }
 

--- a/src/scheduler-evidence.ts
+++ b/src/scheduler-evidence.ts
@@ -90,6 +90,8 @@ const challengerEvidenceReasonSchema = z.enum([
   "window-truncated",
   "estimate-missing",
   "estimator-version-mismatch",
+  "candidate-timestamp-invalid",
+  "shadow-disabled",
 ]);
 
 export const schedulerDecisionPredictionSchema = z.object({
@@ -106,7 +108,7 @@ export const schedulerDecisionPredictionSchema = z.object({
     overdueThresholdSeconds: z.literal(1800),
     taskRef: schedulerTaskRefSchema.nullable(),
     reason: z.enum(["shortest-estimate", "oldest-overdue", "insufficient-evidence"]),
-    evidenceReasons: z.array(challengerEvidenceReasonSchema).max(3).default([]),
+    evidenceReasons: z.array(challengerEvidenceReasonSchema).max(5).default([]),
     serviceEstimate: schedulerServiceEstimateSchema.nullable(),
   }).strict(),
   window: z.object({
@@ -195,6 +197,117 @@ export const schedulerDecisionPredictionSchema = z.object({
   }
 });
 export type SchedulerDecisionPrediction = z.infer<typeof schedulerDecisionPredictionSchema>;
+
+export interface SchedulerShadowCandidate {
+  taskRef: z.input<typeof schedulerTaskRefSchema>;
+  createdAt: string;
+  serviceEstimate: unknown | null;
+}
+
+export interface BuildSchedulerDecisionPredictionInput {
+  decisionId: string;
+  observedAt: string;
+  championTaskRef: z.input<typeof schedulerTaskRefSchema>;
+  candidates: SchedulerShadowCandidate[];
+  pendingEnumerationComplete: boolean;
+  runningEnumerationComplete: boolean;
+  shadowEnabled: boolean;
+}
+
+/**
+ * Build one behavior-neutral FIFO/challenger observation. Candidate order is
+ * the champion's already-filtered FIFO order; this function can observe that
+ * order but cannot replace its first element as the enforced claim.
+ */
+export function buildSchedulerDecisionPrediction(
+  input: BuildSchedulerDecisionPredictionInput,
+): SchedulerDecisionPrediction {
+  const championTaskRef = schedulerTaskRefSchema.parse(input.championTaskRef);
+  const observedAtMs = Date.parse(input.observedAt);
+  if (!Number.isFinite(observedAtMs)) throw new Error("scheduler observation time is invalid");
+  if (input.candidates.length === 0) throw new Error("scheduler prediction requires candidates");
+
+  const candidates = input.candidates.map((candidate) => {
+    const taskRef = schedulerTaskRefSchema.parse(candidate.taskRef);
+    const estimateResult = candidate.serviceEstimate === null
+      ? null
+      : schedulerServiceEstimateSchema.safeParse(candidate.serviceEstimate);
+    const estimateValid = estimateResult?.success === true
+      && Date.parse(estimateResult.data.historyThrough) <= observedAtMs;
+    return {
+      taskRef,
+      createdAt: candidate.createdAt,
+      createdAtMs: Date.parse(candidate.createdAt),
+      estimate: estimateValid ? estimateResult.data : null,
+      estimateInvalid: estimateResult !== null && !estimateValid,
+    };
+  });
+  if (candidates[0]!.taskRef.namespace !== championTaskRef.namespace) {
+    throw new Error("scheduler champion must remain the first eligible FIFO task");
+  }
+
+  const missingEstimates = candidates.filter((candidate) => candidate.estimate === null).length;
+  const invalidEstimate = candidates.some((candidate) => candidate.estimateInvalid);
+  const invalidTimestamp = candidates.some((candidate) => !Number.isFinite(candidate.createdAtMs));
+  const windowComplete = input.pendingEnumerationComplete && input.runningEnumerationComplete;
+  const evidenceReasons: z.infer<typeof challengerEvidenceReasonSchema>[] = [];
+  if (!windowComplete) evidenceReasons.push("window-truncated");
+  if (missingEstimates > 0) evidenceReasons.push("estimate-missing");
+  if (invalidEstimate) evidenceReasons.push("estimator-version-mismatch");
+  if (invalidTimestamp) evidenceReasons.push("candidate-timestamp-invalid");
+  if (!input.shadowEnabled) evidenceReasons.push("shadow-disabled");
+
+  let chosen: (typeof candidates)[number] | null = null;
+  let reason: "shortest-estimate" | "oldest-overdue" | "insufficient-evidence" =
+    "insufficient-evidence";
+  if (evidenceReasons.length === 0) {
+    const oldestOverdue = candidates.find(
+      (candidate) => observedAtMs - candidate.createdAtMs >= 1_800_000,
+    );
+    if (oldestOverdue) {
+      chosen = oldestOverdue;
+      reason = "oldest-overdue";
+    } else {
+      chosen = candidates.reduce((shortest, candidate) =>
+        candidate.estimate!.seconds < shortest.estimate!.seconds ? candidate : shortest,
+      );
+      reason = "shortest-estimate";
+    }
+  }
+
+  const champion = candidates[0]!;
+  const estimatedWorkMinutes = missingEstimates === 0
+    ? candidates.reduce((total, candidate) => total + candidate.estimate!.seconds, 0) / 60
+    : null;
+
+  return schedulerDecisionPredictionSchema.parse({
+    schemaVersion: 1,
+    decisionId: input.decisionId,
+    observedAt: input.observedAt,
+    champion: {
+      policy: windowComplete ? "complete-fifo-v1" : "visible-window-fifo-v1",
+      taskRef: championTaskRef,
+      serviceEstimate: champion.estimate,
+    },
+    challenger: {
+      policy: "bounded-sejf-v1",
+      overdueThresholdSeconds: 1800,
+      taskRef: chosen?.taskRef ?? null,
+      reason,
+      evidenceReasons,
+      serviceEstimate: chosen?.estimate ?? null,
+    },
+    window: {
+      eligibleTasks: candidates.length,
+      pendingEnumerationComplete: input.pendingEnumerationComplete,
+      runningEnumerationComplete: input.runningEnumerationComplete,
+      eligibilityAuthority: "legacy-unbound-group-sequence",
+      estimatedWorkMinutes,
+      missingEstimates,
+    },
+    estimatorVersion: SCHEDULER_ESTIMATOR_VERSION,
+  });
+}
 
 export const schedulerTerminalClassSchema = z.enum([
   "completed",
@@ -423,4 +536,60 @@ export function buildRollingMedianDurationEstimate(
     historyThrough: samples.at(-1)!.clock.releasedAt,
     historyThroughDecisionId: samples.at(-1)!.decisionId,
   });
+}
+
+/**
+ * Bounded estimator state trusted only for this dispatcher process. Callers
+ * add an outcome only after their create-only Munin write returns `created`;
+ * exact-existing or post-restart rows are deliberately not admitted because
+ * durable claim-instance authentication is not available yet.
+ */
+export class SchedulerRuntimeEstimatorCache {
+  private readonly samplesByRuntime = new Map<DispatcherRuntime, Map<string, SchedulerDecisionOutcome>>();
+
+  constructor(private readonly options: SchedulerEstimatorOptions) {
+    if (!Number.isInteger(options.minimumSamples) || options.minimumSamples < 1) {
+      throw new Error("minimumSamples must be a positive integer");
+    }
+    if (!Number.isInteger(options.windowSize) || options.windowSize < options.minimumSamples) {
+      throw new Error("windowSize must be an integer greater than or equal to minimumSamples");
+    }
+  }
+
+  recordCreated(input: unknown): void {
+    const outcome = schedulerDecisionOutcomeSchema.parse(input);
+    for (const samples of this.samplesByRuntime.values()) {
+      const existing = samples.get(outcome.decisionId);
+      if (existing && hashSchedulerOutcome(existing) !== hashSchedulerOutcome(outcome)) {
+        throw new Error(`conflicting scheduler outcomes for decision ${outcome.decisionId}`);
+      }
+      if (existing) return;
+    }
+    if (!outcome.clock.clockComplete) return;
+
+    const samples = this.samplesByRuntime.get(outcome.requestedRuntime) ?? new Map();
+    samples.set(outcome.decisionId, outcome);
+    const ordered = [...samples.values()].sort((left, right) => {
+      const leftTime = left.clock.clockComplete
+        ? left.clock.releasedAt
+        : left.terminalResult.updatedAt;
+      const rightTime = right.clock.clockComplete
+        ? right.clock.releasedAt
+        : right.terminalResult.updatedAt;
+      const timeOrder = Date.parse(leftTime) - Date.parse(rightTime);
+      return timeOrder || left.decisionId.localeCompare(right.decisionId);
+    });
+    for (const stale of ordered.slice(0, Math.max(0, ordered.length - this.options.windowSize))) {
+      samples.delete(stale.decisionId);
+    }
+    this.samplesByRuntime.set(outcome.requestedRuntime, samples);
+  }
+
+  get(runtime: DispatcherRuntime): z.infer<typeof schedulerServiceEstimateSchema> | null {
+    dispatcherRuntimeSchema.parse(runtime);
+    return buildRollingMedianDurationEstimate(
+      [...(this.samplesByRuntime.get(runtime)?.values() ?? [])],
+      this.options,
+    );
+  }
 }

--- a/tests/scheduler-evidence.test.ts
+++ b/tests/scheduler-evidence.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildSchedulerDecisionPrediction,
   buildSchedulerDecisionOutcomeFromTerminalResult,
   buildRollingMedianDurationEstimate,
   buildCompleteSchedulerServiceClock,
@@ -8,6 +9,7 @@ import {
   schedulerDecisionOutcomeSchema,
   schedulerDecisionPredictionSchema,
   schedulerServiceClockEvidenceSchema,
+  SchedulerRuntimeEstimatorCache,
 } from "../src/scheduler-evidence.js";
 import { createHash } from "node:crypto";
 
@@ -56,6 +58,154 @@ function outcome(
 }
 
 describe("scheduler evidence", () => {
+  it("keeps the FIFO champion unchanged when shadow ranking is toggled", () => {
+    const candidates = [
+      {
+        taskRef,
+        createdAt: "2026-07-22T20:50:00.000Z",
+        serviceEstimate: estimate(600),
+      },
+      {
+        taskRef: { namespace: "tasks/20260722-230001-efgh", key: "status" as const },
+        createdAt: "2026-07-22T20:55:00.000Z",
+        serviceEstimate: estimate(60),
+      },
+    ];
+    const base = {
+      decisionId,
+      observedAt: "2026-07-22T21:00:00.000Z",
+      championTaskRef: taskRef,
+      candidates,
+      pendingEnumerationComplete: true,
+      runningEnumerationComplete: true,
+    };
+
+    const disabled = buildSchedulerDecisionPrediction({ ...base, shadowEnabled: false });
+    const enabled = buildSchedulerDecisionPrediction({ ...base, shadowEnabled: true });
+
+    expect(disabled.champion.taskRef).toEqual(taskRef);
+    expect(enabled.champion.taskRef).toEqual(taskRef);
+    expect(disabled.challenger).toMatchObject({
+      taskRef: null,
+      reason: "insufficient-evidence",
+      evidenceReasons: ["shadow-disabled"],
+    });
+    expect(enabled.challenger).toMatchObject({
+      taskRef: candidates[1].taskRef,
+      reason: "shortest-estimate",
+      serviceEstimate: estimate(60),
+    });
+  });
+
+  it("enforces the 30-minute bound before choosing the shortest estimate", () => {
+    const overdue = {
+      taskRef,
+      createdAt: "2026-07-22T20:29:59.999Z",
+      serviceEstimate: estimate(600),
+    };
+    const shorter = {
+      taskRef: { namespace: "tasks/20260722-230001-efgh", key: "status" as const },
+      createdAt: "2026-07-22T20:59:00.000Z",
+      serviceEstimate: estimate(30),
+    };
+    const prediction = buildSchedulerDecisionPrediction({
+      decisionId,
+      observedAt: "2026-07-22T21:00:00.000Z",
+      championTaskRef: taskRef,
+      candidates: [overdue, shorter],
+      pendingEnumerationComplete: true,
+      runningEnumerationComplete: true,
+      shadowEnabled: true,
+    });
+
+    expect(prediction.challenger).toMatchObject({
+      taskRef,
+      reason: "oldest-overdue",
+      serviceEstimate: estimate(600),
+    });
+  });
+
+  it("abstains deterministically for missing estimates, invalid time, and truncated windows", () => {
+    const missing = buildSchedulerDecisionPrediction({
+      decisionId,
+      observedAt: "2026-07-22T21:00:00.000Z",
+      championTaskRef: taskRef,
+      candidates: [{
+        taskRef,
+        createdAt: "not-a-time",
+        serviceEstimate: null,
+      }],
+      pendingEnumerationComplete: false,
+      runningEnumerationComplete: true,
+      shadowEnabled: true,
+    });
+
+    expect(missing.challenger).toEqual({
+      policy: "bounded-sejf-v1",
+      overdueThresholdSeconds: 1800,
+      taskRef: null,
+      reason: "insufficient-evidence",
+      evidenceReasons: ["window-truncated", "estimate-missing", "candidate-timestamp-invalid"],
+      serviceEstimate: null,
+    });
+    expect(missing.window).toMatchObject({
+      missingEstimates: 1,
+      estimatedWorkMinutes: null,
+    });
+  });
+
+  it("abstains on mixed estimator versions or look-ahead history", () => {
+    for (const badEstimate of [
+      { ...estimate(10), estimatorVersion: "scheduler-duration-v2" },
+      estimate(10, "2026-07-22T21:00:00.001Z"),
+    ]) {
+      const prediction = buildSchedulerDecisionPrediction({
+        decisionId,
+        observedAt: "2026-07-22T21:00:00.000Z",
+        championTaskRef: taskRef,
+        candidates: [{
+          taskRef,
+          createdAt: "2026-07-22T20:59:00.000Z",
+          serviceEstimate: badEstimate,
+        }],
+        pendingEnumerationComplete: true,
+        runningEnumerationComplete: true,
+        shadowEnabled: true,
+      });
+
+      expect(prediction.challenger).toMatchObject({
+        reason: "insufficient-evidence",
+        evidenceReasons: ["estimate-missing", "estimator-version-mismatch"],
+      });
+    }
+  });
+
+  it("uses only live-process created outcomes in the runtime estimator cache", () => {
+    const cache = new SchedulerRuntimeEstimatorCache({ minimumSamples: 2, windowSize: 3 });
+    const first = outcome(
+      "00000000-0000-4000-8000-000000000001",
+      "completed",
+      10,
+      "2026-07-22T20:01:00.000Z",
+    );
+    const second = outcome(
+      "00000000-0000-4000-8000-000000000002",
+      "failed",
+      20,
+      "2026-07-22T20:02:00.000Z",
+    );
+
+    expect(cache.get("codex")).toBeNull();
+    cache.recordCreated(first);
+    expect(cache.get("codex")).toBeNull();
+    cache.recordCreated(second);
+    expect(cache.get("codex")).toMatchObject({ seconds: 15, sampleCount: 2 });
+    expect(cache.get("claude")).toBeNull();
+    expect(() => cache.recordCreated({ ...second, terminalClass: "completed" })).toThrow(
+      /conflicting scheduler outcomes/,
+    );
+  });
+
   it("accepts a content-blind abstaining prediction and hashes it deterministically", () => {
     const prediction = schedulerDecisionPredictionSchema.parse({
       schemaVersion: 1,

--- a/tests/scheduler-evidence.test.ts
+++ b/tests/scheduler-evidence.test.ts
@@ -9,6 +9,7 @@ import {
   schedulerDecisionOutcomeSchema,
   schedulerDecisionPredictionSchema,
   schedulerServiceClockEvidenceSchema,
+  resolveSchedulerRuntimeEstimates,
   SchedulerRuntimeEstimatorCache,
 } from "../src/scheduler-evidence.js";
 import { createHash } from "node:crypto";
@@ -88,7 +89,7 @@ describe("scheduler evidence", () => {
     expect(disabled.challenger).toMatchObject({
       taskRef: null,
       reason: "insufficient-evidence",
-      evidenceReasons: ["shadow-disabled"],
+      evidenceReasons: ["estimate-missing", "shadow-disabled"],
     });
     expect(enabled.challenger).toMatchObject({
       taskRef: candidates[1].taskRef,
@@ -125,7 +126,7 @@ describe("scheduler evidence", () => {
     });
   });
 
-  it("abstains deterministically for missing estimates, invalid time, and truncated windows", () => {
+  it("abstains deterministically for missing estimates and truncated windows", () => {
     const missing = buildSchedulerDecisionPrediction({
       decisionId,
       observedAt: "2026-07-22T21:00:00.000Z",
@@ -145,7 +146,7 @@ describe("scheduler evidence", () => {
       overdueThresholdSeconds: 1800,
       taskRef: null,
       reason: "insufficient-evidence",
-      evidenceReasons: ["window-truncated", "estimate-missing", "candidate-timestamp-invalid"],
+      evidenceReasons: ["window-truncated", "estimate-missing"],
       serviceEstimate: null,
     });
     expect(missing.window).toMatchObject({
@@ -178,6 +179,48 @@ describe("scheduler evidence", () => {
         evidenceReasons: ["estimate-missing", "estimator-version-mismatch"],
       });
     }
+  });
+
+  it("treats future-dated candidates as invalid timing evidence", () => {
+    const prediction = buildSchedulerDecisionPrediction({
+      decisionId,
+      observedAt: "2026-07-22T21:00:00.000Z",
+      championTaskRef: taskRef,
+      candidates: [{
+        taskRef,
+        createdAt: "2026-07-22T21:00:00.001Z",
+        serviceEstimate: estimate(10),
+      }],
+      pendingEnumerationComplete: true,
+      runningEnumerationComplete: true,
+      shadowEnabled: true,
+    });
+
+    expect(prediction.challenger).toMatchObject({
+      reason: "insufficient-evidence",
+      evidenceReasons: ["candidate-timestamp-invalid"],
+    });
+  });
+
+  it("skips disabled lookups and memoizes enabled runtime estimates for large queues", () => {
+    const runtimes = Array.from({ length: 4_000 }, (_, index) =>
+      index % 2 === 0 ? "codex" as const : "claude" as const,
+    );
+    let lookups = 0;
+    const lookup = (runtime: "codex" | "claude") => {
+      lookups += 1;
+      return estimate(runtime === "codex" ? 10 : 20);
+    };
+
+    expect(resolveSchedulerRuntimeEstimates(runtimes, false, lookup)).toEqual(
+      Array.from({ length: 4_000 }, () => null),
+    );
+    expect(lookups).toBe(0);
+
+    const resolved = resolveSchedulerRuntimeEstimates(runtimes, true, lookup);
+    expect(lookups).toBe(2);
+    expect(resolved[0]?.seconds).toBe(10);
+    expect(resolved[1]?.seconds).toBe(20);
   });
 
   it("uses only live-process created outcomes in the runtime estimator cache", () => {


### PR DESCRIPTION
## Summary

- build real bounded-SEJF shadow predictions from a live-process rolling median grouped by requested runtime
- keep FIFO selection authoritative and gate challenger computation behind `HUGIN_SCHEDULER_SHADOW=off` by default
- train only from exact-bound outcome writes this process successfully created; cold-start after restart rather than trust unauthenticated durable rows
- use a 3-sample floor and bounded 24-outcome window, with explicit abstentions for disabled, truncated, missing, invalid-version, look-ahead, or invalid-timestamp evidence

## Safety

The champion task is selected before prediction construction and remains `eligibleTasks[0]` regardless of the flag. Evidence failures strip caller pointers and fall open to the same FIFO claim. Outcome persistence and estimator admission remain off the dispatch critical path. Restart/recovery still strips scheduler pointers.

## Verification

- red/green scheduler prediction and estimator tests
- focused: 3 files / 81 tests
- full: 154 files / 2,369 tests
- `npm run build`
- `bash scripts/deploy-pi.test.sh`
- `git diff --check`

Refs #282