### PR TITLE
Persist hash-bound scheduler workload snapshots

### DIFF
--- a/docs/scheduling-shadow-lanes.md
+++ b/docs/scheduling-shadow-lanes.md
@@ -426,10 +426,12 @@ capacity, Hugin must say so truthfully.
 
 ### Executable workload snapshot primitive
 
-`src/scheduler-workload.ts` now defines the strict, behavior-neutral
-`schedulerWorkloadSnapshotSchema` and pure
-`buildSchedulerWorkloadSnapshot(...)` builder. It does not query Munin, write
-evidence, defer a task, reject a task, or influence the claim candidate.
+`src/scheduler-workload.ts` defines the strict, behavior-neutral
+`schedulerWorkloadSnapshotSchema` and pure builders. The live shadow path now
+converts only the complete pending/running pages already fetched by the claim
+loop into an aggregate lower-bound snapshot. It performs no additional Munin
+query, does not defer or reject a task, and cannot influence the claim
+candidate.
 
 The version-1 snapshot contains only aggregate summaries. This abbreviated
 example omits the other five required bucket members for readability:
@@ -478,12 +480,26 @@ past `observedAt` is missing evidence. For a running task, the contribution is
 `max(estimate.seconds - runningElapsedSeconds, 0)`; without a valid elapsed
 clock the running contribution is missing.
 
-A later live-shadow wiring slice must prove these inputs rather than infer
+Accepted snapshots are stored immutably beside the decision prediction. The
+prediction carries the snapshot's canonical SHA-256, so the authenticated
+claim receipt transitively binds the exact aggregate observation. Persistence
+uses the isolated telemetry client after the claim CAS and cannot delay task
+dispatch.
+
+The current binding proves complete pagination for the pending and running
+pages and uses the same legacy group/sequence eligibility window as FIFO.
+Pending tasks receive the already-hydrated per-runtime estimate; lookups are
+memoized across the workload and SEJF observations. Running work has no
+authenticated elapsed-time boundary yet and is therefore present with a
+missing contribution. Pipeline-blocked, approval-gated, and other nonterminal
+enumeration remain explicitly incomplete. The possible total is consequently
+null while known pending minutes provide a conservative subtotal. Disabled or
+truncated shadow paths return before queue traversal or estimate lookup.
+
+Later live-shadow slices must prove the remaining inputs rather than infer
 them from mutable previews:
 
-- complete pagination for every included lifecycle bucket;
 - bucket membership from the canonical status/lifecycle contract;
-- one verified estimator version selected for the observation;
 - running elapsed time derived from an authenticated claim boundary;
 - explicit incompleteness when a lifecycle category or classification cannot
   be enumerated safely.
@@ -503,9 +519,10 @@ policy only after live workload observations are calibrated.
    delivery step is complete.
 3. **Urgency authority:** add digest-bound authenticated urgency, then shadow
    low-to-normal promotion at half of the declared low-class SLA.
-4. **Work-minute shadow:** the strict aggregate primitive is implemented but
-   not live-wired. Next publish complete/known-subtotal queued work from
-   bounded enumerations and validate it against realized waits.
+4. **Work-minute shadow:** accepted decisions now publish hash-bound
+   known-subtotal queued work from complete bounded pending/running
+   enumerations. Next add authenticated running clocks and canonical lifecycle
+   buckets, then validate observations against realized waits.
 5. **Promotion gate:** require a predeclared production experiment, complete
    evidence, zero bound violations, acceptable estimate calibration, and an
    explicit human-reviewed policy decision. The cadence may package evidence;

--- a/docs/scheduling-shadow-lanes.md
+++ b/docs/scheduling-shadow-lanes.md
@@ -491,10 +491,13 @@ pages and uses the same legacy group/sequence eligibility window as FIFO.
 Pending tasks receive the already-hydrated per-runtime estimate; lookups are
 memoized across the workload and SEJF observations. Running work has no
 authenticated elapsed-time boundary yet and is therefore present with a
-missing contribution. Pipeline-blocked, approval-gated, and other nonterminal
-enumeration remain explicitly incomplete. The possible total is consequently
-null while known pending minutes provide a conservative subtotal. Disabled or
-truncated shadow paths return before queue traversal or estimate lookup.
+missing contribution. Broker-owned `orch-v1` pending rows remain counted under
+the explicitly incomplete `otherNonterminal` bucket rather than disappearing
+with the legacy dispatch filter. Pipeline-blocked, approval-gated, and other
+nonterminal enumeration remain explicitly incomplete. The possible total is
+consequently null while known pending minutes provide a conservative subtotal.
+Disabled or truncated shadow paths return before queue traversal or estimate
+lookup.
 
 Later live-shadow slices must prove the remaining inputs rather than infer
 them from mutable previews:

--- a/src/index.ts
+++ b/src/index.ts
@@ -4852,7 +4852,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
           observedAt,
           pendingEnumerationComplete: true,
           runningEnumerationComplete: true,
-          pending: dispatchableResults,
+          pending: results,
           running: runningResults,
           eligibleTaskRefs: eligibleTasks.map((candidate) => ({
             namespace: candidate.namespace,
@@ -4972,8 +4972,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
       if (acceptedWorkloadSnapshot) {
         await persistSchedulerWorkloadSnapshot(
           schedulerEvidenceMunin,
-          acceptedPrediction.decisionId,
-          acceptedPrediction.workloadSnapshotSha256!,
+          acceptedPrediction,
           acceptedWorkloadSnapshot,
         );
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -167,6 +167,11 @@ import {
   type SchedulerTerminalResultRevision,
 } from "./scheduler-evidence.js";
 import {
+  buildSchedulerWorkloadSnapshotFromVisibleQueue,
+  hashSchedulerWorkloadSnapshot,
+  type SchedulerWorkloadSnapshot,
+} from "./scheduler-workload.js";
+import {
   buildSchedulerClaimAttestation,
   buildSchedulerOutcomeAttestation,
   type SchedulerClaimAttestation,
@@ -179,6 +184,7 @@ import {
   persistSchedulerOutcome,
   persistSchedulerOutcomeAttestation,
   persistSchedulerPrediction,
+  persistSchedulerWorkloadSnapshot,
 } from "./scheduler-evidence-store.js";
 import { LearningLoopCollector } from "./learning-loop-collector.js";
 import { LearningRegistryStore } from "./learning-registry-store.js";
@@ -4818,6 +4824,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         .concat("routing:auto")
     : entry.tags;
   let schedulerPrediction: SchedulerDecisionPrediction | null = null;
+  let schedulerWorkloadSnapshot: SchedulerWorkloadSnapshot | null = null;
   let schedulerClaimAttestation: SchedulerClaimAttestation | null = null;
   let schedulerClaimEvidencePersistence: Promise<boolean> | null = null;
   let tagsForClaim = stripSchedulerDecisionPointers(claimInputTags);
@@ -4825,6 +4832,45 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     const compareShadow = config.schedulerShadowEnabled
       && !pendingPage.truncated
       && !runningPage.truncated;
+    const observedAt = new Date().toISOString();
+    const runtimeEstimateMemo = new Map<
+      DispatcherRuntime,
+      ReturnType<typeof schedulerRuntimeEstimator.get>
+    >();
+    const resolveRuntimeEstimate = (runtime: DispatcherRuntime) => {
+      if (runtimeEstimateMemo.has(runtime)) {
+        return runtimeEstimateMemo.get(runtime) ?? null;
+      }
+      const estimate = schedulerRuntimeEstimator.get(runtime);
+      runtimeEstimateMemo.set(runtime, estimate);
+      return estimate;
+    };
+    if (compareShadow) {
+      try {
+        schedulerWorkloadSnapshot = buildSchedulerWorkloadSnapshotFromVisibleQueue({
+          enabled: true,
+          observedAt,
+          pendingEnumerationComplete: true,
+          runningEnumerationComplete: true,
+          pending: dispatchableResults,
+          running: runningResults,
+          eligibleTaskRefs: eligibleTasks.map((candidate) => ({
+            namespace: candidate.namespace,
+            key: "status" as const,
+          })),
+          resolveServiceEstimate: (candidate) => {
+            const runtime = schedulerRequestedRuntimeFromTags(candidate.tags);
+            return runtime ? resolveRuntimeEstimate(runtime) : null;
+          },
+        });
+      } catch (err) {
+        schedulerWorkloadSnapshot = null;
+        console.warn(
+          `Scheduler workload snapshot construction failed for ${taskNs}: `
+            + (err instanceof Error ? err.message : String(err)),
+        );
+      }
+    }
     const schedulerCandidates = compareShadow
       ? (() => {
           const runtimes = eligibleTasks.map((candidate) =>
@@ -4833,7 +4879,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
           const estimates = resolveSchedulerRuntimeEstimates(
             runtimes,
             true,
-            (runtime) => schedulerRuntimeEstimator.get(runtime),
+            resolveRuntimeEstimate,
           );
           return eligibleTasks.map((candidate, index) => ({
             taskRef: { namespace: candidate.namespace, key: "status" as const },
@@ -4848,13 +4894,19 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         }];
     const candidatePrediction = buildSchedulerDecisionPrediction({
       decisionId: randomUUID(),
-      observedAt: new Date().toISOString(),
+      observedAt,
       championTaskRef: { namespace: taskNs, key: "status" },
       candidates: schedulerCandidates,
       eligibleTaskCount: eligibleTasks.length,
       pendingEnumerationComplete: !pendingPage.truncated,
       runningEnumerationComplete: !runningPage.truncated,
       shadowEnabled: config.schedulerShadowEnabled,
+      ...(schedulerWorkloadSnapshot
+        ? {
+            workloadSnapshotSha256:
+              hashSchedulerWorkloadSnapshot(schedulerWorkloadSnapshot),
+          }
+        : {}),
     });
     schedulerPrediction = candidatePrediction;
     tagsForClaim = attachSchedulerDecisionPointer(claimInputTags, {
@@ -4911,6 +4963,21 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
   // stays on the isolated telemetry client and cannot delay dispatch.
   if (schedulerPrediction) {
     const acceptedPrediction = schedulerPrediction;
+    const acceptedWorkloadSnapshot = schedulerWorkloadSnapshot;
+    const persistAcceptedPredictionEvidence = async (): Promise<void> => {
+      await persistSchedulerPrediction(
+        schedulerEvidenceMunin,
+        acceptedPrediction,
+      );
+      if (acceptedWorkloadSnapshot) {
+        await persistSchedulerWorkloadSnapshot(
+          schedulerEvidenceMunin,
+          acceptedPrediction.decisionId,
+          acceptedPrediction.workloadSnapshotSha256!,
+          acceptedWorkloadSnapshot,
+        );
+      }
+    };
     try {
       if (!schedulerClaimedAt) {
         throw new Error("claim acknowledgement omitted updated_at");
@@ -4926,10 +4993,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         processInstanceId,
       }, config.sensitivityCheckpointSecret);
       const acceptedClaimAttestation = schedulerClaimAttestation;
-      schedulerClaimEvidencePersistence = persistSchedulerPrediction(
-        schedulerEvidenceMunin,
-        acceptedPrediction,
-      )
+      schedulerClaimEvidencePersistence = persistAcceptedPredictionEvidence()
         .then(() => persistSchedulerClaimAttestation(
           schedulerEvidenceMunin,
           acceptedClaimAttestation,
@@ -4946,10 +5010,10 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     } catch (err) {
       schedulerClaimAttestation = null;
       schedulerClaimEvidencePersistence = null;
-      void persistSchedulerPrediction(schedulerEvidenceMunin, acceptedPrediction).catch(
+      void persistAcceptedPredictionEvidence().catch(
         (persistErr: unknown) => {
           console.warn(
-            `Scheduler shadow prediction persistence failed for ${taskNs} `
+            `Scheduler shadow prediction evidence persistence failed for ${taskNs} `
               + `(${acceptedPrediction.decisionId}): `
               + (persistErr instanceof Error ? persistErr.message : String(persistErr)),
           );

--- a/src/scheduler-evidence-store.ts
+++ b/src/scheduler-evidence-store.ts
@@ -12,10 +12,16 @@ import {
   schedulerDecisionOutcomeSchema,
   schedulerDecisionPredictionSchema,
 } from "./scheduler-evidence.js";
+import {
+  hashSchedulerWorkloadSnapshot,
+  schedulerWorkloadSnapshotSchema,
+} from "./scheduler-workload.js";
 import { dispatcherRuntimeSchema, type DispatcherRuntime } from "./task-result-schema.js";
 
 const PREDICTION_KEY = "prediction";
 const PREDICTION_TAGS = ["type:scheduler-decision-prediction", "scheduler-shadow:v1"];
+const WORKLOAD_SNAPSHOT_KEY = "workload-snapshot";
+const WORKLOAD_SNAPSHOT_TAGS = ["type:scheduler-workload-snapshot", "scheduler-shadow:v1"];
 const OUTCOME_KEY = "outcome";
 const OUTCOME_TAGS = ["type:scheduler-decision-outcome", "scheduler-shadow:v1"];
 const CLAIM_ATTESTATION_KEY = "claim-attestation";
@@ -42,6 +48,13 @@ export class SchedulerPredictionConflictError extends Error {
   constructor(decisionId: string) {
     super(`scheduler decision ${decisionId} already contains a different prediction`);
     this.name = "SchedulerPredictionConflictError";
+  }
+}
+
+export class SchedulerWorkloadSnapshotConflictError extends Error {
+  constructor(decisionId: string) {
+    super(`scheduler decision ${decisionId} already contains a different workload snapshot`);
+    this.name = "SchedulerWorkloadSnapshotConflictError";
   }
 }
 
@@ -109,6 +122,58 @@ export async function persistSchedulerPrediction(
     const stored = existing ? parseStoredPrediction(existing.content) : null;
     if (!stored || hashSchedulerPrediction(stored) !== hashSchedulerPrediction(prediction)) {
       throw new SchedulerPredictionConflictError(prediction.decisionId);
+    }
+    return { status: "exact-existing" };
+  }
+}
+
+export async function persistSchedulerWorkloadSnapshot(
+  munin: SchedulerEvidenceStoreClient,
+  decisionId: string,
+  expectedSha256: string,
+  input: unknown,
+): Promise<{ status: "created" | "exact-existing" }> {
+  const snapshot = schedulerWorkloadSnapshotSchema.parse(input);
+  const digest = hashSchedulerWorkloadSnapshot(snapshot);
+  if (digest !== expectedSha256) {
+    throw new Error(
+      `scheduler workload snapshot digest does not match prediction for ${decisionId}`,
+    );
+  }
+  const namespace = schedulerDecisionNamespace(decisionId);
+  try {
+    const result = await munin.write(
+      namespace,
+      WORKLOAD_SNAPSHOT_KEY,
+      JSON.stringify(snapshot),
+      WORKLOAD_SNAPSHOT_TAGS,
+      undefined,
+      "internal",
+      true,
+    );
+    if (result.status !== "created") {
+      throw new Error(
+        `scheduler workload snapshot write returned non-created status for `
+          + `${namespace}/${WORKLOAD_SNAPSHOT_KEY}`,
+      );
+    }
+    return { status: "created" };
+  } catch (error) {
+    if (!(error instanceof MuninWriteRejectedError)
+      || error.conflictReason !== "already_exists") {
+      throw error;
+    }
+    const existing = await munin.read(namespace, WORKLOAD_SNAPSHOT_KEY);
+    let stored: unknown = null;
+    try {
+      stored = existing
+        ? schedulerWorkloadSnapshotSchema.parse(JSON.parse(existing.content))
+        : null;
+    } catch {
+      stored = null;
+    }
+    if (!stored || hashSchedulerWorkloadSnapshot(stored) !== digest) {
+      throw new SchedulerWorkloadSnapshotConflictError(decisionId);
     }
     return { status: "exact-existing" };
   }

--- a/src/scheduler-evidence-store.ts
+++ b/src/scheduler-evidence-store.ts
@@ -58,6 +58,13 @@ export class SchedulerWorkloadSnapshotConflictError extends Error {
   }
 }
 
+export class SchedulerWorkloadPredictionBindingError extends Error {
+  constructor(decisionId: string) {
+    super(`scheduler workload snapshot requires the matching stored prediction for ${decisionId}`);
+    this.name = "SchedulerWorkloadPredictionBindingError";
+  }
+}
+
 export class SchedulerOutcomeConflictError extends Error {
   constructor(decisionId: string) {
     super(`scheduler decision ${decisionId} already contains a different outcome`);
@@ -129,18 +136,27 @@ export async function persistSchedulerPrediction(
 
 export async function persistSchedulerWorkloadSnapshot(
   munin: SchedulerEvidenceStoreClient,
-  decisionId: string,
-  expectedSha256: string,
+  predictionInput: unknown,
   input: unknown,
 ): Promise<{ status: "created" | "exact-existing" }> {
+  const prediction = schedulerDecisionPredictionSchema.parse(predictionInput);
   const snapshot = schedulerWorkloadSnapshotSchema.parse(input);
   const digest = hashSchedulerWorkloadSnapshot(snapshot);
-  if (digest !== expectedSha256) {
+  if (digest !== prediction.workloadSnapshotSha256) {
     throw new Error(
-      `scheduler workload snapshot digest does not match prediction for ${decisionId}`,
+      `scheduler workload snapshot digest does not match prediction for `
+        + `${prediction.decisionId}`,
     );
   }
-  const namespace = schedulerDecisionNamespace(decisionId);
+  const namespace = schedulerDecisionNamespace(prediction.decisionId);
+  const predictionEntry = await munin.read(namespace, PREDICTION_KEY);
+  const storedPrediction = predictionEntry
+    ? parseStoredPrediction(predictionEntry.content)
+    : null;
+  if (!storedPrediction
+    || hashSchedulerPrediction(storedPrediction) !== hashSchedulerPrediction(prediction)) {
+    throw new SchedulerWorkloadPredictionBindingError(prediction.decisionId);
+  }
   try {
     const result = await munin.write(
       namespace,
@@ -173,7 +189,7 @@ export async function persistSchedulerWorkloadSnapshot(
       stored = null;
     }
     if (!stored || hashSchedulerWorkloadSnapshot(stored) !== digest) {
-      throw new SchedulerWorkloadSnapshotConflictError(decisionId);
+      throw new SchedulerWorkloadSnapshotConflictError(prediction.decisionId);
     }
     return { status: "exact-existing" };
   }

--- a/src/scheduler-evidence.ts
+++ b/src/scheduler-evidence.ts
@@ -120,6 +120,7 @@ export const schedulerDecisionPredictionSchema = z.object({
     missingEstimates: z.number().int().nonnegative(),
   }).strict(),
   estimatorVersion: z.literal(SCHEDULER_ESTIMATOR_VERSION),
+  workloadSnapshotSha256: sha256Schema.optional(),
 }).strict().superRefine((value, ctx) => {
   const windowComplete = value.window.pendingEnumerationComplete
     && value.window.runningEnumerationComplete;
@@ -213,6 +214,7 @@ export interface BuildSchedulerDecisionPredictionInput {
   pendingEnumerationComplete: boolean;
   runningEnumerationComplete: boolean;
   shadowEnabled: boolean;
+  workloadSnapshotSha256?: string;
 }
 
 /**
@@ -319,6 +321,9 @@ export function buildSchedulerDecisionPrediction(
       missingEstimates,
     },
     estimatorVersion: SCHEDULER_ESTIMATOR_VERSION,
+    ...(input.workloadSnapshotSha256 === undefined
+      ? {}
+      : { workloadSnapshotSha256: input.workloadSnapshotSha256 }),
   });
 }
 

--- a/src/scheduler-workload.ts
+++ b/src/scheduler-workload.ts
@@ -298,10 +298,17 @@ export function buildSchedulerWorkloadSnapshotFromVisibleQueue(
       namespace: task.namespace,
       key: task.key,
     });
+    const orchestrated = task.tags.includes("orch-v1");
     items.push({
       taskRef,
-      buckets: [eligible.has(itemIdentity(taskRef)) ? "dispatchable" : "groupBlocked"],
-      serviceEstimate: input.resolveServiceEstimate(task),
+      buckets: [
+        orchestrated
+          ? "otherNonterminal"
+          : eligible.has(itemIdentity(taskRef))
+            ? "dispatchable"
+            : "groupBlocked",
+      ],
+      serviceEstimate: orchestrated ? null : input.resolveServiceEstimate(task),
     });
   }
   for (const task of input.running) {

--- a/src/scheduler-workload.ts
+++ b/src/scheduler-workload.ts
@@ -1,5 +1,7 @@
+import { createHash } from "node:crypto";
 import { z } from "zod";
 import { canonicalizeJcs } from "./jcs.js";
+import type { MuninQueryResult } from "./munin-client.js";
 import {
   SCHEDULER_ESTIMATOR_VERSION,
   schedulerServiceEstimateSchema,
@@ -102,6 +104,17 @@ export interface BuildSchedulerWorkloadSnapshotInput {
   observedAt: string;
   bucketEnumerationComplete: z.input<typeof bucketCompletenessSchema>;
   items: SchedulerWorkloadItem[];
+}
+
+export interface BuildSchedulerWorkloadSnapshotFromVisibleQueueInput {
+  enabled: boolean;
+  observedAt: string;
+  pendingEnumerationComplete: boolean;
+  runningEnumerationComplete: boolean;
+  pending: readonly MuninQueryResult[];
+  running: readonly MuninQueryResult[];
+  eligibleTaskRefs: readonly z.input<typeof schedulerTaskRefSchema>[];
+  resolveServiceEstimate: (task: MuninQueryResult) => unknown | null;
 }
 
 interface NormalizedWorkItem {
@@ -218,6 +231,9 @@ export function buildSchedulerWorkloadSnapshot(
       });
       continue;
     }
+    if (existing.buckets.has("runningRemaining") !== running) {
+      throw new Error("runningRemaining must be exclusive of non-running buckets");
+    }
     for (const bucket of buckets) existing.buckets.add(bucket);
     if (existing.evidenceFingerprint !== normalized.evidenceFingerprint) {
       existing.contributionSeconds = null;
@@ -252,4 +268,71 @@ export function buildSchedulerWorkloadSnapshot(
     },
     possibleTotalWork: summarize(uniqueItems, allEnumerationComplete),
   });
+}
+
+/**
+ * Convert the pending/running pages already fetched by the claim loop into a
+ * conservative workload observation. Disabled or incomplete enumeration
+ * returns before traversing queue rows or resolving estimates.
+ *
+ * Pending tasks are the only tasks with enough evidence to carry estimates in
+ * this first live binding. Running tasks remain explicit missing work until an
+ * authenticated elapsed-time boundary exists.
+ */
+export function buildSchedulerWorkloadSnapshotFromVisibleQueue(
+  input: BuildSchedulerWorkloadSnapshotFromVisibleQueueInput,
+): SchedulerWorkloadSnapshot | null {
+  if (!input.enabled
+    || !input.pendingEnumerationComplete
+    || !input.runningEnumerationComplete) {
+    return null;
+  }
+
+  const eligible = new Set(input.eligibleTaskRefs.map((rawTaskRef) => {
+    const taskRef = schedulerTaskRefSchema.parse(rawTaskRef);
+    return itemIdentity(taskRef);
+  }));
+  const items: SchedulerWorkloadItem[] = [];
+  for (const task of input.pending) {
+    const taskRef = schedulerTaskRefSchema.parse({
+      namespace: task.namespace,
+      key: task.key,
+    });
+    items.push({
+      taskRef,
+      buckets: [eligible.has(itemIdentity(taskRef)) ? "dispatchable" : "groupBlocked"],
+      serviceEstimate: input.resolveServiceEstimate(task),
+    });
+  }
+  for (const task of input.running) {
+    const taskRef = schedulerTaskRefSchema.parse({
+      namespace: task.namespace,
+      key: task.key,
+    });
+    items.push({
+      taskRef,
+      buckets: ["runningRemaining"],
+      serviceEstimate: null,
+    });
+  }
+
+  return buildSchedulerWorkloadSnapshot({
+    observedAt: input.observedAt,
+    bucketEnumerationComplete: {
+      dispatchable: true,
+      groupBlocked: true,
+      pipelineBlocked: false,
+      approvalGated: false,
+      otherNonterminal: false,
+      runningRemaining: true,
+    },
+    items,
+  });
+}
+
+export function hashSchedulerWorkloadSnapshot(value: unknown): string {
+  const snapshot = schedulerWorkloadSnapshotSchema.parse(value);
+  return createHash("sha256")
+    .update(canonicalizeJcs(snapshot), "utf8")
+    .digest("hex");
 }

--- a/tests/scheduler-evidence-store.test.ts
+++ b/tests/scheduler-evidence-store.test.ts
@@ -212,16 +212,18 @@ describe("scheduler evidence store", () => {
     const munin = new FakeMunin();
     const value = workloadSnapshot();
     const digest = hashSchedulerWorkloadSnapshot(value);
+    const boundPrediction = prediction({ workloadSnapshotSha256: digest });
+    await persistSchedulerPrediction(munin, boundPrediction);
 
-    expect(await persistSchedulerWorkloadSnapshot(munin, decisionId, digest, value)).toEqual({
+    expect(await persistSchedulerWorkloadSnapshot(munin, boundPrediction, value)).toEqual({
       status: "created",
     });
-    expect(munin.writes[0]).toEqual({
+    expect(munin.writes[1]).toEqual({
       namespace: `scheduler/decisions/${decisionId}`,
       key: "workload-snapshot",
       createIfAbsent: true,
     });
-    expect(await persistSchedulerWorkloadSnapshot(munin, decisionId, digest, value)).toEqual({
+    expect(await persistSchedulerWorkloadSnapshot(munin, boundPrediction, value)).toEqual({
       status: "exact-existing",
     });
     const changed = {
@@ -230,16 +232,36 @@ describe("scheduler evidence store", () => {
     };
     await expect(persistSchedulerWorkloadSnapshot(
       munin,
-      decisionId,
-      hashSchedulerWorkloadSnapshot(changed),
+      prediction({ workloadSnapshotSha256: hashSchedulerWorkloadSnapshot(changed) }),
       changed,
-    )).rejects.toThrow(/different workload snapshot/);
+    )).rejects.toThrow(/matching stored prediction/);
+    await expect(persistSchedulerWorkloadSnapshot(
+      munin,
+      boundPrediction,
+      changed,
+    )).rejects.toThrow(/digest does not match prediction/);
+  });
+
+  it("refuses workload evidence without the exact bound prediction already stored", async () => {
+    const value = workloadSnapshot();
+    const digest = hashSchedulerWorkloadSnapshot(value);
+    const boundPrediction = prediction({ workloadSnapshotSha256: digest });
+
     await expect(persistSchedulerWorkloadSnapshot(
       new FakeMunin(),
-      decisionId,
-      "f".repeat(64),
+      boundPrediction,
       value,
-    )).rejects.toThrow(/digest does not match prediction/);
+    )).rejects.toThrow(/matching stored prediction/);
+
+    const munin = new FakeMunin();
+    await persistSchedulerPrediction(munin, prediction({
+      workloadSnapshotSha256: "f".repeat(64),
+    }));
+    await expect(persistSchedulerWorkloadSnapshot(
+      munin,
+      boundPrediction,
+      value,
+    )).rejects.toThrow(/matching stored prediction/);
   });
 
   it("creates claim and outcome attestations immutably and tags outcomes by runtime", async () => {

--- a/tests/scheduler-evidence-store.test.ts
+++ b/tests/scheduler-evidence-store.test.ts
@@ -12,8 +12,13 @@ import {
   persistSchedulerOutcome,
   persistSchedulerOutcomeAttestation,
   persistSchedulerPrediction,
+  persistSchedulerWorkloadSnapshot,
   type SchedulerEvidenceStoreClient,
 } from "../src/scheduler-evidence-store.js";
+import {
+  buildSchedulerWorkloadSnapshot,
+  hashSchedulerWorkloadSnapshot,
+} from "../src/scheduler-workload.js";
 
 const taskNamespace = "tasks/20260723-001500-abcd";
 const decisionId = "34f2d430-6c31-47de-860a-8b22bc97f4d4";
@@ -76,6 +81,25 @@ function outcome(overrides: Record<string, unknown> = {}) {
     },
     ...overrides,
   };
+}
+
+function workloadSnapshot() {
+  return buildSchedulerWorkloadSnapshot({
+    observedAt: "2026-07-22T22:15:00.000Z",
+    bucketEnumerationComplete: {
+      dispatchable: true,
+      groupBlocked: true,
+      pipelineBlocked: false,
+      approvalGated: false,
+      otherNonterminal: false,
+      runningRemaining: true,
+    },
+    items: [{
+      taskRef: { namespace: taskNamespace, key: "status" },
+      buckets: ["dispatchable"],
+      serviceEstimate: null,
+    }],
+  });
 }
 
 function attestations() {
@@ -182,6 +206,40 @@ describe("scheduler evidence store", () => {
       ...value,
       terminalClass: "failed",
     })).rejects.toThrow(/different outcome/);
+  });
+
+  it("creates a workload snapshot separately and refuses a conflicting replay", async () => {
+    const munin = new FakeMunin();
+    const value = workloadSnapshot();
+    const digest = hashSchedulerWorkloadSnapshot(value);
+
+    expect(await persistSchedulerWorkloadSnapshot(munin, decisionId, digest, value)).toEqual({
+      status: "created",
+    });
+    expect(munin.writes[0]).toEqual({
+      namespace: `scheduler/decisions/${decisionId}`,
+      key: "workload-snapshot",
+      createIfAbsent: true,
+    });
+    expect(await persistSchedulerWorkloadSnapshot(munin, decisionId, digest, value)).toEqual({
+      status: "exact-existing",
+    });
+    const changed = {
+      ...value,
+      observedAt: "2026-07-22T22:16:00.000Z",
+    };
+    await expect(persistSchedulerWorkloadSnapshot(
+      munin,
+      decisionId,
+      hashSchedulerWorkloadSnapshot(changed),
+      changed,
+    )).rejects.toThrow(/different workload snapshot/);
+    await expect(persistSchedulerWorkloadSnapshot(
+      new FakeMunin(),
+      decisionId,
+      "f".repeat(64),
+      value,
+    )).rejects.toThrow(/digest does not match prediction/);
   });
 
   it("creates claim and outcome attestations immutably and tags outcomes by runtime", async () => {

--- a/tests/scheduler-evidence.test.ts
+++ b/tests/scheduler-evidence.test.ts
@@ -250,6 +250,7 @@ describe("scheduler evidence", () => {
   });
 
   it("accepts a content-blind abstaining prediction and hashes it deterministically", () => {
+    const workloadSnapshotSha256 = "b".repeat(64);
     const prediction = schedulerDecisionPredictionSchema.parse({
       schemaVersion: 1,
       decisionId,
@@ -276,6 +277,7 @@ describe("scheduler evidence", () => {
         missingEstimates: 1,
       },
       estimatorVersion: "scheduler-duration-v1",
+      workloadSnapshotSha256,
     });
 
     expect(hashSchedulerPrediction(prediction)).toBe(hashSchedulerPrediction({
@@ -283,12 +285,40 @@ describe("scheduler evidence", () => {
       window: { ...prediction.window },
     }));
     expect(hashSchedulerPrediction(prediction)).toMatch(/^[0-9a-f]{64}$/);
+    expect(hashSchedulerPrediction(prediction)).not.toBe(hashSchedulerPrediction({
+      ...prediction,
+      workloadSnapshotSha256: "c".repeat(64),
+    }));
     expect(schedulerDecisionPredictionSchema.safeParse({
       ...prediction,
       challenger: {
         ...prediction.challenger,
         evidenceReasons: ["estimate-missing", "window-truncated"],
       },
+    }).success).toBe(false);
+  });
+
+  it("optionally binds an accepted workload snapshot into the prediction", () => {
+    const workloadSnapshotSha256 = "d".repeat(64);
+    const prediction = buildSchedulerDecisionPrediction({
+      decisionId,
+      observedAt: "2026-07-22T21:00:00.000Z",
+      championTaskRef: taskRef,
+      candidates: [{
+        taskRef,
+        createdAt: "2026-07-22T20:59:00.000Z",
+        serviceEstimate: estimate(60),
+      }],
+      pendingEnumerationComplete: true,
+      runningEnumerationComplete: true,
+      shadowEnabled: true,
+      workloadSnapshotSha256,
+    });
+
+    expect(prediction.workloadSnapshotSha256).toBe(workloadSnapshotSha256);
+    expect(schedulerDecisionPredictionSchema.safeParse({
+      ...prediction,
+      workloadSnapshotSha256: "not-a-digest",
     }).success).toBe(false);
   });
 

--- a/tests/scheduler-workload.test.ts
+++ b/tests/scheduler-workload.test.ts
@@ -238,6 +238,11 @@ describe("scheduler work-minute snapshots", () => {
     const dispatchable = queueRow("aaaa", ["pending", "runtime:codex"]);
     const blocked = queueRow("bbbb", ["pending", "runtime:codex"]);
     const running = queueRow("cccc", ["running", "runtime:claude"]);
+    const orchestrated = queueRow("dddd", [
+      "pending",
+      "runtime:openrouter",
+      "orch-v1",
+    ]);
     let lookups = 0;
 
     const snapshot = buildSchedulerWorkloadSnapshotFromVisibleQueue({
@@ -245,7 +250,7 @@ describe("scheduler work-minute snapshots", () => {
       observedAt,
       pendingEnumerationComplete: true,
       runningEnumerationComplete: true,
-      pending: [dispatchable, blocked],
+      pending: [dispatchable, blocked, orchestrated],
       running: [running],
       eligibleTaskRefs: [{ namespace: dispatchable.namespace, key: "status" }],
       resolveServiceEstimate: () => {
@@ -274,11 +279,18 @@ describe("scheduler work-minute snapshots", () => {
       missingEstimates: 1,
       enumerationComplete: true,
     });
-    expect(snapshot?.possibleTotalWork).toMatchObject({
-      taskCount: 3,
-      knownWorkMinutes: 4,
+    expect(snapshot?.buckets.otherNonterminal).toMatchObject({
+      taskCount: 1,
+      knownWorkMinutes: 0,
       estimatedWorkMinutes: null,
       missingEstimates: 1,
+      enumerationComplete: false,
+    });
+    expect(snapshot?.possibleTotalWork).toMatchObject({
+      taskCount: 4,
+      knownWorkMinutes: 4,
+      estimatedWorkMinutes: null,
+      missingEstimates: 2,
       enumerationComplete: false,
     });
     expect(JSON.stringify(snapshot)).not.toContain("tasks/");

--- a/tests/scheduler-workload.test.ts
+++ b/tests/scheduler-workload.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
+import type { MuninQueryResult } from "../src/munin-client.js";
 import {
   buildSchedulerWorkloadSnapshot,
+  buildSchedulerWorkloadSnapshotFromVisibleQueue,
+  hashSchedulerWorkloadSnapshot,
   schedulerWorkloadSnapshotSchema,
   type SchedulerWorkloadBucketKey,
 } from "../src/scheduler-workload.js";
@@ -41,6 +44,22 @@ function item(
     buckets,
     serviceEstimate,
     ...(runningElapsedSeconds === undefined ? {} : { runningElapsedSeconds }),
+  };
+}
+
+function queueRow(
+  suffix: string,
+  tags: string[],
+): MuninQueryResult {
+  return {
+    id: suffix,
+    namespace: `tasks/20260723-080000-${suffix}`,
+    key: "status",
+    entry_type: "state",
+    content_preview: "",
+    tags,
+    created_at: observedAt,
+    updated_at: observedAt,
   };
 }
 
@@ -205,5 +224,101 @@ describe("scheduler work-minute snapshots", () => {
         item("aaaa", ["groupBlocked"], estimate(60), 10),
       ],
     })).toThrow(/running elapsed requires runningRemaining/);
+    expect(() => buildSchedulerWorkloadSnapshot({
+      observedAt,
+      bucketEnumerationComplete: completeBuckets,
+      items: [
+        item("aaaa", ["groupBlocked"], estimate(60)),
+        item("aaaa", ["runningRemaining"], estimate(60), 10),
+      ],
+    })).toThrow(/runningRemaining must be exclusive/);
+  });
+
+  it("builds a content-blind lower bound from the already-visible queue", () => {
+    const dispatchable = queueRow("aaaa", ["pending", "runtime:codex"]);
+    const blocked = queueRow("bbbb", ["pending", "runtime:codex"]);
+    const running = queueRow("cccc", ["running", "runtime:claude"]);
+    let lookups = 0;
+
+    const snapshot = buildSchedulerWorkloadSnapshotFromVisibleQueue({
+      enabled: true,
+      observedAt,
+      pendingEnumerationComplete: true,
+      runningEnumerationComplete: true,
+      pending: [dispatchable, blocked],
+      running: [running],
+      eligibleTaskRefs: [{ namespace: dispatchable.namespace, key: "status" }],
+      resolveServiceEstimate: () => {
+        lookups += 1;
+        return estimate(120);
+      },
+    });
+
+    expect(lookups).toBe(2);
+    expect(snapshot?.buckets.dispatchable).toMatchObject({
+      taskCount: 1,
+      knownWorkMinutes: 2,
+      estimatedWorkMinutes: 2,
+      enumerationComplete: true,
+    });
+    expect(snapshot?.buckets.groupBlocked).toMatchObject({
+      taskCount: 1,
+      knownWorkMinutes: 2,
+      estimatedWorkMinutes: 2,
+      enumerationComplete: true,
+    });
+    expect(snapshot?.buckets.runningRemaining).toMatchObject({
+      taskCount: 1,
+      knownWorkMinutes: 0,
+      estimatedWorkMinutes: null,
+      missingEstimates: 1,
+      enumerationComplete: true,
+    });
+    expect(snapshot?.possibleTotalWork).toMatchObject({
+      taskCount: 3,
+      knownWorkMinutes: 4,
+      estimatedWorkMinutes: null,
+      missingEstimates: 1,
+      enumerationComplete: false,
+    });
+    expect(JSON.stringify(snapshot)).not.toContain("tasks/");
+    expect(hashSchedulerWorkloadSnapshot(snapshot)).toMatch(/^[0-9a-f]{64}$/);
+    expect(hashSchedulerWorkloadSnapshot(snapshot)).toBe(
+      hashSchedulerWorkloadSnapshot({ ...snapshot!, buckets: { ...snapshot!.buckets } }),
+    );
+  });
+
+  it("does no queue processing or estimate lookup when disabled or truncated", () => {
+    const pending = Array.from({ length: 4_000 }, (_, index) =>
+      queueRow(String(index), ["pending", "runtime:codex"]),
+    );
+    let lookups = 0;
+    const input = {
+      observedAt,
+      pending,
+      running: [] as MuninQueryResult[],
+      eligibleTaskRefs: pending.map((row) => ({
+        namespace: row.namespace,
+        key: "status" as const,
+      })),
+      resolveServiceEstimate: () => {
+        lookups += 1;
+        return estimate(60);
+      },
+    };
+
+    expect(buildSchedulerWorkloadSnapshotFromVisibleQueue({
+      ...input,
+      enabled: false,
+      pendingEnumerationComplete: true,
+      runningEnumerationComplete: true,
+    })).toBeNull();
+    expect(buildSchedulerWorkloadSnapshotFromVisibleQueue({
+      ...input,
+      enabled: true,
+      pendingEnumerationComplete: false,
+      runningEnumerationComplete: true,
+    })).toBeNull();
+    expect(lookups).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary

- derive a conservative aggregate workload snapshot from the complete pending/running pages already fetched by the claim loop
- bind the canonical snapshot digest into the scheduler prediction and require that exact prediction before create-only snapshot persistence
- keep `orch-v1` pending rows visible under explicitly incomplete `otherNonterminal`
- preserve lookup-free disabled/truncated behavior, memoize estimates across workload and SEJF observations, and keep scheduling behavior unchanged

## Review fixes

GPT-5.6 Terra found two P2s on the original head: unverified prediction/snapshot storage binding and omitted `orch-v1` pending work. Both are fixed with regression tests in the exact head on this PR.

## Verification

- red/green focused scheduler workload/evidence/store tests (32 passing)
- `npm test` (157 files, 2,389 tests)
- `npm run build`
- `bash scripts/deploy-pi.test.sh`
- `git diff --check`

Supersedes #304, whose PR head remained stuck on its superseded commit after the branch ref advanced. Advances #282.