### PR TITLE
Persist and hydrate authenticated scheduler history

### DIFF
--- a/docs/scheduling-shadow-lanes.md
+++ b/docs/scheduling-shadow-lanes.md
@@ -200,15 +200,25 @@ per-group minimum sequences rather than a nested scan. A dedicated Munin client
 and fire-and-forget write ensure evidence latency cannot enter the
 claim-to-execution critical path.
 
-The next live slice admits an outcome to estimator memory only after this
-process receives `status: created` for its create-only outcome write. It never
-trains from `exact-existing` or arbitrary post-restart Munin rows: schema and a
-terminal-result hash prove content consistency, but not that Hugin owned the
-claim instance. A restart therefore cold-starts the three-sample runtime
-window and abstains until enough new exact-bound outcomes have been created.
-The cache retains at most the 24 newest complete outcomes per requested
-runtime. This is intentionally conservative until authenticated
-claim-instance provenance exists.
+An outcome enters estimator memory only after the complete authenticated chain
+has been persisted or re-verified. The live writer serializes prediction,
+claim attestation, outcome, and outcome attestation on the isolated telemetry
+client. A crash between any two writes leaves an incomplete chain; it is never
+reconstructed from later state and is excluded after restart. Every record is
+`create_if_absent`; an exact JCS replay is reusable, while conflicting content
+is rejected.
+
+At startup Hugin reads at most the newest 24 outcome-attestation candidates per
+requested runtime. It admits a candidate only when all four immutable evidence
+rows exist, both domain-separated MACs verify, the prediction and outcome share
+the attested decision/task identity, the outcome claim boundary equals the
+attested successful-CAS timestamp, and the current exact
+`result-structured` revision and raw SHA-256 still match the terminal binding.
+The task status content must also still hash to the content bound by the claim
+attestation. Missing rows, tag/runtime mismatch, malformed schemas, stale
+terminal revisions, and MAC or digest conflicts fail closed for that sample.
+The cache retains at most the 24 newest complete verified outcomes per
+requested runtime and still abstains until three samples exist.
 
 ### Authenticated claim/outcome chain
 
@@ -228,16 +238,16 @@ The versioned claim attestation binds:
 The versioned outcome attestation then binds the exact JCS outcome digest and
 terminal-result revision/hash to the full authenticated claim-attestation
 digest. Both use constant-time MAC comparison, reject weak secrets, and fail
-closed on malformed or changed fields. This chain is sufficient for a later
-history reader to distinguish Hugin-authored samples from arbitrary
-create-only rows.
+closed on malformed or changed fields. This chain lets the bounded history
+reader distinguish Hugin-authored samples from arbitrary create-only rows
+without storing task content in scheduler telemetry.
 
 The primitive alone does **not** prove that a mutable current status row is a
 continuous descendant of an older claim. Recovery therefore continues to
-strip scheduler pointers until persistence, crash-gap handling, and replay
-rules for the full chain are implemented and reviewed. Shipping the schemas
-must not silently enable recovery preservation or post-restart estimator
-hydration.
+strip scheduler pointers. Verified terminal-history hydration does not grant
+recovery authority: it authenticates a completed evidence chain, while pointer
+preservation requires a separate proof that every mutable status transition
+descends continuously from the successful claim.
 
 `HUGIN_SCHEDULER_SHADOW=on` enables challenger computation. It defaults to
 `off`; the disabled state persists a bounded `shadow-disabled` abstention.
@@ -248,9 +258,9 @@ open only to that same candidate with caller scheduler pointers stripped.
 Startup, lease-reaper, and interrupted-delivery recovery continue to strip the
 pointer. Schema and digest validation proves content integrity but not that the
 first writer was Hugin or that the pointer came from the successful claim CAS.
-Recovery preservation therefore requires a future immutable, authenticated
-claim-instance binding; mutable status tags plus create-only evidence are not
-sufficient authority.
+Recovery preservation therefore still requires proof of continuous
+current-status descent; the authenticated terminal history described above is
+not sufficient authority.
 
 For a terminal result written by the live in-process claim owner, Hugin retains
 the exact serialized `result-structured` SHA-256 and Munin revision returned by

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,7 +167,17 @@ import {
   type SchedulerTerminalResultRevision,
 } from "./scheduler-evidence.js";
 import {
+  buildSchedulerClaimAttestation,
+  buildSchedulerOutcomeAttestation,
+  type SchedulerClaimAttestation,
+} from "./scheduler-evidence-attestation.js";
+import {
+  loadVerifiedSchedulerOutcomeHistory,
+} from "./scheduler-evidence-history.js";
+import {
+  persistSchedulerClaimAttestation,
   persistSchedulerOutcome,
+  persistSchedulerOutcomeAttestation,
   persistSchedulerPrediction,
 } from "./scheduler-evidence-store.js";
 import { LearningLoopCollector } from "./learning-loop-collector.js";
@@ -721,9 +731,8 @@ const reaperMunin = createMuninClient();
 // request queue plus fire-and-forget writes ensures Munin latency cannot hold
 // up execution after the claim CAS.
 const schedulerEvidenceMunin = createMuninClient();
-// Only outcomes created successfully by this live process enter estimator
-// memory. Durable rows cannot be trusted after restart until scheduler claim
-// instances have an authenticated binding, so restart intentionally cold-starts.
+// Only outcomes with a fully authenticated, exact evidence chain enter this
+// bounded cache. Startup hydration verifies every durable row before admission.
 const schedulerRuntimeEstimator = new SchedulerRuntimeEstimatorCache({
   minimumSamples: 3,
   windowSize: 24,
@@ -2464,6 +2473,8 @@ function stripLeaseTags(tags: string[]): string[] {
 function releaseCurrentClaimWithSchedulerOutcome(input: {
   taskNamespace: string;
   prediction: SchedulerDecisionPrediction | null;
+  claimAttestation: SchedulerClaimAttestation | null;
+  claimEvidencePersistence: Promise<boolean> | null;
   claimedAt: string | null;
   requestedRuntime: DispatcherRuntime;
   effectiveRuntime: DispatcherRuntime;
@@ -2475,7 +2486,8 @@ function releaseCurrentClaimWithSchedulerOutcome(input: {
   const releasedAt = new Date().toISOString();
   currentTask = null;
   currentTaskConfig = null;
-  if (!input.prediction || !input.terminalResult) return;
+  if (!input.prediction || !input.claimAttestation || !input.claimEvidencePersistence
+    || !input.terminalResult) return;
 
   try {
     const outcome = buildSchedulerDecisionOutcomeFromTerminalResult({
@@ -2489,20 +2501,26 @@ function releaseCurrentClaimWithSchedulerOutcome(input: {
       harness: input.harness,
       model: input.model,
     });
-    void persistSchedulerOutcome(schedulerEvidenceMunin, outcome)
-      .then((result) => {
-        // A `created` acknowledgement proves this live dispatcher authored the
-        // immutable row. Never train from exact-existing/replayed rows until
-        // durable claim-instance authentication is available.
-        if (result.status === "created") {
-          try {
-            schedulerRuntimeEstimator.recordCreated(outcome);
-          } catch (err) {
-            console.warn(
-              `Scheduler estimator admission failed for ${input.taskNamespace} ` +
-                `(${outcome.decisionId}): ${err instanceof Error ? err.message : String(err)}`,
-            );
-          }
+    const outcomeAttestation = buildSchedulerOutcomeAttestation({
+      claimAttestation: input.claimAttestation,
+      outcome,
+    }, config.sensitivityCheckpointSecret);
+    void input.claimEvidencePersistence
+      .then(async (claimEvidencePersisted) => {
+        if (!claimEvidencePersisted) return;
+        await persistSchedulerOutcome(schedulerEvidenceMunin, outcome);
+        await persistSchedulerOutcomeAttestation(
+          schedulerEvidenceMunin,
+          outcomeAttestation,
+          outcome.requestedRuntime,
+        );
+        try {
+          schedulerRuntimeEstimator.recordVerified(outcome);
+        } catch (err) {
+          console.warn(
+            `Scheduler estimator admission failed for ${input.taskNamespace} ` +
+              `(${outcome.decisionId}): ${err instanceof Error ? err.message : String(err)}`,
+          );
         }
       })
       .catch((err: unknown) => {
@@ -4800,6 +4818,8 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         .concat("routing:auto")
     : entry.tags;
   let schedulerPrediction: SchedulerDecisionPrediction | null = null;
+  let schedulerClaimAttestation: SchedulerClaimAttestation | null = null;
+  let schedulerClaimEvidencePersistence: Promise<boolean> | null = null;
   let tagsForClaim = stripSchedulerDecisionPointers(claimInputTags);
   try {
     const compareShadow = config.schedulerShadowEnabled
@@ -4857,6 +4877,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
   munin.setSessionId(randomUUID());
   let claimAcceptedAt = entry.updated_at;
   let schedulerClaimedAt: string | null = null;
+  const schedulerPreClaimUpdatedAt = entry.updated_at;
   try {
     const claimResult = await munin.write(
       taskNs,
@@ -4885,18 +4906,61 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     return { hadTask: false, queueDepth };
   }
 
-  // The claim is the scheduling authority. Prediction persistence happens
-  // only after that CAS and is deliberately best-effort: telemetry must never
-  // delay, fail, or reorder a production dispatch.
+  // The claim is the scheduling authority. The prediction and authenticated
+  // claim receipt are persisted sequentially only after that CAS. This chain
+  // stays on the isolated telemetry client and cannot delay dispatch.
   if (schedulerPrediction) {
     const acceptedPrediction = schedulerPrediction;
-    void persistSchedulerPrediction(schedulerEvidenceMunin, acceptedPrediction)
-      .catch((err: unknown) => {
-        console.warn(
-          `Scheduler shadow prediction persistence failed for ${taskNs} (${acceptedPrediction.decisionId}): ` +
-            (err instanceof Error ? err.message : String(err)),
-        );
-      });
+    try {
+      if (!schedulerClaimedAt) {
+        throw new Error("claim acknowledgement omitted updated_at");
+      }
+      schedulerClaimAttestation = buildSchedulerClaimAttestation({
+        decisionId: acceptedPrediction.decisionId,
+        taskRef: acceptedPrediction.champion.taskRef,
+        taskContent: entry.content,
+        preClaimUpdatedAt: schedulerPreClaimUpdatedAt,
+        claimedAt: schedulerClaimedAt,
+        predictionSha256: hashSchedulerPrediction(acceptedPrediction),
+        workerId,
+        processInstanceId,
+      }, config.sensitivityCheckpointSecret);
+      const acceptedClaimAttestation = schedulerClaimAttestation;
+      schedulerClaimEvidencePersistence = persistSchedulerPrediction(
+        schedulerEvidenceMunin,
+        acceptedPrediction,
+      )
+        .then(() => persistSchedulerClaimAttestation(
+          schedulerEvidenceMunin,
+          acceptedClaimAttestation,
+        ))
+        .then(() => true)
+        .catch((err: unknown) => {
+          console.warn(
+            `Scheduler shadow claim evidence persistence failed for ${taskNs} `
+              + `(${acceptedPrediction.decisionId}): `
+              + (err instanceof Error ? err.message : String(err)),
+          );
+          return false;
+        });
+    } catch (err) {
+      schedulerClaimAttestation = null;
+      schedulerClaimEvidencePersistence = null;
+      void persistSchedulerPrediction(schedulerEvidenceMunin, acceptedPrediction).catch(
+        (persistErr: unknown) => {
+          console.warn(
+            `Scheduler shadow prediction persistence failed for ${taskNs} `
+              + `(${acceptedPrediction.decisionId}): `
+              + (persistErr instanceof Error ? persistErr.message : String(persistErr)),
+          );
+        },
+      );
+      console.warn(
+        `Scheduler shadow claim attestation construction failed for ${taskNs} `
+          + `(${acceptedPrediction.decisionId}): `
+          + (err instanceof Error ? err.message : String(err)),
+      );
+    }
   }
 
   // The selected status is now running. Keep /health accurate while the task
@@ -4960,6 +5024,8 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
       releaseCurrentClaimWithSchedulerOutcome({
         taskNamespace: taskNs,
         prediction: schedulerPrediction,
+        claimAttestation: schedulerClaimAttestation,
+        claimEvidencePersistence: schedulerClaimEvidencePersistence,
         claimedAt: schedulerClaimedAt,
         requestedRuntime: "pipeline",
         effectiveRuntime: "pipeline",
@@ -6800,6 +6866,8 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     releaseCurrentClaimWithSchedulerOutcome({
       taskNamespace: taskNs,
       prediction: schedulerPrediction,
+      claimAttestation: schedulerClaimAttestation,
+      claimEvidencePersistence: schedulerClaimEvidencePersistence,
       claimedAt: schedulerClaimedAt,
       requestedRuntime: declaredRuntime as DispatcherRuntime,
       effectiveRuntime: effectiveSchedulerRuntime,
@@ -6856,6 +6924,27 @@ async function pollLoop(): Promise<void> {
 
   // Recover any tasks left running from a previous crash
   await recoverStaleTasks();
+  if (config.sensitivityCheckpointSecret.length >= 32) {
+    try {
+      const history = await loadVerifiedSchedulerOutcomeHistory(
+        schedulerEvidenceMunin,
+        config.sensitivityCheckpointSecret,
+        { windowSize: 24 },
+      );
+      for (const outcome of history.outcomes) {
+        schedulerRuntimeEstimator.recordVerified(outcome);
+      }
+      console.log(
+        `Scheduler history hydration: verified=${history.outcomes.length} `
+          + `rejected=${history.rejected}`,
+      );
+    } catch (err) {
+      console.warn(
+        "Scheduler history hydration failed; estimator will cold-start: "
+          + (err instanceof Error ? err.message : String(err)),
+      );
+    }
+  }
   await reconcileBlockedTasks();
   await runHomeserverLearningRegistryReconciliation();
   await primeTrackedPipelineSummaries();

--- a/src/scheduler-evidence-attestation.ts
+++ b/src/scheduler-evidence-attestation.ts
@@ -144,6 +144,7 @@ export function hashSchedulerClaimAttestation(input: unknown): string {
 export function verifySchedulerClaimAttestation(
   content: string,
   expected: {
+    decisionId: string;
     taskRef: z.input<typeof schedulerTaskRefSchema>;
     taskContent: string;
     predictionSha256: string;
@@ -154,6 +155,7 @@ export function verifySchedulerClaimAttestation(
     requireSecret(secret);
     const parsed = schedulerClaimAttestationSchema.parse(JSON.parse(content));
     const taskRef = schedulerTaskRefSchema.parse(expected.taskRef);
+    if (parsed.decisionId !== z.string().uuid().parse(expected.decisionId)) return undefined;
     if (parsed.taskRef.namespace !== taskRef.namespace) return undefined;
     if (parsed.taskContentSha256 !== sha256Text(expected.taskContent)) return undefined;
     if (parsed.predictionSha256 !== sha256Schema.parse(expected.predictionSha256)) {
@@ -175,6 +177,15 @@ function unsignedOutcome(value: Omit<SchedulerOutcomeAttestation, "hmacSha256">)
   };
 }
 
+function outcomeBindsClaim(
+  outcome: z.infer<typeof schedulerDecisionOutcomeSchema>,
+  claimAttestation: SchedulerClaimAttestation,
+): boolean {
+  return outcome.decisionId === claimAttestation.decisionId
+    && outcome.taskRef.namespace === claimAttestation.taskRef.namespace
+    && outcome.clock.claimedAt === claimAttestation.claimedAt;
+}
+
 export function buildSchedulerOutcomeAttestation(
   input: { claimAttestation: unknown; outcome: unknown },
   secret: string,
@@ -185,8 +196,7 @@ export function buildSchedulerOutcomeAttestation(
     throw new Error("scheduler outcome requires an authentic claim attestation");
   }
   const outcome = schedulerDecisionOutcomeSchema.parse(input.outcome);
-  if (outcome.decisionId !== claimAttestation.decisionId
-    || outcome.taskRef.namespace !== claimAttestation.taskRef.namespace) {
+  if (!outcomeBindsClaim(outcome, claimAttestation)) {
     throw new Error("scheduler outcome does not bind the attested claim");
   }
   const unsigned = unsignedOutcome({
@@ -206,6 +216,10 @@ export function buildSchedulerOutcomeAttestation(
   });
 }
 
+export function hashSchedulerOutcomeAttestation(input: unknown): string {
+  return sha256Text(canonicalizeJcs(schedulerOutcomeAttestationSchema.parse(input)));
+}
+
 export function verifySchedulerOutcomeAttestation(
   content: string,
   expected: { claimAttestation: unknown; outcome: unknown },
@@ -217,7 +231,7 @@ export function verifySchedulerOutcomeAttestation(
     const claimAttestation = schedulerClaimAttestationSchema.parse(expected.claimAttestation);
     if (!claimMacValid(claimAttestation, secret)) return undefined;
     const outcome = schedulerDecisionOutcomeSchema.parse(expected.outcome);
-    if (outcome.decisionId !== claimAttestation.decisionId) return undefined;
+    if (!outcomeBindsClaim(outcome, claimAttestation)) return undefined;
     if (parsed.decisionId !== outcome.decisionId) return undefined;
     if (parsed.claimAttestationSha256 !== hashSchedulerClaimAttestation(claimAttestation)) {
       return undefined;

--- a/src/scheduler-evidence-history.ts
+++ b/src/scheduler-evidence-history.ts
@@ -1,0 +1,249 @@
+import { createHash } from "node:crypto";
+import {
+  verifySchedulerClaimAttestation,
+  verifySchedulerOutcomeAttestation,
+} from "./scheduler-evidence-attestation.js";
+import {
+  hashSchedulerOutcome,
+  hashSchedulerPrediction,
+  schedulerDecisionOutcomeSchema,
+  schedulerDecisionPredictionSchema,
+  type SchedulerDecisionOutcome,
+} from "./scheduler-evidence.js";
+import type {
+  MuninClient,
+  MuninQueryResult,
+  MuninReadRequest,
+  MuninReadResult,
+} from "./munin-client.js";
+import {
+  dispatcherRuntimeSchema,
+  structuredTaskResultSchema,
+  type DispatcherRuntime,
+} from "./task-result-schema.js";
+
+const OUTCOME_ATTESTATION_TAG = "type:scheduler-outcome-attestation";
+const SCHEDULER_SHADOW_TAG = "scheduler-shadow:v1";
+const DECISION_NAMESPACE_PATTERN =
+  /^scheduler\/decisions\/([0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$/;
+
+export interface SchedulerEvidenceHistoryClient {
+  query: Pick<MuninClient, "query">["query"];
+  readBatch(reads: MuninReadRequest[]): Promise<MuninReadResult[]>;
+}
+
+export interface SchedulerEvidenceHistoryOptions {
+  windowSize: number;
+  runtimes?: DispatcherRuntime[];
+}
+
+export interface VerifiedSchedulerOutcomeHistory {
+  outcomes: SchedulerDecisionOutcome[];
+  rejected: number;
+}
+
+interface CandidateRows {
+  query: MuninQueryResult;
+  decisionId: string;
+  prediction: Extract<MuninReadResult, { found: true }>;
+  claimAttestation: Extract<MuninReadResult, { found: true }>;
+  outcome: Extract<MuninReadResult, { found: true }>;
+  outcomeAttestation: Extract<MuninReadResult, { found: true }>;
+}
+
+function sha256(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+function readResultMap(results: MuninReadResult[]): Map<string, MuninReadResult> {
+  return new Map(results.map((result) => [
+    `${result.namespace}\0${result.key}`,
+    result,
+  ]));
+}
+
+function found(
+  rows: Map<string, MuninReadResult>,
+  namespace: string,
+  key: string,
+): Extract<MuninReadResult, { found: true }> | undefined {
+  const result = rows.get(`${namespace}\0${key}`);
+  return result?.found ? result : undefined;
+}
+
+function exactTaskRef(
+  left: { namespace: string; key: string },
+  right: { namespace: string; key: string },
+): boolean {
+  return left.namespace === right.namespace && left.key === right.key;
+}
+
+function terminalClassFor(outcome: string): string {
+  return outcome === "timed_out" ? "timed-out" : outcome;
+}
+
+async function loadRuntimeHistory(
+  munin: SchedulerEvidenceHistoryClient,
+  secret: string,
+  runtime: DispatcherRuntime,
+  windowSize: number,
+): Promise<VerifiedSchedulerOutcomeHistory> {
+  const queried = await munin.query({
+    tags: [
+      OUTCOME_ATTESTATION_TAG,
+      `scheduler-runtime:${runtime}`,
+      SCHEDULER_SHADOW_TAG,
+    ],
+    limit: windowSize,
+  });
+  const references = queried.results.filter((result) =>
+    result.key === "outcome-attestation" && DECISION_NAMESPACE_PATTERN.test(result.namespace)
+  );
+  let rejected = queried.results.length - references.length;
+  if (references.length === 0) return { outcomes: [], rejected };
+
+  const evidenceReads: MuninReadRequest[] = references.flatMap((result) => [
+    { namespace: result.namespace, key: "prediction" },
+    { namespace: result.namespace, key: "claim-attestation" },
+    { namespace: result.namespace, key: "outcome" },
+    { namespace: result.namespace, key: "outcome-attestation" },
+  ]);
+  const evidenceRows = readResultMap(await munin.readBatch(evidenceReads));
+  const candidates: CandidateRows[] = [];
+  for (const query of references) {
+    const decisionId = DECISION_NAMESPACE_PATTERN.exec(query.namespace)?.[1];
+    const prediction = found(evidenceRows, query.namespace, "prediction");
+    const claimAttestation = found(evidenceRows, query.namespace, "claim-attestation");
+    const outcome = found(evidenceRows, query.namespace, "outcome");
+    const outcomeAttestation = found(evidenceRows, query.namespace, "outcome-attestation");
+    if (!decisionId || !prediction || !claimAttestation || !outcome || !outcomeAttestation) {
+      rejected += 1;
+      continue;
+    }
+    candidates.push({
+      query,
+      decisionId,
+      prediction,
+      claimAttestation,
+      outcome,
+      outcomeAttestation,
+    });
+  }
+  if (candidates.length === 0) return { outcomes: [], rejected };
+
+  const parsedCandidates: Array<CandidateRows & {
+    predictionValue: ReturnType<typeof schedulerDecisionPredictionSchema.parse>;
+    outcomeValue: SchedulerDecisionOutcome;
+  }> = [];
+  for (const candidate of candidates) {
+    try {
+      const predictionValue = schedulerDecisionPredictionSchema.parse(
+        JSON.parse(candidate.prediction.content),
+      );
+      const outcomeValue = schedulerDecisionOutcomeSchema.parse(
+        JSON.parse(candidate.outcome.content),
+      );
+      if (predictionValue.decisionId !== candidate.decisionId
+        || outcomeValue.decisionId !== candidate.decisionId
+        || outcomeValue.requestedRuntime !== runtime
+        || !exactTaskRef(predictionValue.champion.taskRef, outcomeValue.taskRef)) {
+        rejected += 1;
+        continue;
+      }
+      parsedCandidates.push({ ...candidate, predictionValue, outcomeValue });
+    } catch {
+      rejected += 1;
+    }
+  }
+  if (parsedCandidates.length === 0) return { outcomes: [], rejected };
+
+  const taskReads: MuninReadRequest[] = parsedCandidates.flatMap((candidate) => [
+    {
+      namespace: candidate.predictionValue.champion.taskRef.namespace,
+      key: "status",
+    },
+    {
+      namespace: candidate.outcomeValue.terminalResult.namespace,
+      key: "result-structured",
+    },
+  ]);
+  const taskRows = readResultMap(await munin.readBatch(taskReads));
+  const outcomes: SchedulerDecisionOutcome[] = [];
+  for (const candidate of parsedCandidates) {
+    try {
+      const taskRef = candidate.predictionValue.champion.taskRef;
+      const status = found(taskRows, taskRef.namespace, "status");
+      const terminal = found(
+        taskRows,
+        candidate.outcomeValue.terminalResult.namespace,
+        "result-structured",
+      );
+      if (!status || !terminal) throw new Error("missing bound task revision");
+      const claimAttestation = verifySchedulerClaimAttestation(
+        candidate.claimAttestation.content,
+        {
+          decisionId: candidate.decisionId,
+          taskRef,
+          taskContent: status.content,
+          predictionSha256: hashSchedulerPrediction(candidate.predictionValue),
+        },
+        secret,
+      );
+      if (!claimAttestation) throw new Error("claim attestation is invalid");
+      const outcomeAttestation = verifySchedulerOutcomeAttestation(
+        candidate.outcomeAttestation.content,
+        {
+          claimAttestation,
+          outcome: candidate.outcomeValue,
+        },
+        secret,
+      );
+      if (!outcomeAttestation) throw new Error("outcome attestation is invalid");
+      if (terminal.updated_at !== candidate.outcomeValue.terminalResult.updatedAt
+        || sha256(terminal.content) !== candidate.outcomeValue.terminalResult.sha256) {
+        throw new Error("terminal revision binding is stale");
+      }
+      const terminalValue = structuredTaskResultSchema.parse(JSON.parse(terminal.content));
+      if (terminalValue.taskNamespace !== taskRef.namespace
+        || terminalClassFor(terminalValue.outcome) !== candidate.outcomeValue.terminalClass) {
+        throw new Error("terminal result does not match scheduler outcome");
+      }
+      outcomes.push(candidate.outcomeValue);
+    } catch {
+      rejected += 1;
+    }
+  }
+  return { outcomes, rejected };
+}
+
+export async function loadVerifiedSchedulerOutcomeHistory(
+  munin: SchedulerEvidenceHistoryClient,
+  secret: string,
+  options: SchedulerEvidenceHistoryOptions,
+): Promise<VerifiedSchedulerOutcomeHistory> {
+  if (!Number.isInteger(options.windowSize) || options.windowSize < 1 || options.windowSize > 50) {
+    throw new Error("scheduler history window size must be an integer from 1 to 50");
+  }
+  if (secret.length < 32) {
+    throw new Error("scheduler history requires an attestation secret of at least 32 characters");
+  }
+  const runtimes = options.runtimes
+    ? dispatcherRuntimeSchema.array().parse(options.runtimes)
+    : [...dispatcherRuntimeSchema.options];
+  const unique = new Map<string, SchedulerDecisionOutcome>();
+  let rejected = 0;
+  for (const runtime of runtimes) {
+    const loaded = await loadRuntimeHistory(munin, secret, runtime, options.windowSize);
+    rejected += loaded.rejected;
+    for (const outcome of loaded.outcomes) {
+      const existing = unique.get(outcome.decisionId);
+      if (existing && hashSchedulerOutcome(existing) !== hashSchedulerOutcome(outcome)) {
+        unique.delete(outcome.decisionId);
+        rejected += 1;
+        continue;
+      }
+      unique.set(outcome.decisionId, outcome);
+    }
+  }
+  return { outcomes: [...unique.values()], rejected };
+}

--- a/src/scheduler-evidence-store.ts
+++ b/src/scheduler-evidence-store.ts
@@ -3,16 +3,24 @@ import {
   type MuninEntry,
 } from "./munin-client.js";
 import {
+  hashSchedulerClaimAttestation,
+  hashSchedulerOutcomeAttestation,
+} from "./scheduler-evidence-attestation.js";
+import {
   hashSchedulerOutcome,
   hashSchedulerPrediction,
   schedulerDecisionOutcomeSchema,
   schedulerDecisionPredictionSchema,
 } from "./scheduler-evidence.js";
+import { dispatcherRuntimeSchema, type DispatcherRuntime } from "./task-result-schema.js";
 
 const PREDICTION_KEY = "prediction";
 const PREDICTION_TAGS = ["type:scheduler-decision-prediction", "scheduler-shadow:v1"];
 const OUTCOME_KEY = "outcome";
 const OUTCOME_TAGS = ["type:scheduler-decision-outcome", "scheduler-shadow:v1"];
+const CLAIM_ATTESTATION_KEY = "claim-attestation";
+const CLAIM_ATTESTATION_TAGS = ["type:scheduler-claim-attestation", "scheduler-shadow:v1"];
+const OUTCOME_ATTESTATION_KEY = "outcome-attestation";
 
 export interface SchedulerEvidenceStoreClient {
   read(
@@ -41,6 +49,20 @@ export class SchedulerOutcomeConflictError extends Error {
   constructor(decisionId: string) {
     super(`scheduler decision ${decisionId} already contains a different outcome`);
     this.name = "SchedulerOutcomeConflictError";
+  }
+}
+
+export class SchedulerClaimAttestationConflictError extends Error {
+  constructor(decisionId: string) {
+    super(`scheduler decision ${decisionId} already contains a different claim attestation`);
+    this.name = "SchedulerClaimAttestationConflictError";
+  }
+}
+
+export class SchedulerOutcomeAttestationConflictError extends Error {
+  constructor(decisionId: string) {
+    super(`scheduler decision ${decisionId} already contains a different outcome attestation`);
+    this.name = "SchedulerOutcomeAttestationConflictError";
   }
 }
 
@@ -130,6 +152,104 @@ export async function persistSchedulerOutcome(
     }
     if (!stored || hashSchedulerOutcome(stored) !== hashSchedulerOutcome(outcome)) {
       throw new SchedulerOutcomeConflictError(outcome.decisionId);
+    }
+    return { status: "exact-existing" };
+  }
+}
+
+export async function persistSchedulerClaimAttestation(
+  munin: SchedulerEvidenceStoreClient,
+  input: unknown,
+): Promise<{ status: "created" | "exact-existing" }> {
+  const content = JSON.stringify(input);
+  const digest = hashSchedulerClaimAttestation(input);
+  const parsed = JSON.parse(content) as { decisionId: string };
+  const namespace = schedulerDecisionNamespace(parsed.decisionId);
+  try {
+    const result = await munin.write(
+      namespace,
+      CLAIM_ATTESTATION_KEY,
+      content,
+      CLAIM_ATTESTATION_TAGS,
+      undefined,
+      "internal",
+      true,
+    );
+    if (result.status !== "created") {
+      throw new Error(
+        `scheduler claim attestation write returned non-created status for `
+          + `${namespace}/${CLAIM_ATTESTATION_KEY}`,
+      );
+    }
+    return { status: "created" };
+  } catch (error) {
+    if (!(error instanceof MuninWriteRejectedError)
+      || error.conflictReason !== "already_exists") {
+      throw error;
+    }
+    const existing = await munin.read(namespace, CLAIM_ATTESTATION_KEY);
+    let storedDigest: string | null = null;
+    try {
+      storedDigest = existing
+        ? hashSchedulerClaimAttestation(JSON.parse(existing.content))
+        : null;
+    } catch {
+      storedDigest = null;
+    }
+    if (storedDigest !== digest) {
+      throw new SchedulerClaimAttestationConflictError(parsed.decisionId);
+    }
+    return { status: "exact-existing" };
+  }
+}
+
+export async function persistSchedulerOutcomeAttestation(
+  munin: SchedulerEvidenceStoreClient,
+  input: unknown,
+  requestedRuntime: DispatcherRuntime,
+): Promise<{ status: "created" | "exact-existing" }> {
+  const runtime = dispatcherRuntimeSchema.parse(requestedRuntime);
+  const content = JSON.stringify(input);
+  const digest = hashSchedulerOutcomeAttestation(input);
+  const parsed = JSON.parse(content) as { decisionId: string };
+  const namespace = schedulerDecisionNamespace(parsed.decisionId);
+  try {
+    const result = await munin.write(
+      namespace,
+      OUTCOME_ATTESTATION_KEY,
+      content,
+      [
+        "type:scheduler-outcome-attestation",
+        `scheduler-runtime:${runtime}`,
+        "scheduler-shadow:v1",
+      ],
+      undefined,
+      "internal",
+      true,
+    );
+    if (result.status !== "created") {
+      throw new Error(
+        `scheduler outcome attestation write returned non-created status for `
+          + `${namespace}/${OUTCOME_ATTESTATION_KEY}`,
+      );
+    }
+    return { status: "created" };
+  } catch (error) {
+    if (!(error instanceof MuninWriteRejectedError)
+      || error.conflictReason !== "already_exists") {
+      throw error;
+    }
+    const existing = await munin.read(namespace, OUTCOME_ATTESTATION_KEY);
+    let storedDigest: string | null = null;
+    try {
+      storedDigest = existing
+        ? hashSchedulerOutcomeAttestation(JSON.parse(existing.content))
+        : null;
+    } catch {
+      storedDigest = null;
+    }
+    if (storedDigest !== digest) {
+      throw new SchedulerOutcomeAttestationConflictError(parsed.decisionId);
     }
     return { status: "exact-existing" };
   }

--- a/src/scheduler-evidence.ts
+++ b/src/scheduler-evidence.ts
@@ -567,10 +567,9 @@ export function buildRollingMedianDurationEstimate(
 }
 
 /**
- * Bounded estimator state trusted only for this dispatcher process. Callers
- * add an outcome only after their create-only Munin write returns `created`;
- * exact-existing or post-restart rows are deliberately not admitted because
- * durable claim-instance authentication is not available yet.
+ * Bounded estimator state for outcomes whose complete authenticated evidence
+ * chain has been verified. Callers may admit a freshly persisted chain or a
+ * post-restart chain loaded from exact immutable rows.
  */
 export class SchedulerRuntimeEstimatorCache {
   private readonly samplesByRuntime = new Map<DispatcherRuntime, Map<string, SchedulerDecisionOutcome>>();
@@ -584,7 +583,7 @@ export class SchedulerRuntimeEstimatorCache {
     }
   }
 
-  recordCreated(input: unknown): void {
+  recordVerified(input: unknown): void {
     const outcome = schedulerDecisionOutcomeSchema.parse(input);
     for (const samples of this.samplesByRuntime.values()) {
       const existing = samples.get(outcome.decisionId);

--- a/tests/scheduler-evidence-attestation.test.ts
+++ b/tests/scheduler-evidence-attestation.test.ts
@@ -3,6 +3,7 @@ import {
   buildSchedulerClaimAttestation,
   buildSchedulerOutcomeAttestation,
   hashSchedulerClaimAttestation,
+  hashSchedulerOutcomeAttestation,
   verifySchedulerClaimAttestation,
   verifySchedulerOutcomeAttestation,
 } from "../src/scheduler-evidence-attestation.js";
@@ -55,6 +56,7 @@ describe("scheduler evidence attestations", () => {
   it("authenticates the exact successful claim transition without storing task content", () => {
     const attestation = claim();
     const verified = verifySchedulerClaimAttestation(JSON.stringify(attestation), {
+      decisionId,
       taskRef,
       taskContent,
       predictionSha256,
@@ -80,12 +82,14 @@ describe("scheduler evidence attestations", () => {
       { ...attestation, hmacSha256: "d".repeat(64) },
     ]) {
       expect(verifySchedulerClaimAttestation(JSON.stringify(tampered), {
+        decisionId,
         taskRef,
         taskContent,
         predictionSha256,
       }, secret)).toBeUndefined();
     }
     expect(verifySchedulerClaimAttestation(JSON.stringify(attestation), {
+      decisionId,
       taskRef,
       taskContent: `${taskContent}\nchanged`,
       predictionSha256,
@@ -104,6 +108,7 @@ describe("scheduler evidence attestations", () => {
       claimAttestation,
       outcome: terminalOutcome,
     }, secret)).toMatchObject({ decisionId });
+    expect(hashSchedulerOutcomeAttestation(attestation)).toMatch(/^[0-9a-f]{64}$/);
     expect(verifySchedulerOutcomeAttestation(JSON.stringify(attestation), {
       claimAttestation,
       outcome: { ...terminalOutcome, terminalClass: "failed" },
@@ -112,6 +117,16 @@ describe("scheduler evidence attestations", () => {
       claimAttestation: { ...claimAttestation, claimedAt: "2026-07-23T01:00:01.000Z" },
       outcome: terminalOutcome,
     }, secret)).toBeUndefined();
+    expect(() => buildSchedulerOutcomeAttestation({
+      claimAttestation,
+      outcome: {
+        ...terminalOutcome,
+        clock: buildCompleteSchedulerServiceClock(
+          "2026-07-23T01:00:01.000Z",
+          "2026-07-23T01:00:10.000Z",
+        ),
+      },
+    }, secret)).toThrow(/does not bind the attested claim/);
   });
 
   it("rejects weak secrets and cross-protocol MAC reuse", () => {
@@ -135,6 +150,6 @@ describe("scheduler evidence attestations", () => {
     expect(verifySchedulerClaimAttestation(JSON.stringify({
       ...claimAttestation,
       hmacSha256: outcomeAttestation.hmacSha256,
-    }), { taskRef, taskContent, predictionSha256 }, secret)).toBeUndefined();
+    }), { decisionId, taskRef, taskContent, predictionSha256 }, secret)).toBeUndefined();
   });
 });

--- a/tests/scheduler-evidence-history.test.ts
+++ b/tests/scheduler-evidence-history.test.ts
@@ -1,0 +1,257 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import {
+  buildSchedulerClaimAttestation,
+  buildSchedulerOutcomeAttestation,
+} from "../src/scheduler-evidence-attestation.js";
+import {
+  hashSchedulerPrediction,
+  type SchedulerDecisionOutcome,
+} from "../src/scheduler-evidence.js";
+import {
+  loadVerifiedSchedulerOutcomeHistory,
+  type SchedulerEvidenceHistoryClient,
+} from "../src/scheduler-evidence-history.js";
+import type {
+  MuninEntry,
+  MuninQueryResult,
+  MuninReadRequest,
+  MuninReadResult,
+} from "../src/munin-client.js";
+
+const secret = "dispatcher-authority-secret-32-bytes-minimum";
+const decisionId = "34f2d430-6c31-47de-860a-8b22bc97f4d4";
+const taskNamespace = "tasks/20260723-020000-abcd";
+const decisionNamespace = `scheduler/decisions/${decisionId}`;
+const statusContent = "## Task: safe\n\n- **Runtime:** codex\n\n### Prompt\nprivate";
+
+function sha256(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+function row(
+  namespace: string,
+  key: string,
+  content: string,
+  tags: string[] = [],
+  updatedAt = "2026-07-23T02:00:10.000Z",
+): MuninEntry & { found: true } {
+  return {
+    found: true,
+    id: `${namespace}/${key}`,
+    namespace,
+    key,
+    content,
+    tags,
+    classification: "internal",
+    created_at: updatedAt,
+    updated_at: updatedAt,
+  };
+}
+
+function fixture() {
+  const prediction = {
+    schemaVersion: 1 as const,
+    decisionId,
+    observedAt: "2026-07-23T02:00:00.000Z",
+    champion: {
+      policy: "complete-fifo-v1" as const,
+      taskRef: { namespace: taskNamespace, key: "status" as const },
+      serviceEstimate: null,
+    },
+    challenger: {
+      policy: "bounded-sejf-v1" as const,
+      overdueThresholdSeconds: 1800,
+      taskRef: null,
+      reason: "insufficient-evidence" as const,
+      evidenceReasons: ["estimate-missing" as const],
+      serviceEstimate: null,
+    },
+    window: {
+      eligibleTasks: 1,
+      pendingEnumerationComplete: true,
+      runningEnumerationComplete: true,
+      eligibilityAuthority: "legacy-unbound-group-sequence" as const,
+      estimatedWorkMinutes: null,
+      missingEstimates: 1,
+    },
+    estimatorVersion: "scheduler-duration-v1" as const,
+  };
+  const result = {
+    schemaVersion: 1 as const,
+    taskId: "20260723-020000-abcd",
+    taskNamespace,
+    lifecycle: "completed" as const,
+    outcome: "completed" as const,
+    runtime: "codex" as const,
+    executor: "codex",
+    resultSource: "runtime",
+    exitCode: 0,
+    completedAt: "2026-07-23T02:00:09.000Z",
+    bodyKind: "response" as const,
+    bodyText: "done",
+  };
+  const resultContent = JSON.stringify(result);
+  const claim = buildSchedulerClaimAttestation({
+    decisionId,
+    taskRef: prediction.champion.taskRef,
+    taskContent: statusContent,
+    preClaimUpdatedAt: "2026-07-23T01:59:59.000Z",
+    claimedAt: "2026-07-23T02:00:00.000Z",
+    predictionSha256: hashSchedulerPrediction(prediction),
+    workerId: "hugin-test",
+    processInstanceId: "hugin-test-123",
+  }, secret);
+  const outcome: SchedulerDecisionOutcome = {
+    schemaVersion: 1,
+    decisionId,
+    taskRef: prediction.champion.taskRef,
+    terminalClass: "completed",
+    clock: {
+      serviceClock: "claim-to-release-v1",
+      clockComplete: true,
+      claimedAt: "2026-07-23T02:00:00.000Z",
+      releasedAt: "2026-07-23T02:00:10.000Z",
+      schedulerServiceSeconds: 10,
+    },
+    requestedRuntime: "codex",
+    effectiveRuntime: "codex",
+    championEstimateSeconds: null,
+    absolutePredictionErrorSeconds: null,
+    longJob: false,
+    terminalResult: {
+      namespace: taskNamespace,
+      key: "result-structured",
+      updatedAt: "2026-07-23T02:00:09.000Z",
+      sha256: sha256(resultContent),
+    },
+  };
+  const outcomeAttestation = buildSchedulerOutcomeAttestation({
+    claimAttestation: claim,
+    outcome,
+  }, secret);
+  return {
+    prediction,
+    claim,
+    outcome,
+    outcomeAttestation,
+    resultContent,
+  };
+}
+
+class FakeHistoryClient implements SchedulerEvidenceHistoryClient {
+  readonly rows = new Map<string, MuninEntry & { found: true }>();
+  readonly queries: Array<{ tags?: string[]; limit?: number }> = [];
+
+  constructor() {
+    const value = fixture();
+    for (const entry of [
+      row(decisionNamespace, "prediction", JSON.stringify(value.prediction)),
+      row(decisionNamespace, "claim-attestation", JSON.stringify(value.claim)),
+      row(decisionNamespace, "outcome", JSON.stringify(value.outcome)),
+      row(
+        decisionNamespace,
+        "outcome-attestation",
+        JSON.stringify(value.outcomeAttestation),
+        [
+          "type:scheduler-outcome-attestation",
+          "scheduler-runtime:codex",
+          "scheduler-shadow:v1",
+        ],
+      ),
+      row(taskNamespace, "status", statusContent),
+      row(
+        taskNamespace,
+        "result-structured",
+        value.resultContent,
+        [],
+        "2026-07-23T02:00:09.000Z",
+      ),
+    ]) {
+      this.rows.set(`${entry.namespace}/${entry.key}`, entry);
+    }
+  }
+
+  async query(opts: {
+    tags?: string[];
+    namespace?: string;
+    limit?: number;
+  }): Promise<{ results: MuninQueryResult[]; total: number }> {
+    this.queries.push({ tags: opts.tags, limit: opts.limit });
+    const results = [...this.rows.values()]
+      .filter((entry) => entry.key === "outcome-attestation")
+      .filter((entry) => (opts.tags ?? []).every((tag) => entry.tags.includes(tag)))
+      .slice(0, opts.limit)
+      .map((entry) => ({
+        id: entry.id,
+        namespace: entry.namespace,
+        key: entry.key,
+        entry_type: "memory",
+        content_preview: "",
+        tags: entry.tags,
+        classification: entry.classification,
+        created_at: entry.created_at,
+        updated_at: entry.updated_at,
+      }));
+    return { results, total: results.length };
+  }
+
+  async readBatch(reads: MuninReadRequest[]): Promise<MuninReadResult[]> {
+    return reads.map(({ namespace, key }) =>
+      this.rows.get(`${namespace}/${key}`) ?? { namespace, key, found: false });
+  }
+}
+
+describe("verified scheduler evidence history", () => {
+  it("hydrates only a complete authenticated chain bound to the exact current result", async () => {
+    const munin = new FakeHistoryClient();
+
+    const loaded = await loadVerifiedSchedulerOutcomeHistory(munin, secret, {
+      windowSize: 24,
+      runtimes: ["codex"],
+    });
+
+    expect(loaded.outcomes).toHaveLength(1);
+    expect(loaded.outcomes[0]?.decisionId).toBe(decisionId);
+    expect(loaded.rejected).toBe(0);
+    expect(munin.queries).toEqual([{
+      tags: [
+        "type:scheduler-outcome-attestation",
+        "scheduler-runtime:codex",
+        "scheduler-shadow:v1",
+      ],
+      limit: 24,
+    }]);
+  });
+
+  it("rejects crash gaps, forged attestations, and changed terminal revisions", async () => {
+    for (const mutate of [
+      (munin: FakeHistoryClient) => {
+        munin.rows.delete(`${decisionNamespace}/claim-attestation`);
+      },
+      (munin: FakeHistoryClient) => {
+        const key = `${decisionNamespace}/outcome-attestation`;
+        const existing = munin.rows.get(key)!;
+        const content = JSON.parse(existing.content);
+        munin.rows.set(key, { ...existing, content: JSON.stringify({
+          ...content,
+          hmacSha256: "f".repeat(64),
+        }) });
+      },
+      (munin: FakeHistoryClient) => {
+        const key = `${taskNamespace}/result-structured`;
+        const existing = munin.rows.get(key)!;
+        munin.rows.set(key, { ...existing, content: `${existing.content}\n` });
+      },
+    ]) {
+      const munin = new FakeHistoryClient();
+      mutate(munin);
+      const loaded = await loadVerifiedSchedulerOutcomeHistory(munin, secret, {
+        windowSize: 24,
+        runtimes: ["codex"],
+      });
+      expect(loaded.outcomes).toEqual([]);
+      expect(loaded.rejected).toBe(1);
+    }
+  });
+});

--- a/tests/scheduler-evidence-store.test.ts
+++ b/tests/scheduler-evidence-store.test.ts
@@ -1,13 +1,23 @@
 import { describe, expect, it } from "vitest";
 import { MuninWriteRejectedError, type MuninEntry } from "../src/munin-client.js";
 import {
+  buildSchedulerClaimAttestation,
+  buildSchedulerOutcomeAttestation,
+} from "../src/scheduler-evidence-attestation.js";
+import {
+  hashSchedulerPrediction,
+} from "../src/scheduler-evidence.js";
+import {
+  persistSchedulerClaimAttestation,
   persistSchedulerOutcome,
+  persistSchedulerOutcomeAttestation,
   persistSchedulerPrediction,
   type SchedulerEvidenceStoreClient,
 } from "../src/scheduler-evidence-store.js";
 
 const taskNamespace = "tasks/20260723-001500-abcd";
 const decisionId = "34f2d430-6c31-47de-860a-8b22bc97f4d4";
+const secret = "dispatcher-authority-secret-32-bytes-minimum";
 
 function prediction(overrides: Record<string, unknown> = {}) {
   return {
@@ -37,6 +47,57 @@ function prediction(overrides: Record<string, unknown> = {}) {
     },
     estimatorVersion: "scheduler-duration-v1",
     ...overrides,
+  };
+}
+
+function outcome(overrides: Record<string, unknown> = {}) {
+  return {
+    schemaVersion: 1,
+    decisionId,
+    taskRef: { namespace: taskNamespace, key: "status" },
+    terminalClass: "completed",
+    clock: {
+      serviceClock: "claim-to-release-v1",
+      clockComplete: true,
+      claimedAt: "2026-07-22T22:15:00.000Z",
+      releasedAt: "2026-07-22T22:16:00.000Z",
+      schedulerServiceSeconds: 60,
+    },
+    requestedRuntime: "codex",
+    effectiveRuntime: "codex",
+    championEstimateSeconds: null,
+    absolutePredictionErrorSeconds: null,
+    longJob: false,
+    terminalResult: {
+      namespace: taskNamespace,
+      key: "result-structured",
+      updatedAt: "2026-07-22T22:15:59.000Z",
+      sha256: "a".repeat(64),
+    },
+    ...overrides,
+  };
+}
+
+function attestations() {
+  const predicted = prediction();
+  const claim = buildSchedulerClaimAttestation({
+    decisionId,
+    taskRef: { namespace: taskNamespace, key: "status" },
+    taskContent: "## Task: safe",
+    preClaimUpdatedAt: "2026-07-22T22:14:59.000Z",
+    claimedAt: "2026-07-22T22:15:00.000Z",
+    predictionSha256: hashSchedulerPrediction(predicted),
+    workerId: "hugin-test",
+    processInstanceId: "hugin-test-123",
+  }, secret);
+  const completed = outcome();
+  return {
+    claim,
+    outcome: completed,
+    outcomeAttestation: buildSchedulerOutcomeAttestation({
+      claimAttestation: claim,
+      outcome: completed,
+    }, secret),
   };
 }
 
@@ -108,30 +169,7 @@ describe("scheduler evidence store", () => {
 
   it("creates outcomes separately and refuses a conflicting immutable replay", async () => {
     const munin = new FakeMunin();
-    const value = {
-      schemaVersion: 1,
-      decisionId,
-      taskRef: { namespace: taskNamespace, key: "status" },
-      terminalClass: "completed",
-      clock: {
-        serviceClock: "claim-to-release-v1",
-        clockComplete: true,
-        claimedAt: "2026-07-22T22:15:00.000Z",
-        releasedAt: "2026-07-22T22:16:00.000Z",
-        schedulerServiceSeconds: 60,
-      },
-      requestedRuntime: "codex",
-      effectiveRuntime: "codex",
-      championEstimateSeconds: null,
-      absolutePredictionErrorSeconds: null,
-      longJob: false,
-      terminalResult: {
-        namespace: taskNamespace,
-        key: "result-structured",
-        updatedAt: "2026-07-22T22:15:59.000Z",
-        sha256: "a".repeat(64),
-      },
-    };
+    const value = outcome();
 
     expect(await persistSchedulerOutcome(munin, value)).toEqual({ status: "created" });
     expect(munin.writes[0]).toEqual({
@@ -144,6 +182,60 @@ describe("scheduler evidence store", () => {
       ...value,
       terminalClass: "failed",
     })).rejects.toThrow(/different outcome/);
+  });
+
+  it("creates claim and outcome attestations immutably and tags outcomes by runtime", async () => {
+    const munin = new FakeMunin();
+    const values = attestations();
+
+    expect(await persistSchedulerClaimAttestation(munin, values.claim)).toEqual({
+      status: "created",
+    });
+    expect(await persistSchedulerOutcomeAttestation(
+      munin,
+      values.outcomeAttestation,
+      "codex",
+    )).toEqual({ status: "created" });
+    expect(munin.writes).toEqual([
+      {
+        namespace: `scheduler/decisions/${decisionId}`,
+        key: "claim-attestation",
+        createIfAbsent: true,
+      },
+      {
+        namespace: `scheduler/decisions/${decisionId}`,
+        key: "outcome-attestation",
+        createIfAbsent: true,
+      },
+    ]);
+    expect(munin.rows.get(
+      `scheduler/decisions/${decisionId}/outcome-attestation`,
+    )?.tags).toContain("scheduler-runtime:codex");
+
+    expect(await persistSchedulerClaimAttestation(munin, values.claim)).toEqual({
+      status: "exact-existing",
+    });
+    expect(await persistSchedulerOutcomeAttestation(
+      munin,
+      values.outcomeAttestation,
+      "codex",
+    )).toEqual({ status: "exact-existing" });
+  });
+
+  it("refuses conflicting immutable claim and outcome attestations", async () => {
+    const munin = new FakeMunin();
+    const values = attestations();
+    await persistSchedulerClaimAttestation(munin, values.claim);
+    await persistSchedulerOutcomeAttestation(munin, values.outcomeAttestation, "codex");
+
+    await expect(persistSchedulerClaimAttestation(munin, {
+      ...values.claim,
+      hmacSha256: "b".repeat(64),
+    })).rejects.toThrow(/different claim attestation/);
+    await expect(persistSchedulerOutcomeAttestation(munin, {
+      ...values.outcomeAttestation,
+      hmacSha256: "c".repeat(64),
+    }, "codex")).rejects.toThrow(/different outcome attestation/);
   });
 
 });

--- a/tests/scheduler-evidence.test.ts
+++ b/tests/scheduler-evidence.test.ts
@@ -239,12 +239,12 @@ describe("scheduler evidence", () => {
     );
 
     expect(cache.get("codex")).toBeNull();
-    cache.recordCreated(first);
+    cache.recordVerified(first);
     expect(cache.get("codex")).toBeNull();
-    cache.recordCreated(second);
+    cache.recordVerified(second);
     expect(cache.get("codex")).toMatchObject({ seconds: 15, sampleCount: 2 });
     expect(cache.get("claude")).toBeNull();
-    expect(() => cache.recordCreated({ ...second, terminalClass: "completed" })).toThrow(
+    expect(() => cache.recordVerified({ ...second, terminalClass: "completed" })).toThrow(
       /conflicting scheduler outcomes/,
     );
   });


### PR DESCRIPTION
Part of #282.

## Summary
- persist prediction, claim attestation, outcome, and outcome attestation as one ordered create-only telemetry chain after the successful claim CAS
- hydrate only bounded per-runtime histories whose full MAC/digest chain, task content binding, and exact terminal-result revision still verify
- keep FIFO/admission behavior and every recovery-pointer stripping rule unchanged

## Safety
- evidence writes remain fire-and-forget on the isolated scheduler Munin client
- crash gaps and conflicting replays fail closed for the affected sample
- no task content is stored in scheduler telemetry
- terminal-history authentication does not grant recovery-pointer authority

## Verification
- `npm run build`
- `npm test` (156 files, 2,379 tests)
- `bash scripts/deploy-pi.test.sh`
- `git diff --check`