### PR TITLE
W4.1: Add signed autonomy proposal receipts

### DIFF
--- a/docs/autonomy-proposal-receipts.md
+++ b/docs/autonomy-proposal-receipts.md
@@ -1,9 +1,10 @@
 # Autonomy proposal receipts (W4.1)
 
 Hugin's ADR-008 boundary is a proposal boundary, not an apply boundary. The
-closed target registry in `src/autonomy/proposal-receipts.ts` names the only
+closed, runtime-deep-frozen versioned target registry in
+`src/autonomy/proposal-receipts.ts` names the only
 Hugin-owned targets that a later controller may consider: macro-routing,
-agent-prompt, agent-harness, and Hugin tool-policy. Every receipt is still
+prompt, harness, and Hugin tool-policy. Every receipt is still
 `proposal-only`; this module contains no adapter, mutation, reload, deploy, or
 promotion entry point.
 
@@ -15,13 +16,16 @@ also refused.
 A receipt is closed, JCS-canonical, HMAC-signed, and contains only opaque refs,
 revisions, timestamps, and SHA-256 digests. It binds the proposal identity,
 experiment/evidence identities, exactly one target/axis, independently supplied
-base revision/digest, candidate-content digest, expiry, and the deployed
-Grimnir ADR-008 policy epoch. It never stores candidate configuration, prompt,
+base revision/digest, candidate-content digest, expiry, and the immutable
+ownership-registry version/digest. The registry itself pins the adopted Grimnir
+ADR-008 constitution ID and digest rather than accepting a caller-selected
+policy label. It never stores candidate configuration, prompt,
 fixture, secret, or gateway response.
 
-`storeAutonomyProposalReceipt` verifies target ownership, policy epoch, expiry,
-current base, canonical digest, and signer before a Munin `create_if_absent`
-write. An exact canonical replay is successful; a conflicting record under the
-same proposal ID is rejected. Receipt persistence does not call a configuration
-or deployment surface. W4.2 owns any future R-exact journal/controller and must
-revalidate this receipt rather than treating persistence as authority.
+`storeAutonomyProposalReceipt` verifies target ownership, registry and policy
+authority, expiry, current base, canonical digest, and signer before a Munin
+`create_if_absent` write. An exact canonical replay is successful; a
+conflicting record under the same proposal ID is rejected. Receipt persistence
+does not call a configuration or deployment surface. W4.2 owns any future
+R-exact journal/controller and must revalidate this receipt rather than treating
+persistence as authority.

--- a/docs/autonomy-proposal-receipts.md
+++ b/docs/autonomy-proposal-receipts.md
@@ -1,0 +1,27 @@
+# Autonomy proposal receipts (W4.1)
+
+Hugin's ADR-008 boundary is a proposal boundary, not an apply boundary. The
+closed target registry in `src/autonomy/proposal-receipts.ts` names the only
+Hugin-owned targets that a later controller may consider: macro-routing,
+agent-prompt, agent-harness, and Hugin tool-policy. Every receipt is still
+`proposal-only`; this module contains no adapter, mutation, reload, deploy, or
+promotion entry point.
+
+The same registry explicitly names cross-owner targets for Gille and Brokkr so
+they cannot be silently re-labelled as Hugin-owned. Logging, test harnesses,
+models, and model configuration are protected and refused. Unknown targets are
+also refused.
+
+A receipt is closed, JCS-canonical, HMAC-signed, and contains only opaque refs,
+revisions, timestamps, and SHA-256 digests. It binds the proposal identity,
+experiment/evidence identities, exactly one target/axis, independently supplied
+base revision/digest, candidate-content digest, expiry, and the deployed
+Grimnir ADR-008 policy epoch. It never stores candidate configuration, prompt,
+fixture, secret, or gateway response.
+
+`storeAutonomyProposalReceipt` verifies target ownership, policy epoch, expiry,
+current base, canonical digest, and signer before a Munin `create_if_absent`
+write. An exact canonical replay is successful; a conflicting record under the
+same proposal ID is rejected. Receipt persistence does not call a configuration
+or deployment surface. W4.2 owns any future R-exact journal/controller and must
+revalidate this receipt rather than treating persistence as authority.

--- a/src/autonomy/proposal-receipts.ts
+++ b/src/autonomy/proposal-receipts.ts
@@ -1,0 +1,201 @@
+/**
+ * Proposal-only autonomy receipt boundary (hugin#329).
+ *
+ * This module intentionally has no configuration adapter, executor, reload, or
+ * deployment dependency. A valid receipt records a content-blind suggestion
+ * for its named owner; W4.2 owns any future R-exact application controller.
+ */
+import { createHash, createHmac, timingSafeEqual } from "node:crypto";
+import { z } from "zod";
+import { canonicalizeJcs } from "../jcs.js";
+import { MuninWriteRejectedError, type MuninClient } from "../munin-client.js";
+import { decodeSecret, type KeyStore } from "../task-signing.js";
+
+const sha256 = z.string().regex(/^sha256:[a-f0-9]{64}$/);
+const opaqueRef = z.string().regex(/^ref:[a-z][a-z0-9-]{2,120}$/);
+const revision = z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._/-]{2,127}$/);
+const targetId = z.string().regex(/^[a-z][a-z0-9-]{2,80}$/);
+const signerId = z.string().regex(/^[a-z][a-z0-9-]{2,80}$/);
+
+export const AUTONOMY_PROPOSAL_SCHEMA_VERSION = "v1" as const;
+export const AUTONOMY_PROPOSAL_POLICY_EPOCH_ID = "grimnir-adr-008-v1" as const;
+export const AUTONOMY_PROPOSAL_SIGNER_KEY_ID = "hugin-autonomy-proposer" as const;
+
+/** Closed registry: broad learning axes never create an implicit apply right. */
+export const proposalTargetRegistry = [
+  { id: "hugin-orin-macro-routing", axis: "routing", owner: "hugin", huginOwned: true },
+  { id: "hugin-agent-prompt", axis: "agent-prompt", owner: "hugin", huginOwned: true },
+  { id: "hugin-agent-harness", axis: "agent-harness", owner: "hugin", huginOwned: true },
+  { id: "hugin-tool-policy", axis: "tool-policy", owner: "hugin", huginOwned: true },
+  { id: "gille-micro-routing", axis: "routing", owner: "gille-inference", huginOwned: false },
+  { id: "gille-served-model-roster", axis: "served-model-roster", owner: "gille-inference", huginOwned: false },
+  { id: "gille-tool-policy", axis: "tool-policy", owner: "gille-inference", huginOwned: false },
+  { id: "brokkr-no-reboot-maintenance", axis: "no-reboot-security-bugfix-maintenance", owner: "brokkr", huginOwned: false },
+  { id: "hugin-logging", axis: "logging", owner: "hugin", huginOwned: false, protected: true },
+  { id: "hugin-test-harness", axis: "test-harness", owner: "hugin", huginOwned: false, protected: true },
+  { id: "gille-model", axis: "model", owner: "gille-inference", huginOwned: false, protected: true },
+  { id: "gille-model-config", axis: "model-config", owner: "gille-inference", huginOwned: false, protected: true },
+] as const;
+
+type ProposalTarget = (typeof proposalTargetRegistry)[number];
+
+const proposalReceiptSchema = z.object({
+  schemaVersion: z.literal(AUTONOMY_PROPOSAL_SCHEMA_VERSION),
+  proposalId: targetId,
+  experimentRef: opaqueRef,
+  evidenceFingerprints: z.array(sha256).min(1).max(32),
+  targetId,
+  axis: z.string().min(1).max(80),
+  owner: z.enum(["hugin", "gille-inference", "brokkr"]),
+  /** Receipts are never authority to mutate; this is deliberately constant. */
+  disposition: z.literal("proposal-only"),
+  base: z.object({ revision, digest: sha256 }).strict(),
+  candidateContentDigest: sha256,
+  expiresAt: z.string().datetime({ offset: true }),
+  policyEpoch: z.object({ id: z.literal(AUTONOMY_PROPOSAL_POLICY_EPOCH_ID), digest: sha256 }).strict(),
+  canonicalProposalDigest: sha256,
+  signerKeyId: z.literal(AUTONOMY_PROPOSAL_SIGNER_KEY_ID),
+  signature: z.string().regex(/^v1:[a-z][a-z0-9-]{2,80}:[a-f0-9]{64}$/),
+}).strict();
+
+export type AutonomyProposalReceipt = z.infer<typeof proposalReceiptSchema>;
+const proposalInputSchema = z.object({
+  proposalId: targetId,
+  experimentRef: opaqueRef,
+  evidenceFingerprints: z.array(sha256).min(1).max(32),
+  targetId,
+  base: z.object({ revision, digest: sha256 }).strict(),
+  candidateContentDigest: sha256,
+  expiresAt: z.string().datetime({ offset: true }),
+  policyEpoch: z.object({ id: z.literal(AUTONOMY_PROPOSAL_POLICY_EPOCH_ID), digest: sha256 }).strict(),
+  signerKeyId: z.literal(AUTONOMY_PROPOSAL_SIGNER_KEY_ID),
+}).strict();
+export type AutonomyProposalInput = z.infer<typeof proposalInputSchema>;
+
+type TargetLookup = ProposalTarget | undefined;
+function targetFor(id: string): TargetLookup {
+  return proposalTargetRegistry.find((candidate) => candidate.id === id);
+}
+
+function requireTarget(id: string): ProposalTarget {
+  const target = targetFor(id);
+  if (!target) throw new Error("unknown-target");
+  if ("protected" in target && target.protected) throw new Error("protected-target");
+  return target;
+}
+
+function signingBody(receipt: Omit<AutonomyProposalReceipt, "signature" | "canonicalProposalDigest">): string {
+  return canonicalizeJcs(receipt);
+}
+
+function sha256Digest(value: string): string {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+export function canonicalAutonomyProposalDigest(
+  receipt: Omit<AutonomyProposalReceipt, "signature" | "canonicalProposalDigest">,
+): string {
+  return sha256Digest(signingBody(receipt));
+}
+
+export function signAutonomyProposalReceipt(
+  receipt: Omit<AutonomyProposalReceipt, "signature">,
+  secretHex: string,
+): string {
+  const secret = decodeSecret(secretHex);
+  const body = canonicalizeJcs(receipt);
+  return `v1:${receipt.signerKeyId}:${createHmac("sha256", secret).update(body).digest("hex")}`;
+}
+
+export function createAutonomyProposalReceipt(input: AutonomyProposalInput, secretHex: string): AutonomyProposalReceipt {
+  const parsedInput = proposalInputSchema.parse(input);
+  const target = requireTarget(parsedInput.targetId);
+  const body = {
+    schemaVersion: AUTONOMY_PROPOSAL_SCHEMA_VERSION,
+    proposalId: parsedInput.proposalId,
+    experimentRef: parsedInput.experimentRef,
+    evidenceFingerprints: parsedInput.evidenceFingerprints,
+    targetId: parsedInput.targetId,
+    axis: target.axis,
+    owner: target.owner,
+    disposition: "proposal-only" as const,
+    base: parsedInput.base,
+    candidateContentDigest: parsedInput.candidateContentDigest,
+    expiresAt: parsedInput.expiresAt,
+    policyEpoch: parsedInput.policyEpoch,
+    signerKeyId: parsedInput.signerKeyId,
+  };
+  const canonicalProposalDigest = canonicalAutonomyProposalDigest(body);
+  return proposalReceiptSchema.parse({
+    ...body,
+    canonicalProposalDigest,
+    signature: signAutonomyProposalReceipt({ ...body, canonicalProposalDigest }, secretHex),
+  });
+}
+
+export type ProposalValidationOptions = {
+  now: () => Date;
+  policyEpochDigest: string;
+  currentBase: { revision: string; digest: string };
+};
+
+export type ProposalVerification = { status: "valid" } | { status: "rejected"; reason: string };
+
+export function verifyAutonomyProposalReceipt(
+  raw: unknown,
+  keys: KeyStore,
+  options: ProposalValidationOptions,
+): ProposalVerification {
+  const parsed = proposalReceiptSchema.safeParse(raw);
+  if (!parsed.success) return { status: "rejected", reason: "invalid-receipt" };
+  const receipt = parsed.data;
+  const target = targetFor(receipt.targetId);
+  if (!target) return { status: "rejected", reason: "unknown-target" };
+  if (("protected" in target && target.protected)) return { status: "rejected", reason: "protected-target" };
+  if (receipt.axis !== target.axis || receipt.owner !== target.owner) return { status: "rejected", reason: "owner-mismatch" };
+  if (Date.parse(receipt.expiresAt) <= options.now().getTime()) return { status: "rejected", reason: "expired" };
+  if (receipt.policyEpoch.digest !== options.policyEpochDigest) return { status: "rejected", reason: "policy-epoch-mismatch" };
+  if (receipt.base.revision !== options.currentBase.revision || receipt.base.digest !== options.currentBase.digest) {
+    return { status: "rejected", reason: "stale-or-mismatched-base" };
+  }
+  const { signature, canonicalProposalDigest, ...body } = receipt;
+  if (canonicalAutonomyProposalDigest(body) !== canonicalProposalDigest) return { status: "rejected", reason: "digest-mismatch" };
+  const key = keys[receipt.signerKeyId];
+  if (!key || !signature.startsWith(`v1:${receipt.signerKeyId}:`)) return { status: "rejected", reason: "invalid-signature" };
+  const expected = signAutonomyProposalReceipt({ ...body, canonicalProposalDigest }, key);
+  const actualHex = signature.split(":")[2];
+  const expectedHex = expected.split(":")[2];
+  if (!actualHex || !expectedHex || actualHex.length !== expectedHex.length || !timingSafeEqual(Buffer.from(actualHex, "hex"), Buffer.from(expectedHex, "hex"))) {
+    return { status: "rejected", reason: "invalid-signature" };
+  }
+  return { status: "valid" };
+}
+
+function storageLocation(receipt: AutonomyProposalReceipt): { namespace: string; key: string } {
+  return {
+    namespace: `autonomy/hugin/proposals/${receipt.proposalId}`,
+    key: "receipt",
+  };
+}
+
+export async function storeAutonomyProposalReceipt(
+  munin: MuninClient,
+  raw: unknown,
+  keys: KeyStore,
+  options: ProposalValidationOptions,
+): Promise<{ status: "stored"; replay: boolean; receipt: AutonomyProposalReceipt } | ProposalVerification> {
+  const verified = verifyAutonomyProposalReceipt(raw, keys, options);
+  if (verified.status !== "valid") return verified;
+  const receipt = proposalReceiptSchema.parse(raw);
+  const { namespace, key } = storageLocation(receipt);
+  const content = canonicalizeJcs(receipt);
+  try {
+    await munin.write(namespace, key, content, ["autonomy:proposal", `owner:${receipt.owner}`, `axis:${receipt.axis}`], undefined, "internal", true);
+    return { status: "stored", replay: false, receipt };
+  } catch (error) {
+    if (!(error instanceof MuninWriteRejectedError) || error.conflictReason !== "already_exists") throw error;
+    const existing = await munin.read(namespace, key);
+    if (!existing || existing.content !== content) return { status: "rejected", reason: "identity-conflict" };
+    return { status: "stored", replay: true, receipt };
+  }
+}

--- a/src/autonomy/proposal-receipts.ts
+++ b/src/autonomy/proposal-receipts.ts
@@ -15,27 +15,56 @@ const sha256 = z.string().regex(/^sha256:[a-f0-9]{64}$/);
 const opaqueRef = z.string().regex(/^ref:[a-z][a-z0-9-]{2,120}$/);
 const revision = z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._/-]{2,127}$/);
 const targetId = z.string().regex(/^[a-z][a-z0-9-]{2,80}$/);
-const signerId = z.string().regex(/^[a-z][a-z0-9-]{2,80}$/);
 
 export const AUTONOMY_PROPOSAL_SCHEMA_VERSION = "v1" as const;
 export const AUTONOMY_PROPOSAL_POLICY_EPOCH_ID = "grimnir-adr-008-v1" as const;
 export const AUTONOMY_PROPOSAL_SIGNER_KEY_ID = "hugin-autonomy-proposer" as const;
+export const AUTONOMY_PROPOSAL_REGISTRY_VERSION = "v1" as const;
+
+/** Exact authority adopted by Grimnir ADR-008/W0, never caller-selected. */
+export const autonomyProposalPolicyAuthority = Object.freeze({
+  id: AUTONOMY_PROPOSAL_POLICY_EPOCH_ID,
+  constitutionId: "grimnir-autonomy-v1",
+  constitutionDigest: "sha256:76b0f28adca0046fad9f1d3d4b3a57046f9a1d11ee2ed232bbc495d2ab663bd0",
+});
 
 /** Closed registry: broad learning axes never create an implicit apply right. */
-export const proposalTargetRegistry = [
-  { id: "hugin-orin-macro-routing", axis: "routing", owner: "hugin", huginOwned: true },
-  { id: "hugin-agent-prompt", axis: "agent-prompt", owner: "hugin", huginOwned: true },
-  { id: "hugin-agent-harness", axis: "agent-harness", owner: "hugin", huginOwned: true },
+const proposalTargets = [
+  { id: "hugin-orin-macro-routing", axis: "macro-routing", owner: "hugin", huginOwned: true },
+  { id: "hugin-agent-prompt", axis: "prompt", owner: "hugin", huginOwned: true },
+  { id: "hugin-agent-harness", axis: "harness", owner: "hugin", huginOwned: true },
   { id: "hugin-tool-policy", axis: "tool-policy", owner: "hugin", huginOwned: true },
-  { id: "gille-micro-routing", axis: "routing", owner: "gille-inference", huginOwned: false },
+  { id: "gille-micro-routing", axis: "micro-routing", owner: "gille-inference", huginOwned: false },
   { id: "gille-served-model-roster", axis: "served-model-roster", owner: "gille-inference", huginOwned: false },
   { id: "gille-tool-policy", axis: "tool-policy", owner: "gille-inference", huginOwned: false },
   { id: "brokkr-no-reboot-maintenance", axis: "no-reboot-security-bugfix-maintenance", owner: "brokkr", huginOwned: false },
-  { id: "hugin-logging", axis: "logging", owner: "hugin", huginOwned: false, protected: true },
-  { id: "hugin-test-harness", axis: "test-harness", owner: "hugin", huginOwned: false, protected: true },
-  { id: "gille-model", axis: "model", owner: "gille-inference", huginOwned: false, protected: true },
-  { id: "gille-model-config", axis: "model-config", owner: "gille-inference", huginOwned: false, protected: true },
 ] as const;
+const protectedTargetIds = ["hugin-logging", "hugin-test-harness", "gille-model", "gille-model-config"] as const;
+
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === "object" && !Object.isFrozen(value)) {
+    for (const child of Object.values(value as Record<string, unknown>)) deepFreeze(child);
+    Object.freeze(value);
+  }
+  return value;
+}
+
+function sha256Digest(value: string): string {
+  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
+}
+
+const ownershipRegistryUnsigned = {
+  kind: "hugin-autonomy-proposal-ownership-registry",
+  version: AUTONOMY_PROPOSAL_REGISTRY_VERSION,
+  policyAuthority: autonomyProposalPolicyAuthority,
+  targets: proposalTargets,
+  protectedTargetIds,
+};
+export const autonomyProposalOwnershipRegistry = deepFreeze({
+  ...ownershipRegistryUnsigned,
+  digest: sha256Digest(canonicalizeJcs(ownershipRegistryUnsigned)),
+});
+export const proposalTargetRegistry = autonomyProposalOwnershipRegistry.targets;
 
 type ProposalTarget = (typeof proposalTargetRegistry)[number];
 
@@ -49,10 +78,18 @@ const proposalReceiptSchema = z.object({
   owner: z.enum(["hugin", "gille-inference", "brokkr"]),
   /** Receipts are never authority to mutate; this is deliberately constant. */
   disposition: z.literal("proposal-only"),
+  ownershipRegistry: z.object({
+    version: z.literal(AUTONOMY_PROPOSAL_REGISTRY_VERSION),
+    digest: sha256,
+  }).strict(),
   base: z.object({ revision, digest: sha256 }).strict(),
   candidateContentDigest: sha256,
   expiresAt: z.string().datetime({ offset: true }),
-  policyEpoch: z.object({ id: z.literal(AUTONOMY_PROPOSAL_POLICY_EPOCH_ID), digest: sha256 }).strict(),
+  policyEpoch: z.object({
+    id: z.literal(AUTONOMY_PROPOSAL_POLICY_EPOCH_ID),
+    constitutionId: z.literal(autonomyProposalPolicyAuthority.constitutionId),
+    constitutionDigest: z.literal(autonomyProposalPolicyAuthority.constitutionDigest),
+  }).strict(),
   canonicalProposalDigest: sha256,
   signerKeyId: z.literal(AUTONOMY_PROPOSAL_SIGNER_KEY_ID),
   signature: z.string().regex(/^v1:[a-z][a-z0-9-]{2,80}:[a-f0-9]{64}$/),
@@ -67,7 +104,6 @@ const proposalInputSchema = z.object({
   base: z.object({ revision, digest: sha256 }).strict(),
   candidateContentDigest: sha256,
   expiresAt: z.string().datetime({ offset: true }),
-  policyEpoch: z.object({ id: z.literal(AUTONOMY_PROPOSAL_POLICY_EPOCH_ID), digest: sha256 }).strict(),
   signerKeyId: z.literal(AUTONOMY_PROPOSAL_SIGNER_KEY_ID),
 }).strict();
 export type AutonomyProposalInput = z.infer<typeof proposalInputSchema>;
@@ -79,17 +115,12 @@ function targetFor(id: string): TargetLookup {
 
 function requireTarget(id: string): ProposalTarget {
   const target = targetFor(id);
-  if (!target) throw new Error("unknown-target");
-  if ("protected" in target && target.protected) throw new Error("protected-target");
+  if (!target) throw new Error(protectedTargetIds.includes(id as typeof protectedTargetIds[number]) ? "protected-target" : "unknown-target");
   return target;
 }
 
 function signingBody(receipt: Omit<AutonomyProposalReceipt, "signature" | "canonicalProposalDigest">): string {
   return canonicalizeJcs(receipt);
-}
-
-function sha256Digest(value: string): string {
-  return `sha256:${createHash("sha256").update(value).digest("hex")}`;
 }
 
 export function canonicalAutonomyProposalDigest(
@@ -119,10 +150,14 @@ export function createAutonomyProposalReceipt(input: AutonomyProposalInput, secr
     axis: target.axis,
     owner: target.owner,
     disposition: "proposal-only" as const,
+    ownershipRegistry: {
+      version: autonomyProposalOwnershipRegistry.version,
+      digest: autonomyProposalOwnershipRegistry.digest,
+    },
     base: parsedInput.base,
     candidateContentDigest: parsedInput.candidateContentDigest,
     expiresAt: parsedInput.expiresAt,
-    policyEpoch: parsedInput.policyEpoch,
+    policyEpoch: autonomyProposalPolicyAuthority,
     signerKeyId: parsedInput.signerKeyId,
   };
   const canonicalProposalDigest = canonicalAutonomyProposalDigest(body);
@@ -135,7 +170,6 @@ export function createAutonomyProposalReceipt(input: AutonomyProposalInput, secr
 
 export type ProposalValidationOptions = {
   now: () => Date;
-  policyEpochDigest: string;
   currentBase: { revision: string; digest: string };
 };
 
@@ -150,11 +184,22 @@ export function verifyAutonomyProposalReceipt(
   if (!parsed.success) return { status: "rejected", reason: "invalid-receipt" };
   const receipt = parsed.data;
   const target = targetFor(receipt.targetId);
-  if (!target) return { status: "rejected", reason: "unknown-target" };
-  if (("protected" in target && target.protected)) return { status: "rejected", reason: "protected-target" };
+  if (!target) return { status: "rejected", reason: protectedTargetIds.includes(receipt.targetId as typeof protectedTargetIds[number]) ? "protected-target" : "unknown-target" };
   if (receipt.axis !== target.axis || receipt.owner !== target.owner) return { status: "rejected", reason: "owner-mismatch" };
-  if (Date.parse(receipt.expiresAt) <= options.now().getTime()) return { status: "rejected", reason: "expired" };
-  if (receipt.policyEpoch.digest !== options.policyEpochDigest) return { status: "rejected", reason: "policy-epoch-mismatch" };
+  if (receipt.ownershipRegistry.version !== autonomyProposalOwnershipRegistry.version || receipt.ownershipRegistry.digest !== autonomyProposalOwnershipRegistry.digest) {
+    return { status: "rejected", reason: "ownership-registry-mismatch" };
+  }
+  if (receipt.policyEpoch.id !== autonomyProposalPolicyAuthority.id || receipt.policyEpoch.constitutionId !== autonomyProposalPolicyAuthority.constitutionId || receipt.policyEpoch.constitutionDigest !== autonomyProposalPolicyAuthority.constitutionDigest) {
+    return { status: "rejected", reason: "policy-epoch-mismatch" };
+  }
+  let nowMs: number;
+  try {
+    nowMs = options.now().getTime();
+  } catch {
+    return { status: "rejected", reason: "invalid-verifier-clock" };
+  }
+  if (!Number.isFinite(nowMs)) return { status: "rejected", reason: "invalid-verifier-clock" };
+  if (Date.parse(receipt.expiresAt) <= nowMs) return { status: "rejected", reason: "expired" };
   if (receipt.base.revision !== options.currentBase.revision || receipt.base.digest !== options.currentBase.digest) {
     return { status: "rejected", reason: "stale-or-mismatched-base" };
   }

--- a/tests/autonomy-proposal-receipts.test.ts
+++ b/tests/autonomy-proposal-receipts.test.ts
@@ -4,6 +4,7 @@ import { MuninWriteRejectedError, type MuninClient } from "../src/munin-client.j
 import {
   createAutonomyProposalReceipt,
   proposalTargetRegistry,
+  autonomyProposalOwnershipRegistry,
   signAutonomyProposalReceipt,
   storeAutonomyProposalReceipt,
   verifyAutonomyProposalReceipt,
@@ -44,7 +45,6 @@ function input(): AutonomyProposalInput {
     base: { revision: "b700c05", digest: digest("base-a") },
     candidateContentDigest: digest("candidate-a"),
     expiresAt: "2026-07-26T15:00:00.000Z",
-    policyEpoch: { id: "grimnir-adr-008-v1", digest: digest("adr-008") },
     signerKeyId: "hugin-autonomy-proposer",
   };
 }
@@ -58,7 +58,14 @@ describe("autonomy proposal receipts", () => {
     const receipt = proposal();
     expect(receipt.disposition).toBe("proposal-only");
     expect(receipt.owner).toBe("hugin");
-    expect(verifyAutonomyProposalReceipt(receipt, KEYS, { now, policyEpochDigest: digest("adr-008"), currentBase: receipt.base })).toEqual({ status: "valid" });
+    expect(verifyAutonomyProposalReceipt(receipt, KEYS, { now, currentBase: receipt.base })).toEqual({ status: "valid" });
+    expect(receipt.ownershipRegistry).toEqual({ version: "v1", digest: autonomyProposalOwnershipRegistry.digest });
+    expect(Object.isFrozen(autonomyProposalOwnershipRegistry)).toBe(true);
+    expect(Object.isFrozen(proposalTargetRegistry)).toBe(true);
+    expect([...new Set(proposalTargetRegistry.map((target) => target.axis))].sort()).toEqual([
+      "harness", "macro-routing", "micro-routing", "no-reboot-security-bugfix-maintenance",
+      "prompt", "served-model-roster", "tool-policy",
+    ]);
     expect(JSON.stringify(receipt)).not.toContain("prompt");
     expect(JSON.stringify(receipt)).not.toContain("candidate-a");
   });
@@ -66,10 +73,10 @@ describe("autonomy proposal receipts", () => {
   it("replays byte-identical receipts and rejects divergent identity content", async () => {
     const munin = new MemoryMunin() as unknown as MuninClient;
     const first = proposal();
-    expect(await storeAutonomyProposalReceipt(munin, first, KEYS, { now, policyEpochDigest: digest("adr-008"), currentBase: first.base })).toMatchObject({ status: "stored", replay: false });
-    expect(await storeAutonomyProposalReceipt(munin, first, KEYS, { now, policyEpochDigest: digest("adr-008"), currentBase: first.base })).toMatchObject({ status: "stored", replay: true });
+    expect(await storeAutonomyProposalReceipt(munin, first, KEYS, { now, currentBase: first.base })).toMatchObject({ status: "stored", replay: false });
+    expect(await storeAutonomyProposalReceipt(munin, first, KEYS, { now, currentBase: first.base })).toMatchObject({ status: "stored", replay: true });
     const divergent = proposal({ candidateContentDigest: digest("different") });
-    expect(await storeAutonomyProposalReceipt(munin, divergent, KEYS, { now, policyEpochDigest: digest("adr-008"), currentBase: divergent.base })).toMatchObject({ status: "rejected", reason: "identity-conflict" });
+    expect(await storeAutonomyProposalReceipt(munin, divergent, KEYS, { now, currentBase: divergent.base })).toMatchObject({ status: "rejected", reason: "identity-conflict" });
     expect(munin.writes).toBe(1);
   });
 
@@ -103,15 +110,25 @@ describe("autonomy proposal receipts", () => {
     expect(() => proposal({ signerKeyId: "some-other-signer" as "hugin-autonomy-proposer" })).toThrow();
   });
 
+  it("rejects explicit apply and multi-axis requests before any Munin write", async () => {
+    const munin = new MemoryMunin() as unknown as MuninClient;
+    const receipt = proposal();
+    expect(await storeAutonomyProposalReceipt(munin, { ...receipt, disposition: "apply" }, KEYS, { now, currentBase: receipt.base })).toMatchObject({ status: "rejected" });
+    expect(await storeAutonomyProposalReceipt(munin, { ...receipt, targetIds: ["hugin-orin-macro-routing", "hugin-agent-prompt"] }, KEYS, { now, currentBase: receipt.base })).toMatchObject({ status: "rejected" });
+    expect(munin.writes).toBe(0);
+  });
+
   it("rejects stale evidence, epoch/base/owner mismatch, and invalid signatures before persistence", async () => {
     const munin = new MemoryMunin() as unknown as MuninClient;
     const receipt = proposal();
-    expect(verifyAutonomyProposalReceipt(receipt, KEYS, { now, policyEpochDigest: digest("wrong"), currentBase: receipt.base })).toMatchObject({ reason: "policy-epoch-mismatch" });
-    expect(verifyAutonomyProposalReceipt(receipt, KEYS, { now, policyEpochDigest: digest("adr-008"), currentBase: { ...receipt.base, digest: digest("other") } })).toMatchObject({ reason: "stale-or-mismatched-base" });
-    expect(verifyAutonomyProposalReceipt({ ...receipt, owner: "gille-inference" }, KEYS, { now, policyEpochDigest: digest("adr-008"), currentBase: receipt.base })).toMatchObject({ reason: "owner-mismatch" });
-    expect(verifyAutonomyProposalReceipt({ ...receipt, signature: `v1:hugin-autonomy-proposer:${"0".repeat(64)}` }, KEYS, { now, policyEpochDigest: digest("adr-008"), currentBase: receipt.base })).toMatchObject({ reason: "invalid-signature" });
+    expect(verifyAutonomyProposalReceipt({ ...receipt, policyEpoch: { ...receipt.policyEpoch, constitutionDigest: digest("wrong") } }, KEYS, { now, currentBase: receipt.base })).toMatchObject({ reason: "invalid-receipt" });
+    expect(verifyAutonomyProposalReceipt({ ...receipt, ownershipRegistry: { ...receipt.ownershipRegistry, digest: digest("wrong") } }, KEYS, { now, currentBase: receipt.base })).toMatchObject({ reason: "ownership-registry-mismatch" });
+    expect(verifyAutonomyProposalReceipt(receipt, KEYS, { now, currentBase: { ...receipt.base, digest: digest("other") } })).toMatchObject({ reason: "stale-or-mismatched-base" });
+    expect(verifyAutonomyProposalReceipt({ ...receipt, owner: "gille-inference" }, KEYS, { now, currentBase: receipt.base })).toMatchObject({ reason: "owner-mismatch" });
+    expect(verifyAutonomyProposalReceipt({ ...receipt, signature: `v1:hugin-autonomy-proposer:${"0".repeat(64)}` }, KEYS, { now, currentBase: receipt.base })).toMatchObject({ reason: "invalid-signature" });
+    expect(verifyAutonomyProposalReceipt(receipt, KEYS, { now: () => new Date("not-a-date"), currentBase: receipt.base })).toMatchObject({ reason: "invalid-verifier-clock" });
     const expired = proposal({ expiresAt: "2026-07-26T13:59:59.000Z" });
-    expect(await storeAutonomyProposalReceipt(munin, expired, KEYS, { now, policyEpochDigest: digest("adr-008"), currentBase: expired.base })).toMatchObject({ status: "rejected", reason: "expired" });
+    expect(await storeAutonomyProposalReceipt(munin, expired, KEYS, { now, currentBase: expired.base })).toMatchObject({ status: "rejected", reason: "expired" });
     expect(munin.writes).toBe(0);
   });
 });

--- a/tests/autonomy-proposal-receipts.test.ts
+++ b/tests/autonomy-proposal-receipts.test.ts
@@ -1,0 +1,117 @@
+import { createHash } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import { MuninWriteRejectedError, type MuninClient } from "../src/munin-client.js";
+import {
+  createAutonomyProposalReceipt,
+  proposalTargetRegistry,
+  signAutonomyProposalReceipt,
+  storeAutonomyProposalReceipt,
+  verifyAutonomyProposalReceipt,
+  type AutonomyProposalReceipt,
+  type AutonomyProposalInput,
+} from "../src/autonomy/proposal-receipts.js";
+
+const SECRET = "d".repeat(64);
+const KEYS = { "hugin-autonomy-proposer": SECRET };
+const now = () => new Date("2026-07-26T14:00:00.000Z");
+const digest = (value: string) => `sha256:${createHash("sha256").update(value).digest("hex")}`;
+
+class MemoryMunin {
+  entries = new Map<string, { content: string; updated_at: string }>();
+  writes = 0;
+  async read(namespace: string, key: string) {
+    const entry = this.entries.get(`${namespace}/${key}`);
+    return entry ? { ...entry, namespace, key, found: true } : null;
+  }
+  async write(namespace: string, key: string, content: string, _tags?: string[], _expected?: string, _classification?: string, createIfAbsent?: boolean) {
+    const id = `${namespace}/${key}`;
+    const existing = this.entries.get(id);
+    if (createIfAbsent && existing) {
+      throw new MuninWriteRejectedError(namespace, key, { error: "conflict", conflict_reason: "already_exists" });
+    }
+    this.writes += 1;
+    this.entries.set(id, { content, updated_at: `2026-07-26T14:00:0${this.writes}.000Z` });
+    return { ok: true, status: existing ? "updated" : "created" };
+  }
+}
+
+function input(): AutonomyProposalInput {
+  return {
+    proposalId: "autonomy-proposal-329-a",
+    experimentRef: "ref:experiment-329-a",
+    evidenceFingerprints: [digest("evidence-a")],
+    targetId: "hugin-orin-macro-routing",
+    base: { revision: "b700c05", digest: digest("base-a") },
+    candidateContentDigest: digest("candidate-a"),
+    expiresAt: "2026-07-26T15:00:00.000Z",
+    policyEpoch: { id: "grimnir-adr-008-v1", digest: digest("adr-008") },
+    signerKeyId: "hugin-autonomy-proposer",
+  };
+}
+
+function proposal(overrides: Partial<AutonomyProposalReceipt> = {}) {
+  return createAutonomyProposalReceipt({ ...input(), ...overrides }, SECRET);
+}
+
+describe("autonomy proposal receipts", () => {
+  it("is an immutable, signed content-blind proposal even for a Hugin-owned target", () => {
+    const receipt = proposal();
+    expect(receipt.disposition).toBe("proposal-only");
+    expect(receipt.owner).toBe("hugin");
+    expect(verifyAutonomyProposalReceipt(receipt, KEYS, { now, policyEpochDigest: digest("adr-008"), currentBase: receipt.base })).toEqual({ status: "valid" });
+    expect(JSON.stringify(receipt)).not.toContain("prompt");
+    expect(JSON.stringify(receipt)).not.toContain("candidate-a");
+  });
+
+  it("replays byte-identical receipts and rejects divergent identity content", async () => {
+    const munin = new MemoryMunin() as unknown as MuninClient;
+    const first = proposal();
+    expect(await storeAutonomyProposalReceipt(munin, first, KEYS, { now, policyEpochDigest: digest("adr-008"), currentBase: first.base })).toMatchObject({ status: "stored", replay: false });
+    expect(await storeAutonomyProposalReceipt(munin, first, KEYS, { now, policyEpochDigest: digest("adr-008"), currentBase: first.base })).toMatchObject({ status: "stored", replay: true });
+    const divergent = proposal({ candidateContentDigest: digest("different") });
+    expect(await storeAutonomyProposalReceipt(munin, divergent, KEYS, { now, policyEpochDigest: digest("adr-008"), currentBase: divergent.base })).toMatchObject({ status: "rejected", reason: "identity-conflict" });
+    expect(munin.writes).toBe(1);
+  });
+
+  it.each([
+    ["gille-micro-routing", "gille-inference"],
+    ["gille-served-model-roster", "gille-inference"],
+    ["brokkr-no-reboot-maintenance", "brokkr"],
+    ["gille-tool-policy", "gille-inference"],
+  ])("keeps cross-owner %s proposal-only and has no apply surface", (targetId, owner) => {
+    const receipt = proposal({ targetId });
+    expect(receipt.owner).toBe(owner);
+    expect(receipt.disposition).toBe("proposal-only");
+    expect(proposalTargetRegistry.find((target) => target.id === targetId)?.huginOwned).toBe(false);
+  });
+
+  it.each([
+    ["hugin-logging", "protected-target"],
+    ["hugin-test-harness", "protected-target"],
+    ["gille-model", "protected-target"],
+    ["gille-model-config", "protected-target"],
+    ["unknown-target", "unknown-target"],
+  ])("fails closed for %s", (targetId, reason) => {
+    expect(() => proposal({ targetId })).toThrow(reason);
+  });
+
+  it("refuses raw configuration fields and an unassigned signer before any durable write", () => {
+    expect(() => createAutonomyProposalReceipt({
+      ...input(),
+      candidateContent: "never persist this prompt or configuration",
+    } as unknown as Parameters<typeof createAutonomyProposalReceipt>[0], SECRET)).toThrow();
+    expect(() => proposal({ signerKeyId: "some-other-signer" as "hugin-autonomy-proposer" })).toThrow();
+  });
+
+  it("rejects stale evidence, epoch/base/owner mismatch, and invalid signatures before persistence", async () => {
+    const munin = new MemoryMunin() as unknown as MuninClient;
+    const receipt = proposal();
+    expect(verifyAutonomyProposalReceipt(receipt, KEYS, { now, policyEpochDigest: digest("wrong"), currentBase: receipt.base })).toMatchObject({ reason: "policy-epoch-mismatch" });
+    expect(verifyAutonomyProposalReceipt(receipt, KEYS, { now, policyEpochDigest: digest("adr-008"), currentBase: { ...receipt.base, digest: digest("other") } })).toMatchObject({ reason: "stale-or-mismatched-base" });
+    expect(verifyAutonomyProposalReceipt({ ...receipt, owner: "gille-inference" }, KEYS, { now, policyEpochDigest: digest("adr-008"), currentBase: receipt.base })).toMatchObject({ reason: "owner-mismatch" });
+    expect(verifyAutonomyProposalReceipt({ ...receipt, signature: `v1:hugin-autonomy-proposer:${"0".repeat(64)}` }, KEYS, { now, policyEpochDigest: digest("adr-008"), currentBase: receipt.base })).toMatchObject({ reason: "invalid-signature" });
+    const expired = proposal({ expiresAt: "2026-07-26T13:59:59.000Z" });
+    expect(await storeAutonomyProposalReceipt(munin, expired, KEYS, { now, policyEpochDigest: digest("adr-008"), currentBase: expired.base })).toMatchObject({ status: "rejected", reason: "expired" });
+    expect(munin.writes).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #329.\n\nImplements a closed, content-blind proposal-only boundary for ADR-008 targets. Hugin-owned targets are enumerated but receive no apply authority; Gille/Brokkr targets remain proposal-only and protected/unknown targets fail closed.\n\nVerification: focused receipt tests, TypeScript build, full suite (160 files / 2,438 tests). M5 dogfood attempted through the canonical gateway; it returned no local model loaded, so no M5 review output was used.\n\nBlocked from ready/merge until Grimnir #170 is merged and the required independent review gates complete.