### PR TITLE
Add behavior-neutral scheduler workload snapshots

### DIFF
--- a/docs/scheduling-shadow-lanes.md
+++ b/docs/scheduling-shadow-lanes.md
@@ -467,12 +467,14 @@ and requires every bucket enumeration to be complete.
 
 The builder accepts safe task references only as transient deduplication
 identities; task references and task content are absent from its aggregate
-output. Overlapping diagnostic membership remains visible in each bucket, but
-the possible total counts one contribution per distinct task. Exact duplicate
-evidence is reusable. Conflicting estimates or running clocks for one task
-invalidate that task's contribution everywhere instead of selecting a value.
-An estimate whose history looks ahead past `observedAt` is missing evidence.
-For a running task, the contribution is
+output. Non-running diagnostic membership may overlap and remains visible in
+each bucket, but the possible total counts one contribution per distinct task.
+`runningRemaining` is mutually exclusive with those buckets, and a running
+elapsed clock on a non-running item is rejected; this prevents representation
+choices from changing the total. Exact duplicate evidence is reusable.
+Conflicting estimates for one task invalidate that task's contribution
+everywhere instead of selecting a value. An estimate whose history looks ahead
+past `observedAt` is missing evidence. For a running task, the contribution is
 `max(estimate.seconds - runningElapsedSeconds, 0)`; without a valid elapsed
 clock the running contribution is missing.
 

--- a/docs/scheduling-shadow-lanes.md
+++ b/docs/scheduling-shadow-lanes.md
@@ -424,6 +424,73 @@ wait and throughput. A later enforcing policy must define, in a separate PR:
 No ordering policy is promoted as an overload fix. When offered work exceeds
 capacity, Hugin must say so truthfully.
 
+### Executable workload snapshot primitive
+
+`src/scheduler-workload.ts` now defines the strict, behavior-neutral
+`schedulerWorkloadSnapshotSchema` and pure
+`buildSchedulerWorkloadSnapshot(...)` builder. It does not query Munin, write
+evidence, defer a task, reject a task, or influence the claim candidate.
+
+The version-1 snapshot contains only aggregate summaries. This abbreviated
+example omits the other five required bucket members for readability:
+
+```json
+{
+  "schemaVersion": 1,
+  "observedAt": "2026-07-23T08:00:00.000Z",
+  "estimatorVersion": "scheduler-duration-v1",
+  "buckets": {
+    "dispatchable": {
+      "taskCount": 4,
+      "knownWorkMinutes": 18,
+      "estimatedWorkMinutes": null,
+      "missingEstimates": 1,
+      "enumerationComplete": true
+    }
+  },
+  "possibleTotalWork": {
+    "taskCount": 11,
+    "knownWorkMinutes": 67,
+    "estimatedWorkMinutes": null,
+    "missingEstimates": 2,
+    "enumerationComplete": false
+  }
+}
+```
+
+All six bucket keys are always present in a schema-valid record. A bucket's
+`knownWorkMinutes` is the subtotal from available nonnegative estimates.
+`estimatedWorkMinutes` is present only when enumeration is complete and every
+distinct task in that summary has usable evidence. Otherwise it is null; zero
+is never used to disguise missing work. `possibleTotalWork` has the same rule
+and requires every bucket enumeration to be complete.
+
+The builder accepts safe task references only as transient deduplication
+identities; task references and task content are absent from its aggregate
+output. Overlapping diagnostic membership remains visible in each bucket, but
+the possible total counts one contribution per distinct task. Exact duplicate
+evidence is reusable. Conflicting estimates or running clocks for one task
+invalidate that task's contribution everywhere instead of selecting a value.
+An estimate whose history looks ahead past `observedAt` is missing evidence.
+For a running task, the contribution is
+`max(estimate.seconds - runningElapsedSeconds, 0)`; without a valid elapsed
+clock the running contribution is missing.
+
+A later live-shadow wiring slice must prove these inputs rather than infer
+them from mutable previews:
+
+- complete pagination for every included lifecycle bucket;
+- bucket membership from the canonical status/lifecycle contract;
+- one verified estimator version selected for the observation;
+- running elapsed time derived from an authenticated claim boundary;
+- explicit incompleteness when a lifecycle category or classification cannot
+  be enumerated safely.
+
+The aggregate snapshot is not an admission verdict. It intentionally has no
+threshold, capacity horizon, submitter exception, deferral state, rejection
+reason, or override field. Those belong to a separately reviewed enforcing
+policy only after live workload observations are calibrated.
+
 ## Delivery sequence
 
 1. **Duration evidence:** implement the versioned historical estimator and
@@ -434,8 +501,9 @@ capacity, Hugin must say so truthfully.
    delivery step is complete.
 3. **Urgency authority:** add digest-bound authenticated urgency, then shadow
    low-to-normal promotion at half of the declared low-class SLA.
-4. **Work-minute shadow:** publish complete/lower-bound queued work and validate
-   it against realized waits.
+4. **Work-minute shadow:** the strict aggregate primitive is implemented but
+   not live-wired. Next publish complete/known-subtotal queued work from
+   bounded enumerations and validate it against realized waits.
 5. **Promotion gate:** require a predeclared production experiment, complete
    evidence, zero bound violations, acceptable estimate calibration, and an
    explicit human-reviewed policy decision. The cadence may package evidence;

--- a/src/scheduler-workload.ts
+++ b/src/scheduler-workload.ts
@@ -1,0 +1,237 @@
+import { z } from "zod";
+import { canonicalizeJcs } from "./jcs.js";
+import {
+  SCHEDULER_ESTIMATOR_VERSION,
+  schedulerServiceEstimateSchema,
+  schedulerTaskRefSchema,
+} from "./scheduler-evidence.js";
+
+export const SCHEDULER_WORKLOAD_SNAPSHOT_VERSION = 1 as const;
+
+const isoTimestampSchema = z.string().datetime({ offset: true });
+const nonnegativeFiniteSchema = z.number().finite().nonnegative();
+
+export const schedulerWorkloadBucketKeySchema = z.enum([
+  "dispatchable",
+  "groupBlocked",
+  "pipelineBlocked",
+  "approvalGated",
+  "otherNonterminal",
+  "runningRemaining",
+]);
+export type SchedulerWorkloadBucketKey = z.infer<
+  typeof schedulerWorkloadBucketKeySchema
+>;
+
+const bucketCompletenessSchema = z.object({
+  dispatchable: z.boolean(),
+  groupBlocked: z.boolean(),
+  pipelineBlocked: z.boolean(),
+  approvalGated: z.boolean(),
+  otherNonterminal: z.boolean(),
+  runningRemaining: z.boolean(),
+}).strict();
+
+const schedulerWorkloadSummarySchema = z.object({
+  taskCount: z.number().int().nonnegative(),
+  knownWorkMinutes: nonnegativeFiniteSchema,
+  estimatedWorkMinutes: nonnegativeFiniteSchema.nullable(),
+  missingEstimates: z.number().int().nonnegative(),
+  enumerationComplete: z.boolean(),
+}).strict().superRefine((value, ctx) => {
+  if (value.missingEstimates > value.taskCount) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["missingEstimates"],
+      message: "missing estimates cannot exceed task count",
+    });
+  }
+  const totalAvailable = value.enumerationComplete && value.missingEstimates === 0;
+  if (totalAvailable !== (value.estimatedWorkMinutes !== null)) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["estimatedWorkMinutes"],
+      message: "estimated total requires complete enumeration and estimates",
+    });
+  }
+  if (value.estimatedWorkMinutes !== null
+    && Math.abs(value.estimatedWorkMinutes - value.knownWorkMinutes) > 1e-9) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["estimatedWorkMinutes"],
+      message: "complete estimated work must equal known work",
+    });
+  }
+});
+
+export const schedulerWorkloadSnapshotSchema = z.object({
+  schemaVersion: z.literal(SCHEDULER_WORKLOAD_SNAPSHOT_VERSION),
+  observedAt: isoTimestampSchema,
+  estimatorVersion: z.literal(SCHEDULER_ESTIMATOR_VERSION),
+  buckets: z.object({
+    dispatchable: schedulerWorkloadSummarySchema,
+    groupBlocked: schedulerWorkloadSummarySchema,
+    pipelineBlocked: schedulerWorkloadSummarySchema,
+    approvalGated: schedulerWorkloadSummarySchema,
+    otherNonterminal: schedulerWorkloadSummarySchema,
+    runningRemaining: schedulerWorkloadSummarySchema,
+  }).strict(),
+  possibleTotalWork: schedulerWorkloadSummarySchema,
+}).strict();
+export type SchedulerWorkloadSnapshot = z.infer<typeof schedulerWorkloadSnapshotSchema>;
+
+export interface SchedulerWorkloadItem {
+  taskRef: z.input<typeof schedulerTaskRefSchema>;
+  buckets: SchedulerWorkloadBucketKey[];
+  serviceEstimate: unknown | null;
+  runningElapsedSeconds?: number;
+}
+
+export interface BuildSchedulerWorkloadSnapshotInput {
+  observedAt: string;
+  bucketEnumerationComplete: z.input<typeof bucketCompletenessSchema>;
+  items: SchedulerWorkloadItem[];
+}
+
+interface NormalizedWorkItem {
+  buckets: Set<SchedulerWorkloadBucketKey>;
+  contributionSeconds: number | null;
+  evidenceFingerprint: string;
+  conflicted: boolean;
+}
+
+function itemIdentity(taskRef: z.infer<typeof schedulerTaskRefSchema>): string {
+  return `${taskRef.namespace}\0${taskRef.key}`;
+}
+
+function normalizeContribution(
+  item: SchedulerWorkloadItem,
+  buckets: SchedulerWorkloadBucketKey[],
+  observedAtMs: number,
+): { contributionSeconds: number | null; evidenceFingerprint: string } {
+  const parsedEstimate = item.serviceEstimate === null
+    ? null
+    : schedulerServiceEstimateSchema.safeParse(item.serviceEstimate);
+  const estimate = parsedEstimate?.success === true
+    && Date.parse(parsedEstimate.data.historyThrough) <= observedAtMs
+    ? parsedEstimate.data
+    : null;
+  const isRunning = buckets.includes("runningRemaining");
+  const elapsed = item.runningElapsedSeconds;
+  const elapsedValid = elapsed !== undefined
+    && Number.isFinite(elapsed)
+    && elapsed >= 0;
+  if (!estimate || (isRunning && !elapsedValid)) {
+    return {
+      contributionSeconds: null,
+      evidenceFingerprint: canonicalizeJcs({
+        estimate: estimate ?? null,
+        runningElapsedSeconds: isRunning && elapsedValid ? elapsed : null,
+      }),
+    };
+  }
+  const contributionSeconds = isRunning
+    ? Math.max(0, estimate.seconds - elapsed!)
+    : estimate.seconds;
+  return {
+    contributionSeconds,
+    evidenceFingerprint: canonicalizeJcs({
+      estimate,
+      runningElapsedSeconds: isRunning ? elapsed : null,
+    }),
+  };
+}
+
+function summarize(
+  items: NormalizedWorkItem[],
+  enumerationComplete: boolean,
+): z.infer<typeof schedulerWorkloadSummarySchema> {
+  const knownSeconds = items.reduce(
+    (total, item) => total + (item.contributionSeconds ?? 0),
+    0,
+  );
+  const missingEstimates = items.filter(
+    (item) => item.contributionSeconds === null || item.conflicted,
+  ).length;
+  const knownWorkMinutes = knownSeconds / 60;
+  return schedulerWorkloadSummarySchema.parse({
+    taskCount: items.length,
+    knownWorkMinutes,
+    estimatedWorkMinutes:
+      enumerationComplete && missingEstimates === 0 ? knownWorkMinutes : null,
+    missingEstimates,
+    enumerationComplete,
+  });
+}
+
+/**
+ * Build a behavior-neutral workload observation. Diagnostic buckets may
+ * overlap, but possibleTotalWork always counts each safe task reference once.
+ * Unknown, future, or conflicting estimates remain explicit missing evidence.
+ */
+export function buildSchedulerWorkloadSnapshot(
+  input: BuildSchedulerWorkloadSnapshotInput,
+): SchedulerWorkloadSnapshot {
+  const observedAt = isoTimestampSchema.parse(input.observedAt);
+  const observedAtMs = Date.parse(observedAt);
+  const completeness = bucketCompletenessSchema.parse(
+    input.bucketEnumerationComplete,
+  );
+  const byTask = new Map<string, NormalizedWorkItem>();
+
+  for (const rawItem of input.items) {
+    const taskRef = schedulerTaskRefSchema.parse(rawItem.taskRef);
+    const buckets = schedulerWorkloadBucketKeySchema
+      .array()
+      .min(1)
+      .parse(rawItem.buckets);
+    if (rawItem.runningElapsedSeconds !== undefined) {
+      nonnegativeFiniteSchema.parse(rawItem.runningElapsedSeconds);
+    }
+    const normalized = normalizeContribution(rawItem, buckets, observedAtMs);
+    const identity = itemIdentity(taskRef);
+    const existing = byTask.get(identity);
+    if (!existing) {
+      byTask.set(identity, {
+        buckets: new Set(buckets),
+        contributionSeconds: normalized.contributionSeconds,
+        evidenceFingerprint: normalized.evidenceFingerprint,
+        conflicted: false,
+      });
+      continue;
+    }
+    for (const bucket of buckets) existing.buckets.add(bucket);
+    if (existing.evidenceFingerprint !== normalized.evidenceFingerprint) {
+      existing.contributionSeconds = null;
+      existing.conflicted = true;
+    }
+  }
+
+  const uniqueItems = [...byTask.values()];
+  const bucketItems = (bucket: SchedulerWorkloadBucketKey) =>
+    uniqueItems.filter((item) => item.buckets.has(bucket));
+  const allEnumerationComplete = schedulerWorkloadBucketKeySchema.options.every(
+    (bucket) => completeness[bucket],
+  );
+
+  return schedulerWorkloadSnapshotSchema.parse({
+    schemaVersion: SCHEDULER_WORKLOAD_SNAPSHOT_VERSION,
+    observedAt,
+    estimatorVersion: SCHEDULER_ESTIMATOR_VERSION,
+    buckets: {
+      dispatchable: summarize(bucketItems("dispatchable"), completeness.dispatchable),
+      groupBlocked: summarize(bucketItems("groupBlocked"), completeness.groupBlocked),
+      pipelineBlocked: summarize(bucketItems("pipelineBlocked"), completeness.pipelineBlocked),
+      approvalGated: summarize(bucketItems("approvalGated"), completeness.approvalGated),
+      otherNonterminal: summarize(
+        bucketItems("otherNonterminal"),
+        completeness.otherNonterminal,
+      ),
+      runningRemaining: summarize(
+        bucketItems("runningRemaining"),
+        completeness.runningRemaining,
+      ),
+    },
+    possibleTotalWork: summarize(uniqueItems, allEnumerationComplete),
+  });
+}

--- a/src/scheduler-workload.ts
+++ b/src/scheduler-workload.ts
@@ -77,7 +77,18 @@ export const schedulerWorkloadSnapshotSchema = z.object({
     runningRemaining: schedulerWorkloadSummarySchema,
   }).strict(),
   possibleTotalWork: schedulerWorkloadSummarySchema,
-}).strict();
+}).strict().superRefine((value, ctx) => {
+  const allBucketsComplete = Object.values(value.buckets).every(
+    (bucket) => bucket.enumerationComplete,
+  );
+  if (value.possibleTotalWork.enumerationComplete !== allBucketsComplete) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["possibleTotalWork", "enumerationComplete"],
+      message: "possible total completeness must match every bucket",
+    });
+  }
+});
 export type SchedulerWorkloadSnapshot = z.infer<typeof schedulerWorkloadSnapshotSchema>;
 
 export interface SchedulerWorkloadItem {
@@ -185,6 +196,13 @@ export function buildSchedulerWorkloadSnapshot(
       .array()
       .min(1)
       .parse(rawItem.buckets);
+    const running = buckets.includes("runningRemaining");
+    if (running && buckets.length !== 1) {
+      throw new Error("runningRemaining must be exclusive of non-running buckets");
+    }
+    if (!running && rawItem.runningElapsedSeconds !== undefined) {
+      throw new Error("running elapsed requires runningRemaining membership");
+    }
     if (rawItem.runningElapsedSeconds !== undefined) {
       nonnegativeFiniteSchema.parse(rawItem.runningElapsedSeconds);
     }

--- a/tests/scheduler-workload.test.ts
+++ b/tests/scheduler-workload.test.ts
@@ -166,11 +166,44 @@ describe("scheduler work-minute snapshots", () => {
     });
     expect(() => schedulerWorkloadSnapshotSchema.parse({
       ...valid,
+      buckets: {
+        ...valid.buckets,
+        dispatchable: {
+          ...valid.buckets.dispatchable,
+          enumerationComplete: false,
+          estimatedWorkMinutes: null,
+        },
+      },
+    })).toThrow(/possible total completeness must match every bucket/);
+    expect(() => schedulerWorkloadSnapshotSchema.parse({
+      ...valid,
       possibleTotalWork: {
         ...valid.possibleTotalWork,
         missingEstimates: 1,
         estimatedWorkMinutes: 1,
       },
     })).toThrow(/estimated total requires complete enumeration and estimates/);
+  });
+
+  it("rejects running/non-running overlap regardless of input representation", () => {
+    expect(() => buildSchedulerWorkloadSnapshot({
+      observedAt,
+      bucketEnumerationComplete: completeBuckets,
+      items: [
+        item(
+          "aaaa",
+          ["runningRemaining", "groupBlocked"],
+          estimate(60),
+          10,
+        ),
+      ],
+    })).toThrow(/runningRemaining must be exclusive/);
+    expect(() => buildSchedulerWorkloadSnapshot({
+      observedAt,
+      bucketEnumerationComplete: completeBuckets,
+      items: [
+        item("aaaa", ["groupBlocked"], estimate(60), 10),
+      ],
+    })).toThrow(/running elapsed requires runningRemaining/);
   });
 });

--- a/tests/scheduler-workload.test.ts
+++ b/tests/scheduler-workload.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSchedulerWorkloadSnapshot,
+  schedulerWorkloadSnapshotSchema,
+  type SchedulerWorkloadBucketKey,
+} from "../src/scheduler-workload.js";
+
+const observedAt = "2026-07-23T08:00:00.000Z";
+const completeBuckets = {
+  dispatchable: true,
+  groupBlocked: true,
+  pipelineBlocked: true,
+  approvalGated: true,
+  otherNonterminal: true,
+  runningRemaining: true,
+};
+
+function estimate(seconds: number, historyThrough = "2026-07-23T07:59:00.000Z") {
+  return {
+    seconds,
+    estimatorVersion: "scheduler-duration-v1",
+    serviceClock: "claim-to-release-v1",
+    source: "verified-terminal-history",
+    sampleCount: 3,
+    historyThrough,
+    historyThroughDecisionId: "34f2d430-6c31-47de-860a-8b22bc97f4d4",
+  };
+}
+
+function item(
+  suffix: string,
+  buckets: SchedulerWorkloadBucketKey[],
+  serviceEstimate: unknown | null,
+  runningElapsedSeconds?: number,
+) {
+  return {
+    taskRef: {
+      namespace: `tasks/20260723-080000-${suffix}`,
+      key: "status" as const,
+    },
+    buckets,
+    serviceEstimate,
+    ...(runningElapsedSeconds === undefined ? {} : { runningElapsedSeconds }),
+  };
+}
+
+describe("scheduler work-minute snapshots", () => {
+  it("keeps overlapping diagnostic buckets but deduplicates possible total work", () => {
+    const snapshot = buildSchedulerWorkloadSnapshot({
+      observedAt,
+      bucketEnumerationComplete: completeBuckets,
+      items: [
+        item("aaaa", ["dispatchable", "approvalGated"], estimate(120)),
+        item("bbbb", ["groupBlocked"], estimate(60)),
+      ],
+    });
+
+    expect(snapshot.buckets.dispatchable).toEqual({
+      taskCount: 1,
+      knownWorkMinutes: 2,
+      estimatedWorkMinutes: 2,
+      missingEstimates: 0,
+      enumerationComplete: true,
+    });
+    expect(snapshot.buckets.approvalGated.estimatedWorkMinutes).toBe(2);
+    expect(snapshot.buckets.groupBlocked.estimatedWorkMinutes).toBe(1);
+    expect(snapshot.possibleTotalWork).toEqual({
+      taskCount: 2,
+      knownWorkMinutes: 3,
+      estimatedWorkMinutes: 3,
+      missingEstimates: 0,
+      enumerationComplete: true,
+    });
+    expect(JSON.stringify(snapshot)).not.toContain("tasks/");
+  });
+
+  it("retains a known lower bound but refuses a total for missing or truncated evidence", () => {
+    const snapshot = buildSchedulerWorkloadSnapshot({
+      observedAt,
+      bucketEnumerationComplete: {
+        ...completeBuckets,
+        dispatchable: false,
+      },
+      items: [
+        item("aaaa", ["dispatchable"], estimate(120)),
+        item("bbbb", ["dispatchable"], null),
+      ],
+    });
+
+    expect(snapshot.buckets.dispatchable).toEqual({
+      taskCount: 2,
+      knownWorkMinutes: 2,
+      estimatedWorkMinutes: null,
+      missingEstimates: 1,
+      enumerationComplete: false,
+    });
+    expect(snapshot.possibleTotalWork).toEqual({
+      taskCount: 2,
+      knownWorkMinutes: 2,
+      estimatedWorkMinutes: null,
+      missingEstimates: 1,
+      enumerationComplete: false,
+    });
+  });
+
+  it("uses running remainder, rejects future estimates, and fails duplicate conflicts closed", () => {
+    const snapshot = buildSchedulerWorkloadSnapshot({
+      observedAt,
+      bucketEnumerationComplete: completeBuckets,
+      items: [
+        item("aaaa", ["runningRemaining"], estimate(120), 30),
+        item(
+          "bbbb",
+          ["otherNonterminal"],
+          estimate(60, "2026-07-23T08:01:00.000Z"),
+        ),
+        item("cccc", ["dispatchable"], estimate(60)),
+        item("cccc", ["approvalGated"], estimate(120)),
+      ],
+    });
+
+    expect(snapshot.buckets.runningRemaining).toMatchObject({
+      taskCount: 1,
+      knownWorkMinutes: 1.5,
+      estimatedWorkMinutes: 1.5,
+      missingEstimates: 0,
+    });
+    expect(snapshot.buckets.otherNonterminal).toMatchObject({
+      knownWorkMinutes: 0,
+      estimatedWorkMinutes: null,
+      missingEstimates: 1,
+    });
+    expect(snapshot.buckets.dispatchable).toMatchObject({
+      taskCount: 1,
+      knownWorkMinutes: 0,
+      estimatedWorkMinutes: null,
+      missingEstimates: 1,
+    });
+    expect(snapshot.buckets.approvalGated).toMatchObject({
+      taskCount: 1,
+      knownWorkMinutes: 0,
+      estimatedWorkMinutes: null,
+      missingEstimates: 1,
+    });
+    expect(snapshot.possibleTotalWork).toMatchObject({
+      taskCount: 3,
+      knownWorkMinutes: 1.5,
+      estimatedWorkMinutes: null,
+      missingEstimates: 2,
+    });
+  });
+
+  it("rejects malformed clocks and contradictory complete totals", () => {
+    expect(() => buildSchedulerWorkloadSnapshot({
+      observedAt,
+      bucketEnumerationComplete: completeBuckets,
+      items: [
+        item("aaaa", ["runningRemaining"], estimate(60), -1),
+      ],
+    })).toThrow();
+
+    const valid = buildSchedulerWorkloadSnapshot({
+      observedAt,
+      bucketEnumerationComplete: completeBuckets,
+      items: [item("aaaa", ["dispatchable"], estimate(60))],
+    });
+    expect(() => schedulerWorkloadSnapshotSchema.parse({
+      ...valid,
+      possibleTotalWork: {
+        ...valid.possibleTotalWork,
+        missingEstimates: 1,
+        estimatedWorkMinutes: 1,
+      },
+    })).toThrow(/estimated total requires complete enumeration and estimates/);
+  });
+});


### PR DESCRIPTION
Part of #282.

## Summary
- add a strict versioned aggregate workload snapshot schema and pure builder
- represent dispatchable, blocked, gated, other nonterminal, and running-remainder work separately
- deduplicate overlapping buckets by safe task reference for the possible total
- retain known-estimate subtotals but emit no total when enumeration, estimates, or running clocks are incomplete
- fail conflicting duplicate evidence and future-looking estimates closed

## Non-goals / safety
- no Munin query or write integration
- no claim-path wiring
- no threshold, admission verdict, deferral, rejection, ordering, or recovery change
- output contains aggregates only; transient task references are not emitted

## Verification
- red/green workload tests
- `npm run build`
- `npm test` (157 files, 2,383 tests)
- `bash scripts/deploy-pi.test.sh`
- `git diff --check`