### PR TITLE
fix: slim the Heimdall descriptor and make status/deploy honest

### DIFF
--- a/src/heimdall-descriptor.ts
+++ b/src/heimdall-descriptor.ts
@@ -3,9 +3,22 @@
  *
  * Returned verbatim by GET /heimdall.json — no auth required, same posture as /health.
  * Schema: https://heimdall.gille.ai/schema/service/v1
+ *
+ * DESCRIBE, DON'T EMBED (#317-follow-up). This file's job is to say what
+ * exists and how to fetch it — identity, status, real deploy facts, and panel
+ * *declarations* — not to ship bulk data. The learning-loop capability/product
+ * evidence (issue #164) used to be inlined here as full table rows on every
+ * ~60s Heimdall poll; it is now pushed on a much slower cadence to Heimdall's
+ * `POST /api/panels` store (src/heimdall-report.ts) and rendered on Hugin's
+ * service page independently of this descriptor. That is the established,
+ * already-deployed "panel data endpoint fetched on demand" pattern (heimdall
+ * issue #57 — see mimir's src/heimdall-report.ts for a live producer example),
+ * not a new contract.
  */
 
 import type { Application } from "express";
+import { readFileSync } from "node:fs";
+import * as path from "node:path";
 import {
   buildLearningLoopPanels,
   computeCapabilityPlane,
@@ -25,16 +38,33 @@ export const HEIMDALL_DESCRIPTOR = {
     criticality: "normal",
   },
   kind: "http-service",
+  // Base/fallback status when no live health input is wired (e.g. the bare
+  // `registerHeimdallDescriptorRoute(app)` call in tests). The real server
+  // always supplies `opts.health` so the wire response reflects live state —
+  // see deriveDescriptorStatus below. This literal is deliberately NOT what
+  // ships from the running service.
   status: "pass",
   version: "0.1.0",
+  // Only facts Hugin genuinely knows about its own runtime placement.
+  // `deployed_commit` is added per-request from the `.deployed-commit` stamp
+  // (same file Heimdall's drift.js reads authoritatively) when present — see
+  // readDeployedCommit. `latest_commit`/`drift`/`deployed_at` are intentionally
+  // OMITTED rather than published as null: Hugin cannot know origin/main's
+  // latest commit without duplicating Heimdall's own drift computation, and a
+  // structure of nulls reads as "failed to determine" when it should read as
+  // "not this service's job to say" (munin-memory's descriptor — the 648-byte
+  // reference — follows the same omission pattern).
   deploy: {
     host: "huginmunin",
+    systemd_unit: "hugin",
     platform: "bare-metal",
   },
   metrics: [],
   // Tier-1 services own their panels: Heimdall's static known-panels fallback is
   // not consulted once /heimdall.json exists, so the task views must be declared
   // here (#135). Rendered live by Heimdall's plugins/hugin.js from the Munin DB.
+  // These ARE thin declarations (id/plugin/view/label) — no data — unlike the
+  // learning-loop typed panels, which are pushed, not declared here.
   panels: [
     { id: "hugin-tasks", plugin: "hugin", view: "tasks", label: "Tasks", refresh: 60, fullWidth: true },
     { id: "hugin-history", plugin: "hugin", view: "history", label: "Task history", refresh: 120, fullWidth: true },
@@ -46,23 +76,95 @@ export const HEIMDALL_DESCRIPTOR = {
   ui: { icon: "cpu", category: "infra" },
 } as const;
 
+const DEPLOYED_COMMIT_FILENAME = ".deployed-commit";
+
+/**
+ * Read the commit Hugin was actually deployed at, from the same
+ * `.deployed-commit` stamp that `scripts/deploy-pi.sh` writes atomically after
+ * every accepted deploy and that Heimdall's drift.js reads authoritatively
+ * (rsync deploys exclude .git/, so an on-disk git checkout would be stale or
+ * absent — the stamp is the one honest source). Returns null — never a
+ * fabricated or partial value — when the file is absent or its content
+ * doesn't look like a hex commit sha (e.g. a fresh dev checkout).
+ */
+export function readDeployedCommit(repoRoot: string = process.cwd()): string | null {
+  try {
+    const raw = readFileSync(path.join(repoRoot, DEPLOYED_COMMIT_FILENAME), "utf8").trim();
+    return /^[0-9a-f]{7,40}$/i.test(raw) ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Live signals the descriptor's `status` is actually derived from. */
+export interface DescriptorHealthInput {
+  /** The dispatcher poll loop is alive (false once shutdown has begun). */
+  polling: boolean;
+  /** Whether the Broker surface is configured at all (HUGIN_BROKER_KEYS set). */
+  brokerConfigured: boolean;
+  /** Broker configured but its bind is retrying or has failed. */
+  brokerDegraded: boolean;
+  /** Tasks stuck in the `blocked` lifecycle — the dispatcher is running fine,
+   * this is a finding that needs attention, not a binary failure. */
+  blockedTasks: number;
+}
+
+export interface DerivedDescriptorStatus {
+  status: "pass" | "warn" | "fail";
+  /** IETF health+json `output` — human-readable detail behind a non-pass
+   * status. null for a clean pass (nothing to say). */
+  output: string | null;
+}
+
+/**
+ * Derive the descriptor's `status` from real dispatcher signals instead of a
+ * hardcoded literal. Deliberately does NOT fold in learning-loop capability/
+ * product evidence (#164) or deploy-commit staleness — those are separate
+ * evidence planes with their own owners (Heimdall's drift.js is authoritative
+ * for deploy freshness) and collapsing them here would be exactly the kind of
+ * "competing capability truth" this codebase avoids elsewhere.
+ *
+ * `fail` only for the dispatcher genuinely not running. `warn` — the "ran
+ * fine, here are N findings" shape, not a flat pass/fail — for a degraded
+ * broker or a nonzero blocked-task count. Otherwise `pass`.
+ */
+export function deriveDescriptorStatus(input: DescriptorHealthInput): DerivedDescriptorStatus {
+  if (!input.polling) {
+    return { status: "fail", output: "dispatcher poll loop is not running" };
+  }
+  if (input.brokerConfigured && input.brokerDegraded) {
+    return { status: "warn", output: "broker bind is degraded (retrying or failed)" };
+  }
+  if (input.blockedTasks > 0) {
+    return {
+      status: "warn",
+      output: `${input.blockedTasks} blocked task(s) awaiting attention`,
+    };
+  }
+  return { status: "pass", output: null };
+}
+
 /**
  * Build the learning-loop health panels (#164) from collected evidence.
  *
  * These are Heimdall TYPED panels (`stat`/`table`/`status`), which Heimdall
- * renders natively with zero per-panel code — unlike the `plugin`/`view` panels
- * above, which require a matching renderer in the heimdall repo. That is what
- * keeps this a Hugin-only change.
+ * renders natively with zero per-panel code. They are no longer embedded in
+ * the descriptor (see module docstring) — src/heimdall-report.ts pushes them
+ * to Heimdall's panel store on its own slower cadence. Kept here (rather than
+ * moved into heimdall-report.ts) because it is pure evidence-plane
+ * computation shared conceptually with the descriptor's health story, and
+ * because moving it would churn the existing #164 test coverage for no
+ * behavioral gain.
  *
  * Fail-open: any collection failure yields honest "no evidence available"
- * panels rather than a broken descriptor.
+ * panels rather than a broken descriptor/push cycle.
  */
 export function buildLearningLoopHealthPanels(
   collector: LearningLoopCollector
 ): TypedPanel[] {
   // Synchronous by design: `collect()` is stale-while-revalidate and returns
-  // immediately. The descriptor must never wait on a cold corpus walk — hanging
-  // /heimdall.json blanks Hugin's whole Heimdall page (#135).
+  // immediately. Neither the descriptor nor the push cycle should ever wait
+  // on a cold corpus walk.
   const {
     ledger,
     tasks,
@@ -88,37 +190,51 @@ export function buildLearningLoopHealthPanels(
   });
 }
 
+export interface RegisterDescriptorRouteOptions {
+  /** Live health snapshot. Called per-request; when absent the base
+   * (fallback) `status: "pass"` ships as-is — see HEIMDALL_DESCRIPTOR. */
+  health?: () => DescriptorHealthInput;
+  /** Root directory to read `.deployed-commit` from. Defaults to
+   * process.cwd(), which is the systemd unit's WorkingDirectory in
+   * production. Overridable for tests. */
+  repoRoot?: string;
+}
+
 /**
  * Register the GET /heimdall.json route on the given Express app.
  * No auth required — same open posture as /health.
  *
- * When a collector is supplied, the learning-loop health panels (#164) are
- * appended to the static descriptor panels. The route NEVER fails on their
- * account: a collector error degrades to the static descriptor, because a
- * broken /heimdall.json would blank Hugin's whole Heimdall page (#135).
+ * The route NEVER fails on account of live-health derivation: a `health`
+ * callback error degrades to the static descriptor, because a broken
+ * /heimdall.json would blank Hugin's whole Heimdall page (#135).
  */
 export function registerHeimdallDescriptorRoute(
   app: Application,
-  collector?: LearningLoopCollector
+  opts?: RegisterDescriptorRouteOptions
 ): void {
   app.get("/heimdall.json", (_req, res) => {
-    if (!collector) {
-      res.json(HEIMDALL_DESCRIPTOR);
+    const deployedCommit = readDeployedCommit(opts?.repoRoot);
+    const base = {
+      ...HEIMDALL_DESCRIPTOR,
+      deploy: {
+        ...HEIMDALL_DESCRIPTOR.deploy,
+        ...(deployedCommit ? { deployed_commit: deployedCommit } : {}),
+      },
+    };
+    if (!opts?.health) {
+      res.json(base);
       return;
     }
     try {
-      const learningPanels = buildLearningLoopHealthPanels(collector);
-      res.json({
-        ...HEIMDALL_DESCRIPTOR,
-        panels: [...HEIMDALL_DESCRIPTOR.panels, ...learningPanels],
-      });
+      const { status, output } = deriveDescriptorStatus(opts.health());
+      res.json({ ...base, status, ...(output ? { output } : {}) });
     } catch (err) {
       console.warn(
-        `[heimdall] learning-loop panels unavailable, serving static descriptor: ${
+        `[heimdall] status derivation failed, serving base descriptor: ${
           err instanceof Error ? err.message : String(err)
         }`
       );
-      res.json(HEIMDALL_DESCRIPTOR);
+      res.json(base);
     }
   });
 }

--- a/src/heimdall-report.ts
+++ b/src/heimdall-report.ts
@@ -1,0 +1,152 @@
+/**
+ * Push Hugin's learning-loop typed panels (#164) to Heimdall's generic panel
+ * store (`POST /api/panels`, heimdall issue #57) instead of embedding their
+ * full row data in every /heimdall.json response (#317-follow-up).
+ *
+ * This mirrors an already-deployed, in-fleet pattern — see mimir's
+ * src/heimdall-report.ts and gille-inference's scripts/post-*-panel.ts — so it
+ * requires NO heimdall-side change: the ingest endpoint, auth, and per-service
+ * rendering already exist and are already used by other producers.
+ *
+ * Env-gated and fail-soft by design:
+ *   - Requires both HEIMDALL_HUB_URL (the full `.../api/panels` URL) and
+ *     HEIMDALL_FLEET_TOKEN. Either absent ⇒ startHeimdallPanelReporter is a
+ *     documented no-op (returns null immediately, never touches the network).
+ *   - Every push has a bounded timeout and never throws past this module —
+ *     a Heimdall outage must never affect Hugin's own dispatcher loop.
+ */
+
+import type { TypedPanel } from "./learning-loop-health.js";
+
+/** The envelope Heimdall's panel-ingest.js validatePanel() accepts. */
+export type PushPanel = { service: string; panel: string; kind: string } & Record<string, unknown>;
+
+/** Push cadence — matches the `refresh: 300` the panels already declare. */
+const REPORT_INTERVAL_MS = 300_000;
+const PUSH_TIMEOUT_MS = 4_000;
+const SERVICE = "hugin";
+
+function isNum(v: unknown): v is number {
+  return typeof v === "number" && Number.isFinite(v);
+}
+
+/**
+ * Convert one descriptor-shaped TypedPanel into a push envelope, or null when
+ * it isn't safely pushable.
+ *
+ * Strips descriptor-only fields (`id` → `panel`, `fullWidth`, `refresh` —
+ * Heimdall's push path doesn't use them). Also guards a real asymmetry
+ * between the two consumer paths: the pull-path normalizer
+ * (heimdall src/contract/panel-data.js normalizeTypedPanelData) is LENIENT —
+ * an invalid `stat.value` is just dropped — but the push path's
+ * validatePanel() HARD-REJECTS the whole panel for it. Hugin's own
+ * "durable handoffs" panel intentionally uses a non-numeric placeholder
+ * ("—") when the product-evidence corpus is unreadable (honesty about
+ * denominators, not a flattering zero) — pushing that would 400 the whole
+ * update. Skipping it here leaves Heimdall's last good value in place
+ * (harmless staleness) rather than losing every other panel in the same
+ * batch to one rejected push.
+ */
+export function toPushPanel(p: TypedPanel): PushPanel | null {
+  const { id, fullWidth: _fullWidth, refresh: _refresh, kind, ...rest } = p;
+  void _fullWidth;
+  void _refresh;
+  if (kind === "stat" && !isNum((rest as { value?: unknown }).value)) return null;
+  if (kind === "status" && typeof (rest as { state?: unknown }).state !== "string") return null;
+  if (kind === "table" && !Array.isArray((rest as { rows?: unknown }).rows)) return null;
+  if (kind === "timeseries" && !Array.isArray((rest as { points?: unknown }).points)) return null;
+  return { service: SERVICE, panel: id, kind, ...rest };
+}
+
+/** Filter + convert a full panel list, dropping unpushable ones. */
+export function buildPushPanels(panels: TypedPanel[]): PushPanel[] {
+  const out: PushPanel[] = [];
+  for (const p of panels) {
+    const pushed = toPushPanel(p);
+    if (pushed) out.push(pushed);
+  }
+  return out;
+}
+
+/**
+ * POST a single panel to the Heimdall hub. Fail-soft: logs and returns on any
+ * non-2xx or network error; never throws.
+ */
+export async function pushPanel(hubUrl: string, token: string, panel: PushPanel): Promise<void> {
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), PUSH_TIMEOUT_MS);
+  try {
+    const response = await fetch(hubUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(panel),
+      signal: ac.signal,
+    });
+    if (!response.ok) {
+      console.warn(
+        `[hugin] Heimdall panel push rejected (panel=${panel.panel}, status=${response.status}).`
+      );
+    }
+  } catch (err) {
+    console.warn(
+      `[hugin] Heimdall panel push failed (panel=${panel.panel}):`,
+      err instanceof Error ? err.message : String(err)
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function runReport(
+  hubUrl: string,
+  token: string,
+  getPanels: () => TypedPanel[]
+): Promise<void> {
+  const panels = buildPushPanels(getPanels());
+  for (const panel of panels) {
+    await pushPanel(hubUrl, token, panel);
+  }
+}
+
+/**
+ * Start the periodic Heimdall panel-push loop.
+ *
+ * `getPanels` is called synchronously on each cycle — pass e.g.
+ * `() => buildLearningLoopHealthPanels(collector)`, which is itself
+ * stale-while-revalidate cached, so this never blocks on a cold corpus walk.
+ *
+ * Env-gated: requires both HEIMDALL_HUB_URL and HEIMDALL_FLEET_TOKEN. Returns
+ * a cleanup function on success, or null when either is absent (safe to
+ * call: logs one debug line, touches no network).
+ *
+ * The interval is unref()'d so it never prevents process exit.
+ */
+export function startHeimdallPanelReporter(getPanels: () => TypedPanel[]): (() => void) | null {
+  const hubUrl = process.env.HEIMDALL_HUB_URL;
+  const token = process.env.HEIMDALL_FLEET_TOKEN;
+
+  if (!hubUrl || !token) {
+    console.debug(
+      "[hugin] Heimdall panel reporter disabled (HEIMDALL_HUB_URL/HEIMDALL_FLEET_TOKEN not set)."
+    );
+    return null;
+  }
+
+  const fire = (): void => {
+    runReport(hubUrl, token, getPanels).catch((err) => {
+      console.warn(
+        "[hugin] Heimdall panel report cycle errored:",
+        err instanceof Error ? err.message : String(err)
+      );
+    });
+  };
+
+  fire();
+  const interval = setInterval(fire, REPORT_INTERVAL_MS);
+  interval.unref();
+
+  return () => clearInterval(interval);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,12 @@ import { createRequire } from "node:module";
 import * as os from "node:os";
 import * as path from "node:path";
 import express from "express";
-import { HEIMDALL_DESCRIPTOR, registerHeimdallDescriptorRoute } from "./heimdall-descriptor.js";
+import {
+  HEIMDALL_DESCRIPTOR,
+  registerHeimdallDescriptorRoute,
+  buildLearningLoopHealthPanels,
+} from "./heimdall-descriptor.js";
+import { startHeimdallPanelReporter } from "./heimdall-report.js";
 import {
   buildDefaultEgressHosts,
   installFetchEgressPolicy,
@@ -7133,12 +7138,30 @@ app.get("/health", (_req, res) => {
 // Learning-loop health panels (#164). Its own LedgerClient (cached, fail-open)
 // so the dashboard surface does not depend on the verdict layer being enabled.
 // The collector is bounded + TTL-cached and can never break /heimdall.json.
-registerHeimdallDescriptorRoute(
-  app,
-  new LearningLoopCollector({
-    munin,
-    ledgerClient: new LedgerClient({ env: process.env }),
-  })
+// The descriptor route below does NOT use this collector — it deliberately
+// keeps identity/health separate from capability/product evidence (see
+// heimdall-descriptor.ts) — but the periodic panel push does, so the one
+// cached corpus walk backs both instead of doubling collection cost.
+const learningLoopCollector = new LearningLoopCollector({
+  munin,
+  ledgerClient: new LedgerClient({ env: process.env }),
+});
+
+registerHeimdallDescriptorRoute(app, {
+  health: () => ({
+    polling: !shuttingDown,
+    brokerConfigured: brokerEnv.enabled,
+    brokerDegraded: computeBrokerHealthField(brokerEnv.enabled, brokerBindStatus).degraded,
+    blockedTasks: lastBlockedTaskCount,
+  }),
+});
+
+// Pushes the learning-loop typed panels (#164) to Heimdall's panel store on a
+// slow (5 min) cadence instead of embedding them in every /heimdall.json
+// response. No-op until HEIMDALL_HUB_URL + HEIMDALL_FLEET_TOKEN are
+// configured in this service's environment; see src/heimdall-report.ts.
+const stopHeimdallPanelReporter = startHeimdallPanelReporter(() =>
+  buildLearningLoopHealthPanels(learningLoopCollector)
 );
 
 // --- Graceful shutdown ---
@@ -7175,6 +7198,7 @@ async function shutdown(signal: string): Promise<void> {
   stopLeaseReaper();
   stopDeliveryRetryReaper();
   stopAuthAlarmReaper();
+  stopHeimdallPanelReporter?.();
 
   // Mark the current task as failed before killing the process
   if (currentTask) {

--- a/tests/heimdall-descriptor.test.ts
+++ b/tests/heimdall-descriptor.test.ts
@@ -1,8 +1,16 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import express from "express";
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
-import { HEIMDALL_DESCRIPTOR, registerHeimdallDescriptorRoute } from "../src/heimdall-descriptor.js";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  HEIMDALL_DESCRIPTOR,
+  registerHeimdallDescriptorRoute,
+  deriveDescriptorStatus,
+  readDeployedCommit,
+} from "../src/heimdall-descriptor.js";
 
 // ---------------------------------------------------------------------------
 // Descriptor shape tests (no HTTP needed)
@@ -74,12 +82,104 @@ describe("HEIMDALL_DESCRIPTOR", () => {
 });
 
 // ---------------------------------------------------------------------------
+// deriveDescriptorStatus — pure function, no hardcoded "pass"
+// ---------------------------------------------------------------------------
+
+describe("deriveDescriptorStatus", () => {
+  it("reports fail when the dispatcher poll loop is not running", () => {
+    const result = deriveDescriptorStatus({
+      polling: false,
+      brokerConfigured: false,
+      brokerDegraded: false,
+      blockedTasks: 0,
+    });
+    expect(result.status).toBe("fail");
+    expect(result.output).toMatch(/poll/i);
+  });
+
+  it("reports warn when the broker is configured but degraded", () => {
+    const result = deriveDescriptorStatus({
+      polling: true,
+      brokerConfigured: true,
+      brokerDegraded: true,
+      blockedTasks: 0,
+    });
+    expect(result.status).toBe("warn");
+    expect(result.output).toMatch(/broker/i);
+  });
+
+  it("ignores broker degradation when the broker is not configured at all", () => {
+    const result = deriveDescriptorStatus({
+      polling: true,
+      brokerConfigured: false,
+      brokerDegraded: true,
+      blockedTasks: 0,
+    });
+    expect(result.status).toBe("pass");
+  });
+
+  it("reports warn with a finding count when tasks are blocked (ran fine, N findings — not a binary)", () => {
+    const result = deriveDescriptorStatus({
+      polling: true,
+      brokerConfigured: true,
+      brokerDegraded: false,
+      blockedTasks: 3,
+    });
+    expect(result.status).toBe("warn");
+    expect(result.output).toContain("3");
+  });
+
+  it("reports pass with no output when everything is nominal", () => {
+    const result = deriveDescriptorStatus({
+      polling: true,
+      brokerConfigured: true,
+      brokerDegraded: false,
+      blockedTasks: 0,
+    });
+    expect(result).toEqual({ status: "pass", output: null });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// readDeployedCommit — reads the same `.deployed-commit` stamp file Heimdall's
+// drift.js reads (authoritative deploy fact, #deploy-honesty)
+// ---------------------------------------------------------------------------
+
+describe("readDeployedCommit", () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns null when no .deployed-commit file exists", () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "hugin-descriptor-test-"));
+    expect(readDeployedCommit(tmpDir)).toBeNull();
+  });
+
+  it("returns the trimmed commit sha when the stamp file is present", () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "hugin-descriptor-test-"));
+    const sha = "a".repeat(40);
+    fs.writeFileSync(path.join(tmpDir, ".deployed-commit"), `${sha}\n`);
+    expect(readDeployedCommit(tmpDir)).toBe(sha);
+  });
+
+  it("returns null for malformed stamp content rather than publishing garbage", () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "hugin-descriptor-test-"));
+    fs.writeFileSync(path.join(tmpDir, ".deployed-commit"), "not-a-sha\n");
+    expect(readDeployedCommit(tmpDir)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // HTTP route test — mount only the /heimdall.json route on a minimal app
 // ---------------------------------------------------------------------------
 
-async function startMinimalApp(): Promise<{ url: string; close: () => void }> {
+async function startMinimalApp(
+  opts?: Parameters<typeof registerHeimdallDescriptorRoute>[1]
+): Promise<{ url: string; close: () => void }> {
   const app = express();
-  registerHeimdallDescriptorRoute(app);
+  registerHeimdallDescriptorRoute(app, opts);
   const server = createServer(app);
   await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
   const { port } = server.address() as AddressInfo;
@@ -100,6 +200,122 @@ describe("GET /heimdall.json", () => {
       expect(body.service?.name).toBe("hugin");
       expect(body._schema).toContain("/service/v1");
       expect(body.kind).toBe("http-service");
+    } finally {
+      close();
+    }
+  });
+
+  it("stays within an order of magnitude of munin-memory's reference descriptor (648 bytes live)", async () => {
+    const { url, close } = await startMinimalApp();
+    try {
+      const res = await fetch(`${url}/heimdall.json`);
+      const raw = await res.text();
+      // Live measurement 2026-07-25: hugin 7754B vs munin-memory 648B before
+      // this change. 2000B keeps real headroom for identity/deploy/panel
+      // declarations while remaining the same order of magnitude, not 12x.
+      expect(raw.length).toBeLessThan(2000);
+    } finally {
+      close();
+    }
+  });
+
+  it("does not embed the learning-loop capability-evidence table (bulk data belongs behind the panel push endpoint, not the descriptor)", async () => {
+    const { url, close } = await startMinimalApp();
+    try {
+      const raw = await (await fetch(`${url}/heimdall.json`)).text();
+      expect(raw).not.toContain("hugin-capability-evidence");
+      expect(raw).not.toContain("M5 recommends");
+      const body = JSON.parse(raw);
+      expect(body.panels).toEqual([
+        { id: "hugin-tasks", plugin: "hugin", view: "tasks", label: "Tasks", refresh: 60, fullWidth: true },
+        { id: "hugin-history", plugin: "hugin", view: "history", label: "Task history", refresh: 120, fullWidth: true },
+      ]);
+    } finally {
+      close();
+    }
+  });
+
+  it("omits deployed_commit/latest_commit/drift/deployed_at rather than publishing nulls when no stamp is available", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "hugin-descriptor-test-"));
+    try {
+      const { url, close } = await startMinimalApp({ repoRoot: tmpDir });
+      try {
+        const res = await fetch(`${url}/heimdall.json`);
+        const body = await res.json();
+        expect(body.deploy).not.toHaveProperty("deployed_commit");
+        expect(body.deploy).not.toHaveProperty("latest_commit");
+        expect(body.deploy).not.toHaveProperty("drift");
+        expect(body.deploy).not.toHaveProperty("deployed_at");
+        // What Hugin genuinely knows about itself stays present.
+        expect(body.deploy.host).toBeTruthy();
+        expect(body.deploy.platform).toBeTruthy();
+      } finally {
+        close();
+      }
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("publishes a real deployed_commit when the .deployed-commit stamp is present (Hugin knows its own deployed revision)", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "hugin-descriptor-test-"));
+    const sha = "b".repeat(40);
+    fs.writeFileSync(path.join(tmpDir, ".deployed-commit"), `${sha}\n`);
+    try {
+      const { url, close } = await startMinimalApp({ repoRoot: tmpDir });
+      try {
+        const res = await fetch(`${url}/heimdall.json`);
+        const body = await res.json();
+        expect(body.deploy.deployed_commit).toBe(sha);
+      } finally {
+        close();
+      }
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("derives status/output from live health input instead of a hardcoded pass", async () => {
+    const { url, close } = await startMinimalApp({
+      health: () => ({
+        polling: true,
+        brokerConfigured: true,
+        brokerDegraded: true,
+        blockedTasks: 0,
+      }),
+    });
+    try {
+      const res = await fetch(`${url}/heimdall.json`);
+      const body = await res.json();
+      expect(body.status).toBe("warn");
+      expect(body.output).toMatch(/broker/i);
+    } finally {
+      close();
+    }
+  });
+
+  it("falls back to the base pass status when no health input is wired (never breaks the route)", async () => {
+    const { url, close } = await startMinimalApp();
+    try {
+      const res = await fetch(`${url}/heimdall.json`);
+      const body = await res.json();
+      expect(body.status).toBe("pass");
+    } finally {
+      close();
+    }
+  });
+
+  it("never fails the route when the health callback throws (fail-open, #135)", async () => {
+    const { url, close } = await startMinimalApp({
+      health: () => {
+        throw new Error("boom");
+      },
+    });
+    try {
+      const res = await fetch(`${url}/heimdall.json`);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.service?.name).toBe("hugin");
     } finally {
       close();
     }

--- a/tests/heimdall-report.test.ts
+++ b/tests/heimdall-report.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  buildPushPanels,
+  toPushPanel,
+  startHeimdallPanelReporter,
+} from "../src/heimdall-report.js";
+import type { TypedPanel } from "../src/learning-loop-health.js";
+
+// ---------------------------------------------------------------------------
+// toPushPanel / buildPushPanels — pure conversion from descriptor-shaped
+// TypedPanel to the Heimdall POST /api/panels envelope (#57 contract).
+// ---------------------------------------------------------------------------
+
+describe("toPushPanel", () => {
+  it("maps a table panel to a push envelope keyed by service=hugin", () => {
+    const panel: TypedPanel = {
+      id: "hugin-capability-evidence",
+      label: "M5 capability evidence",
+      kind: "table",
+      fullWidth: true,
+      refresh: 300,
+      cols: ["Task type", "Model"],
+      rows: [{ "Task type": "summarize", Model: "gpt-oss-120b" }],
+    };
+    expect(toPushPanel(panel)).toEqual({
+      service: "hugin",
+      panel: "hugin-capability-evidence",
+      label: "M5 capability evidence",
+      kind: "table",
+      cols: ["Task type", "Model"],
+      rows: [{ "Task type": "summarize", Model: "gpt-oss-120b" }],
+    });
+  });
+
+  it("strips descriptor-only fields (fullWidth, refresh) — not part of the push envelope", () => {
+    const panel: TypedPanel = {
+      id: "hugin-route-policy",
+      label: "Route policy",
+      kind: "status",
+      refresh: 300,
+      state: "warn",
+      message: "shadow mode",
+    };
+    const pushed = toPushPanel(panel);
+    expect(pushed).not.toHaveProperty("fullWidth");
+    expect(pushed).not.toHaveProperty("refresh");
+    expect(pushed).not.toHaveProperty("id");
+  });
+
+  it("drops a stat panel whose value is not numeric (push path hard-rejects non-numeric stat)", () => {
+    const panel: TypedPanel = {
+      id: "hugin-durable-handoffs",
+      label: "Durable handoffs",
+      kind: "stat",
+      value: "—", // unmeasured placeholder — real value in the pull-path renderer
+    };
+    expect(toPushPanel(panel)).toBeNull();
+  });
+
+  it("keeps a stat panel with a real numeric value", () => {
+    const panel: TypedPanel = {
+      id: "hugin-durable-handoffs",
+      label: "Durable handoffs",
+      kind: "stat",
+      value: 3,
+    };
+    expect(toPushPanel(panel)).toMatchObject({ kind: "stat", value: 3 });
+  });
+
+  it("drops a status panel with a missing/invalid state", () => {
+    const panel: TypedPanel = {
+      id: "broken",
+      label: "Broken",
+      kind: "status",
+      state: 42 as unknown as string,
+    };
+    expect(toPushPanel(panel)).toBeNull();
+  });
+
+  it("drops a table panel whose rows are missing", () => {
+    const panel: TypedPanel = {
+      id: "broken-table",
+      label: "Broken table",
+      kind: "table",
+      cols: ["a"],
+    };
+    expect(toPushPanel(panel)).toBeNull();
+  });
+});
+
+describe("buildPushPanels", () => {
+  it("filters out unpushable panels and keeps the rest, in order", () => {
+    const panels: TypedPanel[] = [
+      { id: "a", label: "A", kind: "table", rows: [{ x: "1" }] },
+      { id: "b", label: "B", kind: "stat", value: "—" },
+      { id: "c", label: "C", kind: "status", state: "pass" },
+    ];
+    const pushed = buildPushPanels(panels);
+    expect(pushed.map((p) => p.panel)).toEqual(["a", "c"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// startHeimdallPanelReporter — env-gating and fetch calls (mirrors mimir's
+// src/heimdall-report.ts pattern, the established in-fleet push convention).
+// ---------------------------------------------------------------------------
+
+describe("startHeimdallPanelReporter", () => {
+  const HUB_URL = "http://hub.local/api/panels";
+  const FLEET_TOKEN = "test-fleet-token";
+
+  const onePanel = (): TypedPanel[] => [
+    { id: "hugin-route-policy", label: "Route policy", kind: "status", state: "pass" },
+  ];
+
+  beforeEach(() => {
+    delete process.env.HEIMDALL_HUB_URL;
+    delete process.env.HEIMDALL_FLEET_TOKEN;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns null and never calls fetch when env vars are absent", () => {
+    const mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+
+    const cleanup = startHeimdallPanelReporter(onePanel);
+
+    expect(cleanup).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("returns null when only HEIMDALL_HUB_URL is set", () => {
+    process.env.HEIMDALL_HUB_URL = HUB_URL;
+    const mockFetch = vi.fn();
+    vi.stubGlobal("fetch", mockFetch);
+
+    expect(startHeimdallPanelReporter(onePanel)).toBeNull();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("POSTs to the configured hub URL with a Bearer token on startup", async () => {
+    process.env.HEIMDALL_HUB_URL = HUB_URL;
+    process.env.HEIMDALL_FLEET_TOKEN = FLEET_TOKEN;
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const cleanup = startHeimdallPanelReporter(onePanel);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(HUB_URL);
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe(`Bearer ${FLEET_TOKEN}`);
+    const body = JSON.parse(init.body as string);
+    expect(body).toMatchObject({ service: "hugin", panel: "hugin-route-policy" });
+
+    cleanup!();
+  });
+
+  it("never throws when fetch rejects (fail-soft)", async () => {
+    process.env.HEIMDALL_HUB_URL = HUB_URL;
+    process.env.HEIMDALL_FLEET_TOKEN = FLEET_TOKEN;
+    const mockFetch = vi.fn().mockRejectedValue(new Error("network down"));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const cleanup = startHeimdallPanelReporter(onePanel);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(typeof cleanup).toBe("function");
+    cleanup!();
+  });
+});


### PR DESCRIPTION
## Summary

The owner's complaint: "loads of alarms, not sure if they are correct, and
the info display is often bloated and not very helpful." Hugin's
`/heimdall.json` was **7,754 bytes live** (measured 2026-07-25) — 12x
munin-memory's 648-byte reference, one of only two services that publish
their own descriptor. Three issues, all addressed:

1. **Bulk data inlined, not described.** The descriptor embedded the full
   `#164` learning-loop capability-evidence table (per task-type/model
   attempts, quality %, maturity, recommendation) on every ~60s Heimdall
   poll. Moved to a periodic push (`src/heimdall-report.ts`) onto Heimdall's
   **existing** `POST /api/panels` store (heimdall issue #57) — the same
   pattern already used in production by mimir
   (`mimir/src/heimdall-report.ts`) and gille-inference's
   `scripts/post-*-panel.ts`. **No heimdall-side change required** — the
   ingest endpoint, auth, and per-service page rendering already exist and
   already serve other producers. Env-gated
   (`HEIMDALL_HUB_URL` + `HEIMDALL_FLEET_TOKEN`) and fail-soft; a documented
   no-op until those are set in Hugin's `.env` on the Pi.
2. **`deploy` block was a structure of nulls.** Now populates
   `deploy.deployed_commit` from the same `.deployed-commit` stamp file
   Heimdall's `drift.js` already reads authoritatively (rsync deploys
   exclude `.git/`, so this stamp is the one honest source). Deliberately
   **omits** `latest_commit`/`drift`/`deployed_at` rather than nulling them —
   Hugin doesn't try to recompute Heimdall's own drift authority (matches
   munin-memory's pattern, the 648B reference).
3. **`status` was a hardcoded `"pass"` literal.** Now derived from real
   dispatcher signals (poll-loop alive, broker bind degraded, blocked-task
   count) via `deriveDescriptorStatus`. Uses the existing (currently inert)
   health+json `output` field to express **"ran fine, N findings"** — e.g.
   `warn` + `"3 blocked task(s) awaiting attention"` — rather than a flat
   binary, while staying inside the current `pass`/`warn`/`fail` schema. This
   is deliberately the shape the parallel Heimdall state-remodeling work
   seems to be heading toward; see "Coordinated change" below.

## Before / after (measured, not estimated)

- Live production descriptor (`ssh huginmunin.local sqlite3 ...`), before this
  change: **7,754 bytes**.
- Local equivalent of the new route, same inputs a running Hugin would supply
  (`health` callback wired, no `.deployed-commit` in a dev checkout): **687
  bytes** — smaller than munin-memory's 648B reference plus its 2 owned
  `plugin`/`view` panel declarations. With a real `.deployed-commit` stamp
  present: **804 bytes**.
- That's an **~11x reduction**, into the same order of magnitude as the
  648-byte reference, not a 12x outlier.

## What moved behind an endpoint vs. removed

- **Moved, not removed**: the capability-evidence table, trial-gate table,
  route-policy status, durable-handoffs stat, and learning-experiments table
  (`buildLearningLoopHealthPanels`, unchanged) now go to Heimdall's panel
  store via push instead of being embedded in the descriptor. The underlying
  evidence computation (`learning-loop-health.ts`) is untouched; only the
  transport changed.
- **Declared, not embedded**: the two `hugin-tasks`/`hugin-history`
  `plugin`/`view` panels stay in the descriptor's `panels` array — they were
  already thin declarations (id/plugin/view/label, no data) and are the model
  for what a descriptor should contain.

## Was Hugin's `status` claim actually correct?

No — it was a static literal, not derived from anything, so it couldn't be
"wrong" in a factual sense but also couldn't be trusted as a signal. It
happened to coincide with "the process is running" most of the time, which
masked the real gap: nothing tied it to broker health or blocked-task
backlog. Separately, Heimdall's "Deploy drift: hugin" alert is computed
**entirely independently** (`heimdall/src/drift.js`, reading the same
`.deployed-commit` stamp + `git ls-remote` on origin/main) — it never reads
Hugin's descriptor at all today, so there was no direct contradiction between
`status: "pass"` and that alert, just two disconnected claims that read as
inconsistent on the dashboard. This PR doesn't fold deploy-drift into
`status` (that would duplicate Heimdall's own drift authority); it makes
`status` honestly reflect dispatcher health, and separately gives the
`deploy` block a real, non-null fact Heimdall's UI can render.

## Coordinated change (flagged, not assumed)

You mentioned a parallel Heimdall change reworking service state into
healthy / completed-with-findings / failed-to-run rather than flat
pass/fail. This PR's `deriveDescriptorStatus` already produces exactly that
shape (`status: "warn"` + a populated `output` string describing the
finding) **using the current schema** — `output` is an existing but
currently-unrendered health+json field in Heimdall's contract
(`src/contract/schema.js` `normalizeDescriptor`), so this should slot into
that work without a producer-side change once Heimdall starts rendering it.
If the new model ends up wanting a distinct third status value or a
structured findings array instead of a string, that would be a
heimdall-side schema addition — flagging it here rather than guessing at
its shape.

## Test plan

- [x] Red first: `tests/heimdall-descriptor.test.ts` (new status/deploy/size
      assertions) and the new `tests/heimdall-report.test.ts` written before
      implementation, confirmed failing for the right reason (module not
      found / old hardcoded-pass / old panel-embedding behavior).
- [x] `npm test` — **159 test files, 2,416 tests, all passing** (real output,
      not asserted).
- [x] `npx tsc --noEmit` and `npm run build` — clean, no errors.
- [x] `bash scripts/deploy-pi.test.sh` — unaffected, all assertions pass
      (this PR does not touch deployment scripts).
- [x] Live descriptor size re-measured via a local Express instance running
      the actual compiled route (not hand-computed).

## Unverified / not done here

- `HEIMDALL_HUB_URL` / `HEIMDALL_FLEET_TOKEN` are not configured in Hugin's
  `.env` on the Pi (out of scope — "do not restart live services"). The
  panel reporter is a safe no-op until an operator sets them; panels will
  keep showing whatever Heimdall already has stored (or nothing) until then.
  Flagging this as the one follow-up needed for the push path to actually
  activate in production.
- Did not attempt to independently recompute deploy drift inside Hugin
  (e.g. `git ls-remote`) — kept that authority solely with Heimdall's
  `drift.js`, per the "don't build a competing capability truth" principle
  already established elsewhere in this codebase for M5 capability evidence.
- Did not modify `heimdall` or `grimnir` — no coordinated change needed for
  this PR's mechanism (push endpoint already exists), only the optional
  `output`-rendering / richer-status-model item flagged above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)