### PR TITLE
W4.3: strict Hugin autonomous config adapters

### DIFF
--- a/docs/hugin-r-exact-config-store.md
+++ b/docs/hugin-r-exact-config-store.md
@@ -1,0 +1,20 @@
+# Hugin R-exact configuration store
+
+`HUGIN_R_EXACT_CONFIG_ROOT` is the owner-installed absolute path for Hugin's
+durable R-exact configuration state. The live Orin macro selector reads only
+that store. If the variable is absent, unsafe, missing, corrupt, or contended,
+the selector returns no route; it never falls back to an in-module route map.
+
+The store is a local, mode-0700 resource. Every mutation uses an exclusive
+cross-process lock, validates the entire closed state, writes a unique fsynced
+temporary file, renames it atomically, then fsyncs the directory. Stored
+candidates and current/snapshot documents are revalidated and digest-bound on
+every read.
+
+This composition makes the macro-routing target real: staged R-exact changes
+are visible to `selectOrinMacroRoute`, persist across restart, and an exact
+recovery returns the selector to its snapshot baseline. The store does not
+install a controller/watchdog/recovery service, owner authority, journal
+backend, or an arming mechanism. Those remain a separate W0 runtime
+composition/deployment dependency; this repository ships no live root or
+environment file.

--- a/docs/hugin-r-exact-config-store.md
+++ b/docs/hugin-r-exact-config-store.md
@@ -47,13 +47,15 @@ parsing. The raw `documents` and `snapshots` objects are limited to 64 and 32
 entries respectively; those cardinalities are rejected before individual
 candidates, snapshots, or documents are deeply validated. Mutations enforce
 the same limits by retaining current and recovery-referenced documents before
-deterministic cache pruning.
+deterministic cache pruning. Snapshot references have one canonical,
+target-and-document-digest-bound form, so accepted keys are bounded as well.
 
 Within those bounds, the store validates the entire closed state, writes a
-unique fsynced temporary file, renames it atomically, then fsyncs the
-directory; a failed write removes only its own UUID-bound temporary file.
-Stored candidates and current/snapshot documents are revalidated and
-digest-bound on every read.
+unique fsynced temporary file, renames it atomically, then fsyncs the directory.
+Before creating that temporary file, it serializes and rejects any result over
+the same 256 KiB ceiling, leaving the prior readable store untouched. A failed
+write removes only its own UUID-bound temporary file. Stored candidates and
+current/snapshot documents are revalidated and digest-bound on every read.
 
 This composition makes the macro-routing target real: staged R-exact changes
 are visible to `selectOrinMacroRoute`, persist across restart, and an exact

--- a/docs/hugin-r-exact-config-store.md
+++ b/docs/hugin-r-exact-config-store.md
@@ -5,11 +5,27 @@ durable R-exact configuration state. The live Orin macro selector reads only
 that store. If the variable is absent, unsafe, missing, corrupt, or contended,
 the selector returns no route; it never falls back to an in-module route map.
 
-The store is a local, mode-0700 resource. Every mutation uses an exclusive
-cross-process lock, validates the entire closed state, writes a unique fsynced
-temporary file, renames it atomically, then fsyncs the directory. Stored
-candidates and current/snapshot documents are revalidated and digest-bound on
-every read.
+The store is a local, mode-0700 resource. Its sole concrete adapter target is
+`hugin-orin-macro-routing`; prompt, harness, and tool-policy remain
+proposal-only W4.1 concepts and have no config adapter here. The payload is a
+canonical, unique subset (including empty) of exactly four reviewed
+`homeserver` `classify|extract` `public|internal` leaves, each immutably pinned
+to `orin` / `qwen2.5-coder:3b`. A promotion therefore changes the live
+selector, and exact recovery proves the prior selector behavior.
+
+Every mutation uses an immediate exclusive cross-process lock. On Linux the
+lock records boot ID, PID start time, and its exact device/inode; only a lock
+proven stale by boot change, process absence, or PID-start mismatch is moved
+away atomically for takeover. A live, corrupt, unreadable, or contended lock
+fails closed without waiting. The selector emits at most one path-free
+diagnostic per missing/corrupt/contended reason and otherwise returns no route.
+
+The store validates the entire closed state, writes a unique fsynced temporary
+file, renames it atomically, then fsyncs the directory; a failed write removes
+only its own UUID-bound temporary file. Staged documents and snapshots are
+bounded (64 and 32 respectively), retaining current and recovery-referenced
+documents before deterministic cache pruning. Stored candidates and
+current/snapshot documents are revalidated and digest-bound on every read.
 
 This composition makes the macro-routing target real: staged R-exact changes
 are visible to `selectOrinMacroRoute`, persist across restart, and an exact

--- a/docs/hugin-r-exact-config-store.md
+++ b/docs/hugin-r-exact-config-store.md
@@ -2,8 +2,9 @@
 
 `HUGIN_R_EXACT_CONFIG_ROOT` is the owner-installed absolute path for Hugin's
 durable R-exact configuration state. The live Orin macro selector reads only
-that store. If the variable is absent, unsafe, missing, corrupt, or contended,
-the selector returns no route; it never falls back to an in-module route map.
+that store. If the variable is absent or the store is unsafe, missing, corrupt,
+or over its closed bounds, the selector returns no route; it never falls back
+to an in-module route map.
 
 The store is a local, mode-0700 resource. Its sole concrete adapter target is
 `hugin-orin-macro-routing`; prompt, harness, and tool-policy remain
@@ -13,19 +14,46 @@ canonical, unique subset (including empty) of exactly four reviewed
 to `orin` / `qwen2.5-coder:3b`. A promotion therefore changes the live
 selector, and exact recovery proves the prior selector behavior.
 
-Every mutation uses an immediate exclusive cross-process lock. On Linux the
-lock records boot ID, PID start time, and its exact device/inode; only a lock
-proven stale by boot change, process absence, or PID-start mismatch is moved
-away atomically for takeover. A live, corrupt, unreadable, or contended lock
-fails closed without waiting. The selector emits at most one path-free
-diagnostic per missing/corrupt/contended reason and otherwise returns no route.
+Every mutation uses an immediate, nonblocking exclusive lock on one persistent
+mode-0600 lock inode. On Linux, Hugin opens that inode with `O_NOFOLLOW`, passes
+the descriptor to `/usr/bin/flock`, and has the helper acquire `flock(2)` on
+the inherited descriptor. The inherited helper descriptor and Hugin's parent
+descriptor share one open file description, so the parent descriptor keeps
+the kernel lock after the helper exits. Closing that descriptor releases the
+lock atomically; process death, including `SIGKILL`, closes it and therefore
+releases the lock too. A contended lock fails immediately. A missing or failed
+`/usr/bin/flock` fails closed without running the mutation.
 
-The store validates the entire closed state, writes a unique fsynced temporary
-file, renames it atomically, then fsyncs the directory; a failed write removes
-only its own UUID-bound temporary file. Staged documents and snapshots are
-bounded (64 and 32 respectively), retaining current and recovery-referenced
-documents before deterministic cache pruning. Stored candidates and
-current/snapshot documents are revalidated and digest-bound on every read.
+The persistent lock file contains no authoritative owner or stale-lease
+metadata. Hugin never decides staleness from a boot ID, PID, or process start
+time, and it never reclaims, renames, or unlinks the lock path. Before running
+the mutation it verifies that the private, single-link regular pathname still
+names the inode opened and locked by descriptor. The Linux lock is advisory:
+it coordinates cooperating Hugin writers. The mode-0700 root and its Unix
+owner are an explicit trust boundary, not a defense against a hostile process
+running as that same owner that ignores the lock or replaces store pathnames.
+
+On non-Linux developer and test hosts, the adapter provides only
+process-local, fail-fast exclusion. It does not claim cross-process safety
+there; the supported deployment platform is Linux. The live selector does not
+take the mutation lock. It reads the complete old or new store produced by the
+atomic rename and therefore does not wait or return a contention result. It
+emits at most one path-free diagnostic per missing or corrupt store reason and
+otherwise returns no route.
+
+The serialized store has a closed maximum size of 262,144 bytes (256 KiB),
+checked from metadata before reading and again from the bytes read before JSON
+parsing. The raw `documents` and `snapshots` objects are limited to 64 and 32
+entries respectively; those cardinalities are rejected before individual
+candidates, snapshots, or documents are deeply validated. Mutations enforce
+the same limits by retaining current and recovery-referenced documents before
+deterministic cache pruning.
+
+Within those bounds, the store validates the entire closed state, writes a
+unique fsynced temporary file, renames it atomically, then fsyncs the
+directory; a failed write removes only its own UUID-bound temporary file.
+Stored candidates and current/snapshot documents are revalidated and
+digest-bound on every read.
 
 This composition makes the macro-routing target real: staged R-exact changes
 are visible to `selectOrinMacroRoute`, persist across restart, and an exact

--- a/src/autonomy/hugin-config-adapter.ts
+++ b/src/autonomy/hugin-config-adapter.ts
@@ -80,6 +80,7 @@ interface StoreState {
 }
 const MAX_STAGED_DOCUMENTS = 64;
 const MAX_SNAPSHOTS = 32;
+const MAX_STORE_BYTES = 256 * 1024;
 const defaults: Record<HuginConfigTargetId, { revision: string; payload: ConfigPayload }> = {
   "hugin-orin-macro-routing": { revision: "orin-macro-route-v1", payload: { routes: [
     { workerProvider: "homeserver", taskType: "classify", sensitivity: "internal", nodeId: "orin", modelId: "qwen2.5-coder:3b" },
@@ -122,6 +123,12 @@ function validateStoreState(raw: unknown): StoreState {
     throw new Error("hugin-config-store-corrupt");
   }
   if (Object.keys(raw.current).sort().join("|") !== [...targetIds].sort().join("|")) throw new Error("hugin-config-store-corrupt");
+  if (Object.keys(raw.documents).length > MAX_STAGED_DOCUMENTS) {
+    throw new Error("hugin-config-store-documents-limit");
+  }
+  if (Object.keys(raw.snapshots).length > MAX_SNAPSHOTS) {
+    throw new Error("hugin-config-store-snapshots-limit");
+  }
   const documents: StoreState["documents"] = {};
   for (const [key, value] of Object.entries(raw.documents)) {
     const candidate = validateHuginConfigCandidate(value);
@@ -257,7 +264,15 @@ export class HuginConfigStore {
   }
   private load(): StoreState {
     const stat = lstatSync(this.#path); if (!stat.isFile() || stat.isSymbolicLink() || (stat.mode & 0o077) !== 0) throw new Error("hugin-config-store-unsafe");
-    try { return validateStoreState(JSON.parse(readFileSync(this.#path, "utf8"))); } catch (error) { if (error instanceof Error && error.message.startsWith("hugin-config-store-")) throw error; throw new Error("hugin-config-store-corrupt"); }
+    if (stat.size > MAX_STORE_BYTES) throw new Error("hugin-config-store-too-large");
+    try {
+      const serialized = readFileSync(this.#path);
+      if (serialized.byteLength > MAX_STORE_BYTES) throw new Error("hugin-config-store-too-large");
+      return validateStoreState(JSON.parse(serialized.toString("utf8")));
+    } catch (error) {
+      if (error instanceof Error && error.message.startsWith("hugin-config-store-")) throw error;
+      throw new Error("hugin-config-store-corrupt");
+    }
   }
   private write(state: StoreState) {
     const temp = `${this.#path}.${process.pid}.${randomUUID()}.tmp`; let fd: number | undefined;

--- a/src/autonomy/hugin-config-adapter.ts
+++ b/src/autonomy/hugin-config-adapter.ts
@@ -6,6 +6,8 @@
  * provide a generic config writer or any Gille/deployment/auth surface.
  */
 import { createHash } from "node:crypto";
+import { closeSync, fsyncSync, lstatSync, mkdirSync, openSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { isAbsolute, join, resolve } from "node:path";
 import { z } from "zod";
 import { canonicalizeJcs } from "../jcs.js";
 import type { RExactConfigTarget } from "./r-exact-types.js";
@@ -18,7 +20,7 @@ export type HuginConfigTargetId = z.infer<typeof targetId>;
 
 const route = z.object({ workerProvider: z.literal("homeserver"), taskType: z.enum(["classify", "extract"]), sensitivity: z.enum(["public", "internal"]), nodeId: z.literal("orin"), modelId: z.literal("qwen2.5-coder:3b") }).strict();
 const macroPayload = z.object({ routes: z.array(route).length(4) }).strict();
-const promptPayload = z.object({ systemPrompt: z.string().min(1).max(4_096) }).strict();
+const promptPayload = z.object({ templateRef: z.string().regex(/^ref:[a-z][a-z0-9-]{2,120}$/), templateDigest: sha256 }).strict();
 const harnessPayload = z.object({ allowedHarnesses: z.array(z.enum(["pi", "opencode"])).min(1).max(2) }).strict();
 const toolPolicyPayload = z.object({ allowedTools: z.array(z.enum(["read", "write", "shell"])).min(1).max(3) }).strict();
 
@@ -61,10 +63,10 @@ const defaults: Record<HuginConfigTargetId, { revision: string; payload: ConfigP
     { workerProvider: "homeserver", taskType: "extract", sensitivity: "internal", nodeId: "orin", modelId: "qwen2.5-coder:3b" },
     { workerProvider: "homeserver", taskType: "extract", sensitivity: "public", nodeId: "orin", modelId: "qwen2.5-coder:3b" },
   ] } },
-  // These source-owned defaults are safe local config payloads, never receipt/journal content.
-  "hugin-agent-prompt": { revision: "agent-prompt-v1", payload: { systemPrompt: "Complete the bounded Hugin task using only its granted context." } },
-  "hugin-agent-harness": { revision: "agent-harness-v1", payload: { allowedHarnesses: ["pi", "opencode"] } },
-  "hugin-tool-policy": { revision: "tool-policy-v1", payload: { allowedTools: ["read", "write", "shell"] } },
+  // Deliberately unconfigured: W4.4 must supply owner-approved manifests.
+  "hugin-agent-prompt": { revision: "agent-prompt-unconfigured", payload: { templateRef: "ref:unconfigured-prompt", templateDigest: digest({ unconfigured: "prompt" }) } },
+  "hugin-agent-harness": { revision: "agent-harness-unconfigured", payload: { allowedHarnesses: ["pi"] } },
+  "hugin-tool-policy": { revision: "tool-policy-unconfigured", payload: { allowedTools: ["read"] } },
 };
 
 function initialDocument(value: { revision: string; payload: ConfigPayload }): StoredDocument {
@@ -80,27 +82,36 @@ const domains = {
 
 /** Owner-local canonical store; mutations are only CAS through a target. */
 export class HuginConfigStore {
-  #current = new Map<HuginConfigTargetId, StoredDocument>();
-  #documents = new Map<string, HuginConfigCandidate>();
-  #snapshots = new Map<string, StoredDocument>();
-  constructor() { for (const id of targetId.options) this.#current.set(id, initialDocument(defaults[id])); }
-  read(id: HuginConfigTargetId): StoredDocument { return clone(this.#current.get(id)!); }
-  readPayload(id: HuginConfigTargetId): ConfigPayload { return clone(this.#current.get(id)!.payload); }
-  stage(raw: unknown): HuginConfigCandidate { const candidate = validateHuginConfigCandidate(raw); this.#documents.set(candidate.candidateDigest, candidate); return clone(candidate); }
-  snapshot(id: HuginConfigTargetId): { ref: string; digest: string } { const doc = this.read(id); const ref = `ref:snapshot-${doc.digest.slice(7, 31)}`; this.#snapshots.set(ref, doc); return { ref, digest: doc.digest }; }
+  #path: string;
+  constructor(root: string) {
+    if (!isAbsolute(root)) throw new Error("hugin-config-root-not-absolute");
+    this.#path = join(resolve(root), "hugin-r-exact-config.json"); mkdirSync(root, { recursive: true, mode: 0o700 });
+    const stat = lstatSync(root); if (!stat.isDirectory() || stat.isSymbolicLink() || (stat.mode & 0o077) !== 0) throw new Error("hugin-config-root-unsafe");
+    if (!this.exists()) this.write({ current: Object.fromEntries(targetId.options.map((id) => [id, initialDocument(defaults[id])])), documents: {}, snapshots: {} });
+  }
+  private exists() { try { lstatSync(this.#path); return true; } catch { return false; } }
+  private load(): { current: Record<HuginConfigTargetId, StoredDocument>; documents: Record<string, HuginConfigCandidate>; snapshots: Record<string, { target: HuginConfigTargetId; document: StoredDocument }> } {
+    const stat = lstatSync(this.#path); if (!stat.isFile() || stat.isSymbolicLink() || (stat.mode & 0o077) !== 0) throw new Error("hugin-config-store-unsafe");
+    try { return JSON.parse(readFileSync(this.#path, "utf8")); } catch { throw new Error("hugin-config-store-corrupt"); }
+  }
+  private write(state: unknown) { const temp = `${this.#path}.tmp`; const fd = openSync(temp, "w", 0o600); try { writeFileSync(fd, canonicalizeJcs(state)); fsyncSync(fd); } finally { closeSync(fd); } renameSync(temp, this.#path); const dir = openSync(resolve(this.#path, ".."), "r"); try { fsyncSync(dir); } finally { closeSync(dir); } }
+  read(id: HuginConfigTargetId): StoredDocument { return clone(this.load().current[id]); }
+  readPayload(id: HuginConfigTargetId): ConfigPayload { return clone(this.load().current[id].payload); }
+  stage(raw: unknown): HuginConfigCandidate { const candidate = validateHuginConfigCandidate(raw); const state = this.load(); state.documents[candidate.candidateDigest] = candidate; this.write(state); return clone(candidate); }
+  snapshot(id: HuginConfigTargetId): { ref: string; digest: string } { const state = this.load(); const doc = state.current[id]; const ref = `ref:snapshot-${id}-${doc.digest.slice(7, 31)}`; state.snapshots[ref] = { target: id, document: doc }; this.write(state); return { ref, digest: doc.digest }; }
   /** Called only by the separately authorized R-exact recovery adapter. */
   restoreSnapshot(id: HuginConfigTargetId, ref: string, expectedDigest: string): { revision: string; digest: string } {
-    const snapshot = this.#snapshots.get(ref);
-    if (!snapshot || snapshot.digest !== expectedDigest) throw new Error("hugin-config-snapshot-unavailable");
-    this.#current.set(id, clone(snapshot));
-    return { revision: snapshot.revision, digest: snapshot.digest };
+    const state = this.load(); const snapshot = state.snapshots[ref];
+    if (!snapshot || snapshot.target !== id || snapshot.document.digest !== expectedDigest) throw new Error("hugin-config-snapshot-unavailable");
+    const current = state.current[id]; if (current.digest === expectedDigest) return { revision: current.revision, digest: current.digest };
+    state.current[id] = clone(snapshot.document); this.write(state); return { revision: snapshot.document.revision, digest: snapshot.document.digest };
   }
   replace(id: HuginConfigTargetId, expected: { revision: string; digest: string }, candidateDigest: string): void {
-    const current = this.#current.get(id)!;
+    const state = this.load(); const current = state.current[id];
     if (current.revision !== expected.revision || current.digest !== expected.digest) throw new Error("hugin-config-stale-base");
-    const candidate = this.#documents.get(candidateDigest);
+    const candidate = state.documents[candidateDigest];
     if (!candidate || candidate.targetId !== id || candidate.base.revision !== expected.revision || candidate.base.digest !== expected.digest) throw new Error("hugin-config-candidate-not-bound-to-base");
-    this.#current.set(id, { revision: candidate.revision, payload: clone(candidate.config), digest: candidate.candidateDigest });
+    state.current[id] = { revision: candidate.revision, payload: clone(candidate.config), digest: candidate.candidateDigest }; this.write(state);
   }
 }
 
@@ -117,7 +128,7 @@ class HuginTarget implements RExactConfigTarget {
   async replaceExact(expected: { revision: string; digest: string }, candidateDigest: string) { this.store.replace(this.id, expected, candidateDigest); }
 }
 
-export function createHuginConfigTargets(store = new HuginConfigStore()): Record<HuginConfigTargetId, RExactConfigTarget> {
+export function createHuginConfigTargets(store: HuginConfigStore): Record<HuginConfigTargetId, RExactConfigTarget> {
   return {
     "hugin-orin-macro-routing": new HuginTarget("hugin-orin-macro-routing", store),
     "hugin-agent-prompt": new HuginTarget("hugin-agent-prompt", store),
@@ -126,17 +137,12 @@ export function createHuginConfigTargets(store = new HuginConfigStore()): Record
   };
 }
 
-const productionStore = new HuginConfigStore();
-export const huginConfigTargets = createHuginConfigTargets(productionStore);
-export function stageHuginConfigCandidate(raw: unknown): HuginConfigCandidate { return productionStore.stage(raw); }
-/** Recovery-only composition seam; journals retain only the snapshot ref/digest. */
-export function restoreHuginConfigSnapshot(target: HuginConfigTargetId, ref: string, digest: string) { return productionStore.restoreSnapshot(target, ref, digest); }
+// Deployment supplies its private durable root; no live directory is created by this module.
 
 /** Read-only route selection uses a cloned canonical source, never a mutable exported map. */
 export function selectHuginMacroRoute(input: { workerProvider: string; taskType: string; sensitivity: "public" | "internal" | "private" }): { nodeId: "orin"; modelId: "qwen2.5-coder:3b" } | null {
   if (input.sensitivity === "private") return null;
-  const payload = productionStore.readPayload("hugin-orin-macro-routing");
-  const routes = macroPayload.parse(payload).routes;
+  const routes = macroPayload.parse(defaults["hugin-orin-macro-routing"].payload).routes;
   const matched = routes.find((entry) => entry.workerProvider === input.workerProvider && entry.taskType === input.taskType && entry.sensitivity === input.sensitivity);
   return matched ? { nodeId: matched.nodeId, modelId: matched.modelId } : null;
 }

--- a/src/autonomy/hugin-config-adapter.ts
+++ b/src/autonomy/hugin-config-adapter.ts
@@ -1,97 +1,142 @@
 /**
- * Strict, content-blind configuration boundary for the ADR-008 Hugin targets.
+ * The only concrete Hugin-owned R-exact configuration adapters (ADR-008).
  *
- * This is deliberately an adapter/store for immutable configuration identities,
- * not a generic configuration service.  It accepts no prompt, model, gateway,
- * logging, deployment, or credential material.  R-exact application remains
- * owned by the controller; this module only exposes the bounded current base.
+ * Candidate documents live in this local, owner-controlled store; receipts and
+ * journals contain only their SHA-256 digest.  This deliberately does not
+ * provide a generic config writer or any Gille/deployment/auth surface.
  */
 import { createHash } from "node:crypto";
 import { z } from "zod";
 import { canonicalizeJcs } from "../jcs.js";
+import type { RExactConfigTarget } from "./r-exact-types.js";
 
 export const HUGIN_CONFIG_ADAPTER_VERSION = "hugin-config-adapter-v1" as const;
-
 const sha256 = z.string().regex(/^sha256:[a-f0-9]{64}$/);
 const revision = z.string().regex(/^[a-z][a-z0-9-]{2,80}$/);
-const targetId = z.enum([
-  "hugin-orin-macro-routing",
-  "hugin-agent-prompt",
-  "hugin-agent-harness",
-  "hugin-tool-policy",
-]);
-
+const targetId = z.enum(["hugin-orin-macro-routing", "hugin-agent-prompt", "hugin-agent-harness", "hugin-tool-policy"]);
 export type HuginConfigTargetId = z.infer<typeof targetId>;
-export type HuginConfigBase = { revision: string; digest: string };
 
-const routeSchema = z.object({
-  workerProvider: z.literal("homeserver"),
-  taskType: z.enum(["classify", "extract"]),
-  sensitivity: z.enum(["public", "internal"]),
-  nodeId: z.literal("orin"),
-  // This is a fixed implementation identity, not a mutable model setting.
-  modelId: z.literal("qwen2.5-coder:3b"),
-}).strict();
+const route = z.object({ workerProvider: z.literal("homeserver"), taskType: z.enum(["classify", "extract"]), sensitivity: z.enum(["public", "internal"]), nodeId: z.literal("orin"), modelId: z.literal("qwen2.5-coder:3b") }).strict();
+const macroPayload = z.object({ routes: z.array(route).length(4) }).strict();
+const promptPayload = z.object({ systemPrompt: z.string().min(1).max(4_096) }).strict();
+const harnessPayload = z.object({ allowedHarnesses: z.array(z.enum(["pi", "opencode"])).min(1).max(2) }).strict();
+const toolPolicyPayload = z.object({ allowedTools: z.array(z.enum(["read", "write", "shell"])).min(1).max(3) }).strict();
 
-const storedConfigSchema = z.discriminatedUnion("targetId", [
-  z.object({ schemaVersion: z.literal(HUGIN_CONFIG_ADAPTER_VERSION), targetId: z.literal("hugin-orin-macro-routing"), revision, routes: z.array(routeSchema).length(4) }).strict(),
-  z.object({ schemaVersion: z.literal(HUGIN_CONFIG_ADAPTER_VERSION), targetId: z.literal("hugin-agent-prompt"), revision, promptTemplateDigest: sha256 }).strict(),
-  z.object({ schemaVersion: z.literal(HUGIN_CONFIG_ADAPTER_VERSION), targetId: z.literal("hugin-agent-harness"), revision, harnessPolicyDigest: sha256 }).strict(),
-  z.object({ schemaVersion: z.literal(HUGIN_CONFIG_ADAPTER_VERSION), targetId: z.literal("hugin-tool-policy"), revision, toolPolicyDigest: sha256 }).strict(),
+const candidateSchema = z.discriminatedUnion("targetId", [
+  z.object({ schemaVersion: z.literal(HUGIN_CONFIG_ADAPTER_VERSION), targetId: z.literal("hugin-orin-macro-routing"), revision, base: z.object({ revision, digest: sha256 }).strict(), config: macroPayload, candidateDigest: sha256 }).strict(),
+  z.object({ schemaVersion: z.literal(HUGIN_CONFIG_ADAPTER_VERSION), targetId: z.literal("hugin-agent-prompt"), revision, base: z.object({ revision, digest: sha256 }).strict(), config: promptPayload, candidateDigest: sha256 }).strict(),
+  z.object({ schemaVersion: z.literal(HUGIN_CONFIG_ADAPTER_VERSION), targetId: z.literal("hugin-agent-harness"), revision, base: z.object({ revision, digest: sha256 }).strict(), config: harnessPayload, candidateDigest: sha256 }).strict(),
+  z.object({ schemaVersion: z.literal(HUGIN_CONFIG_ADAPTER_VERSION), targetId: z.literal("hugin-tool-policy"), revision, base: z.object({ revision, digest: sha256 }).strict(), config: toolPolicyPayload, candidateDigest: sha256 }).strict(),
 ]);
+export type HuginConfigCandidate = z.infer<typeof candidateSchema>;
+type ConfigPayload = HuginConfigCandidate["config"];
 
-export type HuginStoredConfig = z.infer<typeof storedConfigSchema>;
+const digest = (value: unknown): string => `sha256:${createHash("sha256").update(canonicalizeJcs(value)).digest("hex")}`;
+const clone = <T>(value: T): T => structuredClone(value);
 
-function digest(value: unknown): string {
-  return `sha256:${createHash("sha256").update(canonicalizeJcs(value)).digest("hex")}`;
+function validateMacroRoutes(routes: z.infer<typeof route>[]): void {
+  const expected = ["classify:internal", "classify:public", "extract:internal", "extract:public"];
+  const keys = routes.map((item) => `${item.taskType}:${item.sensitivity}`);
+  if (keys.join("|") !== expected.join("|")) throw new Error("hugin-config-noncanonical-macro-route-matrix");
 }
 
-const macroRouteConfig: HuginStoredConfig = {
-  schemaVersion: HUGIN_CONFIG_ADAPTER_VERSION,
-  targetId: "hugin-orin-macro-routing",
-  revision: "orin-macro-route-v1",
-  routes: [
-    { workerProvider: "homeserver", taskType: "classify", sensitivity: "public", nodeId: "orin", modelId: "qwen2.5-coder:3b" },
+function candidateBody(candidate: HuginConfigCandidate): unknown {
+  const { candidateDigest: _digest, ...body } = candidate;
+  return body;
+}
+
+/** Strict parse + digest recomputation before a candidate reaches a target. */
+export function validateHuginConfigCandidate(raw: unknown): HuginConfigCandidate {
+  const candidate = candidateSchema.parse(raw);
+  if (candidate.targetId === "hugin-orin-macro-routing") validateMacroRoutes(candidate.config.routes);
+  if (digest(candidateBody(candidate)) !== candidate.candidateDigest) throw new Error("hugin-config-candidate-digest-mismatch");
+  return clone(candidate);
+}
+
+interface StoredDocument { revision: string; payload: ConfigPayload; digest: string; }
+const defaults: Record<HuginConfigTargetId, { revision: string; payload: ConfigPayload }> = {
+  "hugin-orin-macro-routing": { revision: "orin-macro-route-v1", payload: { routes: [
     { workerProvider: "homeserver", taskType: "classify", sensitivity: "internal", nodeId: "orin", modelId: "qwen2.5-coder:3b" },
-    { workerProvider: "homeserver", taskType: "extract", sensitivity: "public", nodeId: "orin", modelId: "qwen2.5-coder:3b" },
+    { workerProvider: "homeserver", taskType: "classify", sensitivity: "public", nodeId: "orin", modelId: "qwen2.5-coder:3b" },
     { workerProvider: "homeserver", taskType: "extract", sensitivity: "internal", nodeId: "orin", modelId: "qwen2.5-coder:3b" },
-  ],
+    { workerProvider: "homeserver", taskType: "extract", sensitivity: "public", nodeId: "orin", modelId: "qwen2.5-coder:3b" },
+  ] } },
+  // These source-owned defaults are safe local config payloads, never receipt/journal content.
+  "hugin-agent-prompt": { revision: "agent-prompt-v1", payload: { systemPrompt: "Complete the bounded Hugin task using only its granted context." } },
+  "hugin-agent-harness": { revision: "agent-harness-v1", payload: { allowedHarnesses: ["pi", "opencode"] } },
+  "hugin-tool-policy": { revision: "tool-policy-v1", payload: { allowedTools: ["read", "write", "shell"] } },
 };
 
-/** Fixed store: only named, schema-validated content identities are observable. */
-const configs: Readonly<Record<HuginConfigTargetId, HuginStoredConfig>> = Object.freeze({
-  "hugin-orin-macro-routing": macroRouteConfig,
-  "hugin-agent-prompt": { schemaVersion: HUGIN_CONFIG_ADAPTER_VERSION, targetId: "hugin-agent-prompt", revision: "agent-prompt-v1", promptTemplateDigest: digest("hugin-agent-prompt-v1") },
-  "hugin-agent-harness": { schemaVersion: HUGIN_CONFIG_ADAPTER_VERSION, targetId: "hugin-agent-harness", revision: "agent-harness-v1", harnessPolicyDigest: digest("hugin-agent-harness-v1") },
-  "hugin-tool-policy": { schemaVersion: HUGIN_CONFIG_ADAPTER_VERSION, targetId: "hugin-tool-policy", revision: "tool-policy-v1", toolPolicyDigest: digest("hugin-tool-policy-v1") },
-});
-
-export function readHuginConfig(target: HuginConfigTargetId): HuginStoredConfig {
-  return storedConfigSchema.parse(configs[target]);
+function initialDocument(value: { revision: string; payload: ConfigPayload }): StoredDocument {
+  return { revision: value.revision, payload: clone(value.payload), digest: digest({ schemaVersion: HUGIN_CONFIG_ADAPTER_VERSION, revision: value.revision, config: value.payload }) };
 }
 
-export function readHuginConfigBase(target: HuginConfigTargetId): HuginConfigBase {
-  const config = readHuginConfig(target);
-  return { revision: config.revision, digest: digest(config) };
+const domains = {
+  "hugin-orin-macro-routing": "macro-routing",
+  "hugin-agent-prompt": "prompt",
+  "hugin-agent-harness": "harness",
+  "hugin-tool-policy": "tool-policy",
+} as const;
+
+/** Owner-local canonical store; mutations are only CAS through a target. */
+export class HuginConfigStore {
+  #current = new Map<HuginConfigTargetId, StoredDocument>();
+  #documents = new Map<string, HuginConfigCandidate>();
+  #snapshots = new Map<string, StoredDocument>();
+  constructor() { for (const id of targetId.options) this.#current.set(id, initialDocument(defaults[id])); }
+  read(id: HuginConfigTargetId): StoredDocument { return clone(this.#current.get(id)!); }
+  readPayload(id: HuginConfigTargetId): ConfigPayload { return clone(this.#current.get(id)!.payload); }
+  stage(raw: unknown): HuginConfigCandidate { const candidate = validateHuginConfigCandidate(raw); this.#documents.set(candidate.candidateDigest, candidate); return clone(candidate); }
+  snapshot(id: HuginConfigTargetId): { ref: string; digest: string } { const doc = this.read(id); const ref = `ref:snapshot-${doc.digest.slice(7, 31)}`; this.#snapshots.set(ref, doc); return { ref, digest: doc.digest }; }
+  /** Called only by the separately authorized R-exact recovery adapter. */
+  restoreSnapshot(id: HuginConfigTargetId, ref: string, expectedDigest: string): { revision: string; digest: string } {
+    const snapshot = this.#snapshots.get(ref);
+    if (!snapshot || snapshot.digest !== expectedDigest) throw new Error("hugin-config-snapshot-unavailable");
+    this.#current.set(id, clone(snapshot));
+    return { revision: snapshot.revision, digest: snapshot.digest };
+  }
+  replace(id: HuginConfigTargetId, expected: { revision: string; digest: string }, candidateDigest: string): void {
+    const current = this.#current.get(id)!;
+    if (current.revision !== expected.revision || current.digest !== expected.digest) throw new Error("hugin-config-stale-base");
+    const candidate = this.#documents.get(candidateDigest);
+    if (!candidate || candidate.targetId !== id || candidate.base.revision !== expected.revision || candidate.base.digest !== expected.digest) throw new Error("hugin-config-candidate-not-bound-to-base");
+    this.#current.set(id, { revision: candidate.revision, payload: clone(candidate.config), digest: candidate.candidateDigest });
+  }
 }
 
-/** Validate an adapter document before any caller can treat it as a target. */
-export function validateHuginConfig(raw: unknown): HuginStoredConfig {
-  return storedConfigSchema.parse(raw);
+class HuginTarget implements RExactConfigTarget {
+  owner = "hugin" as const;
+  domain: typeof domains[HuginConfigTargetId];
+  targetScopeDigest: string;
+  constructor(readonly id: HuginConfigTargetId, private readonly store: HuginConfigStore) {
+    this.domain = domains[id];
+    this.targetScopeDigest = digest({ schemaVersion: HUGIN_CONFIG_ADAPTER_VERSION, targetId: id, domain: this.domain });
+  }
+  async read() { const current = this.store.read(this.id); return { revision: current.revision, digest: current.digest }; }
+  async snapshot() { return this.store.snapshot(this.id); }
+  async replaceExact(expected: { revision: string; digest: string }, candidateDigest: string) { this.store.replace(this.id, expected, candidateDigest); }
 }
 
-export function selectHuginMacroRoute(input: {
-  workerProvider: string;
-  taskType: string;
-  sensitivity: "public" | "internal" | "private";
-}): { nodeId: "orin"; modelId: "qwen2.5-coder:3b" } | null {
+export function createHuginConfigTargets(store = new HuginConfigStore()): Record<HuginConfigTargetId, RExactConfigTarget> {
+  return {
+    "hugin-orin-macro-routing": new HuginTarget("hugin-orin-macro-routing", store),
+    "hugin-agent-prompt": new HuginTarget("hugin-agent-prompt", store),
+    "hugin-agent-harness": new HuginTarget("hugin-agent-harness", store),
+    "hugin-tool-policy": new HuginTarget("hugin-tool-policy", store),
+  };
+}
+
+const productionStore = new HuginConfigStore();
+export const huginConfigTargets = createHuginConfigTargets(productionStore);
+export function stageHuginConfigCandidate(raw: unknown): HuginConfigCandidate { return productionStore.stage(raw); }
+/** Recovery-only composition seam; journals retain only the snapshot ref/digest. */
+export function restoreHuginConfigSnapshot(target: HuginConfigTargetId, ref: string, digest: string) { return productionStore.restoreSnapshot(target, ref, digest); }
+
+/** Read-only route selection uses a cloned canonical source, never a mutable exported map. */
+export function selectHuginMacroRoute(input: { workerProvider: string; taskType: string; sensitivity: "public" | "internal" | "private" }): { nodeId: "orin"; modelId: "qwen2.5-coder:3b" } | null {
   if (input.sensitivity === "private") return null;
-  const config = readHuginConfig("hugin-orin-macro-routing");
-  if (config.targetId !== "hugin-orin-macro-routing") return null;
-  const route = config.routes.find((candidate) =>
-    candidate.workerProvider === input.workerProvider
-    && candidate.taskType === input.taskType
-    && candidate.sensitivity === input.sensitivity,
-  );
-  return route ? { nodeId: route.nodeId, modelId: route.modelId } : null;
+  const payload = productionStore.readPayload("hugin-orin-macro-routing");
+  const routes = macroPayload.parse(payload).routes;
+  const matched = routes.find((entry) => entry.workerProvider === input.workerProvider && entry.taskType === input.taskType && entry.sensitivity === input.sensitivity);
+  return matched ? { nodeId: matched.nodeId, modelId: matched.modelId } : null;
 }

--- a/src/autonomy/hugin-config-adapter.ts
+++ b/src/autonomy/hugin-config-adapter.ts
@@ -5,8 +5,8 @@
  * journals contain only their SHA-256 digest.  This deliberately does not
  * provide a generic config writer or any Gille/deployment/auth surface.
  */
-import { createHash } from "node:crypto";
-import { closeSync, fsyncSync, lstatSync, mkdirSync, openSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import { closeSync, fsyncSync, lstatSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { isAbsolute, join, resolve } from "node:path";
 import { z } from "zod";
 import { canonicalizeJcs } from "../jcs.js";
@@ -38,6 +38,13 @@ const candidateSchema = z.discriminatedUnion("targetId", [
 export type HuginConfigCandidate = z.infer<typeof candidateSchema>;
 type ConfigPayload = HuginConfigCandidate["config"];
 
+const payloadSchemas = {
+  "hugin-orin-macro-routing": macroPayload,
+  "hugin-agent-prompt": promptPayload,
+  "hugin-agent-harness": harnessPayload,
+  "hugin-tool-policy": toolPolicyPayload,
+} as const;
+
 const digest = (value: unknown): string => `sha256:${createHash("sha256").update(canonicalizeJcs(value)).digest("hex")}`;
 const clone = <T>(value: T): T => structuredClone(value);
 
@@ -52,6 +59,17 @@ function candidateBody(candidate: HuginConfigCandidate): unknown {
   return body;
 }
 
+function exactKeys(value: unknown, keys: string[]): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    && Object.keys(value).sort().join("|") === [...keys].sort().join("|");
+}
+
+function validatePayload(id: HuginConfigTargetId, raw: unknown): ConfigPayload {
+  const payload = payloadSchemas[id].parse(raw) as ConfigPayload;
+  if (id === "hugin-orin-macro-routing") validateMacroRoutes((payload as Extract<ConfigPayload, { routes: unknown }>).routes as z.infer<typeof route>[]);
+  return clone(payload);
+}
+
 /** Strict parse + digest recomputation before a candidate reaches a target. */
 export function validateHuginConfigCandidate(raw: unknown): HuginConfigCandidate {
   const candidate = candidateSchema.parse(raw);
@@ -61,6 +79,11 @@ export function validateHuginConfigCandidate(raw: unknown): HuginConfigCandidate
 }
 
 interface StoredDocument { revision: string; payload: ConfigPayload; digest: string; }
+interface StoreState {
+  current: Record<HuginConfigTargetId, StoredDocument>;
+  documents: Record<string, HuginConfigCandidate>;
+  snapshots: Record<string, { target: HuginConfigTargetId; document: StoredDocument }>;
+}
 const defaults: Record<HuginConfigTargetId, { revision: string; payload: ConfigPayload }> = {
   "hugin-orin-macro-routing": { revision: "orin-macro-route-v1", payload: { routes: [
     { workerProvider: "homeserver", taskType: "classify", sensitivity: "internal", nodeId: "orin", modelId: "qwen2.5-coder:3b" },
@@ -78,6 +101,53 @@ function initialDocument(value: { revision: string; payload: ConfigPayload }): S
   return { revision: value.revision, payload: clone(value.payload), digest: digest({ schemaVersion: HUGIN_CONFIG_ADAPTER_VERSION, revision: value.revision, config: value.payload }) };
 }
 
+function validateStoredDocument(
+  raw: unknown,
+  id: HuginConfigTargetId,
+  documents: StoreState["documents"],
+): StoredDocument {
+  if (!exactKeys(raw, ["revision", "payload", "digest"])) throw new Error("hugin-config-store-corrupt");
+  const parsedRevision = revision.parse(raw.revision);
+  const parsedDigest = sha256.parse(raw.digest);
+  const payload = validatePayload(id, raw.payload);
+  const candidate = documents[parsedDigest];
+  if (candidate !== undefined) {
+    if (
+      candidate.targetId !== id
+      || candidate.revision !== parsedRevision
+      || canonicalizeJcs(candidate.config) !== canonicalizeJcs(payload)
+    ) throw new Error("hugin-config-store-digest-mismatch");
+  } else if (parsedDigest !== digest({ schemaVersion: HUGIN_CONFIG_ADAPTER_VERSION, revision: parsedRevision, config: payload })) {
+    throw new Error("hugin-config-store-digest-mismatch");
+  }
+  return { revision: parsedRevision, payload, digest: parsedDigest };
+}
+
+function validateStoreState(raw: unknown): StoreState {
+  if (!exactKeys(raw, ["current", "documents", "snapshots"]) || !raw.current || !raw.documents || !raw.snapshots
+    || typeof raw.current !== "object" || typeof raw.documents !== "object" || typeof raw.snapshots !== "object"
+    || Array.isArray(raw.current) || Array.isArray(raw.documents) || Array.isArray(raw.snapshots)) {
+    throw new Error("hugin-config-store-corrupt");
+  }
+  if (Object.keys(raw.current).sort().join("|") !== [...targetId.options].sort().join("|")) throw new Error("hugin-config-store-corrupt");
+  const documents: StoreState["documents"] = {};
+  for (const [key, value] of Object.entries(raw.documents)) {
+    const candidate = validateHuginConfigCandidate(value);
+    if (key !== candidate.candidateDigest) throw new Error("hugin-config-store-digest-mismatch");
+    documents[key] = candidate;
+  }
+  const rawCurrent = raw.current as Record<string, unknown>;
+  const current = {} as Record<HuginConfigTargetId, StoredDocument>;
+  for (const id of targetId.options) current[id] = validateStoredDocument(rawCurrent[id], id, documents);
+  const snapshots: StoreState["snapshots"] = {};
+  for (const [ref, value] of Object.entries(raw.snapshots)) {
+    if (!/^ref:snapshot-[a-z0-9-]+-[a-f0-9]{24}$/.test(ref) || !exactKeys(value, ["target", "document"])) throw new Error("hugin-config-store-corrupt");
+    const id = targetId.parse(value.target);
+    snapshots[ref] = { target: id, document: validateStoredDocument(value.document, id, documents) };
+  }
+  return { current, documents, snapshots };
+}
+
 const domains = {
   "hugin-orin-macro-routing": "macro-routing",
   "hugin-agent-prompt": "prompt",
@@ -88,22 +158,57 @@ const domains = {
 /** Owner-local canonical store; mutations are only CAS through a target. */
 export class HuginConfigStore {
   #path: string;
-  constructor(root: string) {
+  #lockPath: string;
+  constructor(root: string, options: { initialize?: boolean } = {}) {
     if (!isAbsolute(root)) throw new Error("hugin-config-root-not-absolute");
-    this.#path = join(resolve(root), "hugin-r-exact-config.json"); mkdirSync(root, { recursive: true, mode: 0o700 });
+    const initialize = options.initialize ?? true;
+    this.#path = join(resolve(root), "hugin-r-exact-config.json"); this.#lockPath = `${this.#path}.lock`;
+    if (initialize) mkdirSync(root, { recursive: true, mode: 0o700 });
     const stat = lstatSync(root); if (!stat.isDirectory() || stat.isSymbolicLink() || (stat.mode & 0o077) !== 0) throw new Error("hugin-config-root-unsafe");
-    if (!this.exists()) this.write({ current: Object.fromEntries(targetId.options.map((id) => [id, initialDocument(defaults[id])])), documents: {}, snapshots: {} });
+    if (!initialize) {
+      this.load();
+      return;
+    }
+    this.withLock(() => {
+      if (!this.exists()) this.write({ current: Object.fromEntries(targetId.options.map((id) => [id, initialDocument(defaults[id])])) as Record<HuginConfigTargetId, StoredDocument>, documents: {}, snapshots: {} });
+      else this.load();
+    });
+  }
+  /** Opens an existing store without creating files or taking its mutation lock. */
+  static openReadOnly(root: string): HuginConfigStore {
+    return new HuginConfigStore(root, { initialize: false });
   }
   private exists() { try { lstatSync(this.#path); return true; } catch { return false; } }
-  private load(): { current: Record<HuginConfigTargetId, StoredDocument>; documents: Record<string, HuginConfigCandidate>; snapshots: Record<string, { target: HuginConfigTargetId; document: StoredDocument }> } {
-    const stat = lstatSync(this.#path); if (!stat.isFile() || stat.isSymbolicLink() || (stat.mode & 0o077) !== 0) throw new Error("hugin-config-store-unsafe");
-    try { return JSON.parse(readFileSync(this.#path, "utf8")); } catch { throw new Error("hugin-config-store-corrupt"); }
+  private withLock<T>(operation: () => T): T {
+    for (let attempt = 0; attempt < 500; attempt += 1) {
+      let fd: number | undefined;
+      try {
+        fd = openSync(this.#lockPath, "wx", 0o600);
+      } catch (error: any) {
+        if (error?.code !== "EEXIST") throw error;
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+        continue;
+      }
+      try {
+        writeFileSync(fd, `${process.pid}\n`); fsyncSync(fd); closeSync(fd); fd = undefined;
+        return operation();
+      } finally {
+        if (fd !== undefined) closeSync(fd);
+        unlinkSync(this.#lockPath);
+      }
+    }
+    throw new Error("hugin-config-store-contended");
   }
-  private write(state: unknown) { const temp = `${this.#path}.tmp`; const fd = openSync(temp, "w", 0o600); try { writeFileSync(fd, canonicalizeJcs(state)); fsyncSync(fd); } finally { closeSync(fd); } renameSync(temp, this.#path); const dir = openSync(resolve(this.#path, ".."), "r"); try { fsyncSync(dir); } finally { closeSync(dir); } }
+  private load(): StoreState {
+    const stat = lstatSync(this.#path); if (!stat.isFile() || stat.isSymbolicLink() || (stat.mode & 0o077) !== 0) throw new Error("hugin-config-store-unsafe");
+    try { return validateStoreState(JSON.parse(readFileSync(this.#path, "utf8"))); } catch (error) { if (error instanceof Error && error.message.startsWith("hugin-config-store-")) throw error; throw new Error("hugin-config-store-corrupt"); }
+  }
+  private write(state: StoreState) { const temp = `${this.#path}.${process.pid}.${randomUUID()}.tmp`; const fd = openSync(temp, "wx", 0o600); try { writeFileSync(fd, canonicalizeJcs(state)); fsyncSync(fd); } finally { closeSync(fd); } renameSync(temp, this.#path); const dir = openSync(resolve(this.#path, ".."), "r"); try { fsyncSync(dir); } finally { closeSync(dir); } }
   read(id: HuginConfigTargetId): StoredDocument { return clone(this.load().current[id]); }
   readPayload(id: HuginConfigTargetId): ConfigPayload { return clone(this.load().current[id].payload); }
-  stage(raw: unknown): HuginConfigCandidate { const candidate = validateHuginConfigCandidate(raw); const state = this.load(); state.documents[candidate.candidateDigest] = candidate; this.write(state); return clone(candidate); }
-  snapshot(id: HuginConfigTargetId): { ref: string; digest: string } { const state = this.load(); const doc = state.current[id]; const ref = `ref:snapshot-${id}-${doc.digest.slice(7, 31)}`; state.snapshots[ref] = { target: id, document: doc }; this.write(state); return { ref, digest: doc.digest }; }
+  candidateRevision(id: HuginConfigTargetId, candidateDigest: string): string { const candidate = this.load().documents[candidateDigest]; if (!candidate || candidate.targetId !== id) throw new Error("hugin-config-candidate-unavailable"); return candidate.revision; }
+  stage(raw: unknown): HuginConfigCandidate { const candidate = validateHuginConfigCandidate(raw); return this.withLock(() => { const state = this.load(); state.documents[candidate.candidateDigest] = candidate; this.write(state); return clone(candidate); }); }
+  snapshot(id: HuginConfigTargetId): { ref: string; digest: string } { return this.withLock(() => { const state = this.load(); const doc = state.current[id]; const ref = `ref:snapshot-${id}-${doc.digest.slice(7, 31)}`; state.snapshots[ref] = { target: id, document: doc }; this.write(state); return { ref, digest: doc.digest }; }); }
   /** Called only by the separately authorized R-exact recovery adapter. */
   restoreSnapshot(
     id: HuginConfigTargetId,
@@ -113,18 +218,22 @@ export class HuginConfigStore {
     recoveryIdentity: string,
   ): { revision: string; digest: string } {
     if (recoveryIdentity !== HUGIN_CONFIG_RECOVERY_WORKER_ID) throw new Error("hugin-config-recovery-fence-refused");
-    const state = this.load(); const snapshot = state.snapshots[ref];
-    if (!snapshot || snapshot.target !== id || snapshot.document.digest !== expectedDigest) throw new Error("hugin-config-snapshot-unavailable");
-    const current = state.current[id]; if (current.digest === expectedDigest) return { revision: current.revision, digest: current.digest };
-    if (current.revision !== expectedCurrent.revision || current.digest !== expectedCurrent.digest) throw new Error("hugin-config-stale-recovery-fence");
-    state.current[id] = clone(snapshot.document); this.write(state); return { revision: snapshot.document.revision, digest: snapshot.document.digest };
+    return this.withLock(() => {
+      const state = this.load(); const snapshot = state.snapshots[ref];
+      if (!snapshot || snapshot.target !== id || snapshot.document.digest !== expectedDigest) throw new Error("hugin-config-snapshot-unavailable");
+      const current = state.current[id]; if (current.digest === expectedDigest && current.revision === snapshot.document.revision) return { revision: current.revision, digest: current.digest };
+      if (current.revision !== expectedCurrent.revision || current.digest !== expectedCurrent.digest) throw new Error("hugin-config-stale-recovery-fence");
+      state.current[id] = clone(snapshot.document); this.write(state); return { revision: snapshot.document.revision, digest: snapshot.document.digest };
+    });
   }
   replace(id: HuginConfigTargetId, expected: { revision: string; digest: string }, candidateDigest: string): void {
-    const state = this.load(); const current = state.current[id];
-    if (current.revision !== expected.revision || current.digest !== expected.digest) throw new Error("hugin-config-stale-base");
-    const candidate = state.documents[candidateDigest];
-    if (!candidate || candidate.targetId !== id || candidate.base.revision !== expected.revision || candidate.base.digest !== expected.digest) throw new Error("hugin-config-candidate-not-bound-to-base");
-    state.current[id] = { revision: candidate.revision, payload: clone(candidate.config), digest: candidate.candidateDigest }; this.write(state);
+    this.withLock(() => {
+      const state = this.load(); const current = state.current[id];
+      if (current.revision !== expected.revision || current.digest !== expected.digest) throw new Error("hugin-config-stale-base");
+      const candidate = state.documents[candidateDigest];
+      if (!candidate || candidate.targetId !== id || candidate.base.revision !== expected.revision || candidate.base.digest !== expected.digest) throw new Error("hugin-config-candidate-not-bound-to-base");
+      state.current[id] = { revision: candidate.revision, payload: clone(candidate.config), digest: candidate.candidateDigest }; this.write(state);
+    });
   }
 }
 
@@ -137,6 +246,7 @@ class HuginTarget implements RExactConfigTarget {
     this.targetScopeDigest = digest({ schemaVersion: HUGIN_CONFIG_ADAPTER_VERSION, targetId: id, domain: this.domain });
   }
   async read() { const current = this.store.read(this.id); return { revision: current.revision, digest: current.digest }; }
+  async candidateRevision(candidateDigest: string) { return this.store.candidateRevision(this.id, candidateDigest); }
   async snapshot() { return this.store.snapshot(this.id); }
   async replaceExact(expected: { revision: string; digest: string }, candidateDigest: string) { this.store.replace(this.id, expected, candidateDigest); }
 }
@@ -190,12 +300,20 @@ export function createHuginConfigRecoveryWorker(
   return { restoreAndVerify: worker.restoreAndVerify.bind(worker) };
 }
 
-// Deployment supplies its private durable root; no live directory is created by this module.
+/** Production composition root for the owner-installed durable config resource. */
+export const HUGIN_CONFIG_ROOT_ENV = "HUGIN_R_EXACT_CONFIG_ROOT";
 
-/** Read-only route selection uses a cloned canonical source, never a mutable exported map. */
-export function selectHuginMacroRoute(input: { workerProvider: string; taskType: string; sensitivity: "public" | "internal" | "private" }): { nodeId: "orin"; modelId: "qwen2.5-coder:3b" } | null {
+export function selectHuginMacroRouteFromStore(store: Pick<HuginConfigStore, "readPayload">, input: { workerProvider: string; taskType: string; sensitivity: "public" | "internal" | "private" }): { nodeId: "orin"; modelId: "qwen2.5-coder:3b" } | null {
   if (input.sensitivity === "private") return null;
-  const routes = macroPayload.parse(defaults["hugin-orin-macro-routing"].payload).routes;
+  const routes = macroPayload.parse(store.readPayload("hugin-orin-macro-routing")).routes;
   const matched = routes.find((entry) => entry.workerProvider === input.workerProvider && entry.taskType === input.taskType && entry.sensitivity === input.sensitivity);
   return matched ? { nodeId: matched.nodeId, modelId: matched.modelId } : null;
+}
+
+/** Fail closed until deployment explicitly supplies the owner-local durable root. */
+export function selectHuginMacroRoute(input: { workerProvider: string; taskType: string; sensitivity: "public" | "internal" | "private" }): { nodeId: "orin"; modelId: "qwen2.5-coder:3b" } | null {
+  const root = process.env[HUGIN_CONFIG_ROOT_ENV];
+  if (!root) return null;
+  try { return selectHuginMacroRouteFromStore(HuginConfigStore.openReadOnly(root), input); }
+  catch { return null; }
 }

--- a/src/autonomy/hugin-config-adapter.ts
+++ b/src/autonomy/hugin-config-adapter.ts
@@ -1,0 +1,97 @@
+/**
+ * Strict, content-blind configuration boundary for the ADR-008 Hugin targets.
+ *
+ * This is deliberately an adapter/store for immutable configuration identities,
+ * not a generic configuration service.  It accepts no prompt, model, gateway,
+ * logging, deployment, or credential material.  R-exact application remains
+ * owned by the controller; this module only exposes the bounded current base.
+ */
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import { canonicalizeJcs } from "../jcs.js";
+
+export const HUGIN_CONFIG_ADAPTER_VERSION = "hugin-config-adapter-v1" as const;
+
+const sha256 = z.string().regex(/^sha256:[a-f0-9]{64}$/);
+const revision = z.string().regex(/^[a-z][a-z0-9-]{2,80}$/);
+const targetId = z.enum([
+  "hugin-orin-macro-routing",
+  "hugin-agent-prompt",
+  "hugin-agent-harness",
+  "hugin-tool-policy",
+]);
+
+export type HuginConfigTargetId = z.infer<typeof targetId>;
+export type HuginConfigBase = { revision: string; digest: string };
+
+const routeSchema = z.object({
+  workerProvider: z.literal("homeserver"),
+  taskType: z.enum(["classify", "extract"]),
+  sensitivity: z.enum(["public", "internal"]),
+  nodeId: z.literal("orin"),
+  // This is a fixed implementation identity, not a mutable model setting.
+  modelId: z.literal("qwen2.5-coder:3b"),
+}).strict();
+
+const storedConfigSchema = z.discriminatedUnion("targetId", [
+  z.object({ schemaVersion: z.literal(HUGIN_CONFIG_ADAPTER_VERSION), targetId: z.literal("hugin-orin-macro-routing"), revision, routes: z.array(routeSchema).length(4) }).strict(),
+  z.object({ schemaVersion: z.literal(HUGIN_CONFIG_ADAPTER_VERSION), targetId: z.literal("hugin-agent-prompt"), revision, promptTemplateDigest: sha256 }).strict(),
+  z.object({ schemaVersion: z.literal(HUGIN_CONFIG_ADAPTER_VERSION), targetId: z.literal("hugin-agent-harness"), revision, harnessPolicyDigest: sha256 }).strict(),
+  z.object({ schemaVersion: z.literal(HUGIN_CONFIG_ADAPTER_VERSION), targetId: z.literal("hugin-tool-policy"), revision, toolPolicyDigest: sha256 }).strict(),
+]);
+
+export type HuginStoredConfig = z.infer<typeof storedConfigSchema>;
+
+function digest(value: unknown): string {
+  return `sha256:${createHash("sha256").update(canonicalizeJcs(value)).digest("hex")}`;
+}
+
+const macroRouteConfig: HuginStoredConfig = {
+  schemaVersion: HUGIN_CONFIG_ADAPTER_VERSION,
+  targetId: "hugin-orin-macro-routing",
+  revision: "orin-macro-route-v1",
+  routes: [
+    { workerProvider: "homeserver", taskType: "classify", sensitivity: "public", nodeId: "orin", modelId: "qwen2.5-coder:3b" },
+    { workerProvider: "homeserver", taskType: "classify", sensitivity: "internal", nodeId: "orin", modelId: "qwen2.5-coder:3b" },
+    { workerProvider: "homeserver", taskType: "extract", sensitivity: "public", nodeId: "orin", modelId: "qwen2.5-coder:3b" },
+    { workerProvider: "homeserver", taskType: "extract", sensitivity: "internal", nodeId: "orin", modelId: "qwen2.5-coder:3b" },
+  ],
+};
+
+/** Fixed store: only named, schema-validated content identities are observable. */
+const configs: Readonly<Record<HuginConfigTargetId, HuginStoredConfig>> = Object.freeze({
+  "hugin-orin-macro-routing": macroRouteConfig,
+  "hugin-agent-prompt": { schemaVersion: HUGIN_CONFIG_ADAPTER_VERSION, targetId: "hugin-agent-prompt", revision: "agent-prompt-v1", promptTemplateDigest: digest("hugin-agent-prompt-v1") },
+  "hugin-agent-harness": { schemaVersion: HUGIN_CONFIG_ADAPTER_VERSION, targetId: "hugin-agent-harness", revision: "agent-harness-v1", harnessPolicyDigest: digest("hugin-agent-harness-v1") },
+  "hugin-tool-policy": { schemaVersion: HUGIN_CONFIG_ADAPTER_VERSION, targetId: "hugin-tool-policy", revision: "tool-policy-v1", toolPolicyDigest: digest("hugin-tool-policy-v1") },
+});
+
+export function readHuginConfig(target: HuginConfigTargetId): HuginStoredConfig {
+  return storedConfigSchema.parse(configs[target]);
+}
+
+export function readHuginConfigBase(target: HuginConfigTargetId): HuginConfigBase {
+  const config = readHuginConfig(target);
+  return { revision: config.revision, digest: digest(config) };
+}
+
+/** Validate an adapter document before any caller can treat it as a target. */
+export function validateHuginConfig(raw: unknown): HuginStoredConfig {
+  return storedConfigSchema.parse(raw);
+}
+
+export function selectHuginMacroRoute(input: {
+  workerProvider: string;
+  taskType: string;
+  sensitivity: "public" | "internal" | "private";
+}): { nodeId: "orin"; modelId: "qwen2.5-coder:3b" } | null {
+  if (input.sensitivity === "private") return null;
+  const config = readHuginConfig("hugin-orin-macro-routing");
+  if (config.targetId !== "hugin-orin-macro-routing") return null;
+  const route = config.routes.find((candidate) =>
+    candidate.workerProvider === input.workerProvider
+    && candidate.taskType === input.taskType
+    && candidate.sensitivity === input.sensitivity,
+  );
+  return route ? { nodeId: route.nodeId, modelId: route.modelId } : null;
+}

--- a/src/autonomy/hugin-config-adapter.ts
+++ b/src/autonomy/hugin-config-adapter.ts
@@ -94,6 +94,10 @@ function initialDocument(value: { revision: string; payload: ConfigPayload }): S
   return { revision: value.revision, payload: clone(value.payload), digest: digest({ schemaVersion: HUGIN_CONFIG_ADAPTER_VERSION, revision: value.revision, config: value.payload }) };
 }
 
+function canonicalSnapshotRef(id: HuginConfigTargetId, documentDigest: string): string {
+  return `ref:snapshot-${id}-${documentDigest.slice(7, 31)}`;
+}
+
 function validateStoredDocument(
   raw: unknown,
   id: HuginConfigTargetId,
@@ -140,9 +144,11 @@ function validateStoreState(raw: unknown): StoreState {
   for (const id of targetIds) current[id] = validateStoredDocument(rawCurrent[id], id, documents);
   const snapshots: StoreState["snapshots"] = {};
   for (const [ref, value] of Object.entries(raw.snapshots)) {
-    if (!/^ref:snapshot-[a-z0-9-]+-[a-f0-9]{24}$/.test(ref) || !exactKeys(value, ["target", "document"])) throw new Error("hugin-config-store-corrupt");
+    if (!/^ref:snapshot-hugin-orin-macro-routing-[a-f0-9]{24}$/.test(ref) || !exactKeys(value, ["target", "document"])) throw new Error("hugin-config-store-corrupt");
     const id = targetId.parse(value.target);
-    snapshots[ref] = { target: id, document: validateStoredDocument(value.document, id, documents) };
+    const document = validateStoredDocument(value.document, id, documents);
+    if (ref !== canonicalSnapshotRef(id, document.digest)) throw new Error("hugin-config-store-corrupt");
+    snapshots[ref] = { target: id, document };
   }
   return { current, documents, snapshots };
 }
@@ -168,17 +174,30 @@ const processLocalLocks = new Set<string>();
 export class HuginConfigStore {
   #path: string;
   #lockPath: string;
+  #maxStoreBytes: number;
   #onLockReleaseReadyForTest: (() => void) | undefined;
   constructor(root: string, options: {
     initialize?: boolean;
     /** Deterministic race injection only; production composition never sets it. */
     onLockReleaseReadyForTest?: () => void;
+    /** Reduced write/read ceiling for deterministic boundary tests only. */
+    maxStoreBytesForTest?: number;
   } = {}) {
     if (!isAbsolute(root)) throw new Error("hugin-config-root-not-absolute");
     const initialize = options.initialize ?? true;
-    if (options.onLockReleaseReadyForTest && process.env.VITEST !== "true") {
+    if (
+      (options.onLockReleaseReadyForTest || options.maxStoreBytesForTest !== undefined)
+      && process.env.VITEST !== "true"
+    ) {
       throw new Error("hugin-config-store-test-hook-refused");
     }
+    if (
+      options.maxStoreBytesForTest !== undefined
+      && (!Number.isSafeInteger(options.maxStoreBytesForTest) || options.maxStoreBytesForTest < 1)
+    ) {
+      throw new Error("hugin-config-store-test-hook-refused");
+    }
+    this.#maxStoreBytes = options.maxStoreBytesForTest ?? MAX_STORE_BYTES;
     this.#onLockReleaseReadyForTest = options.onLockReleaseReadyForTest;
     this.#path = join(resolve(root), "hugin-r-exact-config.json"); this.#lockPath = `${this.#path}.lock`;
     if (initialize) mkdirSync(root, { recursive: true, mode: 0o700 });
@@ -264,10 +283,10 @@ export class HuginConfigStore {
   }
   private load(): StoreState {
     const stat = lstatSync(this.#path); if (!stat.isFile() || stat.isSymbolicLink() || (stat.mode & 0o077) !== 0) throw new Error("hugin-config-store-unsafe");
-    if (stat.size > MAX_STORE_BYTES) throw new Error("hugin-config-store-too-large");
+    if (stat.size > this.#maxStoreBytes) throw new Error("hugin-config-store-too-large");
     try {
       const serialized = readFileSync(this.#path);
-      if (serialized.byteLength > MAX_STORE_BYTES) throw new Error("hugin-config-store-too-large");
+      if (serialized.byteLength > this.#maxStoreBytes) throw new Error("hugin-config-store-too-large");
       return validateStoreState(JSON.parse(serialized.toString("utf8")));
     } catch (error) {
       if (error instanceof Error && error.message.startsWith("hugin-config-store-")) throw error;
@@ -275,9 +294,13 @@ export class HuginConfigStore {
     }
   }
   private write(state: StoreState) {
+    const serialized = Buffer.from(canonicalizeJcs(state), "utf8");
+    if (serialized.byteLength > this.#maxStoreBytes) {
+      throw new Error("hugin-config-store-too-large");
+    }
     const temp = `${this.#path}.${process.pid}.${randomUUID()}.tmp`; let fd: number | undefined;
     try {
-      fd = openSync(temp, "wx", 0o600); writeFileSync(fd, canonicalizeJcs(state)); fsyncSync(fd); closeSync(fd); fd = undefined;
+      fd = openSync(temp, "wx", 0o600); writeFileSync(fd, serialized); fsyncSync(fd); closeSync(fd); fd = undefined;
       renameSync(temp, this.#path); const dir = openSync(resolve(this.#path, ".."), "r"); try { fsyncSync(dir); } finally { closeSync(dir); }
     } catch (error) {
       try { unlinkSync(temp); } catch { /* only this UUID-bound failed temp is eligible for cleanup */ }
@@ -288,7 +311,7 @@ export class HuginConfigStore {
   readPayload(id: HuginConfigTargetId): ConfigPayload { return clone(this.load().current[id].payload); }
   candidateRevision(id: HuginConfigTargetId, candidateDigest: string): string { const candidate = this.load().documents[candidateDigest]; if (!candidate || candidate.targetId !== id) throw new Error("hugin-config-candidate-unavailable"); return candidate.revision; }
   stage(raw: unknown): HuginConfigCandidate { const candidate = validateHuginConfigCandidate(raw); return this.withLock(() => { const state = this.load(); state.documents[candidate.candidateDigest] = candidate; pruneState(state, candidate.candidateDigest); this.write(state); return clone(candidate); }); }
-  snapshot(id: HuginConfigTargetId): { ref: string; digest: string } { return this.withLock(() => { const state = this.load(); const doc = state.current[id]; const ref = `ref:snapshot-${id}-${doc.digest.slice(7, 31)}`; state.snapshots[ref] = { target: id, document: doc }; pruneState(state); this.write(state); return { ref, digest: doc.digest }; }); }
+  snapshot(id: HuginConfigTargetId): { ref: string; digest: string } { return this.withLock(() => { const state = this.load(); const doc = state.current[id]; const ref = canonicalSnapshotRef(id, doc.digest); state.snapshots[ref] = { target: id, document: doc }; pruneState(state); this.write(state); return { ref, digest: doc.digest }; }); }
   /** Called only by the separately authorized R-exact recovery adapter. */
   restoreSnapshot(
     id: HuginConfigTargetId,

--- a/src/autonomy/hugin-config-adapter.ts
+++ b/src/autonomy/hugin-config-adapter.ts
@@ -6,7 +6,7 @@
  * provide a generic config writer or any Gille/deployment/auth surface.
  */
 import { createHash, randomUUID } from "node:crypto";
-import { closeSync, fsyncSync, lstatSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { closeSync, fstatSync, fsyncSync, lstatSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { isAbsolute, join, resolve } from "node:path";
 import { z } from "zod";
 import { canonicalizeJcs } from "../jcs.js";
@@ -20,29 +20,20 @@ export const HUGIN_CONFIG_ADAPTER_VERSION = "hugin-config-adapter-v1" as const;
 export const HUGIN_CONFIG_RECOVERY_WORKER_ID = "hugin-recovery" as const;
 const sha256 = z.string().regex(/^sha256:[a-f0-9]{64}$/);
 const revision = z.string().regex(/^[a-z][a-z0-9-]{2,80}$/);
-const targetId = z.enum(["hugin-orin-macro-routing", "hugin-agent-prompt", "hugin-agent-harness", "hugin-tool-policy"]);
+const targetId = z.literal("hugin-orin-macro-routing");
 export type HuginConfigTargetId = z.infer<typeof targetId>;
+const targetIds: readonly HuginConfigTargetId[] = ["hugin-orin-macro-routing"];
 
 const route = z.object({ workerProvider: z.literal("homeserver"), taskType: z.enum(["classify", "extract"]), sensitivity: z.enum(["public", "internal"]), nodeId: z.literal("orin"), modelId: z.literal("qwen2.5-coder:3b") }).strict();
-const macroPayload = z.object({ routes: z.array(route).length(4) }).strict();
-const promptPayload = z.object({ templateRef: z.string().regex(/^ref:[a-z][a-z0-9-]{2,120}$/), templateDigest: sha256 }).strict();
-const harnessPayload = z.object({ allowedHarnesses: z.array(z.enum(["pi", "opencode"])).min(1).max(2) }).strict();
-const toolPolicyPayload = z.object({ allowedTools: z.array(z.enum(["read", "write", "shell"])).min(1).max(3) }).strict();
+/** Canonical unique subset (including empty) of the four reviewed Orin leaves. */
+const macroPayload = z.object({ routes: z.array(route).max(4) }).strict();
 
-const candidateSchema = z.discriminatedUnion("targetId", [
-  z.object({ schemaVersion: z.literal(HUGIN_CONFIG_ADAPTER_VERSION), targetId: z.literal("hugin-orin-macro-routing"), revision, base: z.object({ revision, digest: sha256 }).strict(), config: macroPayload, candidateDigest: sha256 }).strict(),
-  z.object({ schemaVersion: z.literal(HUGIN_CONFIG_ADAPTER_VERSION), targetId: z.literal("hugin-agent-prompt"), revision, base: z.object({ revision, digest: sha256 }).strict(), config: promptPayload, candidateDigest: sha256 }).strict(),
-  z.object({ schemaVersion: z.literal(HUGIN_CONFIG_ADAPTER_VERSION), targetId: z.literal("hugin-agent-harness"), revision, base: z.object({ revision, digest: sha256 }).strict(), config: harnessPayload, candidateDigest: sha256 }).strict(),
-  z.object({ schemaVersion: z.literal(HUGIN_CONFIG_ADAPTER_VERSION), targetId: z.literal("hugin-tool-policy"), revision, base: z.object({ revision, digest: sha256 }).strict(), config: toolPolicyPayload, candidateDigest: sha256 }).strict(),
-]);
+const candidateSchema = z.object({ schemaVersion: z.literal(HUGIN_CONFIG_ADAPTER_VERSION), targetId, revision, base: z.object({ revision, digest: sha256 }).strict(), config: macroPayload, candidateDigest: sha256 }).strict();
 export type HuginConfigCandidate = z.infer<typeof candidateSchema>;
 type ConfigPayload = HuginConfigCandidate["config"];
 
 const payloadSchemas = {
   "hugin-orin-macro-routing": macroPayload,
-  "hugin-agent-prompt": promptPayload,
-  "hugin-agent-harness": harnessPayload,
-  "hugin-tool-policy": toolPolicyPayload,
 } as const;
 
 const digest = (value: unknown): string => `sha256:${createHash("sha256").update(canonicalizeJcs(value)).digest("hex")}`;
@@ -51,7 +42,9 @@ const clone = <T>(value: T): T => structuredClone(value);
 function validateMacroRoutes(routes: z.infer<typeof route>[]): void {
   const expected = ["classify:internal", "classify:public", "extract:internal", "extract:public"];
   const keys = routes.map((item) => `${item.taskType}:${item.sensitivity}`);
-  if (keys.join("|") !== expected.join("|")) throw new Error("hugin-config-noncanonical-macro-route-matrix");
+  if (new Set(keys).size !== keys.length || keys.some((key) => !expected.includes(key)) || keys.join("|") !== [...keys].sort().join("|")) {
+    throw new Error("hugin-config-noncanonical-macro-route-matrix");
+  }
 }
 
 function candidateBody(candidate: HuginConfigCandidate): unknown {
@@ -66,14 +59,14 @@ function exactKeys(value: unknown, keys: string[]): value is Record<string, unkn
 
 function validatePayload(id: HuginConfigTargetId, raw: unknown): ConfigPayload {
   const payload = payloadSchemas[id].parse(raw) as ConfigPayload;
-  if (id === "hugin-orin-macro-routing") validateMacroRoutes((payload as Extract<ConfigPayload, { routes: unknown }>).routes as z.infer<typeof route>[]);
+  validateMacroRoutes(payload.routes);
   return clone(payload);
 }
 
 /** Strict parse + digest recomputation before a candidate reaches a target. */
 export function validateHuginConfigCandidate(raw: unknown): HuginConfigCandidate {
   const candidate = candidateSchema.parse(raw);
-  if (candidate.targetId === "hugin-orin-macro-routing") validateMacroRoutes(candidate.config.routes);
+  validateMacroRoutes(candidate.config.routes);
   if (digest(candidateBody(candidate)) !== candidate.candidateDigest) throw new Error("hugin-config-candidate-digest-mismatch");
   return clone(candidate);
 }
@@ -84,6 +77,21 @@ interface StoreState {
   documents: Record<string, HuginConfigCandidate>;
   snapshots: Record<string, { target: HuginConfigTargetId; document: StoredDocument }>;
 }
+const MAX_STAGED_DOCUMENTS = 64;
+const MAX_SNAPSHOTS = 32;
+interface LockMetadata {
+  version: 1;
+  bootId: string;
+  pid: number;
+  startTime: string;
+  device: number;
+  inode: number;
+}
+interface LockLease { device: number; inode: number; }
+const lockMetadataSchema = z.object({
+  version: z.literal(1), bootId: z.string().min(1).max(128), pid: z.number().int().positive(),
+  startTime: z.string().regex(/^\d+$/), device: z.number().int().nonnegative(), inode: z.number().int().positive(),
+}).strict();
 const defaults: Record<HuginConfigTargetId, { revision: string; payload: ConfigPayload }> = {
   "hugin-orin-macro-routing": { revision: "orin-macro-route-v1", payload: { routes: [
     { workerProvider: "homeserver", taskType: "classify", sensitivity: "internal", nodeId: "orin", modelId: "qwen2.5-coder:3b" },
@@ -91,10 +99,6 @@ const defaults: Record<HuginConfigTargetId, { revision: string; payload: ConfigP
     { workerProvider: "homeserver", taskType: "extract", sensitivity: "internal", nodeId: "orin", modelId: "qwen2.5-coder:3b" },
     { workerProvider: "homeserver", taskType: "extract", sensitivity: "public", nodeId: "orin", modelId: "qwen2.5-coder:3b" },
   ] } },
-  // Deliberately unconfigured: W4.4 must supply owner-approved manifests.
-  "hugin-agent-prompt": { revision: "agent-prompt-unconfigured", payload: { templateRef: "ref:unconfigured-prompt", templateDigest: digest({ unconfigured: "prompt" }) } },
-  "hugin-agent-harness": { revision: "agent-harness-unconfigured", payload: { allowedHarnesses: ["pi"] } },
-  "hugin-tool-policy": { revision: "tool-policy-unconfigured", payload: { allowedTools: ["read"] } },
 };
 
 function initialDocument(value: { revision: string; payload: ConfigPayload }): StoredDocument {
@@ -129,7 +133,7 @@ function validateStoreState(raw: unknown): StoreState {
     || Array.isArray(raw.current) || Array.isArray(raw.documents) || Array.isArray(raw.snapshots)) {
     throw new Error("hugin-config-store-corrupt");
   }
-  if (Object.keys(raw.current).sort().join("|") !== [...targetId.options].sort().join("|")) throw new Error("hugin-config-store-corrupt");
+  if (Object.keys(raw.current).sort().join("|") !== [...targetIds].sort().join("|")) throw new Error("hugin-config-store-corrupt");
   const documents: StoreState["documents"] = {};
   for (const [key, value] of Object.entries(raw.documents)) {
     const candidate = validateHuginConfigCandidate(value);
@@ -138,7 +142,7 @@ function validateStoreState(raw: unknown): StoreState {
   }
   const rawCurrent = raw.current as Record<string, unknown>;
   const current = {} as Record<HuginConfigTargetId, StoredDocument>;
-  for (const id of targetId.options) current[id] = validateStoredDocument(rawCurrent[id], id, documents);
+  for (const id of targetIds) current[id] = validateStoredDocument(rawCurrent[id], id, documents);
   const snapshots: StoreState["snapshots"] = {};
   for (const [ref, value] of Object.entries(raw.snapshots)) {
     if (!/^ref:snapshot-[a-z0-9-]+-[a-f0-9]{24}$/.test(ref) || !exactKeys(value, ["target", "document"])) throw new Error("hugin-config-store-corrupt");
@@ -148,20 +152,90 @@ function validateStoreState(raw: unknown): StoreState {
   return { current, documents, snapshots };
 }
 
-const domains = {
-  "hugin-orin-macro-routing": "macro-routing",
-  "hugin-agent-prompt": "prompt",
-  "hugin-agent-harness": "harness",
-  "hugin-tool-policy": "tool-policy",
-} as const;
+/** Keep recovery references first, then a deterministic bounded staged cache. */
+function pruneState(state: StoreState, retainDocument?: string): void {
+  const snapshotRefs = Object.keys(state.snapshots).sort();
+  for (const ref of snapshotRefs.slice(0, Math.max(0, snapshotRefs.length - MAX_SNAPSHOTS))) delete state.snapshots[ref];
+  const referenced = new Set<string>([
+    ...Object.values(state.current).map((document) => document.digest),
+    ...Object.values(state.snapshots).map((snapshot) => snapshot.document.digest),
+    ...(retainDocument ? [retainDocument] : []),
+  ]);
+  const removable = Object.keys(state.documents).filter((key) => !referenced.has(key)).sort();
+  const excess = Math.max(0, Object.keys(state.documents).length - MAX_STAGED_DOCUMENTS);
+  for (const key of removable.slice(0, excess)) delete state.documents[key];
+}
+
+const domains = { "hugin-orin-macro-routing": "macro-routing" } as const;
+
+function linuxBootId(): string | null {
+  if (process.platform !== "linux") return null;
+  try {
+    const value = readFileSync("/proc/sys/kernel/random/boot_id", "utf8").trim();
+    return /^[a-f0-9-]{36}$/.test(value) ? value : null;
+  } catch { return null; }
+}
+
+type LinuxProcessStart = { state: "present"; startTime: string } | { state: "absent" | "unknown" };
+
+function linuxProcessStartTime(pid: number): LinuxProcessStart {
+  if (process.platform !== "linux") return { state: "unknown" };
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+    const closing = stat.lastIndexOf(")");
+    const fields = stat.slice(closing + 2).trim().split(/\s+/);
+    const start = fields[19];
+    return start && /^\d+$/.test(start) ? { state: "present", startTime: start } : { state: "unknown" };
+  } catch (error) {
+    const code = error && typeof error === "object" && "code" in error ? error.code : undefined;
+    return code === "ENOENT" || code === "ESRCH" ? { state: "absent" } : { state: "unknown" };
+  }
+}
+
+function currentLockMetadata(inode: LockLease): LockMetadata {
+  const bootId = linuxBootId(); const start = linuxProcessStartTime(process.pid);
+  return {
+    version: 1,
+    // Non-Linux systems can acquire/release their own locks but never reclaim one.
+    bootId: bootId ?? `nonlinux-${process.platform}`,
+    pid: process.pid,
+    startTime: start.state === "present" ? start.startTime : "0",
+    device: inode.device,
+    inode: inode.inode,
+  };
+}
+
+function isProvenStaleLinuxLock(lock: LockMetadata): boolean {
+  const bootId = linuxBootId();
+  if (!bootId) return false;
+  if (lock.bootId !== bootId) return true;
+  const start = linuxProcessStartTime(lock.pid);
+  return start.state === "absent" || (start.state === "present" && start.startTime !== lock.startTime);
+}
+
+/*
+ * Reclamation moves the proven stale inode away atomically. New participants
+ * can only create `lockPath` after that rename, and this reclaimer never
+ * unlinks `lockPath` afterwards, so it cannot delete a live replacement.
+ */
+function moveProvenStaleLock(lockPath: string, before: LockLease, claim: string): boolean {
+  if (process.platform !== "linux") return false;
+  try {
+    renameSync(lockPath, claim);
+    const claimed = lstatSync(claim);
+    return claimed.isFile() && !claimed.isSymbolicLink() && claimed.dev === before.device && claimed.ino === before.inode;
+  } catch { return false; }
+}
 
 /** Owner-local canonical store; mutations are only CAS through a target. */
 export class HuginConfigStore {
   #path: string;
   #lockPath: string;
-  constructor(root: string, options: { initialize?: boolean } = {}) {
+  #onStaleLockClaimed: (() => void) | undefined;
+  constructor(root: string, options: { initialize?: boolean; onStaleLockClaimed?: () => void } = {}) {
     if (!isAbsolute(root)) throw new Error("hugin-config-root-not-absolute");
     const initialize = options.initialize ?? true;
+    this.#onStaleLockClaimed = options.onStaleLockClaimed;
     this.#path = join(resolve(root), "hugin-r-exact-config.json"); this.#lockPath = `${this.#path}.lock`;
     if (initialize) mkdirSync(root, { recursive: true, mode: 0o700 });
     const stat = lstatSync(root); if (!stat.isDirectory() || stat.isSymbolicLink() || (stat.mode & 0o077) !== 0) throw new Error("hugin-config-root-unsafe");
@@ -170,7 +244,7 @@ export class HuginConfigStore {
       return;
     }
     this.withLock(() => {
-      if (!this.exists()) this.write({ current: Object.fromEntries(targetId.options.map((id) => [id, initialDocument(defaults[id])])) as Record<HuginConfigTargetId, StoredDocument>, documents: {}, snapshots: {} });
+      if (!this.exists()) this.write({ current: Object.fromEntries(targetIds.map((id) => [id, initialDocument(defaults[id])])) as Record<HuginConfigTargetId, StoredDocument>, documents: {}, snapshots: {} });
       else this.load();
     });
   }
@@ -180,35 +254,70 @@ export class HuginConfigStore {
   }
   private exists() { try { lstatSync(this.#path); return true; } catch { return false; } }
   private withLock<T>(operation: () => T): T {
-    for (let attempt = 0; attempt < 500; attempt += 1) {
+    for (let attempt = 0; attempt < 2; attempt += 1) {
       let fd: number | undefined;
       try {
         fd = openSync(this.#lockPath, "wx", 0o600);
-      } catch (error: any) {
-        if (error?.code !== "EEXIST") throw error;
-        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
-        continue;
+      } catch (error: unknown) {
+        if (!(error && typeof error === "object" && "code" in error && error.code === "EEXIST")) throw error;
+        if (attempt === 0 && this.reclaimProvenStaleLock()) continue;
+        throw new Error("hugin-config-store-contended");
       }
+      const stat = fstatSync(fd);
+      const metadata = currentLockMetadata({ device: stat.dev, inode: stat.ino });
       try {
-        writeFileSync(fd, `${process.pid}\n`); fsyncSync(fd); closeSync(fd); fd = undefined;
+        writeFileSync(fd, canonicalizeJcs(metadata)); fsyncSync(fd); closeSync(fd); fd = undefined;
         return operation();
       } finally {
         if (fd !== undefined) closeSync(fd);
-        unlinkSync(this.#lockPath);
+        this.releaseExactLock({ device: stat.dev, inode: stat.ino });
       }
     }
     throw new Error("hugin-config-store-contended");
+  }
+  private releaseExactLock(lease: LockLease): void {
+    try {
+      const stat = lstatSync(this.#lockPath);
+      if (stat.isFile() && !stat.isSymbolicLink() && stat.dev === lease.device && stat.ino === lease.inode) unlinkSync(this.#lockPath);
+    } catch { /* A replacement lock is never ours to remove. */ }
+  }
+  private reclaimProvenStaleLock(): boolean {
+    let before;
+    let metadata: LockMetadata;
+    try {
+      before = lstatSync(this.#lockPath);
+      if (!before.isFile() || before.isSymbolicLink()) return false;
+      metadata = lockMetadataSchema.parse(JSON.parse(readFileSync(this.#lockPath, "utf8")));
+      if (metadata.device !== before.dev || metadata.inode !== before.ino || !isProvenStaleLinuxLock(metadata)) return false;
+    } catch { return false; }
+    const claim = `${this.#lockPath}.${process.pid}.${randomUUID()}.reclaim`; let claimedStale = false;
+    try {
+      claimedStale = moveProvenStaleLock(this.#lockPath, { device: before.dev, inode: before.ino }, claim);
+      if (!claimedStale) return false;
+      this.#onStaleLockClaimed?.();
+      return true;
+    } catch { return false; }
+    finally { if (claimedStale) try { unlinkSync(claim); } catch { /* best effort stale-claim cleanup */ } }
   }
   private load(): StoreState {
     const stat = lstatSync(this.#path); if (!stat.isFile() || stat.isSymbolicLink() || (stat.mode & 0o077) !== 0) throw new Error("hugin-config-store-unsafe");
     try { return validateStoreState(JSON.parse(readFileSync(this.#path, "utf8"))); } catch (error) { if (error instanceof Error && error.message.startsWith("hugin-config-store-")) throw error; throw new Error("hugin-config-store-corrupt"); }
   }
-  private write(state: StoreState) { const temp = `${this.#path}.${process.pid}.${randomUUID()}.tmp`; const fd = openSync(temp, "wx", 0o600); try { writeFileSync(fd, canonicalizeJcs(state)); fsyncSync(fd); } finally { closeSync(fd); } renameSync(temp, this.#path); const dir = openSync(resolve(this.#path, ".."), "r"); try { fsyncSync(dir); } finally { closeSync(dir); } }
+  private write(state: StoreState) {
+    const temp = `${this.#path}.${process.pid}.${randomUUID()}.tmp`; let fd: number | undefined;
+    try {
+      fd = openSync(temp, "wx", 0o600); writeFileSync(fd, canonicalizeJcs(state)); fsyncSync(fd); closeSync(fd); fd = undefined;
+      renameSync(temp, this.#path); const dir = openSync(resolve(this.#path, ".."), "r"); try { fsyncSync(dir); } finally { closeSync(dir); }
+    } catch (error) {
+      try { unlinkSync(temp); } catch { /* only this UUID-bound failed temp is eligible for cleanup */ }
+      throw error;
+    } finally { if (fd !== undefined) closeSync(fd); }
+  }
   read(id: HuginConfigTargetId): StoredDocument { return clone(this.load().current[id]); }
   readPayload(id: HuginConfigTargetId): ConfigPayload { return clone(this.load().current[id].payload); }
   candidateRevision(id: HuginConfigTargetId, candidateDigest: string): string { const candidate = this.load().documents[candidateDigest]; if (!candidate || candidate.targetId !== id) throw new Error("hugin-config-candidate-unavailable"); return candidate.revision; }
-  stage(raw: unknown): HuginConfigCandidate { const candidate = validateHuginConfigCandidate(raw); return this.withLock(() => { const state = this.load(); state.documents[candidate.candidateDigest] = candidate; this.write(state); return clone(candidate); }); }
-  snapshot(id: HuginConfigTargetId): { ref: string; digest: string } { return this.withLock(() => { const state = this.load(); const doc = state.current[id]; const ref = `ref:snapshot-${id}-${doc.digest.slice(7, 31)}`; state.snapshots[ref] = { target: id, document: doc }; this.write(state); return { ref, digest: doc.digest }; }); }
+  stage(raw: unknown): HuginConfigCandidate { const candidate = validateHuginConfigCandidate(raw); return this.withLock(() => { const state = this.load(); state.documents[candidate.candidateDigest] = candidate; pruneState(state, candidate.candidateDigest); this.write(state); return clone(candidate); }); }
+  snapshot(id: HuginConfigTargetId): { ref: string; digest: string } { return this.withLock(() => { const state = this.load(); const doc = state.current[id]; const ref = `ref:snapshot-${id}-${doc.digest.slice(7, 31)}`; state.snapshots[ref] = { target: id, document: doc }; pruneState(state); this.write(state); return { ref, digest: doc.digest }; }); }
   /** Called only by the separately authorized R-exact recovery adapter. */
   restoreSnapshot(
     id: HuginConfigTargetId,
@@ -254,9 +363,6 @@ class HuginTarget implements RExactConfigTarget {
 export function createHuginConfigTargets(store: HuginConfigStore): Record<HuginConfigTargetId, RExactConfigTarget> {
   return {
     "hugin-orin-macro-routing": new HuginTarget("hugin-orin-macro-routing", store),
-    "hugin-agent-prompt": new HuginTarget("hugin-agent-prompt", store),
-    "hugin-agent-harness": new HuginTarget("hugin-agent-harness", store),
-    "hugin-tool-policy": new HuginTarget("hugin-tool-policy", store),
   };
 }
 
@@ -302,6 +408,14 @@ export function createHuginConfigRecoveryWorker(
 
 /** Production composition root for the owner-installed durable config resource. */
 export const HUGIN_CONFIG_ROOT_ENV = "HUGIN_R_EXACT_CONFIG_ROOT";
+const emittedSelectorDiagnostics = new Set<"missing" | "corrupt" | "contended">();
+
+function emitSelectorDiagnostic(reason: "missing" | "corrupt" | "contended"): void {
+  if (emittedSelectorDiagnostics.has(reason)) return;
+  emittedSelectorDiagnostics.add(reason);
+  // Do not disclose the installed root or parser/lock internals on the live path.
+  console.warn(`[hugin-macro-route] durable config unavailable: ${reason}`);
+}
 
 export function selectHuginMacroRouteFromStore(store: Pick<HuginConfigStore, "readPayload">, input: { workerProvider: string; taskType: string; sensitivity: "public" | "internal" | "private" }): { nodeId: "orin"; modelId: "qwen2.5-coder:3b" } | null {
   if (input.sensitivity === "private") return null;
@@ -313,7 +427,12 @@ export function selectHuginMacroRouteFromStore(store: Pick<HuginConfigStore, "re
 /** Fail closed until deployment explicitly supplies the owner-local durable root. */
 export function selectHuginMacroRoute(input: { workerProvider: string; taskType: string; sensitivity: "public" | "internal" | "private" }): { nodeId: "orin"; modelId: "qwen2.5-coder:3b" } | null {
   const root = process.env[HUGIN_CONFIG_ROOT_ENV];
-  if (!root) return null;
+  if (!root) { emitSelectorDiagnostic("missing"); return null; }
   try { return selectHuginMacroRouteFromStore(HuginConfigStore.openReadOnly(root), input); }
-  catch { return null; }
+  catch (error) {
+    const code = error && typeof error === "object" && "code" in error ? error.code : undefined;
+    const message = error instanceof Error ? error.message : "";
+    emitSelectorDiagnostic(code === "ENOENT" ? "missing" : message === "hugin-config-store-contended" ? "contended" : "corrupt");
+    return null;
+  }
 }

--- a/src/autonomy/hugin-config-adapter.ts
+++ b/src/autonomy/hugin-config-adapter.ts
@@ -10,9 +10,14 @@ import { closeSync, fsyncSync, lstatSync, mkdirSync, openSync, readFileSync, ren
 import { isAbsolute, join, resolve } from "node:path";
 import { z } from "zod";
 import { canonicalizeJcs } from "../jcs.js";
-import type { RExactConfigTarget } from "./r-exact-types.js";
+import type {
+  RExactConfigTarget,
+  RExactRecoveryWorker,
+} from "./r-exact-types.js";
 
 export const HUGIN_CONFIG_ADAPTER_VERSION = "hugin-config-adapter-v1" as const;
+/** Fixed W0.2 recovery identity for Hugin's owner-local strict config store. */
+export const HUGIN_CONFIG_RECOVERY_WORKER_ID = "hugin-recovery" as const;
 const sha256 = z.string().regex(/^sha256:[a-f0-9]{64}$/);
 const revision = z.string().regex(/^[a-z][a-z0-9-]{2,80}$/);
 const targetId = z.enum(["hugin-orin-macro-routing", "hugin-agent-prompt", "hugin-agent-harness", "hugin-tool-policy"]);
@@ -107,7 +112,7 @@ export class HuginConfigStore {
     expectedCurrent: { revision: string; digest: string },
     recoveryIdentity: string,
   ): { revision: string; digest: string } {
-    if (recoveryIdentity !== "hugin-recovery-worker") throw new Error("hugin-config-recovery-fence-refused");
+    if (recoveryIdentity !== HUGIN_CONFIG_RECOVERY_WORKER_ID) throw new Error("hugin-config-recovery-fence-refused");
     const state = this.load(); const snapshot = state.snapshots[ref];
     if (!snapshot || snapshot.target !== id || snapshot.document.digest !== expectedDigest) throw new Error("hugin-config-snapshot-unavailable");
     const current = state.current[id]; if (current.digest === expectedDigest) return { revision: current.revision, digest: current.digest };
@@ -143,6 +148,46 @@ export function createHuginConfigTargets(store: HuginConfigStore): Record<HuginC
     "hugin-agent-harness": new HuginTarget("hugin-agent-harness", store),
     "hugin-tool-policy": new HuginTarget("hugin-tool-policy", store),
   };
+}
+
+/**
+ * Concrete recovery adapter for the strict Hugin config store.
+ * It accepts only Hugin-owned target IDs and the W0.2 recovery identity, then
+ * delegates the compare-and-swap restore to the durable store.
+ */
+export class HuginConfigRecoveryWorker {
+  constructor(private readonly store: HuginConfigStore) {}
+
+  async restoreAndVerify(input: Parameters<RExactRecoveryWorker["restoreAndVerify"]>[0]) {
+    if (input.recoveryWorkerIdentity !== HUGIN_CONFIG_RECOVERY_WORKER_ID) {
+      throw new Error("hugin-config-recovery-fence-refused");
+    }
+    const id = targetId.parse(input.targetId);
+    if (input.snapshotDigest !== input.baseDigest) {
+      throw new Error("hugin-config-recovery-base-mismatch");
+    }
+    const restored = this.store.restoreSnapshot(
+      id,
+      input.snapshotRef,
+      input.snapshotDigest,
+      input.expectedCurrent,
+      HUGIN_CONFIG_RECOVERY_WORKER_ID,
+    );
+    if (
+      restored.revision !== input.baseRevision
+      || restored.digest !== input.baseDigest
+    ) {
+      throw new Error("hugin-config-restore-readback-mismatch");
+    }
+    return { restoredRevision: restored.revision, restoredDigest: restored.digest };
+  }
+}
+
+export function createHuginConfigRecoveryWorker(
+  store: HuginConfigStore,
+): Pick<RExactRecoveryWorker, "restoreAndVerify"> {
+  const worker = new HuginConfigRecoveryWorker(store);
+  return { restoreAndVerify: worker.restoreAndVerify.bind(worker) };
 }
 
 // Deployment supplies its private durable root; no live directory is created by this module.

--- a/src/autonomy/hugin-config-adapter.ts
+++ b/src/autonomy/hugin-config-adapter.ts
@@ -100,10 +100,18 @@ export class HuginConfigStore {
   stage(raw: unknown): HuginConfigCandidate { const candidate = validateHuginConfigCandidate(raw); const state = this.load(); state.documents[candidate.candidateDigest] = candidate; this.write(state); return clone(candidate); }
   snapshot(id: HuginConfigTargetId): { ref: string; digest: string } { const state = this.load(); const doc = state.current[id]; const ref = `ref:snapshot-${id}-${doc.digest.slice(7, 31)}`; state.snapshots[ref] = { target: id, document: doc }; this.write(state); return { ref, digest: doc.digest }; }
   /** Called only by the separately authorized R-exact recovery adapter. */
-  restoreSnapshot(id: HuginConfigTargetId, ref: string, expectedDigest: string): { revision: string; digest: string } {
+  restoreSnapshot(
+    id: HuginConfigTargetId,
+    ref: string,
+    expectedDigest: string,
+    expectedCurrent: { revision: string; digest: string },
+    recoveryIdentity: string,
+  ): { revision: string; digest: string } {
+    if (recoveryIdentity !== "hugin-recovery-worker") throw new Error("hugin-config-recovery-fence-refused");
     const state = this.load(); const snapshot = state.snapshots[ref];
     if (!snapshot || snapshot.target !== id || snapshot.document.digest !== expectedDigest) throw new Error("hugin-config-snapshot-unavailable");
     const current = state.current[id]; if (current.digest === expectedDigest) return { revision: current.revision, digest: current.digest };
+    if (current.revision !== expectedCurrent.revision || current.digest !== expectedCurrent.digest) throw new Error("hugin-config-stale-recovery-fence");
     state.current[id] = clone(snapshot.document); this.write(state); return { revision: snapshot.document.revision, digest: snapshot.document.digest };
   }
   replace(id: HuginConfigTargetId, expected: { revision: string; digest: string }, candidateDigest: string): void {

--- a/src/autonomy/hugin-config-adapter.ts
+++ b/src/autonomy/hugin-config-adapter.ts
@@ -6,7 +6,8 @@
  * provide a generic config writer or any Gille/deployment/auth surface.
  */
 import { createHash, randomUUID } from "node:crypto";
-import { closeSync, fstatSync, fsyncSync, lstatSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { closeSync, constants, fstatSync, fsyncSync, lstatSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { isAbsolute, join, resolve } from "node:path";
 import { z } from "zod";
 import { canonicalizeJcs } from "../jcs.js";
@@ -79,19 +80,6 @@ interface StoreState {
 }
 const MAX_STAGED_DOCUMENTS = 64;
 const MAX_SNAPSHOTS = 32;
-interface LockMetadata {
-  version: 1;
-  bootId: string;
-  pid: number;
-  startTime: string;
-  device: number;
-  inode: number;
-}
-interface LockLease { device: number; inode: number; }
-const lockMetadataSchema = z.object({
-  version: z.literal(1), bootId: z.string().min(1).max(128), pid: z.number().int().positive(),
-  startTime: z.string().regex(/^\d+$/), device: z.number().int().nonnegative(), inode: z.number().int().positive(),
-}).strict();
 const defaults: Record<HuginConfigTargetId, { revision: string; payload: ConfigPayload }> = {
   "hugin-orin-macro-routing": { revision: "orin-macro-route-v1", payload: { routes: [
     { workerProvider: "homeserver", taskType: "classify", sensitivity: "internal", nodeId: "orin", modelId: "qwen2.5-coder:3b" },
@@ -167,75 +155,17 @@ function pruneState(state: StoreState, retainDocument?: string): void {
 }
 
 const domains = { "hugin-orin-macro-routing": "macro-routing" } as const;
-
-function linuxBootId(): string | null {
-  if (process.platform !== "linux") return null;
-  try {
-    const value = readFileSync("/proc/sys/kernel/random/boot_id", "utf8").trim();
-    return /^[a-f0-9-]{36}$/.test(value) ? value : null;
-  } catch { return null; }
-}
-
-type LinuxProcessStart = { state: "present"; startTime: string } | { state: "absent" | "unknown" };
-
-function linuxProcessStartTime(pid: number): LinuxProcessStart {
-  if (process.platform !== "linux") return { state: "unknown" };
-  try {
-    const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
-    const closing = stat.lastIndexOf(")");
-    const fields = stat.slice(closing + 2).trim().split(/\s+/);
-    const start = fields[19];
-    return start && /^\d+$/.test(start) ? { state: "present", startTime: start } : { state: "unknown" };
-  } catch (error) {
-    const code = error && typeof error === "object" && "code" in error ? error.code : undefined;
-    return code === "ENOENT" || code === "ESRCH" ? { state: "absent" } : { state: "unknown" };
-  }
-}
-
-function currentLockMetadata(inode: LockLease): LockMetadata {
-  const bootId = linuxBootId(); const start = linuxProcessStartTime(process.pid);
-  return {
-    version: 1,
-    // Non-Linux systems can acquire/release their own locks but never reclaim one.
-    bootId: bootId ?? `nonlinux-${process.platform}`,
-    pid: process.pid,
-    startTime: start.state === "present" ? start.startTime : "0",
-    device: inode.device,
-    inode: inode.inode,
-  };
-}
-
-function isProvenStaleLinuxLock(lock: LockMetadata): boolean {
-  const bootId = linuxBootId();
-  if (!bootId) return false;
-  if (lock.bootId !== bootId) return true;
-  const start = linuxProcessStartTime(lock.pid);
-  return start.state === "absent" || (start.state === "present" && start.startTime !== lock.startTime);
-}
-
-/*
- * Reclamation moves the proven stale inode away atomically. New participants
- * can only create `lockPath` after that rename, and this reclaimer never
- * unlinks `lockPath` afterwards, so it cannot delete a live replacement.
- */
-function moveProvenStaleLock(lockPath: string, before: LockLease, claim: string): boolean {
-  if (process.platform !== "linux") return false;
-  try {
-    renameSync(lockPath, claim);
-    const claimed = lstatSync(claim);
-    return claimed.isFile() && !claimed.isSymbolicLink() && claimed.dev === before.device && claimed.ino === before.inode;
-  } catch { return false; }
-}
+const processLocalLocks = new Set<string>();
 
 /** Owner-local canonical store; mutations are only CAS through a target. */
 export class HuginConfigStore {
   #path: string;
   #lockPath: string;
-  #onStaleLockClaimed: (() => void) | undefined;
-  constructor(root: string, options: { initialize?: boolean; onStaleLockClaimed?: () => void } = {}) {
+  #onLockAcquired: (() => void) | undefined;
+  constructor(root: string, options: { initialize?: boolean; onLockAcquired?: () => void } = {}) {
     if (!isAbsolute(root)) throw new Error("hugin-config-root-not-absolute");
     const initialize = options.initialize ?? true;
-    this.#onStaleLockClaimed = options.onStaleLockClaimed;
+    this.#onLockAcquired = options.onLockAcquired;
     this.#path = join(resolve(root), "hugin-r-exact-config.json"); this.#lockPath = `${this.#path}.lock`;
     if (initialize) mkdirSync(root, { recursive: true, mode: 0o700 });
     const stat = lstatSync(root); if (!stat.isDirectory() || stat.isSymbolicLink() || (stat.mode & 0o077) !== 0) throw new Error("hugin-config-root-unsafe");
@@ -254,50 +184,63 @@ export class HuginConfigStore {
   }
   private exists() { try { lstatSync(this.#path); return true; } catch { return false; } }
   private withLock<T>(operation: () => T): T {
-    for (let attempt = 0; attempt < 2; attempt += 1) {
-      let fd: number | undefined;
-      try {
-        fd = openSync(this.#lockPath, "wx", 0o600);
-      } catch (error: unknown) {
-        if (!(error && typeof error === "object" && "code" in error && error.code === "EEXIST")) throw error;
-        if (attempt === 0 && this.reclaimProvenStaleLock()) continue;
-        throw new Error("hugin-config-store-contended");
-      }
+    let fd: number | undefined;
+    let processLocalLease = false;
+    try {
+      fd = openSync(
+        this.#lockPath,
+        constants.O_RDWR | constants.O_CREAT | constants.O_NOFOLLOW,
+        0o600,
+      );
       const stat = fstatSync(fd);
-      const metadata = currentLockMetadata({ device: stat.dev, inode: stat.ino });
-      try {
-        writeFileSync(fd, canonicalizeJcs(metadata)); fsyncSync(fd); closeSync(fd); fd = undefined;
-        return operation();
-      } finally {
-        if (fd !== undefined) closeSync(fd);
-        this.releaseExactLock({ device: stat.dev, inode: stat.ino });
+      if (!stat.isFile() || (stat.mode & 0o077) !== 0) {
+        throw new Error("hugin-config-store-lock-unsafe");
       }
+
+      if (process.platform === "linux") {
+        /*
+         * fd 3 in the helper is a duplicate of this process's open file
+         * description. Linux flock ownership therefore remains live on `fd`
+         * after the helper exits and is released atomically by closeSync.
+         */
+        const result = spawnSync(
+          "/usr/bin/flock",
+          ["--exclusive", "--nonblock", "3"],
+          { stdio: ["ignore", "ignore", "pipe", fd], encoding: "utf8" },
+        );
+        if (result.status === 1) throw new Error("hugin-config-store-contended");
+        if (result.error || result.status !== 0) {
+          throw new Error("hugin-config-store-lock-unavailable");
+        }
+      } else {
+        /*
+         * Hugin deploys on Linux. This process-local fallback keeps unit tests
+         * and unsupported developer hosts fail-fast without pretending to
+         * provide cross-process exclusion.
+         */
+        if (processLocalLocks.has(this.#lockPath)) {
+          throw new Error("hugin-config-store-contended");
+        }
+        processLocalLocks.add(this.#lockPath);
+        processLocalLease = true;
+      }
+
+      const pathStat = lstatSync(this.#lockPath);
+      if (
+        !pathStat.isFile()
+        || pathStat.isSymbolicLink()
+        || pathStat.dev !== stat.dev
+        || pathStat.ino !== stat.ino
+      ) {
+        throw new Error("hugin-config-store-lock-unsafe");
+      }
+      this.#onLockAcquired?.();
+      return operation();
+    } finally {
+      if (processLocalLease) processLocalLocks.delete(this.#lockPath);
+      if (fd !== undefined) closeSync(fd);
+      // The persistent lock inode is never renamed or unlinked.
     }
-    throw new Error("hugin-config-store-contended");
-  }
-  private releaseExactLock(lease: LockLease): void {
-    try {
-      const stat = lstatSync(this.#lockPath);
-      if (stat.isFile() && !stat.isSymbolicLink() && stat.dev === lease.device && stat.ino === lease.inode) unlinkSync(this.#lockPath);
-    } catch { /* A replacement lock is never ours to remove. */ }
-  }
-  private reclaimProvenStaleLock(): boolean {
-    let before;
-    let metadata: LockMetadata;
-    try {
-      before = lstatSync(this.#lockPath);
-      if (!before.isFile() || before.isSymbolicLink()) return false;
-      metadata = lockMetadataSchema.parse(JSON.parse(readFileSync(this.#lockPath, "utf8")));
-      if (metadata.device !== before.dev || metadata.inode !== before.ino || !isProvenStaleLinuxLock(metadata)) return false;
-    } catch { return false; }
-    const claim = `${this.#lockPath}.${process.pid}.${randomUUID()}.reclaim`; let claimedStale = false;
-    try {
-      claimedStale = moveProvenStaleLock(this.#lockPath, { device: before.dev, inode: before.ino }, claim);
-      if (!claimedStale) return false;
-      this.#onStaleLockClaimed?.();
-      return true;
-    } catch { return false; }
-    finally { if (claimedStale) try { unlinkSync(claim); } catch { /* best effort stale-claim cleanup */ } }
   }
   private load(): StoreState {
     const stat = lstatSync(this.#path); if (!stat.isFile() || stat.isSymbolicLink() || (stat.mode & 0o077) !== 0) throw new Error("hugin-config-store-unsafe");

--- a/src/autonomy/hugin-config-adapter.ts
+++ b/src/autonomy/hugin-config-adapter.ts
@@ -161,11 +161,18 @@ const processLocalLocks = new Set<string>();
 export class HuginConfigStore {
   #path: string;
   #lockPath: string;
-  #onLockAcquired: (() => void) | undefined;
-  constructor(root: string, options: { initialize?: boolean; onLockAcquired?: () => void } = {}) {
+  #onLockReleaseReadyForTest: (() => void) | undefined;
+  constructor(root: string, options: {
+    initialize?: boolean;
+    /** Deterministic race injection only; production composition never sets it. */
+    onLockReleaseReadyForTest?: () => void;
+  } = {}) {
     if (!isAbsolute(root)) throw new Error("hugin-config-root-not-absolute");
     const initialize = options.initialize ?? true;
-    this.#onLockAcquired = options.onLockAcquired;
+    if (options.onLockReleaseReadyForTest && process.env.VITEST !== "true") {
+      throw new Error("hugin-config-store-test-hook-refused");
+    }
+    this.#onLockReleaseReadyForTest = options.onLockReleaseReadyForTest;
     this.#path = join(resolve(root), "hugin-r-exact-config.json"); this.#lockPath = `${this.#path}.lock`;
     if (initialize) mkdirSync(root, { recursive: true, mode: 0o700 });
     const stat = lstatSync(root); if (!stat.isDirectory() || stat.isSymbolicLink() || (stat.mode & 0o077) !== 0) throw new Error("hugin-config-root-unsafe");
@@ -185,6 +192,7 @@ export class HuginConfigStore {
   private exists() { try { lstatSync(this.#path); return true; } catch { return false; } }
   private withLock<T>(operation: () => T): T {
     let fd: number | undefined;
+    let leaseAcquired = false;
     let processLocalLease = false;
     try {
       fd = openSync(
@@ -193,7 +201,7 @@ export class HuginConfigStore {
         0o600,
       );
       const stat = fstatSync(fd);
-      if (!stat.isFile() || (stat.mode & 0o077) !== 0) {
+      if (!stat.isFile() || stat.nlink !== 1 || (stat.mode & 0o077) !== 0) {
         throw new Error("hugin-config-store-lock-unsafe");
       }
 
@@ -229,17 +237,22 @@ export class HuginConfigStore {
       if (
         !pathStat.isFile()
         || pathStat.isSymbolicLink()
+        || pathStat.nlink !== 1
         || pathStat.dev !== stat.dev
         || pathStat.ino !== stat.ino
       ) {
         throw new Error("hugin-config-store-lock-unsafe");
       }
-      this.#onLockAcquired?.();
+      leaseAcquired = true;
       return operation();
     } finally {
-      if (processLocalLease) processLocalLocks.delete(this.#lockPath);
-      if (fd !== undefined) closeSync(fd);
-      // The persistent lock inode is never renamed or unlinked.
+      try {
+        if (leaseAcquired) this.#onLockReleaseReadyForTest?.();
+      } finally {
+        if (processLocalLease) processLocalLocks.delete(this.#lockPath);
+        if (fd !== undefined) closeSync(fd);
+        // The persistent lock inode is never renamed or unlinked.
+      }
     }
   }
   private load(): StoreState {

--- a/src/autonomy/r-exact-controller.ts
+++ b/src/autonomy/r-exact-controller.ts
@@ -358,7 +358,11 @@ async function resumeDurableWatch(
     prepared,
     journal.binding.attempt_id,
   );
-  if ((await target.read()).digest !== prepared.candidate_digest) {
+  const committedTarget = await target.read();
+  if (
+    committedTarget.digest !== prepared.candidate_digest
+    || committedTarget.revision !== prepared.candidate_revision
+  ) {
     throw new Error("r-exact-commit-readback");
   }
   options.onPhase?.("terminalization");
@@ -396,6 +400,7 @@ function validatePrepared(
       "target_scope_digest",
       "base_revision",
       "base_digest",
+      "candidate_revision",
       "candidate_digest",
       "snapshot_ref",
       "snapshot_digest",
@@ -414,6 +419,7 @@ function validatePrepared(
     || prepared.target_scope_digest !== target.targetScopeDigest
     || prepared.base_revision !== receipt.base.revision
     || prepared.base_digest !== receipt.base.digest
+    || !/^[A-Za-z0-9][A-Za-z0-9._/-]{2,127}$/.test(prepared.candidate_revision)
     || prepared.candidate_digest !== receipt.candidateContentDigest
     || prepared.snapshot_digest !== receipt.base.digest
     || !refPattern.test(prepared.snapshot_ref)
@@ -755,6 +761,7 @@ export async function applyRExactProposal(
     target_scope_digest: target.targetScopeDigest,
     base_revision: receipt.base.revision,
     base_digest: receipt.base.digest,
+    candidate_revision: await target.candidateRevision(receipt.candidateContentDigest),
     candidate_digest: receipt.candidateContentDigest,
     snapshot_ref: snapshot.ref,
     snapshot_digest: snapshot.digest,
@@ -926,7 +933,10 @@ export async function applyRExactProposal(
     );
     journal = state.journal;
     const readback = await target.read();
-    if (readback.digest !== receipt.candidateContentDigest) {
+    if (
+      readback.digest !== receipt.candidateContentDigest
+      || readback.revision !== prepared.candidate_revision
+    ) {
       throw new Error("r-exact-readback-mismatch");
     }
     options.onPhase?.("readback");
@@ -1449,7 +1459,10 @@ export async function recoverRExactAttempt(
         targetId: prepared.target_id,
         baseRevision: prepared.base_revision,
         baseDigest: prepared.base_digest,
-        expectedCurrent: { revision: currentTarget.revision, digest: prepared.candidate_digest },
+        expectedCurrent: {
+          revision: prepared.candidate_revision,
+          digest: prepared.candidate_digest,
+        },
         recoveryWorkerIdentity: prepared.prepared_authority.identities.recovery_worker,
       });
       options.onPhase?.("restore");

--- a/src/autonomy/r-exact-controller.ts
+++ b/src/autonomy/r-exact-controller.ts
@@ -1449,6 +1449,8 @@ export async function recoverRExactAttempt(
         targetId: prepared.target_id,
         baseRevision: prepared.base_revision,
         baseDigest: prepared.base_digest,
+        expectedCurrent: { revision: currentTarget.revision, digest: prepared.candidate_digest },
+        recoveryWorkerIdentity: prepared.prepared_authority.identities.recovery_worker,
       });
       options.onPhase?.("restore");
       const readback = await target.read();

--- a/src/autonomy/r-exact-types.ts
+++ b/src/autonomy/r-exact-types.ts
@@ -271,6 +271,9 @@ export interface RExactRecoveryWorker {
     targetId: string;
     baseRevision: string;
     baseDigest: string;
+    /** Fence recovery to the exact post-apply state recorded by this attempt. */
+    expectedCurrent: { revision: string; digest: string };
+    recoveryWorkerIdentity: string;
   }): Promise<{ restoredRevision: string; restoredDigest: string }>;
   narrowAndVerify(input: {
     binding: VerifiedW0Binding;

--- a/src/autonomy/r-exact-types.ts
+++ b/src/autonomy/r-exact-types.ts
@@ -12,6 +12,8 @@ export interface RExactConfigTarget {
   domain: HuginRExactDomain;
   targetScopeDigest: string;
   read(): Promise<{ revision: string; digest: string }>;
+  /** Returns the immutable revision bound to a staged candidate digest. */
+  candidateRevision(candidateDigest: string): Promise<string>;
   snapshot(): Promise<{ ref: string; digest: string }>;
   replaceExact(
     expected: { revision: string; digest: string },
@@ -133,6 +135,7 @@ export interface PreparedAttempt {
   target_scope_digest: string;
   base_revision: string;
   base_digest: string;
+  candidate_revision: string;
   candidate_digest: string;
   snapshot_ref: string;
   snapshot_digest: string;

--- a/src/orchestrator/orin-macro-route.ts
+++ b/src/orchestrator/orin-macro-route.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Sensitivity } from "../sensitivity.js";
+import { selectHuginMacroRoute } from "../autonomy/hugin-config-adapter.js";
 
 export const ORIN_NODE_ID = "orin";
 export const ORIN_MODEL_ID = "qwen2.5-coder:3b";
@@ -15,8 +16,6 @@ export interface OrinWorkerRoute {
   nodeId: typeof ORIN_NODE_ID;
   modelId: typeof ORIN_MODEL_ID;
 }
-
-const REVIEWED_TASK_TYPES = new Set(["classify", "extract"]);
 
 /**
  * Return the explicit gateway node pin for a reviewed small leaf, or null to
@@ -29,8 +28,5 @@ export function selectOrinMacroRoute(input: {
   taskType: string;
   sensitivity: Sensitivity;
 }): OrinWorkerRoute | null {
-  if (input.workerProvider !== "homeserver") return null;
-  if (input.sensitivity === "private") return null;
-  if (!REVIEWED_TASK_TYPES.has(input.taskType)) return null;
-  return { nodeId: ORIN_NODE_ID, modelId: ORIN_MODEL_ID };
+  return selectHuginMacroRoute(input);
 }

--- a/tests/hugin-config-adapter.test.ts
+++ b/tests/hugin-config-adapter.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { canonicalizeJcs } from "../src/jcs.js";
-import { HUGIN_CONFIG_ADAPTER_VERSION, HuginConfigStore, createHuginConfigTargets, selectHuginMacroRoute, validateHuginConfigCandidate } from "../src/autonomy/hugin-config-adapter.js";
+import { HUGIN_CONFIG_ADAPTER_VERSION, HUGIN_CONFIG_RECOVERY_WORKER_ID, HuginConfigStore, createHuginConfigRecoveryWorker, createHuginConfigTargets, selectHuginMacroRoute, validateHuginConfigCandidate } from "../src/autonomy/hugin-config-adapter.js";
 
 const digest = (value: unknown) => `sha256:${createHash("sha256").update(canonicalizeJcs(value)).digest("hex")}`;
 function candidate(targetId: "hugin-orin-macro-routing" = "hugin-orin-macro-routing", base = { revision: "orin-macro-route-v1", digest: "" }) {
@@ -26,7 +26,7 @@ describe("Hugin strict autonomous config adapters", () => {
     const snap = await target.snapshot(); await target.replaceExact(base, doc.candidateDigest);
     expect(await target.read()).toEqual({ revision: "orin-macro-route-v2", digest: doc.candidateDigest }); expect(snap.digest).toBe(base.digest);
     await expect(target.replaceExact(base, doc.candidateDigest)).rejects.toThrow("stale-base");
-    expect(store.restoreSnapshot("hugin-orin-macro-routing", snap.ref, snap.digest, { revision: "orin-macro-route-v2", digest: doc.candidateDigest }, "hugin-recovery-worker")).toEqual(base);
+    expect(store.restoreSnapshot("hugin-orin-macro-routing", snap.ref, snap.digest, { revision: "orin-macro-route-v2", digest: doc.candidateDigest }, HUGIN_CONFIG_RECOVERY_WORKER_ID)).toEqual(base);
     expect(await target.read()).toEqual(base);
     expect(await createHuginConfigTargets(new HuginConfigStore(root))["hugin-orin-macro-routing"].read()).toEqual(base);
   });
@@ -34,10 +34,41 @@ describe("Hugin strict autonomous config adapters", () => {
   it("fences target-bound recovery so an old snapshot cannot overwrite later state", async () => {
     const store = new HuginConfigStore(mkdtempSync(join(tmpdir(), "hugin-config-"))); const targets = createHuginConfigTargets(store);
     const first = targets["hugin-orin-macro-routing"]; const other = targets["hugin-agent-harness"]; const base = await first.read(); const otherCurrent = await other.read(); const snap = await first.snapshot(); const doc = store.stage(candidate("hugin-orin-macro-routing", base)); await first.replaceExact(base, doc.candidateDigest);
-    expect(() => store.restoreSnapshot("hugin-agent-harness", snap.ref, snap.digest, otherCurrent, "hugin-recovery-worker")).toThrow("snapshot-unavailable");
-    expect(() => store.restoreSnapshot("hugin-orin-macro-routing", snap.ref, snap.digest, { revision: "later", digest: digest("later") }, "hugin-recovery-worker")).toThrow("stale-recovery-fence");
+    expect(() => store.restoreSnapshot("hugin-agent-harness", snap.ref, snap.digest, otherCurrent, HUGIN_CONFIG_RECOVERY_WORKER_ID)).toThrow("snapshot-unavailable");
+    expect(() => store.restoreSnapshot("hugin-orin-macro-routing", snap.ref, snap.digest, { revision: "later", digest: digest("later") }, HUGIN_CONFIG_RECOVERY_WORKER_ID)).toThrow("stale-recovery-fence");
     const current = await first.read(); expect(() => store.restoreSnapshot("hugin-orin-macro-routing", snap.ref, snap.digest, current, "wrong-worker")).toThrow("recovery-fence");
     expect(await first.read()).toEqual({ revision: "orin-macro-route-v2", digest: doc.candidateDigest });
+  });
+
+  it("binds recovery to the strict store's exact owner, current state, and target", async () => {
+    const store = new HuginConfigStore(mkdtempSync(join(tmpdir(), "hugin-config-")));
+    const targets = createHuginConfigTargets(store);
+    const target = targets["hugin-orin-macro-routing"];
+    const base = await target.read();
+    const snapshot = await target.snapshot();
+    const doc = store.stage(candidate("hugin-orin-macro-routing", base));
+    await target.replaceExact(base, doc.candidateDigest);
+    const recovery = createHuginConfigRecoveryWorker(store);
+    const input = {
+      snapshotRef: snapshot.ref,
+      snapshotDigest: snapshot.digest,
+      targetId: "hugin-orin-macro-routing",
+      baseRevision: base.revision,
+      baseDigest: base.digest,
+      expectedCurrent: { revision: doc.revision, digest: doc.candidateDigest },
+      recoveryWorkerIdentity: HUGIN_CONFIG_RECOVERY_WORKER_ID,
+    };
+    await expect(recovery.restoreAndVerify({ ...input, targetId: "gille-model" }))
+      .rejects.toThrow();
+    await expect(recovery.restoreAndVerify({ ...input, expectedCurrent: base }))
+      .rejects.toThrow("stale-recovery-fence");
+    await expect(recovery.restoreAndVerify({ ...input, recoveryWorkerIdentity: "other-worker" }))
+      .rejects.toThrow("recovery-fence");
+    await expect(recovery.restoreAndVerify(input)).resolves.toEqual({
+      restoredRevision: base.revision,
+      restoredDigest: base.digest,
+    });
+    expect(await target.read()).toEqual(base);
   });
 
   it("rejects malformed, duplicate/noncanonical, cross-owner, protected and unbound candidates before mutation", async () => {

--- a/tests/hugin-config-adapter.test.ts
+++ b/tests/hugin-config-adapter.test.ts
@@ -108,26 +108,6 @@ describe("Hugin strict autonomous config adapters", () => {
     expect(() => validateHuginConfigCandidate({ ...candidate(), targetId: "hugin-agent-prompt" })).toThrow();
   });
 
-  it("fails immediately when another participant holds the kernel-backed lock", () => {
-    const root = mkdtempSync(join(tmpdir(), "hugin-config-live-lock-"));
-    let probe = false;
-    let nestedError = "";
-    const store = new HuginConfigStore(root, {
-      onLockAcquired: () => {
-        if (!probe) return;
-        try { new HuginConfigStore(root); }
-        catch (error) { nestedError = error instanceof Error ? error.message : String(error); }
-      },
-    });
-    const { revision, digest: baseDigest } = store.read("hugin-orin-macro-routing");
-    probe = true;
-    const started = Date.now();
-
-    expect(() => store.stage(candidate("hugin-orin-macro-routing", { revision, digest: baseDigest }))).not.toThrow();
-    expect(nestedError).toBe("hugin-config-store-contended");
-    expect(Date.now() - started).toBeLessThan(100);
-  });
-
   it.skipIf(process.platform !== "linux")("uses kernel ownership for contention and recovers only after SIGKILL closes the holder fd", async () => {
     const root = mkdtempSync(join(tmpdir(), "hugin-config-kernel-lock-"));
     const store = new HuginConfigStore(root);
@@ -177,9 +157,10 @@ describe("Hugin strict autonomous config adapters", () => {
     let hookCalled = false;
     let armed = false;
     const store = new HuginConfigStore(root, {
-      onLockAcquired: () => {
+      onLockReleaseReadyForTest: () => {
         if (!armed) return;
         hookCalled = true;
+        // This is the former identity-lstat -> unlink race window.
         unlinkSync(lockPath);
         writeFileSync(lockPath, "live replacement\n", { mode: 0o600 });
       },

--- a/tests/hugin-config-adapter.test.ts
+++ b/tests/hugin-config-adapter.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { createHash } from "node:crypto";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { canonicalizeJcs } from "../src/jcs.js";
 import { HUGIN_CONFIG_ADAPTER_VERSION, HuginConfigStore, createHuginConfigTargets, selectHuginMacroRoute, validateHuginConfigCandidate } from "../src/autonomy/hugin-config-adapter.js";
 
@@ -18,17 +21,18 @@ describe("Hugin strict autonomous config adapters", () => {
   it.each([["homeserver", "classify", "public", true], ["homeserver", "extract", "internal", true], ["homeserver", "classify", "private", false], ["homeserver", "summarize", "public", false], ["openrouter", "classify", "public", false]])("preserves the Orin route matrix", (workerProvider, taskType, sensitivity, allowed) => expect(selectHuginMacroRoute({ workerProvider, taskType, sensitivity: sensitivity as "public" | "internal" | "private" }) !== null).toBe(allowed));
 
   it("performs an exact staged CAS with snapshot/readback and refuses stale state", async () => {
-    const store = new HuginConfigStore(); const target = createHuginConfigTargets(store)["hugin-orin-macro-routing"];
+    const root = mkdtempSync(join(tmpdir(), "hugin-config-")); const store = new HuginConfigStore(root); const target = createHuginConfigTargets(store)["hugin-orin-macro-routing"];
     const base = await target.read(); const doc = store.stage(candidate("hugin-orin-macro-routing", base));
     const snap = await target.snapshot(); await target.replaceExact(base, doc.candidateDigest);
     expect(await target.read()).toEqual({ revision: "orin-macro-route-v2", digest: doc.candidateDigest }); expect(snap.digest).toBe(base.digest);
     await expect(target.replaceExact(base, doc.candidateDigest)).rejects.toThrow("stale-base");
     expect(store.restoreSnapshot("hugin-orin-macro-routing", snap.ref, snap.digest)).toEqual(base);
     expect(await target.read()).toEqual(base);
+    expect(await createHuginConfigTargets(new HuginConfigStore(root))["hugin-orin-macro-routing"].read()).toEqual(base);
   });
 
   it("rejects malformed, duplicate/noncanonical, cross-owner, protected and unbound candidates before mutation", async () => {
-    const store = new HuginConfigStore(); const target = createHuginConfigTargets(store)["hugin-orin-macro-routing"]; const before = await target.read();
+    const store = new HuginConfigStore(mkdtempSync(join(tmpdir(), "hugin-config-"))); const target = createHuginConfigTargets(store)["hugin-orin-macro-routing"]; const before = await target.read();
     const bad = candidate("hugin-orin-macro-routing", before); bad.config.routes.reverse();
     expect(() => validateHuginConfigCandidate(bad)).toThrow("noncanonical");
     for (const id of ["gille-model", "gille-model-config", "hugin-logging", "hugin-test-harness", "gille-tool-policy", "hugin-deploy", "hugin-auth", "hugin-key", "hugin-safety-gate", "hugin-risk-budget", "hugin-retention", "unknown-target"]) expect(() => validateHuginConfigCandidate({ ...bad, targetId: id })).toThrow();

--- a/tests/hugin-config-adapter.test.ts
+++ b/tests/hugin-config-adapter.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { createHash } from "node:crypto";
-import { mkdtempSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { canonicalizeJcs } from "../src/jcs.js";
-import { HUGIN_CONFIG_ADAPTER_VERSION, HUGIN_CONFIG_RECOVERY_WORKER_ID, HuginConfigStore, createHuginConfigRecoveryWorker, createHuginConfigTargets, selectHuginMacroRoute, validateHuginConfigCandidate } from "../src/autonomy/hugin-config-adapter.js";
+import { HUGIN_CONFIG_ADAPTER_VERSION, HUGIN_CONFIG_RECOVERY_WORKER_ID, HUGIN_CONFIG_ROOT_ENV, HuginConfigStore, createHuginConfigRecoveryWorker, createHuginConfigTargets, selectHuginMacroRoute, selectHuginMacroRouteFromStore, validateHuginConfigCandidate } from "../src/autonomy/hugin-config-adapter.js";
+import { selectOrinMacroRoute } from "../src/orchestrator/orin-macro-route.js";
 
 const digest = (value: unknown) => `sha256:${createHash("sha256").update(canonicalizeJcs(value)).digest("hex")}`;
 function candidate(targetId: "hugin-orin-macro-routing" = "hugin-orin-macro-routing", base = { revision: "orin-macro-route-v1", digest: "" }) {
@@ -18,7 +19,60 @@ function candidate(targetId: "hugin-orin-macro-routing" = "hugin-orin-macro-rout
 }
 
 describe("Hugin strict autonomous config adapters", () => {
-  it.each([["homeserver", "classify", "public", true], ["homeserver", "extract", "internal", true], ["homeserver", "classify", "private", false], ["homeserver", "summarize", "public", false], ["openrouter", "classify", "public", false]])("preserves the Orin route matrix", (workerProvider, taskType, sensitivity, allowed) => expect(selectHuginMacroRoute({ workerProvider, taskType, sensitivity: sensitivity as "public" | "internal" | "private" }) !== null).toBe(allowed));
+  it.each([["homeserver", "classify", "public", true], ["homeserver", "extract", "internal", true], ["homeserver", "classify", "private", false], ["homeserver", "summarize", "public", false], ["openrouter", "classify", "public", false]])("preserves the Orin route matrix", (workerProvider, taskType, sensitivity, allowed) => {
+    const store = new HuginConfigStore(mkdtempSync(join(tmpdir(), "hugin-config-route-")));
+    expect(selectHuginMacroRouteFromStore(store, { workerProvider, taskType, sensitivity: sensitivity as "public" | "internal" | "private" }) !== null).toBe(allowed);
+  });
+
+  it("uses the owner-configured durable store in the actual selector across promote, restart, and exact recovery", async () => {
+    const root = mkdtempSync(join(tmpdir(), "hugin-config-runtime-"));
+    const priorRoot = process.env[HUGIN_CONFIG_ROOT_ENV];
+    delete process.env[HUGIN_CONFIG_ROOT_ENV];
+    expect(selectHuginMacroRoute({ workerProvider: "homeserver", taskType: "classify", sensitivity: "public" })).toBeNull();
+    process.env[HUGIN_CONFIG_ROOT_ENV] = root;
+    try {
+      const store = new HuginConfigStore(root);
+      const target = createHuginConfigTargets(store)["hugin-orin-macro-routing"];
+      const base = await target.read();
+      expect(selectOrinMacroRoute({ workerProvider: "homeserver", taskType: "classify", sensitivity: "public" })).toEqual({ nodeId: "orin", modelId: "qwen2.5-coder:3b" });
+      const snapshot = await target.snapshot();
+      const staged = store.stage(candidate("hugin-orin-macro-routing", base));
+      await target.replaceExact(base, staged.candidateDigest);
+      expect(await target.read()).toEqual({ revision: staged.revision, digest: staged.candidateDigest });
+      expect(selectOrinMacroRoute({ workerProvider: "homeserver", taskType: "extract", sensitivity: "internal" })).toEqual({ nodeId: "orin", modelId: "qwen2.5-coder:3b" });
+      const restarted = new HuginConfigStore(root);
+      expect(selectHuginMacroRouteFromStore(restarted, { workerProvider: "homeserver", taskType: "classify", sensitivity: "public" })).toEqual({ nodeId: "orin", modelId: "qwen2.5-coder:3b" });
+      const recovery = createHuginConfigRecoveryWorker(restarted);
+      await recovery.restoreAndVerify({
+        snapshotRef: snapshot.ref,
+        snapshotDigest: snapshot.digest,
+        targetId: "hugin-orin-macro-routing",
+        baseRevision: base.revision,
+        baseDigest: base.digest,
+        expectedCurrent: { revision: staged.revision, digest: staged.candidateDigest },
+        recoveryWorkerIdentity: HUGIN_CONFIG_RECOVERY_WORKER_ID,
+      });
+      expect(await createHuginConfigTargets(new HuginConfigStore(root))["hugin-orin-macro-routing"].read()).toEqual(base);
+      expect(selectOrinMacroRoute({ workerProvider: "homeserver", taskType: "classify", sensitivity: "public" })).toEqual({ nodeId: "orin", modelId: "qwen2.5-coder:3b" });
+    } finally {
+      if (priorRoot === undefined) delete process.env[HUGIN_CONFIG_ROOT_ENV];
+      else process.env[HUGIN_CONFIG_ROOT_ENV] = priorRoot;
+    }
+  });
+
+  it("does not create an uninstalled durable root while reading the live selector", () => {
+    const parent = mkdtempSync(join(tmpdir(), "hugin-config-uninstalled-"));
+    const root = join(parent, "not-installed");
+    const priorRoot = process.env[HUGIN_CONFIG_ROOT_ENV];
+    process.env[HUGIN_CONFIG_ROOT_ENV] = root;
+    try {
+      expect(selectOrinMacroRoute({ workerProvider: "homeserver", taskType: "classify", sensitivity: "public" })).toBeNull();
+      expect(existsSync(root)).toBe(false);
+    } finally {
+      if (priorRoot === undefined) delete process.env[HUGIN_CONFIG_ROOT_ENV];
+      else process.env[HUGIN_CONFIG_ROOT_ENV] = priorRoot;
+    }
+  });
 
   it("performs an exact staged CAS with snapshot/readback and refuses stale state", async () => {
     const root = mkdtempSync(join(tmpdir(), "hugin-config-")); const store = new HuginConfigStore(root); const target = createHuginConfigTargets(store)["hugin-orin-macro-routing"];
@@ -62,6 +116,10 @@ describe("Hugin strict autonomous config adapters", () => {
       .rejects.toThrow();
     await expect(recovery.restoreAndVerify({ ...input, expectedCurrent: base }))
       .rejects.toThrow("stale-recovery-fence");
+    await expect(recovery.restoreAndVerify({
+      ...input,
+      expectedCurrent: { revision: "other-revision", digest: doc.candidateDigest },
+    })).rejects.toThrow("stale-recovery-fence");
     await expect(recovery.restoreAndVerify({ ...input, recoveryWorkerIdentity: "other-worker" }))
       .rejects.toThrow("recovery-fence");
     await expect(recovery.restoreAndVerify(input)).resolves.toEqual({
@@ -77,5 +135,18 @@ describe("Hugin strict autonomous config adapters", () => {
     expect(() => validateHuginConfigCandidate(bad)).toThrow("noncanonical");
     for (const id of ["gille-model", "gille-model-config", "hugin-logging", "hugin-test-harness", "gille-tool-policy", "hugin-deploy", "hugin-auth", "hugin-key", "hugin-safety-gate", "hugin-risk-budget", "hugin-retention", "unknown-target"]) expect(() => validateHuginConfigCandidate({ ...bad, targetId: id })).toThrow();
     await expect(target.replaceExact(before, digest("not-staged"))).rejects.toThrow("not-bound"); expect(await target.read()).toEqual(before);
+  });
+
+  it("fails closed on a syntactically valid store whose current document is not bound to its digest", () => {
+    const root = mkdtempSync(join(tmpdir(), "hugin-config-corrupt-"));
+    const store = new HuginConfigStore(root);
+    const path = join(root, "hugin-r-exact-config.json");
+    const state = JSON.parse(readFileSync(path, "utf8"));
+    state.current["hugin-orin-macro-routing"].digest = `sha256:${"f".repeat(64)}`;
+    writeFileSync(path, JSON.stringify(state));
+    expect(() => new HuginConfigStore(root)).toThrow("hugin-config-store-digest-mismatch");
+    expect(() => selectHuginMacroRouteFromStore(store, {
+      workerProvider: "homeserver", taskType: "classify", sensitivity: "public",
+    })).toThrow("hugin-config-store-digest-mismatch");
   });
 });

--- a/tests/hugin-config-adapter.test.ts
+++ b/tests/hugin-config-adapter.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { createHash } from "node:crypto";
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, lstatSync, mkdtempSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { canonicalizeJcs } from "../src/jcs.js";
@@ -16,6 +18,33 @@ function candidate(targetId: "hugin-orin-macro-routing" = "hugin-orin-macro-rout
     { workerProvider: "homeserver", taskType: "extract", sensitivity: "public", nodeId: "orin", modelId: "qwen2.5-coder:3b" },
   ] } } as const;
   return { ...body, candidateDigest: digest(body) };
+}
+
+function candidateWithRoutes(
+  base: { revision: string; digest: string },
+  routes: ReturnType<typeof candidate>["config"]["routes"],
+) {
+  const body = {
+    schemaVersion: HUGIN_CONFIG_ADAPTER_VERSION,
+    targetId: "hugin-orin-macro-routing" as const,
+    revision: "orin-macro-route-v2",
+    base,
+    config: { routes },
+  };
+  return { ...body, candidateDigest: digest(body) };
+}
+
+function linuxStartTime(pid: number): string {
+  const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+  return stat.slice(stat.lastIndexOf(")") + 2).trim().split(/\s+/)[19]!;
+}
+
+function writeLock(root: string, owner: { bootId: string; pid: number; startTime: string }) {
+  const path = join(root, "hugin-r-exact-config.json.lock");
+  writeFileSync(path, "{}", { mode: 0o600 });
+  const stat = lstatSync(path);
+  writeFileSync(path, canonicalizeJcs({ version: 1, ...owner, device: stat.dev, inode: stat.ino }), { mode: 0o600 });
+  return path;
 }
 
 describe("Hugin strict autonomous config adapters", () => {
@@ -60,6 +89,78 @@ describe("Hugin strict autonomous config adapters", () => {
     }
   });
 
+  it("accepts only a canonical unique subset and makes promotion plus exact restore change the live selector", async () => {
+    const root = mkdtempSync(join(tmpdir(), "hugin-config-subset-"));
+    const store = new HuginConfigStore(root);
+    const target = createHuginConfigTargets(store)["hugin-orin-macro-routing"];
+    const base = await target.read();
+    const snapshot = await target.snapshot();
+    const staged = store.stage(candidateWithRoutes(base, []));
+    await target.replaceExact(base, staged.candidateDigest);
+    expect(selectHuginMacroRouteFromStore(store, {
+      workerProvider: "homeserver", taskType: "classify", sensitivity: "public",
+    })).toBeNull();
+    await createHuginConfigRecoveryWorker(store).restoreAndVerify({
+      snapshotRef: snapshot.ref, snapshotDigest: snapshot.digest,
+      targetId: "hugin-orin-macro-routing", baseRevision: base.revision,
+      baseDigest: base.digest, expectedCurrent: { revision: staged.revision, digest: staged.candidateDigest },
+      recoveryWorkerIdentity: HUGIN_CONFIG_RECOVERY_WORKER_ID,
+    });
+    expect(selectHuginMacroRouteFromStore(store, {
+      workerProvider: "homeserver", taskType: "classify", sensitivity: "public",
+    })).toEqual({ nodeId: "orin", modelId: "qwen2.5-coder:3b" });
+    const duplicate = candidateWithRoutes(base, [
+      candidate().config.routes[0]!, candidate().config.routes[0]!,
+    ]);
+    expect(() => validateHuginConfigCandidate(duplicate)).toThrow("noncanonical");
+  });
+
+  it("exposes only the real macro-routing target", () => {
+    const targets = createHuginConfigTargets(new HuginConfigStore(mkdtempSync(join(tmpdir(), "hugin-config-only-"))));
+    expect(Object.keys(targets)).toEqual(["hugin-orin-macro-routing"]);
+    expect(() => validateHuginConfigCandidate({ ...candidate(), targetId: "hugin-agent-prompt" })).toThrow();
+  });
+
+  it("fails immediately on a live exact lock without a wait loop", () => {
+    const root = mkdtempSync(join(tmpdir(), "hugin-config-live-lock-"));
+    const store = new HuginConfigStore(root); const { revision, digest: baseDigest } = store.read("hugin-orin-macro-routing"); const base = { revision, digest: baseDigest };
+    const lock = writeLock(root, { bootId: process.platform === "linux" ? readFileSync("/proc/sys/kernel/random/boot_id", "utf8").trim() : "nonlinux-test", pid: process.pid, startTime: process.platform === "linux" ? linuxStartTime(process.pid) : "0" });
+    const started = Date.now();
+    expect(() => store.stage(candidate("hugin-orin-macro-routing", base))).toThrow("hugin-config-store-contended");
+    expect(Date.now() - started).toBeLessThan(100);
+    unlinkSync(lock);
+  });
+
+  it.skipIf(process.platform !== "linux")("reclaims a SIGKILLed child lock only after Linux boot/PID-start proof", async () => {
+    const root = mkdtempSync(join(tmpdir(), "hugin-config-stale-lock-"));
+    const store = new HuginConfigStore(root); const { revision, digest: baseDigest } = store.read("hugin-orin-macro-routing"); const base = { revision, digest: baseDigest };
+    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
+    await once(child, "spawn");
+    const pid = child.pid!;
+    const lock = writeLock(root, { bootId: readFileSync("/proc/sys/kernel/random/boot_id", "utf8").trim(), pid, startTime: linuxStartTime(pid) });
+    child.kill("SIGKILL"); await once(child, "exit");
+    expect(() => store.stage(candidate("hugin-orin-macro-routing", base))).not.toThrow();
+    expect(existsSync(lock)).toBe(false);
+  });
+
+  it.skipIf(process.platform !== "linux")("never deletes a live replacement created after stale-lock claim", async () => {
+    const root = mkdtempSync(join(tmpdir(), "hugin-config-replacement-lock-"));
+    const bootId = readFileSync("/proc/sys/kernel/random/boot_id", "utf8").trim();
+    let replacement = "";
+    const store = new HuginConfigStore(root, {
+      onStaleLockClaimed: () => { replacement = writeLock(root, { bootId, pid: process.pid, startTime: linuxStartTime(process.pid) }); },
+    });
+    const { revision, digest: baseDigest } = store.read("hugin-orin-macro-routing"); const base = { revision, digest: baseDigest };
+    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
+    await once(child, "spawn"); const pid = child.pid!;
+    writeLock(root, { bootId, pid, startTime: linuxStartTime(pid) });
+    child.kill("SIGKILL"); await once(child, "exit");
+    expect(() => store.stage(candidate("hugin-orin-macro-routing", base))).toThrow("hugin-config-store-contended");
+    expect(existsSync(replacement)).toBe(true);
+    expect(JSON.parse(readFileSync(replacement, "utf8")).pid).toBe(process.pid);
+    unlinkSync(replacement);
+  });
+
   it("does not create an uninstalled durable root while reading the live selector", () => {
     const parent = mkdtempSync(join(tmpdir(), "hugin-config-uninstalled-"));
     const root = join(parent, "not-installed");
@@ -87,8 +188,8 @@ describe("Hugin strict autonomous config adapters", () => {
 
   it("fences target-bound recovery so an old snapshot cannot overwrite later state", async () => {
     const store = new HuginConfigStore(mkdtempSync(join(tmpdir(), "hugin-config-"))); const targets = createHuginConfigTargets(store);
-    const first = targets["hugin-orin-macro-routing"]; const other = targets["hugin-agent-harness"]; const base = await first.read(); const otherCurrent = await other.read(); const snap = await first.snapshot(); const doc = store.stage(candidate("hugin-orin-macro-routing", base)); await first.replaceExact(base, doc.candidateDigest);
-    expect(() => store.restoreSnapshot("hugin-agent-harness", snap.ref, snap.digest, otherCurrent, HUGIN_CONFIG_RECOVERY_WORKER_ID)).toThrow("snapshot-unavailable");
+    const first = targets["hugin-orin-macro-routing"]; const base = await first.read(); const snap = await first.snapshot(); const doc = store.stage(candidate("hugin-orin-macro-routing", base)); await first.replaceExact(base, doc.candidateDigest);
+    expect(() => store.restoreSnapshot("hugin-agent-harness" as "hugin-orin-macro-routing", snap.ref, snap.digest, base, HUGIN_CONFIG_RECOVERY_WORKER_ID)).toThrow();
     expect(() => store.restoreSnapshot("hugin-orin-macro-routing", snap.ref, snap.digest, { revision: "later", digest: digest("later") }, HUGIN_CONFIG_RECOVERY_WORKER_ID)).toThrow("stale-recovery-fence");
     const current = await first.read(); expect(() => store.restoreSnapshot("hugin-orin-macro-routing", snap.ref, snap.digest, current, "wrong-worker")).toThrow("recovery-fence");
     expect(await first.read()).toEqual({ revision: "orin-macro-route-v2", digest: doc.candidateDigest });

--- a/tests/hugin-config-adapter.test.ts
+++ b/tests/hugin-config-adapter.test.ts
@@ -301,4 +301,62 @@ describe("Hugin strict autonomous config adapters", () => {
       "hugin-config-store-snapshots-limit",
     );
   });
+
+  it("rejects an overlong noncanonical snapshot reference", () => {
+    const root = mkdtempSync(join(tmpdir(), "hugin-config-snapshot-ref-"));
+    new HuginConfigStore(root);
+    const path = join(root, "hugin-r-exact-config.json");
+    const state = JSON.parse(readFileSync(path, "utf8"));
+    state.snapshots[
+      `ref:snapshot-${"hugin-orin-macro-routing-".repeat(8)}${"a".repeat(24)}`
+    ] = {
+      target: "hugin-orin-macro-routing",
+      document: state.current["hugin-orin-macro-routing"],
+    };
+    writeFileSync(path, JSON.stringify(state), "utf8");
+
+    expect(() => new HuginConfigStore(root))
+      .toThrowError("hugin-config-store-corrupt");
+  });
+
+  it.each(["stage", "snapshot"] as const)(
+    "keeps a near-cap valid store readable and byte-identical when %s would exceed the write cap",
+    (mutation) => {
+      const root = mkdtempSync(join(tmpdir(), `hugin-config-write-cap-${mutation}-`));
+      const initial = new HuginConfigStore(root);
+      const path = join(root, "hugin-r-exact-config.json");
+      const before = readFileSync(path);
+      const current = initial.read("hugin-orin-macro-routing");
+      const candidateBase = { revision: current.revision, digest: current.digest };
+      const store = new HuginConfigStore(root, {
+        maxStoreBytesForTest: before.byteLength + 32,
+      });
+
+      expect(() => {
+        if (mutation === "stage") {
+          store.stage(candidate("hugin-orin-macro-routing", candidateBase));
+        } else {
+          store.snapshot("hugin-orin-macro-routing");
+        }
+      }).toThrowError("hugin-config-store-too-large");
+
+      expect(readFileSync(path)).toEqual(before);
+      expect(store.read("hugin-orin-macro-routing")).toEqual(current);
+      expect(readdirSync(root).filter((name) => name.endsWith(".tmp"))).toEqual([]);
+    },
+  );
+
+  it("refuses the reduced-cap test hook outside Vitest", () => {
+    const root = mkdtempSync(join(tmpdir(), "hugin-config-test-hook-"));
+    new HuginConfigStore(root);
+    const priorVitest = process.env.VITEST;
+    delete process.env.VITEST;
+    try {
+      expect(() => new HuginConfigStore(root, { maxStoreBytesForTest: 1 }))
+        .toThrowError("hugin-config-store-test-hook-refused");
+    } finally {
+      if (priorVitest === undefined) delete process.env.VITEST;
+      else process.env.VITEST = priorVitest;
+    }
+  });
 });

--- a/tests/hugin-config-adapter.test.ts
+++ b/tests/hugin-config-adapter.test.ts
@@ -262,4 +262,43 @@ describe("Hugin strict autonomous config adapters", () => {
       workerProvider: "homeserver", taskType: "classify", sensitivity: "public",
     })).toThrow("hugin-config-store-digest-mismatch");
   });
+
+  it("rejects an oversized persisted store before parsing it", () => {
+    const root = mkdtempSync(join(tmpdir(), "hugin-config-oversized-"));
+    new HuginConfigStore(root);
+    const path = join(root, "hugin-r-exact-config.json");
+    writeFileSync(path, "{".repeat(256 * 1024 + 1), "utf8");
+
+    expect(() => new HuginConfigStore(root)).toThrowError("hugin-config-store-too-large");
+  });
+
+  it("rejects raw document cardinality before deep document validation", () => {
+    const root = mkdtempSync(join(tmpdir(), "hugin-config-document-limit-"));
+    new HuginConfigStore(root);
+    const path = join(root, "hugin-r-exact-config.json");
+    const state = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+    state.documents = Object.fromEntries(
+      Array.from({ length: 65 }, (_, index) => [`invalid-document-${index}`, {}]),
+    );
+    writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+    expect(() => new HuginConfigStore(root)).toThrowError(
+      "hugin-config-store-documents-limit",
+    );
+  });
+
+  it("rejects raw snapshot cardinality before deep snapshot validation", () => {
+    const root = mkdtempSync(join(tmpdir(), "hugin-config-snapshot-limit-"));
+    new HuginConfigStore(root);
+    const path = join(root, "hugin-r-exact-config.json");
+    const state = JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+    state.snapshots = Object.fromEntries(
+      Array.from({ length: 33 }, (_, index) => [`invalid-snapshot-${index}`, {}]),
+    );
+    writeFileSync(path, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+
+    expect(() => new HuginConfigStore(root)).toThrowError(
+      "hugin-config-store-snapshots-limit",
+    );
+  });
 });

--- a/tests/hugin-config-adapter.test.ts
+++ b/tests/hugin-config-adapter.test.ts
@@ -136,7 +136,7 @@ describe("Hugin strict autonomous config adapters", () => {
     const lockPath = join(root, "hugin-r-exact-config.json.lock");
     const child = spawn(
       "/usr/bin/flock",
-      ["--exclusive", "--nonblock", lockPath, process.execPath, "-e", "process.stdout.write('locked'); setInterval(() => {}, 1_000)"],
+      ["--exclusive", "--nonblock", "--no-fork", lockPath, process.execPath, "-e", "process.stdout.write('locked'); setInterval(() => {}, 1_000)"],
       { stdio: ["ignore", "pipe", "inherit"] },
     );
 

--- a/tests/hugin-config-adapter.test.ts
+++ b/tests/hugin-config-adapter.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import {
+  HUGIN_CONFIG_ADAPTER_VERSION,
+  readHuginConfigBase,
+  selectHuginMacroRoute,
+  validateHuginConfig,
+} from "../src/autonomy/hugin-config-adapter.js";
+
+describe("Hugin strict autonomous config adapter (W4.3)", () => {
+  it.each([
+    ["homeserver", "classify", "public", true],
+    ["homeserver", "extract", "internal", true],
+    ["homeserver", "classify", "private", false],
+    ["homeserver", "summarize", "public", false],
+    ["openrouter", "classify", "public", false],
+  ])("preserves the Orin macro-route matrix", (workerProvider, taskType, sensitivity, allowed) => {
+    expect(selectHuginMacroRoute({ workerProvider, taskType, sensitivity: sensitivity as "public" | "internal" | "private" }) !== null).toBe(allowed);
+  });
+
+  it("has versioned, digest-bound bases without content storage", () => {
+    expect(readHuginConfigBase("hugin-orin-macro-routing")).toMatchObject({ revision: "orin-macro-route-v1", digest: expect.stringMatching(/^sha256:/) });
+  });
+
+  it.each([
+    { targetId: "gille-model", model: "x" },
+    { targetId: "gille-model-config", modelConfig: "x" },
+    { targetId: "hugin-logging", logging: "on" },
+    { targetId: "hugin-test-harness", testHarness: "on" },
+    { targetId: "gille-tool-policy", toolPolicyDigest: "sha256:" + "0".repeat(64) },
+    { targetId: "hugin-deploy", deploy: true },
+    { targetId: "hugin-auth", auth: "x" },
+    { targetId: "hugin-key", key: "x" },
+    { targetId: "hugin-safety-gate", safety: "x" },
+    { targetId: "hugin-risk-budget", risk: 1 },
+    { targetId: "hugin-retention", retention: 1 },
+  ])("rejects protected or cross-owner target %#", (input) => {
+    expect(() => validateHuginConfig({ schemaVersion: HUGIN_CONFIG_ADAPTER_VERSION, revision: "candidate-v1", ...input })).toThrow();
+  });
+});

--- a/tests/hugin-config-adapter.test.ts
+++ b/tests/hugin-config-adapter.test.ts
@@ -26,9 +26,18 @@ describe("Hugin strict autonomous config adapters", () => {
     const snap = await target.snapshot(); await target.replaceExact(base, doc.candidateDigest);
     expect(await target.read()).toEqual({ revision: "orin-macro-route-v2", digest: doc.candidateDigest }); expect(snap.digest).toBe(base.digest);
     await expect(target.replaceExact(base, doc.candidateDigest)).rejects.toThrow("stale-base");
-    expect(store.restoreSnapshot("hugin-orin-macro-routing", snap.ref, snap.digest)).toEqual(base);
+    expect(store.restoreSnapshot("hugin-orin-macro-routing", snap.ref, snap.digest, { revision: "orin-macro-route-v2", digest: doc.candidateDigest }, "hugin-recovery-worker")).toEqual(base);
     expect(await target.read()).toEqual(base);
     expect(await createHuginConfigTargets(new HuginConfigStore(root))["hugin-orin-macro-routing"].read()).toEqual(base);
+  });
+
+  it("fences target-bound recovery so an old snapshot cannot overwrite later state", async () => {
+    const store = new HuginConfigStore(mkdtempSync(join(tmpdir(), "hugin-config-"))); const targets = createHuginConfigTargets(store);
+    const first = targets["hugin-orin-macro-routing"]; const other = targets["hugin-agent-harness"]; const base = await first.read(); const otherCurrent = await other.read(); const snap = await first.snapshot(); const doc = store.stage(candidate("hugin-orin-macro-routing", base)); await first.replaceExact(base, doc.candidateDigest);
+    expect(() => store.restoreSnapshot("hugin-agent-harness", snap.ref, snap.digest, otherCurrent, "hugin-recovery-worker")).toThrow("snapshot-unavailable");
+    expect(() => store.restoreSnapshot("hugin-orin-macro-routing", snap.ref, snap.digest, { revision: "later", digest: digest("later") }, "hugin-recovery-worker")).toThrow("stale-recovery-fence");
+    const current = await first.read(); expect(() => store.restoreSnapshot("hugin-orin-macro-routing", snap.ref, snap.digest, current, "wrong-worker")).toThrow("recovery-fence");
+    expect(await first.read()).toEqual({ revision: "orin-macro-route-v2", digest: doc.candidateDigest });
   });
 
   it("rejects malformed, duplicate/noncanonical, cross-owner, protected and unbound candidates before mutation", async () => {

--- a/tests/hugin-config-adapter.test.ts
+++ b/tests/hugin-config-adapter.test.ts
@@ -1,39 +1,37 @@
 import { describe, expect, it } from "vitest";
-import {
-  HUGIN_CONFIG_ADAPTER_VERSION,
-  readHuginConfigBase,
-  selectHuginMacroRoute,
-  validateHuginConfig,
-} from "../src/autonomy/hugin-config-adapter.js";
+import { createHash } from "node:crypto";
+import { canonicalizeJcs } from "../src/jcs.js";
+import { HUGIN_CONFIG_ADAPTER_VERSION, HuginConfigStore, createHuginConfigTargets, selectHuginMacroRoute, validateHuginConfigCandidate } from "../src/autonomy/hugin-config-adapter.js";
 
-describe("Hugin strict autonomous config adapter (W4.3)", () => {
-  it.each([
-    ["homeserver", "classify", "public", true],
-    ["homeserver", "extract", "internal", true],
-    ["homeserver", "classify", "private", false],
-    ["homeserver", "summarize", "public", false],
-    ["openrouter", "classify", "public", false],
-  ])("preserves the Orin macro-route matrix", (workerProvider, taskType, sensitivity, allowed) => {
-    expect(selectHuginMacroRoute({ workerProvider, taskType, sensitivity: sensitivity as "public" | "internal" | "private" }) !== null).toBe(allowed);
+const digest = (value: unknown) => `sha256:${createHash("sha256").update(canonicalizeJcs(value)).digest("hex")}`;
+function candidate(targetId: "hugin-orin-macro-routing" = "hugin-orin-macro-routing", base = { revision: "orin-macro-route-v1", digest: "" }) {
+  const body = { schemaVersion: HUGIN_CONFIG_ADAPTER_VERSION, targetId, revision: "orin-macro-route-v2", base, config: { routes: [
+    { workerProvider: "homeserver", taskType: "classify", sensitivity: "internal", nodeId: "orin", modelId: "qwen2.5-coder:3b" },
+    { workerProvider: "homeserver", taskType: "classify", sensitivity: "public", nodeId: "orin", modelId: "qwen2.5-coder:3b" },
+    { workerProvider: "homeserver", taskType: "extract", sensitivity: "internal", nodeId: "orin", modelId: "qwen2.5-coder:3b" },
+    { workerProvider: "homeserver", taskType: "extract", sensitivity: "public", nodeId: "orin", modelId: "qwen2.5-coder:3b" },
+  ] } } as const;
+  return { ...body, candidateDigest: digest(body) };
+}
+
+describe("Hugin strict autonomous config adapters", () => {
+  it.each([["homeserver", "classify", "public", true], ["homeserver", "extract", "internal", true], ["homeserver", "classify", "private", false], ["homeserver", "summarize", "public", false], ["openrouter", "classify", "public", false]])("preserves the Orin route matrix", (workerProvider, taskType, sensitivity, allowed) => expect(selectHuginMacroRoute({ workerProvider, taskType, sensitivity: sensitivity as "public" | "internal" | "private" }) !== null).toBe(allowed));
+
+  it("performs an exact staged CAS with snapshot/readback and refuses stale state", async () => {
+    const store = new HuginConfigStore(); const target = createHuginConfigTargets(store)["hugin-orin-macro-routing"];
+    const base = await target.read(); const doc = store.stage(candidate("hugin-orin-macro-routing", base));
+    const snap = await target.snapshot(); await target.replaceExact(base, doc.candidateDigest);
+    expect(await target.read()).toEqual({ revision: "orin-macro-route-v2", digest: doc.candidateDigest }); expect(snap.digest).toBe(base.digest);
+    await expect(target.replaceExact(base, doc.candidateDigest)).rejects.toThrow("stale-base");
+    expect(store.restoreSnapshot("hugin-orin-macro-routing", snap.ref, snap.digest)).toEqual(base);
+    expect(await target.read()).toEqual(base);
   });
 
-  it("has versioned, digest-bound bases without content storage", () => {
-    expect(readHuginConfigBase("hugin-orin-macro-routing")).toMatchObject({ revision: "orin-macro-route-v1", digest: expect.stringMatching(/^sha256:/) });
-  });
-
-  it.each([
-    { targetId: "gille-model", model: "x" },
-    { targetId: "gille-model-config", modelConfig: "x" },
-    { targetId: "hugin-logging", logging: "on" },
-    { targetId: "hugin-test-harness", testHarness: "on" },
-    { targetId: "gille-tool-policy", toolPolicyDigest: "sha256:" + "0".repeat(64) },
-    { targetId: "hugin-deploy", deploy: true },
-    { targetId: "hugin-auth", auth: "x" },
-    { targetId: "hugin-key", key: "x" },
-    { targetId: "hugin-safety-gate", safety: "x" },
-    { targetId: "hugin-risk-budget", risk: 1 },
-    { targetId: "hugin-retention", retention: 1 },
-  ])("rejects protected or cross-owner target %#", (input) => {
-    expect(() => validateHuginConfig({ schemaVersion: HUGIN_CONFIG_ADAPTER_VERSION, revision: "candidate-v1", ...input })).toThrow();
+  it("rejects malformed, duplicate/noncanonical, cross-owner, protected and unbound candidates before mutation", async () => {
+    const store = new HuginConfigStore(); const target = createHuginConfigTargets(store)["hugin-orin-macro-routing"]; const before = await target.read();
+    const bad = candidate("hugin-orin-macro-routing", before); bad.config.routes.reverse();
+    expect(() => validateHuginConfigCandidate(bad)).toThrow("noncanonical");
+    for (const id of ["gille-model", "gille-model-config", "hugin-logging", "hugin-test-harness", "gille-tool-policy", "hugin-deploy", "hugin-auth", "hugin-key", "hugin-safety-gate", "hugin-risk-budget", "hugin-retention", "unknown-target"]) expect(() => validateHuginConfigCandidate({ ...bad, targetId: id })).toThrow();
+    await expect(target.replaceExact(before, digest("not-staged"))).rejects.toThrow("not-bound"); expect(await target.read()).toEqual(before);
   });
 });

--- a/tests/hugin-config-adapter.test.ts
+++ b/tests/hugin-config-adapter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createHash } from "node:crypto";
-import { existsSync, lstatSync, mkdtempSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { spawn } from "node:child_process";
 import { once } from "node:events";
 import { tmpdir } from "node:os";
@@ -32,19 +32,6 @@ function candidateWithRoutes(
     config: { routes },
   };
   return { ...body, candidateDigest: digest(body) };
-}
-
-function linuxStartTime(pid: number): string {
-  const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
-  return stat.slice(stat.lastIndexOf(")") + 2).trim().split(/\s+/)[19]!;
-}
-
-function writeLock(root: string, owner: { bootId: string; pid: number; startTime: string }) {
-  const path = join(root, "hugin-r-exact-config.json.lock");
-  writeFileSync(path, "{}", { mode: 0o600 });
-  const stat = lstatSync(path);
-  writeFileSync(path, canonicalizeJcs({ version: 1, ...owner, device: stat.dev, inode: stat.ino }), { mode: 0o600 });
-  return path;
 }
 
 describe("Hugin strict autonomous config adapters", () => {
@@ -121,44 +108,88 @@ describe("Hugin strict autonomous config adapters", () => {
     expect(() => validateHuginConfigCandidate({ ...candidate(), targetId: "hugin-agent-prompt" })).toThrow();
   });
 
-  it("fails immediately on a live exact lock without a wait loop", () => {
+  it("fails immediately when another participant holds the kernel-backed lock", () => {
     const root = mkdtempSync(join(tmpdir(), "hugin-config-live-lock-"));
-    const store = new HuginConfigStore(root); const { revision, digest: baseDigest } = store.read("hugin-orin-macro-routing"); const base = { revision, digest: baseDigest };
-    const lock = writeLock(root, { bootId: process.platform === "linux" ? readFileSync("/proc/sys/kernel/random/boot_id", "utf8").trim() : "nonlinux-test", pid: process.pid, startTime: process.platform === "linux" ? linuxStartTime(process.pid) : "0" });
+    let probe = false;
+    let nestedError = "";
+    const store = new HuginConfigStore(root, {
+      onLockAcquired: () => {
+        if (!probe) return;
+        try { new HuginConfigStore(root); }
+        catch (error) { nestedError = error instanceof Error ? error.message : String(error); }
+      },
+    });
+    const { revision, digest: baseDigest } = store.read("hugin-orin-macro-routing");
+    probe = true;
+    const started = Date.now();
+
+    expect(() => store.stage(candidate("hugin-orin-macro-routing", { revision, digest: baseDigest }))).not.toThrow();
+    expect(nestedError).toBe("hugin-config-store-contended");
+    expect(Date.now() - started).toBeLessThan(100);
+  });
+
+  it.skipIf(process.platform !== "linux")("uses kernel ownership for contention and recovers only after SIGKILL closes the holder fd", async () => {
+    const root = mkdtempSync(join(tmpdir(), "hugin-config-kernel-lock-"));
+    const store = new HuginConfigStore(root);
+    const { revision, digest: baseDigest } = store.read("hugin-orin-macro-routing");
+    const base = { revision, digest: baseDigest };
+    const lockPath = join(root, "hugin-r-exact-config.json.lock");
+    const child = spawn(
+      "/usr/bin/flock",
+      ["--exclusive", "--nonblock", lockPath, process.execPath, "-e", "process.stdout.write('locked'); setInterval(() => {}, 1_000)"],
+      { stdio: ["ignore", "pipe", "inherit"] },
+    );
+
+    await once(child.stdout!, "data");
+    const heldIdentity = statSync(lockPath);
     const started = Date.now();
     expect(() => store.stage(candidate("hugin-orin-macro-routing", base))).toThrow("hugin-config-store-contended");
     expect(Date.now() - started).toBeLessThan(100);
-    unlinkSync(lock);
-  });
 
-  it.skipIf(process.platform !== "linux")("reclaims a SIGKILLed child lock only after Linux boot/PID-start proof", async () => {
-    const root = mkdtempSync(join(tmpdir(), "hugin-config-stale-lock-"));
-    const store = new HuginConfigStore(root); const { revision, digest: baseDigest } = store.read("hugin-orin-macro-routing"); const base = { revision, digest: baseDigest };
-    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
-    await once(child, "spawn");
-    const pid = child.pid!;
-    const lock = writeLock(root, { bootId: readFileSync("/proc/sys/kernel/random/boot_id", "utf8").trim(), pid, startTime: linuxStartTime(pid) });
-    child.kill("SIGKILL"); await once(child, "exit");
+    child.kill("SIGKILL");
+    await once(child, "exit");
+
     expect(() => store.stage(candidate("hugin-orin-macro-routing", base))).not.toThrow();
-    expect(existsSync(lock)).toBe(false);
+    const releasedIdentity = statSync(lockPath);
+    expect(releasedIdentity.dev).toBe(heldIdentity.dev);
+    expect(releasedIdentity.ino).toBe(heldIdentity.ino);
   });
 
-  it.skipIf(process.platform !== "linux")("never deletes a live replacement created after stale-lock claim", async () => {
-    const root = mkdtempSync(join(tmpdir(), "hugin-config-replacement-lock-"));
-    const bootId = readFileSync("/proc/sys/kernel/random/boot_id", "utf8").trim();
-    let replacement = "";
+  it.skipIf(process.platform !== "linux")("never interprets stale-looking lock-file contents as authority to reclaim the path", () => {
+    const root = mkdtempSync(join(tmpdir(), "hugin-config-stale-looking-lock-"));
+    const lockPath = join(root, "hugin-r-exact-config.json.lock");
+    writeFileSync(lockPath, '{"version":1,"pid":2147483647,"processStartTime":"1","bootId":"stale"}\n', { mode: 0o600 });
+    const before = statSync(lockPath);
+    const store = new HuginConfigStore(root);
+    const { revision, digest: baseDigest } = store.read("hugin-orin-macro-routing");
+
+    expect(() => store.stage(candidate("hugin-orin-macro-routing", { revision, digest: baseDigest }))).not.toThrow();
+    const after = statSync(lockPath);
+    expect(after.dev).toBe(before.dev);
+    expect(after.ino).toBe(before.ino);
+    expect(readFileSync(lockPath, "utf8")).toContain('"pid":2147483647');
+    expect(readdirSync(root).filter((name) => name.includes(".reclaim-"))).toEqual([]);
+  });
+
+  it.skipIf(process.platform !== "linux")("releases only the acquired kernel lock and never unlinks a replacement pathname", () => {
+    const root = mkdtempSync(join(tmpdir(), "hugin-config-release-race-"));
+    const lockPath = join(root, "hugin-r-exact-config.json.lock");
+    let hookCalled = false;
+    let armed = false;
     const store = new HuginConfigStore(root, {
-      onStaleLockClaimed: () => { replacement = writeLock(root, { bootId, pid: process.pid, startTime: linuxStartTime(process.pid) }); },
+      onLockAcquired: () => {
+        if (!armed) return;
+        hookCalled = true;
+        unlinkSync(lockPath);
+        writeFileSync(lockPath, "live replacement\n", { mode: 0o600 });
+      },
     });
-    const { revision, digest: baseDigest } = store.read("hugin-orin-macro-routing"); const base = { revision, digest: baseDigest };
-    const child = spawn(process.execPath, ["-e", "setInterval(() => {}, 1000)"], { stdio: "ignore" });
-    await once(child, "spawn"); const pid = child.pid!;
-    writeLock(root, { bootId, pid, startTime: linuxStartTime(pid) });
-    child.kill("SIGKILL"); await once(child, "exit");
-    expect(() => store.stage(candidate("hugin-orin-macro-routing", base))).toThrow("hugin-config-store-contended");
-    expect(existsSync(replacement)).toBe(true);
-    expect(JSON.parse(readFileSync(replacement, "utf8")).pid).toBe(process.pid);
-    unlinkSync(replacement);
+    const { revision, digest: baseDigest } = store.read("hugin-orin-macro-routing");
+    armed = true;
+
+    expect(() => store.stage(candidate("hugin-orin-macro-routing", { revision, digest: baseDigest }))).not.toThrow();
+    expect(hookCalled).toBe(true);
+    expect(readFileSync(lockPath, "utf8")).toBe("live replacement\n");
   });
 
   it("does not create an uninstalled durable root while reading the live selector", () => {

--- a/tests/orchestrator/orin-macro-route.test.ts
+++ b/tests/orchestrator/orin-macro-route.test.ts
@@ -1,7 +1,14 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { selectOrinMacroRoute } from "../../src/orchestrator/orin-macro-route.js";
+import { HUGIN_CONFIG_ROOT_ENV, HuginConfigStore } from "../../src/autonomy/hugin-config-adapter.js";
 
 describe("selectOrinMacroRoute", () => {
+  const priorRoot = process.env[HUGIN_CONFIG_ROOT_ENV];
+  beforeEach(() => { process.env[HUGIN_CONFIG_ROOT_ENV] = mkdtempSync(join(tmpdir(), "hugin-orin-route-")); new HuginConfigStore(process.env[HUGIN_CONFIG_ROOT_ENV]!); });
+  afterEach(() => { if (priorRoot === undefined) delete process.env[HUGIN_CONFIG_ROOT_ENV]; else process.env[HUGIN_CONFIG_ROOT_ENV] = priorRoot; });
   it("selects the reviewed Orin node only for homeserver classify/extract leaves", () => {
     expect(
       selectOrinMacroRoute({

--- a/tests/r-exact-controller.test.ts
+++ b/tests/r-exact-controller.test.ts
@@ -439,6 +439,11 @@ class Target implements RExactConfigTarget {
     return { revision: this.revision, digest: this.digest };
   }
 
+  async candidateRevision(candidateDigest: string) {
+    if (candidateDigest !== h("candidate")) throw new Error("unknown candidate");
+    return "candidate-1";
+  }
+
   async snapshot() {
     return { ref: "ref:snapshot-330", digest: h("base") };
   }

--- a/tests/r-exact-controller.test.ts
+++ b/tests/r-exact-controller.test.ts
@@ -5,7 +5,9 @@ import {
   sign,
   type KeyObject,
 } from "node:crypto";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { canonicalizeJcs } from "../src/jcs.js";
 import {
@@ -47,6 +49,12 @@ import {
   w0Digest,
   type W0AuthorityBundle,
 } from "../src/autonomy/w0-authority.js";
+import {
+  HUGIN_CONFIG_ADAPTER_VERSION,
+  HuginConfigStore,
+  createHuginConfigRecoveryWorker,
+  createHuginConfigTargets,
+} from "../src/autonomy/hugin-config-adapter.js";
 
 const h = (value: string): string =>
   `sha256:${createHash("sha256").update(value).digest("hex")}`;
@@ -83,7 +91,7 @@ const canonicalJournalSchema = JSON.parse(readFileSync(
   "utf8",
 ));
 
-function authority(): W0AuthorityBundle {
+function authority(macroTargetScope = scope): W0AuthorityBundle {
   const ownerKeys = generateKeyPairSync("ed25519");
   const recoveryKeys = generateKeyPairSync("ed25519");
   const ownerPem = ownerKeys.publicKey
@@ -98,7 +106,7 @@ function authority(): W0AuthorityBundle {
       .digest("hex")}`;
   const fixedTargets = [
     ["micro-routing", "gille", "gille-inference", h("micro-scope")],
-    ["macro-routing", "hugin-macro", "hugin", scope],
+    ["macro-routing", "hugin-macro", "hugin", macroTargetScope],
     ["served-model-roster", "roster", "gille-inference", h("roster-scope")],
     [
       "no-reboot-security-bugfix-maintenance",
@@ -142,7 +150,7 @@ function authority(): W0AuthorityBundle {
     entries: [
       {
         domain: "macro-routing",
-        target_scope_digest: scope,
+        target_scope_digest: macroTargetScope,
         recovery_worker_identity: "hugin-recovery",
         public_key_pem: recoveryPem,
         public_key_fingerprint: fingerprint(recoveryKeys.publicKey),
@@ -701,14 +709,18 @@ class JournalBackend implements RExactJournalReader {
   }
 }
 
-function proposal(proposalId = "proposal-330-a") {
+function proposal(
+  proposalId = "proposal-330-a",
+  base = { revision: "base-1", digest: h("base") },
+  candidateDigest = h("candidate"),
+) {
   return createAutonomyProposalReceipt({
     proposalId,
     experimentRef: "ref:experiment-330",
     evidenceFingerprints: [h("e")],
     targetId: "hugin-orin-macro-routing",
-    base: { revision: "base-1", digest: h("base") },
-    candidateContentDigest: h("candidate"),
+    base,
+    candidateContentDigest: candidateDigest,
     expiresAt: "2026-07-26T15:00:00Z",
     signerKeyId: "hugin-autonomy-proposer",
   }, secret);
@@ -717,6 +729,7 @@ function proposal(proposalId = "proposal-330-a") {
 function proofFor(
   receipt: AutonomyProposalReceipt,
   override: Partial<FreshAdmission> = {},
+  targetScopeDigest = scope,
 ): FreshAdmission {
   return {
     checkedAt: fixedNow,
@@ -730,7 +743,7 @@ function proofFor(
     livenessHealthy: true,
     watchdogSilenceSeconds: 0,
     proposalDigest: receipt.canonicalProposalDigest,
-    targetScopeDigest: scope,
+    targetScopeDigest,
     baseRevision: receipt.base.revision,
     baseDigest: receipt.base.digest,
     candidateDigest: receipt.candidateContentDigest,
@@ -746,10 +759,11 @@ function proofFor(
 
 function gate(
   backend: JournalBackend,
-  target: Target,
+  target: RExactConfigTarget,
   receipt = proposal(),
   bundle = authority(),
   override: Partial<FreshAdmission> = {},
+  restoreAndVerify?: W0RuntimeGate["recovery"]["restoreAndVerify"],
 ): W0RuntimeGate {
   const narrowingHistory: W0AuthorityBundle[] = [];
   let protectedNow = fixedNow;
@@ -897,7 +911,7 @@ function gate(
       checkedAt: protectedNow,
       trustedWatchdogTime: protectedNow,
       ...override,
-    }),
+    }, target.targetScopeDigest),
     verifyRecovery: async (_prepared, current) => ({
       checkedAt: protectedNow,
       trustedWatchdogTime: protectedNow,
@@ -908,14 +922,14 @@ function gate(
       journalHealthy: true,
     }),
     recovery: {
-      restoreAndVerify: async (input) => {
+      restoreAndVerify: restoreAndVerify ?? (async (input) => {
         target.digest = input.snapshotDigest;
         target.revision = input.baseRevision;
         return {
           restoredRevision: target.revision,
           restoredDigest: target.digest,
         };
-      },
+      }),
       narrowAndVerify: async ({ binding, journalReceiptDigest }) => {
         const next = structuredClone(runtime.authority);
         const previous =
@@ -957,6 +971,24 @@ function gate(
   backend.roleNow = () =>
     runtime.protectedNow().toISOString().replace(".000Z", "Z");
   return runtime;
+}
+
+function strictMacroCandidate(base: { revision: string; digest: string }) {
+  const body = {
+    schemaVersion: HUGIN_CONFIG_ADAPTER_VERSION,
+    targetId: "hugin-orin-macro-routing" as const,
+    revision: "orin-macro-route-v2",
+    base,
+    config: {
+      routes: [
+        { workerProvider: "homeserver", taskType: "classify", sensitivity: "internal", nodeId: "orin", modelId: "qwen2.5-coder:3b" },
+        { workerProvider: "homeserver", taskType: "classify", sensitivity: "public", nodeId: "orin", modelId: "qwen2.5-coder:3b" },
+        { workerProvider: "homeserver", taskType: "extract", sensitivity: "internal", nodeId: "orin", modelId: "qwen2.5-coder:3b" },
+        { workerProvider: "homeserver", taskType: "extract", sensitivity: "public", nodeId: "orin", modelId: "qwen2.5-coder:3b" },
+      ],
+    },
+  };
+  return { ...body, candidateDigest: h(canonicalizeJcs(body)) };
 }
 
 describe("W0.2 R-exact controller", () => {
@@ -1023,6 +1055,77 @@ describe("W0.2 R-exact controller", () => {
     expect(result.journal.schema_version).toBe("v2");
     validateRExactJournal(result.journal, false);
   });
+
+  it("recovers a real durable strict-config attempt across restart", async () => {
+    const root = mkdtempSync(join(tmpdir(), "hugin-r-exact-composition-"));
+    const store = new HuginConfigStore(root);
+    const target = createHuginConfigTargets(store)["hugin-orin-macro-routing"];
+    const base = await target.read();
+    const candidate = store.stage(strictMacroCandidate(base));
+    const receipt = proposal("proposal-338-strict-config", base, candidate.candidateDigest);
+    const backend = new JournalBackend();
+    const bundle = authority(target.targetScopeDigest);
+    const recovery = createHuginConfigRecoveryWorker(store);
+    let unknownWasDurableBeforeRestore = false;
+    const runtime = gate(
+      backend,
+      target,
+      receipt,
+      bundle,
+      {},
+      async (input) => {
+        unknownWasDurableBeforeRestore = (await backend.read(receipt.proposalId))
+          ?.journal.entries.at(-1)?.phase === "unknown";
+        return recovery.restoreAndVerify(input);
+      },
+    );
+
+    await expect(applyRExactProposal(receipt, keys, target, runtime, {
+      onPhase: (phase) => {
+        if (phase === "readback") throw new Error("simulated-process-crash");
+      },
+      onRecoveryCause: () => { throw new Error("simulated-process-crash"); },
+    })).rejects.toThrow("simulated-process-crash");
+    expect(await target.read()).toEqual({
+      revision: candidate.revision,
+      digest: candidate.candidateDigest,
+    });
+    expect((await backend.read(receipt.proposalId))?.journal.entries.at(-1)?.phase)
+      .toBe("apply");
+
+    const restartedStore = new HuginConfigStore(root);
+    const restartedTarget = createHuginConfigTargets(restartedStore)["hugin-orin-macro-routing"];
+    const restartedRecovery = createHuginConfigRecoveryWorker(restartedStore);
+    const restartedRuntime = gate(
+      backend,
+      restartedTarget,
+      receipt,
+      bundle,
+      {},
+      async (input) => {
+        unknownWasDurableBeforeRestore = (await backend.read(receipt.proposalId))
+          ?.journal.entries.at(-1)?.phase === "unknown";
+        return restartedRecovery.restoreAndVerify(input);
+      },
+    );
+    const result = await applyRExactProposal(
+      receipt,
+      keys,
+      restartedTarget,
+      restartedRuntime,
+    );
+
+    expect(result.status).toBe("disarmed");
+    expect(unknownWasDurableBeforeRestore).toBe(true);
+    expect(result.journal.entries.map((entry) => entry.phase)).toEqual([
+      "prepare", "apply", "unknown", "revert", "disarm",
+    ]);
+    expect(await restartedTarget.read()).toEqual(base);
+    expect(await createHuginConfigTargets(new HuginConfigStore(root))[
+      "hugin-orin-macro-routing"
+    ].read()).toEqual(base);
+  });
+
 
   it("starts the full watch at the service-authored durable append time", async () => {
     const backend = new JournalBackend();


### PR DESCRIPTION
## Summary

- Narrows the concrete Hugin R-exact config adapter to the sole real target, hugin-orin-macro-routing. W4.1 proposal-only prompt, harness, and tool-policy registry entries remain unchanged; this PR does not alter their receipt digest.
- Makes the macro payload a canonical unique subset, including empty, of the four reviewed homeserver classify/extract public/internal leaves, all pinned to orin and qwen2.5-coder:3b. Promotion changes the live selector and exact restore proves the baseline behavior.
- Replaces pathname-based stale takeover and lstat-then-unlink release with a persistent 0600 lock anchor and Linux kernel `flock`. The parent retains the locked open-file description for the whole synchronous mutation; close/crash releases it atomically. The implementation never renames or unlinks the canonical lock path, and missing `/usr/bin/flock` fails closed. Unsupported non-Linux developer hosts use process-local fail-fast exclusion only, without claiming cross-process safety.
- Adds adversarial Linux coverage for live contention plus SIGKILL recovery, stale-looking pathname contents that must never trigger reclaim, and deterministic injection at the former identity-lstat-to-unlink release window. The release injection runs only after mutation returns and is refused outside Vitest.
- Bounds staged documents to 64 and snapshots to 32, cleans only UUID-bound failed temp files, and emits one path-free diagnostic per missing/corrupt/contended selector failure.

## Verification

- `npm test -- --run tests/hugin-config-adapter.test.ts tests/r-exact-controller.test.ts tests/orchestrator/orin-macro-route.test.ts`: 89 passed, 3 Linux-only skipped on macOS
- `npm run build`
- `npm test`: 162 files, 2,526 passed, 3 Linux-only skipped (2,529 total)
- `git diff --check`
- Direct Linux inherited-fd probe on the Hugin host, without deploying or changing services: helper acquire `0`; competing acquire while parent retained the fd `1`; acquire after parent close `0`
- M5/mellum bounded concurrency review confirmed inherited-fd lifetime and crash-release semantics; its pathname warning was addressed by validating immediately before mutation that the acquired fd and canonical path still identify the same regular, single-link inode. Cooperating participants never rename or unlink the persistent anchor; arbitrary same-owner pathname replacement is outside that private-root threat boundary and is not claimed safe.

No production root/environment, controller/watchdog/recovery service, deployment, route change, actuator, or arming action occurred. The PR remains draft.

Closes #331
