### PR TITLE
feat: add scheduler evidence attestations

### DIFF
--- a/docs/scheduling-shadow-lanes.md
+++ b/docs/scheduling-shadow-lanes.md
@@ -210,6 +210,35 @@ The cache retains at most the 24 newest complete outcomes per requested
 runtime. This is intentionally conservative until authenticated
 claim-instance provenance exists.
 
+### Authenticated claim/outcome chain
+
+The first provenance primitive uses the dispatcher-only
+`HUGIN_SENSITIVITY_CHECKPOINT_SECRET` through separate domain-derived HMAC
+keys; scheduler MACs cannot be replayed as sensitivity checkpoints, claim MACs,
+or outcome MACs across protocols. No task content enters the attestation.
+
+The versioned claim attestation binds:
+
+- decision UUID, safe task reference, and SHA-256 of the exact task content;
+- the claim CAS precondition revision and Munin's successful claim
+  acknowledgement timestamp;
+- the exact prediction SHA-256 already attached to that claim;
+- worker and process-instance identity.
+
+The versioned outcome attestation then binds the exact JCS outcome digest and
+terminal-result revision/hash to the full authenticated claim-attestation
+digest. Both use constant-time MAC comparison, reject weak secrets, and fail
+closed on malformed or changed fields. This chain is sufficient for a later
+history reader to distinguish Hugin-authored samples from arbitrary
+create-only rows.
+
+The primitive alone does **not** prove that a mutable current status row is a
+continuous descendant of an older claim. Recovery therefore continues to
+strip scheduler pointers until persistence, crash-gap handling, and replay
+rules for the full chain are implemented and reviewed. Shipping the schemas
+must not silently enable recovery preservation or post-restart estimator
+hydration.
+
 `HUGIN_SCHEDULER_SHADOW=on` enables challenger computation. It defaults to
 `off`; the disabled state persists a bounded `shadow-disabled` abstention.
 Whether enabled or disabled, `eligibleTasks[0]` remains the exact FIFO claim

--- a/src/scheduler-evidence-attestation.ts
+++ b/src/scheduler-evidence-attestation.ts
@@ -1,0 +1,239 @@
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
+import { z } from "zod";
+import { canonicalizeJcs } from "./jcs.js";
+import {
+  hashSchedulerOutcome,
+  schedulerDecisionOutcomeSchema,
+  schedulerTaskRefSchema,
+} from "./scheduler-evidence.js";
+
+export const SCHEDULER_CLAIM_ATTESTATION_VERSION =
+  "hugin-scheduler-claim-attestation/v1" as const;
+export const SCHEDULER_OUTCOME_ATTESTATION_VERSION =
+  "hugin-scheduler-outcome-attestation/v1" as const;
+
+const isoTimestampSchema = z.string().datetime({ offset: true });
+const sha256Schema = z.string().regex(/^[0-9a-f]{64}$/);
+const dispatcherIdentitySchema = z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._:-]{0,159}$/);
+
+const schedulerClaimAttestationSchema = z.object({
+  version: z.literal(SCHEDULER_CLAIM_ATTESTATION_VERSION),
+  decisionId: z.string().uuid(),
+  taskRef: schedulerTaskRefSchema,
+  taskContentSha256: sha256Schema,
+  preClaimUpdatedAt: isoTimestampSchema,
+  claimedAt: isoTimestampSchema,
+  predictionSha256: sha256Schema,
+  workerId: dispatcherIdentitySchema,
+  processInstanceId: dispatcherIdentitySchema,
+  hmacSha256: sha256Schema,
+}).strict().superRefine((value, ctx) => {
+  if (Date.parse(value.claimedAt) < Date.parse(value.preClaimUpdatedAt)) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["claimedAt"],
+      message: "claim acknowledgement precedes its CAS precondition",
+    });
+  }
+});
+export type SchedulerClaimAttestation = z.infer<typeof schedulerClaimAttestationSchema>;
+
+const schedulerOutcomeAttestationSchema = z.object({
+  version: z.literal(SCHEDULER_OUTCOME_ATTESTATION_VERSION),
+  decisionId: z.string().uuid(),
+  claimAttestationSha256: sha256Schema,
+  outcomeSha256: sha256Schema,
+  terminalResult: schedulerDecisionOutcomeSchema.shape.terminalResult,
+  hmacSha256: sha256Schema,
+}).strict();
+export type SchedulerOutcomeAttestation = z.infer<typeof schedulerOutcomeAttestationSchema>;
+
+function requireSecret(secret: string): void {
+  if (secret.length < 32) {
+    throw new Error("scheduler attestation secret must contain at least 32 characters");
+  }
+}
+
+function derivedKey(secret: string, domain: string): Buffer {
+  requireSecret(secret);
+  return createHmac("sha256", secret).update(domain, "utf8").digest();
+}
+
+function sha256Text(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+function sign(unsigned: object, secret: string, domain: string): string {
+  return createHmac("sha256", derivedKey(secret, domain))
+    .update(canonicalizeJcs(unsigned), "utf8")
+    .digest("hex");
+}
+
+function macMatches(actualHex: string, expectedHex: string): boolean {
+  const actual = Buffer.from(actualHex, "hex");
+  const expected = Buffer.from(expectedHex, "hex");
+  return actual.length === expected.length && timingSafeEqual(actual, expected);
+}
+
+function unsignedClaim(value: Omit<SchedulerClaimAttestation, "hmacSha256">) {
+  return {
+    version: value.version,
+    decisionId: value.decisionId,
+    taskRef: value.taskRef,
+    taskContentSha256: value.taskContentSha256,
+    preClaimUpdatedAt: value.preClaimUpdatedAt,
+    claimedAt: value.claimedAt,
+    predictionSha256: value.predictionSha256,
+    workerId: value.workerId,
+    processInstanceId: value.processInstanceId,
+  };
+}
+
+function claimMacValid(attestation: SchedulerClaimAttestation, secret: string): boolean {
+  return macMatches(
+    attestation.hmacSha256,
+    sign(
+      unsignedClaim(attestation),
+      secret,
+      "hugin-scheduler-claim-attestation/server-key/v1",
+    ),
+  );
+}
+
+export interface BuildSchedulerClaimAttestationInput {
+  decisionId: string;
+  taskRef: z.input<typeof schedulerTaskRefSchema>;
+  taskContent: string;
+  preClaimUpdatedAt: string;
+  claimedAt: string;
+  predictionSha256: string;
+  workerId: string;
+  processInstanceId: string;
+}
+
+export function buildSchedulerClaimAttestation(
+  input: BuildSchedulerClaimAttestationInput,
+  secret: string,
+): SchedulerClaimAttestation {
+  requireSecret(secret);
+  const unsigned = unsignedClaim({
+    version: SCHEDULER_CLAIM_ATTESTATION_VERSION,
+    decisionId: input.decisionId,
+    taskRef: schedulerTaskRefSchema.parse(input.taskRef),
+    taskContentSha256: sha256Text(input.taskContent),
+    preClaimUpdatedAt: input.preClaimUpdatedAt,
+    claimedAt: input.claimedAt,
+    predictionSha256: input.predictionSha256,
+    workerId: input.workerId,
+    processInstanceId: input.processInstanceId,
+  });
+  return schedulerClaimAttestationSchema.parse({
+    ...unsigned,
+    hmacSha256: sign(
+      unsigned,
+      secret,
+      "hugin-scheduler-claim-attestation/server-key/v1",
+    ),
+  });
+}
+
+export function hashSchedulerClaimAttestation(input: unknown): string {
+  return sha256Text(canonicalizeJcs(schedulerClaimAttestationSchema.parse(input)));
+}
+
+export function verifySchedulerClaimAttestation(
+  content: string,
+  expected: {
+    taskRef: z.input<typeof schedulerTaskRefSchema>;
+    taskContent: string;
+    predictionSha256: string;
+  },
+  secret: string,
+): SchedulerClaimAttestation | undefined {
+  try {
+    requireSecret(secret);
+    const parsed = schedulerClaimAttestationSchema.parse(JSON.parse(content));
+    const taskRef = schedulerTaskRefSchema.parse(expected.taskRef);
+    if (parsed.taskRef.namespace !== taskRef.namespace) return undefined;
+    if (parsed.taskContentSha256 !== sha256Text(expected.taskContent)) return undefined;
+    if (parsed.predictionSha256 !== sha256Schema.parse(expected.predictionSha256)) {
+      return undefined;
+    }
+    return claimMacValid(parsed, secret) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function unsignedOutcome(value: Omit<SchedulerOutcomeAttestation, "hmacSha256">) {
+  return {
+    version: value.version,
+    decisionId: value.decisionId,
+    claimAttestationSha256: value.claimAttestationSha256,
+    outcomeSha256: value.outcomeSha256,
+    terminalResult: value.terminalResult,
+  };
+}
+
+export function buildSchedulerOutcomeAttestation(
+  input: { claimAttestation: unknown; outcome: unknown },
+  secret: string,
+): SchedulerOutcomeAttestation {
+  requireSecret(secret);
+  const claimAttestation = schedulerClaimAttestationSchema.parse(input.claimAttestation);
+  if (!claimMacValid(claimAttestation, secret)) {
+    throw new Error("scheduler outcome requires an authentic claim attestation");
+  }
+  const outcome = schedulerDecisionOutcomeSchema.parse(input.outcome);
+  if (outcome.decisionId !== claimAttestation.decisionId
+    || outcome.taskRef.namespace !== claimAttestation.taskRef.namespace) {
+    throw new Error("scheduler outcome does not bind the attested claim");
+  }
+  const unsigned = unsignedOutcome({
+    version: SCHEDULER_OUTCOME_ATTESTATION_VERSION,
+    decisionId: outcome.decisionId,
+    claimAttestationSha256: hashSchedulerClaimAttestation(claimAttestation),
+    outcomeSha256: hashSchedulerOutcome(outcome),
+    terminalResult: outcome.terminalResult,
+  });
+  return schedulerOutcomeAttestationSchema.parse({
+    ...unsigned,
+    hmacSha256: sign(
+      unsigned,
+      secret,
+      "hugin-scheduler-outcome-attestation/server-key/v1",
+    ),
+  });
+}
+
+export function verifySchedulerOutcomeAttestation(
+  content: string,
+  expected: { claimAttestation: unknown; outcome: unknown },
+  secret: string,
+): SchedulerOutcomeAttestation | undefined {
+  try {
+    requireSecret(secret);
+    const parsed = schedulerOutcomeAttestationSchema.parse(JSON.parse(content));
+    const claimAttestation = schedulerClaimAttestationSchema.parse(expected.claimAttestation);
+    if (!claimMacValid(claimAttestation, secret)) return undefined;
+    const outcome = schedulerDecisionOutcomeSchema.parse(expected.outcome);
+    if (outcome.decisionId !== claimAttestation.decisionId) return undefined;
+    if (parsed.decisionId !== outcome.decisionId) return undefined;
+    if (parsed.claimAttestationSha256 !== hashSchedulerClaimAttestation(claimAttestation)) {
+      return undefined;
+    }
+    if (parsed.outcomeSha256 !== hashSchedulerOutcome(outcome)) return undefined;
+    if (canonicalizeJcs(parsed.terminalResult) !== canonicalizeJcs(outcome.terminalResult)) {
+      return undefined;
+    }
+    const unsigned = unsignedOutcome(parsed);
+    const expectedMac = sign(
+      unsigned,
+      secret,
+      "hugin-scheduler-outcome-attestation/server-key/v1",
+    );
+    return macMatches(parsed.hmacSha256, expectedMac) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/tests/scheduler-evidence-attestation.test.ts
+++ b/tests/scheduler-evidence-attestation.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSchedulerClaimAttestation,
+  buildSchedulerOutcomeAttestation,
+  hashSchedulerClaimAttestation,
+  verifySchedulerClaimAttestation,
+  verifySchedulerOutcomeAttestation,
+} from "../src/scheduler-evidence-attestation.js";
+import { buildCompleteSchedulerServiceClock } from "../src/scheduler-evidence.js";
+
+const secret = "dispatcher-authority-secret-32-bytes-minimum";
+const taskRef = { namespace: "tasks/20260723-010000-abcd", key: "status" as const };
+const decisionId = "34f2d430-6c31-47de-860a-8b22bc97f4d4";
+const predictionSha256 = "a".repeat(64);
+const taskContent = "## Task: safe\n\n- **Runtime:** codex\n\n### Prompt\nredacted";
+
+function claim() {
+  return buildSchedulerClaimAttestation({
+    decisionId,
+    taskRef,
+    taskContent,
+    preClaimUpdatedAt: "2026-07-23T00:59:59.000Z",
+    claimedAt: "2026-07-23T01:00:00.000Z",
+    predictionSha256,
+    workerId: "hugin-huginmunin",
+    processInstanceId: "hugin-huginmunin-1234",
+  }, secret);
+}
+
+function outcome() {
+  return {
+    schemaVersion: 1,
+    decisionId,
+    taskRef,
+    terminalClass: "completed" as const,
+    clock: buildCompleteSchedulerServiceClock(
+      "2026-07-23T01:00:00.000Z",
+      "2026-07-23T01:00:10.000Z",
+    ),
+    requestedRuntime: "codex" as const,
+    effectiveRuntime: "codex" as const,
+    championEstimateSeconds: null,
+    absolutePredictionErrorSeconds: null,
+    longJob: false,
+    terminalResult: {
+      namespace: taskRef.namespace,
+      key: "result-structured" as const,
+      updatedAt: "2026-07-23T01:00:09.999Z",
+      sha256: "b".repeat(64),
+    },
+  };
+}
+
+describe("scheduler evidence attestations", () => {
+  it("authenticates the exact successful claim transition without storing task content", () => {
+    const attestation = claim();
+    const verified = verifySchedulerClaimAttestation(JSON.stringify(attestation), {
+      taskRef,
+      taskContent,
+      predictionSha256,
+    }, secret);
+
+    expect(verified).toMatchObject({
+      decisionId,
+      taskRef,
+      preClaimUpdatedAt: "2026-07-23T00:59:59.000Z",
+      claimedAt: "2026-07-23T01:00:00.000Z",
+      predictionSha256,
+    });
+    expect(JSON.stringify(attestation)).not.toContain("### Prompt");
+    expect(hashSchedulerClaimAttestation(attestation)).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("fails closed on claim field, content, prediction, or MAC tampering", () => {
+    const attestation = claim();
+    for (const tampered of [
+      { ...attestation, decisionId: "5f1848e1-d3fb-46bf-9121-e1f38e79d158" },
+      { ...attestation, claimedAt: "2026-07-23T01:00:01.000Z" },
+      { ...attestation, predictionSha256: "c".repeat(64) },
+      { ...attestation, hmacSha256: "d".repeat(64) },
+    ]) {
+      expect(verifySchedulerClaimAttestation(JSON.stringify(tampered), {
+        taskRef,
+        taskContent,
+        predictionSha256,
+      }, secret)).toBeUndefined();
+    }
+    expect(verifySchedulerClaimAttestation(JSON.stringify(attestation), {
+      taskRef,
+      taskContent: `${taskContent}\nchanged`,
+      predictionSha256,
+    }, secret)).toBeUndefined();
+  });
+
+  it("binds an exact scheduler outcome to the authenticated claim", () => {
+    const claimAttestation = claim();
+    const terminalOutcome = outcome();
+    const attestation = buildSchedulerOutcomeAttestation({
+      claimAttestation,
+      outcome: terminalOutcome,
+    }, secret);
+
+    expect(verifySchedulerOutcomeAttestation(JSON.stringify(attestation), {
+      claimAttestation,
+      outcome: terminalOutcome,
+    }, secret)).toMatchObject({ decisionId });
+    expect(verifySchedulerOutcomeAttestation(JSON.stringify(attestation), {
+      claimAttestation,
+      outcome: { ...terminalOutcome, terminalClass: "failed" },
+    }, secret)).toBeUndefined();
+    expect(verifySchedulerOutcomeAttestation(JSON.stringify(attestation), {
+      claimAttestation: { ...claimAttestation, claimedAt: "2026-07-23T01:00:01.000Z" },
+      outcome: terminalOutcome,
+    }, secret)).toBeUndefined();
+  });
+
+  it("rejects weak secrets and cross-protocol MAC reuse", () => {
+    expect(() => buildSchedulerClaimAttestation({
+      decisionId,
+      taskRef,
+      taskContent,
+      preClaimUpdatedAt: "2026-07-23T00:59:59.000Z",
+      claimedAt: "2026-07-23T01:00:00.000Z",
+      predictionSha256,
+      workerId: "hugin-huginmunin",
+      processInstanceId: "hugin-huginmunin-1234",
+    }, "short")).toThrow(/at least 32/);
+
+    const claimAttestation = claim();
+    const terminalOutcome = outcome();
+    const outcomeAttestation = buildSchedulerOutcomeAttestation({
+      claimAttestation,
+      outcome: terminalOutcome,
+    }, secret);
+    expect(verifySchedulerClaimAttestation(JSON.stringify({
+      ...claimAttestation,
+      hmacSha256: outcomeAttestation.hmacSha256,
+    }), { taskRef, taskContent, predictionSha256 }, secret)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- add a versioned HMAC claim attestation binding decision ID, safe task ref/content hash, claim CAS precondition and acknowledgement, prediction digest, and dispatcher instance
- add a separate domain-separated outcome attestation binding the exact JCS outcome and terminal-result revision/hash to the authenticated claim
- use constant-time MAC checks and the existing dispatcher-only secret through protocol-specific derived keys
- keep this slice behavior-neutral: no persistence, recovery-pointer preservation, or restart hydration is enabled yet

## Security boundary

Create-only schema validity does not prove Hugin owned a claim. These primitives establish the cryptographic chain needed for a later history reader. They intentionally do not claim that a mutable current status row continuously descends from an older claim; recovery continues stripping scheduler pointers.

## Verification

- red/green attestation tests covering field/content/prediction/MAC tampering, exact outcome binding, weak secrets, and cross-protocol MAC reuse
- full: 155 files / 2,375 tests
- `npm run build`
- `bash scripts/deploy-pi.test.sh`
- `git diff --check`

Refs #282