### PR TITLE
ci: migrate GitHub Actions off Node 20 runtime and immutable-pin them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,9 @@ jobs:
   build-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 20
           cache: npm

--- a/tests/ci-workflow.test.ts
+++ b/tests/ci-workflow.test.ts
@@ -1,0 +1,13 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+describe("CI workflow action runtime contract (#316)", () => {
+  it("uses immutable Node 24-native action pins while preserving the Node 20 project runtime", async () => {
+    const workflow = await readFile(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8");
+
+    expect(workflow).toContain("actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1");
+    expect(workflow).toContain("actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0");
+    expect(workflow).toContain("node-version: 20");
+    expect(workflow).not.toMatch(/actions\/(checkout|setup-node)@v\d/);
+  });
+});


### PR DESCRIPTION
## Summary
- Inventoried the repository's single workflow (`.github/workflows/ci.yml`) and its two third-party actions.
- Replaced `actions/checkout@v4` and `actions/setup-node@v4` (Node 20 runtime, deprecated) with maintained Node 24-native releases, pinned to full commit SHAs with same-line version comments.
- Preserved all triggers, concurrency config, job/step structure, and the project's own Node 20 runtime target (`node-version: 20`) byte-for-byte aside from the action refs.
- Added `tests/ci-workflow.test.ts`, a regression test that asserts the pinned SHAs are present and fails on any floating `checkout`/`setup-node` ref.

## Pins changed
| Action | Old | New |
|---|---|---|
| `actions/checkout` | `@v4` | `@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1` |
| `actions/setup-node` | `@v4` | `@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0` |

## Verification
- Both SHAs verified against the official upstream tag refs via `gh api repos/<owner>/<repo>/git/ref/tags/<tag>` (both were lightweight tags pointing directly at commits, no dereference needed).
- Both `action.yml` manifests fetched at the pinned ref and confirmed to declare `runs.using: node24`.
- `npm ci` — clean install.
- `npm run build` (tsc, project's typecheck) — passed with no errors.
- Focused new test: `npx vitest run tests/ci-workflow.test.ts` — 1/1 passed.
- Full suite: `npm test` — 158 test files, 2390 tests, all passed (includes the new regression test).

## Caveats
- Repository has only one workflow file (`ci.yml`); no `[skip ci]`/bot-PR-suppression workflow exists here to preserve.
- This workflow has no `permissions:` block to begin with, so none was added or asserted in the regression test.

Closes #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)