### PR TITLE
Trim MCP discovery payload and pin the wire contract (#318)

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -27,6 +27,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { BrokerClient } from "./mcp/broker-client.js";
 import { ALIAS_MAP_VERSION, buildTools, type HuginTool } from "./mcp/tools.js";
 import { aliasSchema, type Alias } from "./broker/types.js";
+import { HUGIN_MCP_SERVER_INSTRUCTIONS } from "./mcp/server-instructions.js";
 
 const SERVER_NAME = "hugin-mcp";
 const SERVER_VERSION = "0.1.0";
@@ -123,7 +124,10 @@ export async function main(): Promise<void> {
     executableAliases: brokerContract.executableAliases,
   });
 
-  const server = new McpServer({ name: SERVER_NAME, version: SERVER_VERSION });
+  const server = new McpServer(
+    { name: SERVER_NAME, version: SERVER_VERSION },
+    { instructions: HUGIN_MCP_SERVER_INSTRUCTIONS },
+  );
 
   const allTools: HuginTool<Record<string, unknown>>[] = [
     tools.submit as HuginTool<Record<string, unknown>>,

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -22,15 +22,12 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { BrokerClient } from "./mcp/broker-client.js";
-import { ALIAS_MAP_VERSION, buildTools, type HuginTool } from "./mcp/tools.js";
-import { aliasSchema, type Alias } from "./broker/types.js";
-import { HUGIN_MCP_SERVER_INSTRUCTIONS } from "./mcp/server-instructions.js";
-
-const SERVER_NAME = "hugin-mcp";
-const SERVER_VERSION = "0.1.0";
+import {
+  createHuginMcpServer,
+  discoverBrokerContract,
+} from "./mcp/server-factory.js";
 
 function readRequiredEnv(name: string): string {
   const value = process.env[name];
@@ -39,62 +36,6 @@ function readRequiredEnv(name: string): string {
     process.exit(1);
   }
   return value;
-}
-
-/**
- * Discover the broker's current `alias_map_version` so submit envelopes
- * carry the live value instead of a hard-coded constant. The broker
- * uses this to detect orchestrator skew when it bumps the alias map.
- *
- * If `/v1/delegate/models` is unreachable or malformed, retain the compiled
- * alias-map version for diagnostics but return an empty executable alias set.
- * That keeps MCP startup non-blocking while disabling submission until the
- * client reconnects and successfully discovers the Broker contract.
- */
-interface BrokerContractDiscovery {
-  aliasMapVersion: number;
-  executableAliases: Alias[];
-}
-
-async function discoverBrokerContract(
-  broker: BrokerClient,
-): Promise<BrokerContractDiscovery> {
-  try {
-    const response = await broker.models();
-    if (
-      response &&
-      typeof response === "object" &&
-      "alias_map_version" in response
-    ) {
-      const candidate = (response as { alias_map_version: unknown })
-        .alias_map_version;
-      if (typeof candidate === "number" && Number.isInteger(candidate) && candidate > 0) {
-        const rawAliases = "aliases" in response
-          ? (response as { aliases: unknown }).aliases
-          : undefined;
-        const executableAliases = Array.isArray(rawAliases)
-          ? rawAliases.flatMap((entry) => {
-              if (!entry || typeof entry !== "object" || !("alias" in entry)) {
-                return [];
-              }
-              const parsed = aliasSchema.safeParse(
-                (entry as { alias: unknown }).alias,
-              );
-              return parsed.success ? [parsed.data] : [];
-            })
-          : [];
-        return { aliasMapVersion: candidate, executableAliases };
-      }
-    }
-    process.stderr.write(
-      `hugin-mcp: /v1/delegate/models did not advertise a valid contract; submission disabled (compiled alias map ${ALIAS_MAP_VERSION})\n`,
-    );
-  } catch (err) {
-    process.stderr.write(
-      `hugin-mcp: failed to discover Broker contract (${err instanceof Error ? err.message : String(err)}); submission disabled (compiled alias map ${ALIAS_MAP_VERSION})\n`,
-    );
-  }
-  return { aliasMapVersion: ALIAS_MAP_VERSION, executableAliases: [] };
 }
 
 function readOptionalNumber(name: string, fallback: number): number {
@@ -116,43 +57,12 @@ export async function main(): Promise<void> {
 
   const broker = new BrokerClient({ baseUrl, bearerToken, requestTimeoutMs });
   const brokerContract = await discoverBrokerContract(broker);
-  const tools = buildTools({
+  const server = createHuginMcpServer({
     broker,
     sessionId: randomUUID(),
     submitter,
-    aliasMapVersion: brokerContract.aliasMapVersion,
-    executableAliases: brokerContract.executableAliases,
+    brokerContract,
   });
-
-  const server = new McpServer(
-    { name: SERVER_NAME, version: SERVER_VERSION },
-    { instructions: HUGIN_MCP_SERVER_INSTRUCTIONS },
-  );
-
-  const allTools: HuginTool<Record<string, unknown>>[] = [
-    tools.submit as HuginTool<Record<string, unknown>>,
-    tools.await_ as HuginTool<Record<string, unknown>>,
-    tools.rate as HuginTool<Record<string, unknown>>,
-    tools.list as HuginTool<Record<string, unknown>>,
-    tools.models as HuginTool<Record<string, unknown>>,
-    tools.friction as HuginTool<Record<string, unknown>>,
-    tools.experimentCreate as HuginTool<Record<string, unknown>>,
-    tools.experimentObserve as HuginTool<Record<string, unknown>>,
-    tools.experimentRate as HuginTool<Record<string, unknown>>,
-    tools.experimentStatus as HuginTool<Record<string, unknown>>,
-    tools.experimentPromote as HuginTool<Record<string, unknown>>,
-  ];
-  for (const tool of allTools) {
-    server.registerTool(
-      tool.name,
-      {
-        title: tool.title,
-        description: tool.description,
-        inputSchema: tool.inputShape,
-      },
-      async (input: Record<string, unknown>) => tool.handler(input),
-    );
-  }
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/src/mcp/server-factory.ts
+++ b/src/mcp/server-factory.ts
@@ -1,0 +1,119 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { aliasSchema, type Alias } from "../broker/types.js";
+import type { BrokerClient } from "./broker-client.js";
+import {
+  ALIAS_MAP_VERSION,
+  buildTools,
+  type HuginTool,
+} from "./tools.js";
+import { HUGIN_MCP_SERVER_INSTRUCTIONS } from "./server-instructions.js";
+
+export const SERVER_NAME = "hugin-mcp";
+export const SERVER_VERSION = "0.1.0";
+
+export interface BrokerContractDiscovery {
+  aliasMapVersion: number;
+  executableAliases: Alias[];
+}
+
+/**
+ * Discover the broker's current `alias_map_version` so submit envelopes
+ * carry the live value instead of a hard-coded constant. The broker
+ * uses this to detect orchestrator skew when it bumps the alias map.
+ *
+ * If `/v1/delegate/models` is unreachable or malformed, retain the compiled
+ * alias-map version for diagnostics but return an empty executable alias set.
+ * That keeps MCP startup non-blocking while disabling submission until the
+ * client reconnects and successfully discovers the Broker contract.
+ */
+export async function discoverBrokerContract(
+  broker: Pick<BrokerClient, "models">,
+): Promise<BrokerContractDiscovery> {
+  try {
+    const response = await broker.models();
+    if (
+      response &&
+      typeof response === "object" &&
+      "alias_map_version" in response
+    ) {
+      const candidate = (response as { alias_map_version: unknown })
+        .alias_map_version;
+      if (typeof candidate === "number" && Number.isInteger(candidate) && candidate > 0) {
+        const rawAliases = "aliases" in response
+          ? (response as { aliases: unknown }).aliases
+          : undefined;
+        const executableAliases = Array.isArray(rawAliases)
+          ? rawAliases.flatMap((entry) => {
+              if (!entry || typeof entry !== "object" || !("alias" in entry)) {
+                return [];
+              }
+              const parsed = aliasSchema.safeParse(
+                (entry as { alias: unknown }).alias,
+              );
+              return parsed.success ? [parsed.data] : [];
+            })
+          : [];
+        return { aliasMapVersion: candidate, executableAliases };
+      }
+    }
+    process.stderr.write(
+      `hugin-mcp: /v1/delegate/models did not advertise a valid contract; submission disabled (compiled alias map ${ALIAS_MAP_VERSION})\n`,
+    );
+  } catch (err) {
+    process.stderr.write(
+      `hugin-mcp: failed to discover Broker contract (${err instanceof Error ? err.message : String(err)}); submission disabled (compiled alias map ${ALIAS_MAP_VERSION})\n`,
+    );
+  }
+  return { aliasMapVersion: ALIAS_MAP_VERSION, executableAliases: [] };
+}
+
+function registerHuginTools(
+  server: McpServer,
+  tools: ReturnType<typeof buildTools>,
+): void {
+  const allTools: HuginTool<Record<string, unknown>>[] = [
+    tools.submit as HuginTool<Record<string, unknown>>,
+    tools.await_ as HuginTool<Record<string, unknown>>,
+    tools.rate as HuginTool<Record<string, unknown>>,
+    tools.list as HuginTool<Record<string, unknown>>,
+    tools.models as HuginTool<Record<string, unknown>>,
+    tools.friction as HuginTool<Record<string, unknown>>,
+    tools.experimentCreate as HuginTool<Record<string, unknown>>,
+    tools.experimentObserve as HuginTool<Record<string, unknown>>,
+    tools.experimentRate as HuginTool<Record<string, unknown>>,
+    tools.experimentStatus as HuginTool<Record<string, unknown>>,
+    tools.experimentPromote as HuginTool<Record<string, unknown>>,
+  ];
+  for (const tool of allTools) {
+    server.registerTool(
+      tool.name,
+      {
+        title: tool.title,
+        description: tool.description,
+        inputSchema: tool.inputShape,
+      },
+      async (input: Record<string, unknown>) => tool.handler(input),
+    );
+  }
+}
+
+export function createHuginMcpServer(options: {
+  broker: BrokerClient;
+  sessionId: string;
+  submitter: string;
+  brokerContract: BrokerContractDiscovery;
+}): McpServer {
+  const tools = buildTools({
+    broker: options.broker,
+    sessionId: options.sessionId,
+    submitter: options.submitter,
+    aliasMapVersion: options.brokerContract.aliasMapVersion,
+    executableAliases: options.brokerContract.executableAliases,
+  });
+  const server = new McpServer(
+    { name: SERVER_NAME, version: SERVER_VERSION },
+    { instructions: HUGIN_MCP_SERVER_INSTRUCTIONS },
+  );
+  registerHuginTools(server, tools);
+  return server;
+}

--- a/src/mcp/server-instructions.ts
+++ b/src/mcp/server-instructions.ts
@@ -1,0 +1,10 @@
+export const HUGIN_MCP_SHARED_PREAMBLE =
+  "Hugin fills the Broker envelope fields and safe defaults, so callers specify the task or learning event rather than protocol metadata like destination, durability, delivery, or escalation.";
+
+export const HUGIN_MCP_SERVER_INSTRUCTIONS = [
+  HUGIN_MCP_SHARED_PREAMBLE,
+  "Use `hugin_models` when alias availability matters; it returns only aliases with a live Broker executor.",
+  "Closed vocabularies are encoded in tool schemas as enums or discriminated unions. Prefer those fields over prose guesses.",
+  "`hugin_submit` returns a durable `task_id` plus `idempotency_key`; `hugin_await` polls it; `hugin_rate` appends an exact-bound quality receipt.",
+  "The `hugin_experiment_*` tools are content-blind. Prompts and fixtures stay in their owning repositories while Hugin stores versions and SHA-256 fingerprints.",
+].join(" ");

--- a/src/mcp/server-instructions.ts
+++ b/src/mcp/server-instructions.ts
@@ -1,10 +1,4 @@
-export const HUGIN_MCP_SHARED_PREAMBLE =
-  "Hugin fills the Broker envelope fields and safe defaults, so callers specify the task or learning event rather than protocol metadata like destination, durability, delivery, or escalation.";
-
 export const HUGIN_MCP_SERVER_INSTRUCTIONS = [
-  HUGIN_MCP_SHARED_PREAMBLE,
-  "Use `hugin_models` when alias availability matters; it returns only aliases with a live Broker executor.",
-  "Closed vocabularies are encoded in tool schemas as enums or discriminated unions. Prefer those fields over prose guesses.",
-  "`hugin_submit` returns a durable `task_id` plus `idempotency_key`; `hugin_await` polls it; `hugin_rate` appends an exact-bound quality receipt.",
-  "The `hugin_experiment_*` tools are content-blind. Prompts and fixtures stay in their owning repositories while Hugin stores versions and SHA-256 fingerprints.",
+  "Each `hugin_submit` is one bounded M5 `/delegate` leaf.",
+  "M5 owns model/capability evidence; Hugin owns durable task, delivery, and review state.",
 ].join(" ");

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -391,7 +391,7 @@ export function buildTools(deps: ToolDeps): {
     name: "hugin_await",
     title: "Read the current state of a delegated task",
     description:
-      "Idempotent read of task `status` (`running` | `completed` | `failed`). While `running`, includes lease data and `orphan_suspected`. Use `verbosity: summary` for a compact result with refs to the full terminal record.",
+      "Idempotent read of current task state. Returns immediately and is safe to poll. While active, includes lease info and `orphan_suspected` (true once the lease has expired without completion). Use `verbosity: summary` for a compact result with refs to the full terminal record.",
     inputShape: awaitInputShape,
     handler: async (rawInput) => {
       try {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -94,14 +94,11 @@ export interface ToolDeps {
 
 export const submitInputShape = {
   task_type: taskTypeSchema.describe(
-    "Canonical M5 task type. The gateway uses it for capability routing and ledger evidence.",
+    "Canonical M5 task type for routing and ledger evidence.",
   ),
-  prompt: z
-    .string()
-    .min(1)
-    .describe("The full task prompt to hand to the runtime."),
+  prompt: z.string().min(1),
   alias_requested: aliasSchema.describe(
-    "Logical alias. The live executable set is discovered from `hugin_models` when the MCP starts.",
+    "Executable alias. Live set comes from `hugin_models` at MCP startup.",
   ),
   worktree: worktreeSpecSchema
     .optional()
@@ -126,49 +123,47 @@ export const submitInputShape = {
   acceptance: z.discriminatedUnion("mode", [
     z.object({ mode: z.literal("l1_review") }).strict(),
     z.object({ mode: z.literal("verifier"), verifier: verifierSpecSchema }).strict(),
-  ]).optional().describe("Acceptance contract. Defaults to explicit L1 review."),
-  parent_task_id: z.string().min(1).optional().describe("Optional L1 parent-task correlation id."),
+  ]).optional().describe("Defaults to `l1_review`."),
+  parent_task_id: z.string().min(1).optional().describe("Optional parent-task correlation id."),
   idempotency_key: z
     .string()
     .uuid()
     .optional()
-    .describe(
-      "Override the auto-generated idempotency key. Useful when the caller knows the request is a retry of an earlier one.",
-    ),
+    .describe("Retry-key override. Reuse only for the same logical request."),
 };
 const submitInputSchema = z.object(submitInputShape);
 
 export const awaitInputShape = {
   task_id: z.string().min(1).describe("Task id returned by `hugin_submit`."),
   verbosity: z.enum(["full", "summary"]).optional().describe(
-    "Response detail. Omit or use `full` for the canonical durable result; use `summary` for a compact projection with refs to the full result.",
+    "Use `summary` for a compact result with refs to the full record.",
   ),
 };
 const awaitInputSchema = z.object(awaitInputShape);
 
 export const rateInputShape = {
   task_id: z.string().min(1),
-  rating: ratingSchema.describe("Review verdict."),
+  rating: ratingSchema,
   rating_reason: z.string().min(1),
-  verification_outcome: verificationOutcomeSchema.describe("Post-review disposition."),
+  verification_outcome: verificationOutcomeSchema,
   retries_count: z.number().int().nonnegative().optional(),
   reviewer_role: z.enum(["independent", "self"]).optional()
-    .describe("Authenticated reviewer attestation. Same-task owners cannot claim independent."),
+    .describe("Reviewer attestation. Same-task owners cannot claim `independent`."),
   correction: qualityCorrectionRequestSchema.optional().describe(
-    "Append-only native v2 correction shape. Names the predecessor and carries content-blind rubric, failure, configuration, and successor provenance. The Broker derives the attempt only from accepted authoritative LearningTask evidence in the exact structured result; callers cannot provide or infer it.",
+    "Append-only v2 correction. Broker derives the attempt from accepted LearningTask evidence; callers cannot supply it.",
   ),
   expected_binding: z.object({
     task_document_sha256: z.string().regex(/^[0-9a-f]{64}$/),
     structured_result_sha256: z.string().regex(/^[0-9a-f]{64}$/),
     repository_diff_sha256: z.string().regex(/^[0-9a-f]{64}$/).optional(),
-  }).strict().optional().describe("Optional exact hashes reviewed by the caller; stale hashes are rejected."),
+  }).strict().optional().describe("Optional reviewed hashes; stale bindings are rejected."),
 };
 const rateInputSchema = z.object(rateInputShape);
 
 export const listInputShape = {
   limit: z.number().int().min(1).max(500).optional(),
   since_ts: z.string().min(1).optional(),
-  outcome: z.enum(["completed", "failed", "running", "any"]).optional().describe("Status filter."),
+  outcome: z.enum(["completed", "failed", "running", "any"]).optional(),
   alias: aliasSchema.optional(),
 };
 const listInputSchema = z.object(listInputShape);
@@ -343,8 +338,8 @@ export function buildTools(deps: ToolDeps): {
     ...submitInputShape,
     alias_requested: executableAliasInput.describe(
       executableAliases.length > 0
-        ? `Executable logical alias. Live set: ${executableAliases.join(", ")}.`
-        : "No Broker alias currently has an enabled executor; submission is disabled.",
+        ? `Executable alias. Live set: ${executableAliases.join(", ")}.`
+        : "Submission disabled: no Broker alias has a live executor.",
     ),
   };
   const activeSubmitInputSchema = z.object(activeSubmitInputShape);
@@ -353,7 +348,7 @@ export function buildTools(deps: ToolDeps): {
     name: "hugin_submit",
     title: "Submit a delegation task to Hugin",
     description:
-      "Submit one bounded task and get back the durable task_id plus idempotency_key. Reuse that key only to retry the same logical request. For judgment-flavored task_type values (classify, qa-factual, triage, memory-decision, claim-verify) submitted with the default `l1_review` acceptance and a prompt with no rubric, the response carries a non-blocking `warnings` array — the task still runs, but attach a mechanical `acceptance.verifier` or add a rubric/grading-criteria section to the prompt for stronger capability evidence.",
+      "Submit one task. Returns durable `task_id` + `idempotency_key`; reuse the key only for the same logical retry. Judgment-style tasks without a rubric or `acceptance.verifier` may return non-blocking `warnings`.",
     inputShape: activeSubmitInputShape,
     handler: async (rawInput) => {
       let idempotencyKey: string | undefined;
@@ -396,7 +391,7 @@ export function buildTools(deps: ToolDeps): {
     name: "hugin_await",
     title: "Read the current state of a delegated task",
     description:
-      "Idempotent read of the broker's current task state. Returns immediately. While the task is still active, the response also carries lease info and an `orphan_suspected` flag (true once the lease has expired without completion). Use `verbosity: summary` to avoid inlining full terminal provenance; the summary includes a namespace/key ref to it. Safe to poll.",
+      "Idempotent read of task `status` (`running` | `completed` | `failed`). While `running`, includes lease data and `orphan_suspected`. Use `verbosity: summary` for a compact result with refs to the full terminal record.",
     inputShape: awaitInputShape,
     handler: async (rawInput) => {
       try {
@@ -423,7 +418,7 @@ export function buildTools(deps: ToolDeps): {
     name: "hugin_rate",
     title: "Record an exact-bound task quality review",
     description:
-      "Append an authenticated quality receipt for a terminal Hugin task, bound to its current task/result/repository evidence. This does not directly modify M5's capability ledger.",
+      "Append an authenticated quality receipt bound to the current terminal task/result/repository evidence.",
     inputShape: rateInputShape,
     handler: async (rawInput) => {
       try {
@@ -440,7 +435,7 @@ export function buildTools(deps: ToolDeps): {
     name: "hugin_list",
     title: "List recent delegated tasks",
     description:
-      "List this authenticated principal's recent canonical Munin tasks, plus its read-only historical orch-v1 rows. A true truncated field means a Munin query hit its result cap and may have omitted tasks, so total is only a lower bound.",
+      "List recent tasks for this authenticated principal. If `truncated` is true, the query hit its cap and `total` is only a lower bound.",
     inputShape: listInputShape,
     handler: async (rawInput) => {
       try {
@@ -457,7 +452,7 @@ export function buildTools(deps: ToolDeps): {
     name: "hugin_models",
     title: "Read the active alias map and runtime registry",
     description:
-      "Returns only aliases with a live Broker executor and the runtime rows they can actually dispatch to.",
+      "Read aliases with a live Broker executor and the runtime rows they can dispatch to.",
     inputShape: modelsInputShape,
     handler: async () => {
       try {
@@ -473,7 +468,7 @@ export function buildTools(deps: ToolDeps): {
     name: "hugin_report_friction",
     title: "Report friction encountered while solving a task",
     description:
-      "Persist one concrete capability, environment, or specification friction event in Hugin's shared signals/friction corpus. Use task_id when the event came from a Hugin task. This is operational evidence, not a semantic task rating.",
+      "Persist one concrete capability, environment, or spec friction event. Use `task_id` when applicable; this is operational evidence, not a semantic rating.",
     inputShape: frictionInputShape,
     handler: async (rawInput) => {
       try {
@@ -489,7 +484,7 @@ export function buildTools(deps: ToolDeps): {
     name: "hugin_experiment_create",
     title: "Create a versioned learning experiment",
     description:
-      "Create or idempotently reopen one content-blind champion/challenger experiment. Exactly one logging, test-harness, prompt, harness, model, model-config, or routing axis may differ. Prompts and fixtures stay in their owning repos; only versions and SHA-256 fingerprints are stored.",
+      "Create or reopen one content-blind experiment where exactly one axis differs. Hugin stores versions and SHA-256 fingerprints, not prompts or fixtures.",
     inputShape: experimentCreateInputShape,
     handler: async (rawInput) => {
       try {
@@ -505,7 +500,7 @@ export function buildTools(deps: ToolDeps): {
     name: "hugin_experiment_observe",
     title: "Record one experiment-arm observation",
     description:
-      "Append idempotent evidence for one champion or challenger run. Matching uses sample_id; promotion is evaluated only from matched pairs, requires holdout and independent verification coverage, and automatically rejects measured regressions.",
+      "Append idempotent evidence for one champion or challenger run. Promotion uses matched pairs plus holdout and independent verification coverage, and rejects measured regressions.",
     inputShape: experimentObserveInputShape,
     handler: async (rawInput) => {
       try {
@@ -521,7 +516,7 @@ export function buildTools(deps: ToolDeps): {
     name: "hugin_experiment_rate",
     title: "Add a product rating to an experiment run",
     description:
-      "Enrich one already-recorded unrated run with its human/downstream usefulness outcome and optional review time. The transition is one-way and idempotent; an existing rating can never be overwritten.",
+      "Add a one-way product rating to an already-recorded run, with optional review time.",
     inputShape: learningExperimentRateInputShape,
     handler: async (rawInput) => {
       try {
@@ -537,7 +532,7 @@ export function buildTools(deps: ToolDeps): {
     name: "hugin_experiment_status",
     title: "Read a learning experiment and its promotion gate",
     description:
-      "Read the durable experiment state, matched-pair metrics, guard failures, dominant failure signals, and next action. A promotion-ready state is evidence for operator review, never an uncontrolled production mutation.",
+      "Read experiment state, matched-pair metrics, gate failures, dominant failure signals, and next action.",
     inputShape: experimentStatusInputShape,
     handler: async (rawInput) => {
       try {
@@ -553,7 +548,7 @@ export function buildTools(deps: ToolDeps): {
     name: "hugin_experiment_promote",
     title: "Record reviewed promotion of a winning challenger",
     description:
-      "After the owning configuration repository has applied and reviewed a promotion-ready challenger, advance the scope's durable champion pointer. Requires the exact evaluated fingerprint and an applied commit/config reference. Future experiments for the scope must start from this champion.",
+      "After the owning config repo has applied a reviewed winner, advance the scope's durable champion pointer using the exact evaluated fingerprint.",
     inputShape: experimentPromoteInputShape,
     handler: async (rawInput) => {
       try {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -148,9 +148,9 @@ const awaitInputSchema = z.object(awaitInputShape);
 
 export const rateInputShape = {
   task_id: z.string().min(1),
-  rating: ratingSchema.describe("`pass` / `partial` / `redo` / `wrong`."),
+  rating: ratingSchema.describe("Review verdict."),
   rating_reason: z.string().min(1),
-  verification_outcome: verificationOutcomeSchema,
+  verification_outcome: verificationOutcomeSchema.describe("Post-review disposition."),
   retries_count: z.number().int().nonnegative().optional(),
   reviewer_role: z.enum(["independent", "self"]).optional()
     .describe("Authenticated reviewer attestation. Same-task owners cannot claim independent."),
@@ -168,7 +168,7 @@ const rateInputSchema = z.object(rateInputShape);
 export const listInputShape = {
   limit: z.number().int().min(1).max(500).optional(),
   since_ts: z.string().min(1).optional(),
-  outcome: z.enum(["completed", "failed", "running", "any"]).optional(),
+  outcome: z.enum(["completed", "failed", "running", "any"]).optional().describe("Status filter."),
   alias: aliasSchema.optional(),
 };
 const listInputSchema = z.object(listInputShape);
@@ -353,7 +353,7 @@ export function buildTools(deps: ToolDeps): {
     name: "hugin_submit",
     title: "Submit a delegation task to Hugin",
     description:
-      "Persist one bounded task in Hugin's durable lifecycle and execute it as one M5 `/delegate` leaf. M5 chooses the model and owns capability evidence; Hugin owns lifecycle and delivery. Returns the task_id and idempotency_key — reuse that key only to retry the same logical request. For judgment-flavored task_type values (classify, qa-factual, triage, memory-decision, claim-verify) submitted with the default `l1_review` acceptance and a prompt with no rubric, the response carries a non-blocking `warnings` array — the task still runs, but attach a mechanical `acceptance.verifier` or add a rubric/grading-criteria section to the prompt for stronger capability evidence.",
+      "Submit one bounded task and get back the durable task_id plus idempotency_key. Reuse that key only to retry the same logical request. For judgment-flavored task_type values (classify, qa-factual, triage, memory-decision, claim-verify) submitted with the default `l1_review` acceptance and a prompt with no rubric, the response carries a non-blocking `warnings` array — the task still runs, but attach a mechanical `acceptance.verifier` or add a rubric/grading-criteria section to the prompt for stronger capability evidence.",
     inputShape: activeSubmitInputShape,
     handler: async (rawInput) => {
       let idempotencyKey: string | undefined;
@@ -396,7 +396,7 @@ export function buildTools(deps: ToolDeps): {
     name: "hugin_await",
     title: "Read the current state of a delegated task",
     description:
-      "Idempotent read of a task's status: `running` / `completed` / `failed`. Returns immediately. While `running`, the response also carries lease info and an `orphan_suspected` flag (true once the lease has expired without completion). Use `verbosity: summary` to avoid inlining full terminal provenance; the summary includes a namespace/key ref to it. Safe to poll.",
+      "Idempotent read of the broker's current task state. Returns immediately. While the task is still active, the response also carries lease info and an `orphan_suspected` flag (true once the lease has expired without completion). Use `verbosity: summary` to avoid inlining full terminal provenance; the summary includes a namespace/key ref to it. Safe to poll.",
     inputShape: awaitInputShape,
     handler: async (rawInput) => {
       try {

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -391,7 +391,7 @@ export function buildTools(deps: ToolDeps): {
     name: "hugin_await",
     title: "Read the current state of a delegated task",
     description:
-      "Idempotent read of current task state. Returns immediately and is safe to poll. While active, includes lease info and `orphan_suspected` (true once the lease has expired without completion). Use `verbosity: summary` for a compact result with refs to the full terminal record.",
+      "Idempotent read of current task state: `running` / `completed` / `failed`. Returns immediately and is safe to poll. While active, includes lease info and `orphan_suspected` (true once the lease has expired without completion). Use `verbosity: summary` for a compact result with refs to the full terminal record.",
     inputShape: awaitInputShape,
     handler: async (rawInput) => {
       try {

--- a/tests/mcp/tools.test.ts
+++ b/tests/mcp/tools.test.ts
@@ -1,22 +1,51 @@
 import { describe, expect, it, vi } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   ALIAS_MAP_VERSION,
   ENVELOPE_VERSION,
   buildTools,
-  type HuginTool,
 } from "../../src/mcp/tools.js";
 import {
   BrokerHttpError,
   BrokerNetworkError,
   type BrokerClient,
 } from "../../src/mcp/broker-client.js";
+import {
+  createHuginMcpServer,
+  discoverBrokerContract,
+} from "../../src/mcp/server-factory.js";
 import { HUGIN_MCP_SERVER_INSTRUCTIONS } from "../../src/mcp/server-instructions.js";
 import { makeExperimentInput, makeObservation } from "../fixtures/learning.js";
 
+const ISSUE_318_WIRE_MODELS_RESPONSE = {
+  alias_map_version: ALIAS_MAP_VERSION,
+  effective_at: "2026-07-28T00:00:00.000Z",
+  aliases: [{
+    alias: "m5",
+    runtime_row_id: "homeserver-m5",
+  }],
+  runtime_rows: [{
+    id: "homeserver-m5",
+    runtime: "homeserver",
+    provider: "m5",
+    egress: "loopback-only",
+    family: "one-shot",
+    auto_eligible: false,
+    zdr_required: true,
+  }],
+  policy_version: "zdr-v1+rlv-v1",
+} as const;
+// Reproducible discovery gate:
+// `byteLength(client.getInstructions()) + byteLength(JSON.stringify(await client.listTools()))`
+// measured through the production `discoverBrokerContract()` + `createHuginMcpServer()` path.
+// Parent `20f2cef` measured 30_361 bytes. This source tree measures 28_596 bytes,
+// so the ratchet allows only a 96-byte slack to 28_692 bytes.
 const ISSUE_318_PARENT_DISCOVERY_BYTES = 30_361;
+const ISSUE_318_CURRENT_DISCOVERY_BYTES = 28_596;
+const ISSUE_318_DISCOVERY_SLACK_BYTES = 96;
+const ISSUE_318_DISCOVERY_CEILING_BYTES =
+  ISSUE_318_CURRENT_DISCOVERY_BYTES + ISSUE_318_DISCOVERY_SLACK_BYTES;
 const M5_BOUNDARY_PHRASE =
   "M5 owns model/capability evidence; Hugin owns durable task, delivery, and review state.";
 const M5_BOUNDED_LEAF_PHRASE =
@@ -48,41 +77,23 @@ async function connectWireClient(
   overrides: Partial<BrokerClient> = {},
 ): Promise<{
   client: Client;
+  models: ReturnType<typeof vi.fn>;
   close: () => Promise<void>;
 }> {
-  const tools = buildTools({
-    broker: fakeBroker(overrides),
+  const models = "models" in overrides && overrides.models
+    ? overrides.models as ReturnType<typeof vi.fn>
+    : vi.fn(async () => ISSUE_318_WIRE_MODELS_RESPONSE);
+  const broker = fakeBroker({
+    models,
+    ...overrides,
+  });
+  const brokerContract = await discoverBrokerContract(broker);
+  const server = createHuginMcpServer({
+    broker,
     sessionId: "sess",
     submitter: "claude-code",
+    brokerContract,
   });
-  const server = new McpServer(
-    { name: "hugin-mcp", version: "0.1.0" },
-    { instructions: HUGIN_MCP_SERVER_INSTRUCTIONS },
-  );
-  const allTools: HuginTool<Record<string, unknown>>[] = [
-    tools.submit as HuginTool<Record<string, unknown>>,
-    tools.await_ as HuginTool<Record<string, unknown>>,
-    tools.rate as HuginTool<Record<string, unknown>>,
-    tools.list as HuginTool<Record<string, unknown>>,
-    tools.models as HuginTool<Record<string, unknown>>,
-    tools.friction as HuginTool<Record<string, unknown>>,
-    tools.experimentCreate as HuginTool<Record<string, unknown>>,
-    tools.experimentObserve as HuginTool<Record<string, unknown>>,
-    tools.experimentRate as HuginTool<Record<string, unknown>>,
-    tools.experimentStatus as HuginTool<Record<string, unknown>>,
-    tools.experimentPromote as HuginTool<Record<string, unknown>>,
-  ];
-  for (const tool of allTools) {
-    server.registerTool(
-      tool.name,
-      {
-        title: tool.title,
-        description: tool.description,
-        inputSchema: tool.inputShape,
-      },
-      async (input: Record<string, unknown>) => tool.handler(input),
-    );
-  }
 
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   const client = new Client({ name: "wire-test", version: "0.0.0" });
@@ -90,6 +101,7 @@ async function connectWireClient(
 
   return {
     client,
+    models,
     close: async () => {
       await client.close();
     },
@@ -159,11 +171,20 @@ describe("hugin-mcp discovery wire surface", () => {
         findToolDefinition(discovery.listToolsResult, "hugin_list"),
         ["inputSchema"],
       );
+      const createSchema = schemaPath(
+        findToolDefinition(discovery.listToolsResult, "hugin_experiment_create"),
+        ["inputSchema"],
+      );
       const observeSchema = schemaPath(
         findToolDefinition(discovery.listToolsResult, "hugin_experiment_observe"),
         ["inputSchema"],
       );
+      const experimentRateSchema = schemaPath(
+        findToolDefinition(discovery.listToolsResult, "hugin_experiment_rate"),
+        ["inputSchema"],
+      );
 
+      expect(harness.models).toHaveBeenCalledTimes(1);
       expect(discovery.instructions).toBe(HUGIN_MCP_SERVER_INSTRUCTIONS);
       expect(schemaPath(submitSchema, ["properties", "task_type", "enum"])).toEqual([
         "draft",
@@ -221,28 +242,97 @@ describe("hugin-mcp discovery wire surface", () => {
         "running",
         "any",
       ]);
+      expect(schemaPath(createSchema, ["properties", "change_axis", "enum"])).toEqual([
+        "logging",
+        "test-harness",
+        "agent-prompt",
+        "agent-harness",
+        "model",
+        "model-config",
+        "routing",
+      ]);
+      expect(schemaPath(createSchema, ["properties", "gates", "properties", "primaryMetric", "enum"])).toEqual([
+        "quality-rate",
+        "useful-rate",
+        "rescue-rate",
+        "latency-ms",
+        "cost-usd",
+        "human-review-seconds",
+        "edit-start-ms",
+        "observability-coverage",
+        "verifier-score",
+      ]);
+      expect(schemaPath(createSchema, ["properties", "champion", "properties", "model", "properties", "config", "properties", "reasoning", "enum"])).toEqual([
+        "off",
+        "low",
+        "medium",
+        "high",
+      ]);
+      expect(schemaPath(observeSchema, ["properties", "arm", "enum"])).toEqual([
+        "champion",
+        "challenger",
+      ]);
+      expect(schemaPath(observeSchema, ["properties", "quality_outcome", "enum"])).toEqual([
+        "pass",
+        "fail",
+        "unverified",
+        "infra-error",
+      ]);
+      expect(schemaPath(observeSchema, ["properties", "product_outcome", "enum"])).toEqual([
+        "accepted-unchanged",
+        "minor-edit",
+        "major-rewrite",
+        "discarded",
+        "unrated",
+      ]);
+      expect(schemaPath(observeSchema, ["properties", "verifier", "properties", "kind", "enum"])).toEqual([
+        "mechanical",
+        "human",
+        "judge",
+        "none",
+      ]);
       expect(schemaPath(observeSchema, ["properties", "agent_checks", "properties", "state", "enum"])).toEqual([
         "none",
         "attempted",
         "unobservable",
         "partial",
       ]);
+      expect(schemaPath(observeSchema, ["properties", "agent_checks", "properties", "attempts", "items", "properties", "kind", "enum"])).toEqual([
+        "typescript",
+        "test",
+        "lint",
+        "build",
+        "validation",
+      ]);
+      expect(schemaPath(observeSchema, ["properties", "agent_checks", "properties", "attempts", "items", "properties", "status", "enum"])).toEqual([
+        "passed",
+        "failed",
+        "execution-error",
+      ]);
+      expect(schemaPath(experimentRateSchema, ["properties", "product_outcome", "enum"])).toEqual([
+        "accepted-unchanged",
+        "minor-edit",
+        "major-rewrite",
+        "discarded",
+      ]);
     } finally {
       await harness.close();
     }
   });
 
-  it("keeps the combined discovery payload below the issue-318 parent baseline", async () => {
+  it("records the current discovery payload and ratchets it below the parent with small slack", async () => {
     const harness = await connectWireClient();
     try {
       const discovery = await readWireDiscovery(harness.client);
+      expect(discovery.combinedBytes).toBe(ISSUE_318_CURRENT_DISCOVERY_BYTES);
       expect(discovery.combinedBytes).toBeLessThan(ISSUE_318_PARENT_DISCOVERY_BYTES);
+      expect(discovery.combinedBytes).toBeLessThanOrEqual(ISSUE_318_DISCOVERY_CEILING_BYTES);
     } finally {
       await harness.close();
     }
   });
 
-  it("preserves the M5/Hugin boundary exactly once and keeps await statuses discoverable", async () => {
+  it("preserves the M5/Hugin boundary exactly once and keeps await polling semantics discoverable", async () => {
     const harness = await connectWireClient();
     try {
       const discovery = await readWireDiscovery(harness.client);
@@ -260,15 +350,20 @@ describe("hugin-mcp discovery wire surface", () => {
       expect(countOccurrences(discovery.instructions, M5_BOUNDARY_PHRASE)).toBe(1);
       expect(toolDescriptions.filter((description) => description.includes(M5_BOUNDED_LEAF_PHRASE))).toEqual([]);
       expect(toolDescriptions.filter((description) => description.includes(M5_BOUNDARY_PHRASE))).toEqual([]);
-      expect(awaitDescription).toContain("`running`");
-      expect(awaitDescription).toContain("`completed`");
-      expect(awaitDescription).toContain("`failed`");
+      expect(awaitDescription).toContain("Returns immediately");
+      expect(awaitDescription).toContain("safe to poll");
+      expect(awaitDescription).toContain("`orphan_suspected`");
+      expect(awaitDescription).toContain("once the lease has expired without completion");
     } finally {
       await harness.close();
     }
   });
 
   it("supports a naive schema-only caller submit and await sequence", async () => {
+    const models = vi.fn(async () => ({
+      ...ISSUE_318_WIRE_MODELS_RESPONSE,
+      alias_map_version: 7,
+    }));
     const submit = vi.fn(async () => ({ task_id: "t-wire", state: "pending" }));
     const await_ = vi.fn(async () => ({
       status: "completed",
@@ -278,7 +373,7 @@ describe("hugin-mcp discovery wire surface", () => {
         bodyText: "done",
       },
     }));
-    const harness = await connectWireClient({ submit, await_ });
+    const harness = await connectWireClient({ models, submit, await_ });
     try {
       const discovery = await readWireDiscovery(harness.client);
       const aliasRequested = schemaPath(
@@ -298,6 +393,10 @@ describe("hugin-mcp discovery wire surface", () => {
       expect(submitPayload).toMatchObject({
         task_id: "t-wire",
       });
+      expect(submit).toHaveBeenCalledWith(expect.objectContaining({
+        alias_map_version: 7,
+        alias_requested: "m5",
+      }));
 
       const awaitResult = await harness.client.callTool({
         name: "hugin_await",

--- a/tests/mcp/tools.test.ts
+++ b/tests/mcp/tools.test.ts
@@ -39,10 +39,11 @@ const ISSUE_318_WIRE_MODELS_RESPONSE = {
 // Reproducible discovery gate:
 // `byteLength(client.getInstructions()) + byteLength(JSON.stringify(await client.listTools()))`
 // measured through the production `discoverBrokerContract()` + `createHuginMcpServer()` path.
-// Parent `20f2cef` measured 30_361 bytes. This source tree measures 28_596 bytes,
-// so the ratchet allows only a 96-byte slack to 28_692 bytes.
+// Parent `20f2cef` measured 30_361 bytes through its equivalent inline server construction.
+// This source tree measures 28_632 bytes,
+// so the ratchet allows only a 96-byte slack to 28_728 bytes.
 const ISSUE_318_PARENT_DISCOVERY_BYTES = 30_361;
-const ISSUE_318_CURRENT_DISCOVERY_BYTES = 28_596;
+const ISSUE_318_CURRENT_DISCOVERY_BYTES = 28_632;
 const ISSUE_318_DISCOVERY_SLACK_BYTES = 96;
 const ISSUE_318_DISCOVERY_CEILING_BYTES =
   ISSUE_318_CURRENT_DISCOVERY_BYTES + ISSUE_318_DISCOVERY_SLACK_BYTES;
@@ -352,6 +353,7 @@ describe("hugin-mcp discovery wire surface", () => {
       expect(toolDescriptions.filter((description) => description.includes(M5_BOUNDARY_PHRASE))).toEqual([]);
       expect(awaitDescription).toContain("Returns immediately");
       expect(awaitDescription).toContain("safe to poll");
+      expect(awaitDescription).toContain("`running` / `completed` / `failed`");
       expect(awaitDescription).toContain("`orphan_suspected`");
       expect(awaitDescription).toContain("once the lease has expired without completion");
     } finally {

--- a/tests/mcp/tools.test.ts
+++ b/tests/mcp/tools.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
+import { normalizeObjectSchema } from "@modelcontextprotocol/sdk/server/zod-compat.js";
+import { toJsonSchemaCompat } from "@modelcontextprotocol/sdk/server/zod-json-schema-compat.js";
 import {
   ALIAS_MAP_VERSION,
   ENVELOPE_VERSION,
@@ -9,6 +11,10 @@ import {
   BrokerNetworkError,
   type BrokerClient,
 } from "../../src/mcp/broker-client.js";
+import {
+  HUGIN_MCP_SERVER_INSTRUCTIONS,
+  HUGIN_MCP_SHARED_PREAMBLE,
+} from "../../src/mcp/server-instructions.js";
 import { makeExperimentInput, makeObservation } from "../fixtures/learning.js";
 
 function fakeBroker(overrides: Partial<BrokerClient> = {}): BrokerClient {
@@ -32,6 +38,188 @@ function fakeBroker(overrides: Partial<BrokerClient> = {}): BrokerClient {
 function parseResult(result: { content: { text: string }[]; isError?: boolean }): unknown {
   return JSON.parse(result.content[0]!.text);
 }
+
+function schemaForInputShape(inputShape: Record<string, unknown>): Record<string, unknown> {
+  const schema = normalizeObjectSchema(inputShape);
+  if (!schema) throw new Error("expected an object schema");
+  return toJsonSchemaCompat(schema, {
+    strictUnions: true,
+    pipeStrategy: "input",
+  }) as Record<string, unknown>;
+}
+
+function schemaPath(
+  value: unknown,
+  path: ReadonlyArray<string | number>,
+): unknown {
+  return path.reduce<unknown>((current, segment) => {
+    if (current === null || current === undefined) return undefined;
+    if (typeof segment === "number") {
+      return Array.isArray(current) ? current[segment] : undefined;
+    }
+    return typeof current === "object" ? (current as Record<string, unknown>)[segment] : undefined;
+  }, value);
+}
+
+describe("buildTools — MCP schema visibility", () => {
+  const tools = buildTools({
+    broker: fakeBroker(),
+    sessionId: "sess",
+    submitter: "claude-code",
+  });
+
+  it("surfaces closed submit/rate/list vocabularies in the discovery schema", () => {
+    const submitSchema = schemaForInputShape(tools.submit.inputShape);
+    const rateSchema = schemaForInputShape(tools.rate.inputShape);
+    const listSchema = schemaForInputShape(tools.list.inputShape);
+
+    expect(schemaPath(submitSchema, ["properties", "task_type", "enum"])).toEqual([
+      "draft",
+      "code-implement",
+      "code-edit",
+      "code-review",
+      "unit-test-gen",
+      "summarize",
+      "extract",
+      "classify",
+      "data-transform",
+      "regex",
+      "sql",
+      "reason-math",
+      "reason-hard",
+      "rewrite",
+      "translate",
+      "plan-decompose",
+      "qa-factual",
+      "triage",
+      "memory-decision",
+      "research-plan",
+      "source-distill",
+      "claim-verify",
+      "gap-check",
+      "synthesis",
+      "conversation",
+      "other",
+    ]);
+    expect(schemaPath(submitSchema, ["properties", "alias_requested", "enum"])).toEqual(["m5"]);
+    expect(schemaPath(submitSchema, ["properties", "acceptance", "oneOf", 0, "properties", "mode", "const"])).toBe("l1_review");
+    expect(schemaPath(submitSchema, ["properties", "acceptance", "oneOf", 1, "properties", "mode", "const"])).toBe("verifier");
+
+    expect(schemaPath(rateSchema, ["properties", "rating", "enum"])).toEqual([
+      "pass",
+      "partial",
+      "redo",
+      "wrong",
+    ]);
+    expect(schemaPath(rateSchema, ["properties", "verification_outcome", "enum"])).toEqual([
+      "accepted_unchanged",
+      "minor_edit",
+      "major_rewrite",
+      "discarded",
+      "escalated_to_claude",
+    ]);
+    expect(schemaPath(rateSchema, ["properties", "reviewer_role", "enum"])).toEqual([
+      "independent",
+      "self",
+    ]);
+
+    expect(schemaPath(listSchema, ["properties", "outcome", "enum"])).toEqual([
+      "completed",
+      "failed",
+      "running",
+      "any",
+    ]);
+  });
+
+  it("surfaces experiment vocabularies in the discovery schema", () => {
+    const createSchema = schemaForInputShape(tools.experimentCreate.inputShape);
+    const observeSchema = schemaForInputShape(tools.experimentObserve.inputShape);
+    const rateSchema = schemaForInputShape(tools.experimentRate.inputShape);
+
+    expect(schemaPath(createSchema, ["properties", "change_axis", "enum"])).toEqual([
+      "logging",
+      "test-harness",
+      "agent-prompt",
+      "agent-harness",
+      "model",
+      "model-config",
+      "routing",
+    ]);
+    expect(schemaPath(createSchema, ["properties", "gates", "properties", "primaryMetric", "enum"])).toEqual([
+      "quality-rate",
+      "useful-rate",
+      "rescue-rate",
+      "latency-ms",
+      "cost-usd",
+      "human-review-seconds",
+      "edit-start-ms",
+      "observability-coverage",
+      "verifier-score",
+    ]);
+    expect(schemaPath(createSchema, ["properties", "champion", "properties", "model", "properties", "config", "properties", "reasoning", "enum"])).toEqual([
+      "off",
+      "low",
+      "medium",
+      "high",
+    ]);
+
+    expect(schemaPath(observeSchema, ["properties", "arm", "enum"])).toEqual([
+      "champion",
+      "challenger",
+    ]);
+    expect(schemaPath(observeSchema, ["properties", "quality_outcome", "enum"])).toEqual([
+      "pass",
+      "fail",
+      "unverified",
+      "infra-error",
+    ]);
+    expect(schemaPath(observeSchema, ["properties", "product_outcome", "enum"])).toEqual([
+      "accepted-unchanged",
+      "minor-edit",
+      "major-rewrite",
+      "discarded",
+      "unrated",
+    ]);
+    expect(schemaPath(observeSchema, ["properties", "verifier", "properties", "kind", "enum"])).toEqual([
+      "mechanical",
+      "human",
+      "judge",
+      "none",
+    ]);
+    expect(schemaPath(observeSchema, ["properties", "agent_checks", "properties", "state", "enum"])).toEqual([
+      "none",
+      "attempted",
+      "unobservable",
+      "partial",
+    ]);
+    expect(schemaPath(observeSchema, ["properties", "agent_checks", "properties", "attempts", "items", "properties", "kind", "enum"])).toEqual([
+      "typescript",
+      "test",
+      "lint",
+      "build",
+      "validation",
+    ]);
+    expect(schemaPath(observeSchema, ["properties", "agent_checks", "properties", "attempts", "items", "properties", "status", "enum"])).toEqual([
+      "passed",
+      "failed",
+      "execution-error",
+    ]);
+
+    expect(schemaPath(rateSchema, ["properties", "product_outcome", "enum"])).toEqual([
+      "accepted-unchanged",
+      "minor-edit",
+      "major-rewrite",
+      "discarded",
+    ]);
+  });
+
+  it("moves the shared Hugin preamble to server instructions without duplicating it per tool", () => {
+    expect(HUGIN_MCP_SERVER_INSTRUCTIONS).toContain(HUGIN_MCP_SHARED_PREAMBLE);
+    for (const tool of Object.values(tools)) {
+      expect(tool.description).not.toContain(HUGIN_MCP_SHARED_PREAMBLE);
+    }
+  });
+});
 
 describe("buildTools — hugin_submit", () => {
   it.each(["draft", "conversation"] as const)(

--- a/tests/mcp/tools.test.ts
+++ b/tests/mcp/tools.test.ts
@@ -1,21 +1,26 @@
 import { describe, expect, it, vi } from "vitest";
-import { normalizeObjectSchema } from "@modelcontextprotocol/sdk/server/zod-compat.js";
-import { toJsonSchemaCompat } from "@modelcontextprotocol/sdk/server/zod-json-schema-compat.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   ALIAS_MAP_VERSION,
   ENVELOPE_VERSION,
   buildTools,
+  type HuginTool,
 } from "../../src/mcp/tools.js";
 import {
   BrokerHttpError,
   BrokerNetworkError,
   type BrokerClient,
 } from "../../src/mcp/broker-client.js";
-import {
-  HUGIN_MCP_SERVER_INSTRUCTIONS,
-  HUGIN_MCP_SHARED_PREAMBLE,
-} from "../../src/mcp/server-instructions.js";
+import { HUGIN_MCP_SERVER_INSTRUCTIONS } from "../../src/mcp/server-instructions.js";
 import { makeExperimentInput, makeObservation } from "../fixtures/learning.js";
+
+const ISSUE_318_PARENT_DISCOVERY_BYTES = 30_361;
+const M5_BOUNDARY_PHRASE =
+  "M5 owns model/capability evidence; Hugin owns durable task, delivery, and review state.";
+const M5_BOUNDED_LEAF_PHRASE =
+  "Each `hugin_submit` is one bounded M5 `/delegate` leaf.";
 
 function fakeBroker(overrides: Partial<BrokerClient> = {}): BrokerClient {
   const noop = vi.fn(async () => ({}));
@@ -39,13 +44,76 @@ function parseResult(result: { content: { text: string }[]; isError?: boolean })
   return JSON.parse(result.content[0]!.text);
 }
 
-function schemaForInputShape(inputShape: Record<string, unknown>): Record<string, unknown> {
-  const schema = normalizeObjectSchema(inputShape);
-  if (!schema) throw new Error("expected an object schema");
-  return toJsonSchemaCompat(schema, {
-    strictUnions: true,
-    pipeStrategy: "input",
-  }) as Record<string, unknown>;
+async function connectWireClient(
+  overrides: Partial<BrokerClient> = {},
+): Promise<{
+  client: Client;
+  close: () => Promise<void>;
+}> {
+  const tools = buildTools({
+    broker: fakeBroker(overrides),
+    sessionId: "sess",
+    submitter: "claude-code",
+  });
+  const server = new McpServer(
+    { name: "hugin-mcp", version: "0.1.0" },
+    { instructions: HUGIN_MCP_SERVER_INSTRUCTIONS },
+  );
+  const allTools: HuginTool<Record<string, unknown>>[] = [
+    tools.submit as HuginTool<Record<string, unknown>>,
+    tools.await_ as HuginTool<Record<string, unknown>>,
+    tools.rate as HuginTool<Record<string, unknown>>,
+    tools.list as HuginTool<Record<string, unknown>>,
+    tools.models as HuginTool<Record<string, unknown>>,
+    tools.friction as HuginTool<Record<string, unknown>>,
+    tools.experimentCreate as HuginTool<Record<string, unknown>>,
+    tools.experimentObserve as HuginTool<Record<string, unknown>>,
+    tools.experimentRate as HuginTool<Record<string, unknown>>,
+    tools.experimentStatus as HuginTool<Record<string, unknown>>,
+    tools.experimentPromote as HuginTool<Record<string, unknown>>,
+  ];
+  for (const tool of allTools) {
+    server.registerTool(
+      tool.name,
+      {
+        title: tool.title,
+        description: tool.description,
+        inputSchema: tool.inputShape,
+      },
+      async (input: Record<string, unknown>) => tool.handler(input),
+    );
+  }
+
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "wire-test", version: "0.0.0" });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+  return {
+    client,
+    close: async () => {
+      await client.close();
+    },
+  };
+}
+
+async function readWireDiscovery(client: Client): Promise<{
+  instructions: string;
+  listToolsResult: Awaited<ReturnType<Client["listTools"]>>;
+  instructionsBytes: number;
+  listResultBytes: number;
+  combinedBytes: number;
+}> {
+  const listToolsResult = await client.listTools();
+  const instructions = client.getInstructions() ?? "";
+  const instructionsBytes = Buffer.byteLength(instructions, "utf8");
+  const listResultBytes = Buffer.byteLength(JSON.stringify(listToolsResult), "utf8");
+  return {
+    instructions,
+    listToolsResult,
+    instructionsBytes,
+    listResultBytes,
+    combinedBytes: instructionsBytes + listResultBytes,
+  };
 }
 
 function schemaPath(
@@ -61,162 +129,196 @@ function schemaPath(
   }, value);
 }
 
-describe("buildTools — MCP schema visibility", () => {
-  const tools = buildTools({
-    broker: fakeBroker(),
-    sessionId: "sess",
-    submitter: "claude-code",
+function findToolDefinition(
+  listToolsResult: Awaited<ReturnType<Client["listTools"]>>,
+  name: string,
+): Record<string, unknown> {
+  const tool = listToolsResult.tools.find((candidate) => candidate.name === name);
+  if (!tool) throw new Error(`missing tool ${name}`);
+  return tool as Record<string, unknown>;
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+describe("hugin-mcp discovery wire surface", () => {
+  it("emits InitializeResult.instructions and closed vocabularies through the real MCP client", async () => {
+    const harness = await connectWireClient();
+    try {
+      const discovery = await readWireDiscovery(harness.client);
+      const submitSchema = schemaPath(
+        findToolDefinition(discovery.listToolsResult, "hugin_submit"),
+        ["inputSchema"],
+      );
+      const rateSchema = schemaPath(
+        findToolDefinition(discovery.listToolsResult, "hugin_rate"),
+        ["inputSchema"],
+      );
+      const listSchema = schemaPath(
+        findToolDefinition(discovery.listToolsResult, "hugin_list"),
+        ["inputSchema"],
+      );
+      const observeSchema = schemaPath(
+        findToolDefinition(discovery.listToolsResult, "hugin_experiment_observe"),
+        ["inputSchema"],
+      );
+
+      expect(discovery.instructions).toBe(HUGIN_MCP_SERVER_INSTRUCTIONS);
+      expect(schemaPath(submitSchema, ["properties", "task_type", "enum"])).toEqual([
+        "draft",
+        "code-implement",
+        "code-edit",
+        "code-review",
+        "unit-test-gen",
+        "summarize",
+        "extract",
+        "classify",
+        "data-transform",
+        "regex",
+        "sql",
+        "reason-math",
+        "reason-hard",
+        "rewrite",
+        "translate",
+        "plan-decompose",
+        "qa-factual",
+        "triage",
+        "memory-decision",
+        "research-plan",
+        "source-distill",
+        "claim-verify",
+        "gap-check",
+        "synthesis",
+        "conversation",
+        "other",
+      ]);
+      expect(schemaPath(submitSchema, ["properties", "alias_requested", "enum"])).toEqual(["m5"]);
+      expect(schemaPath(submitSchema, ["properties", "acceptance", "oneOf", 0, "properties", "mode", "const"])).toBe("l1_review");
+      expect(schemaPath(submitSchema, ["properties", "acceptance", "oneOf", 1, "properties", "mode", "const"])).toBe("verifier");
+
+      expect(schemaPath(rateSchema, ["properties", "rating", "enum"])).toEqual([
+        "pass",
+        "partial",
+        "redo",
+        "wrong",
+      ]);
+      expect(schemaPath(rateSchema, ["properties", "verification_outcome", "enum"])).toEqual([
+        "accepted_unchanged",
+        "minor_edit",
+        "major_rewrite",
+        "discarded",
+        "escalated_to_claude",
+      ]);
+      expect(schemaPath(rateSchema, ["properties", "reviewer_role", "enum"])).toEqual([
+        "independent",
+        "self",
+      ]);
+
+      expect(schemaPath(listSchema, ["properties", "outcome", "enum"])).toEqual([
+        "completed",
+        "failed",
+        "running",
+        "any",
+      ]);
+      expect(schemaPath(observeSchema, ["properties", "agent_checks", "properties", "state", "enum"])).toEqual([
+        "none",
+        "attempted",
+        "unobservable",
+        "partial",
+      ]);
+    } finally {
+      await harness.close();
+    }
   });
 
-  it("surfaces closed submit/rate/list vocabularies in the discovery schema", () => {
-    const submitSchema = schemaForInputShape(tools.submit.inputShape);
-    const rateSchema = schemaForInputShape(tools.rate.inputShape);
-    const listSchema = schemaForInputShape(tools.list.inputShape);
-
-    expect(schemaPath(submitSchema, ["properties", "task_type", "enum"])).toEqual([
-      "draft",
-      "code-implement",
-      "code-edit",
-      "code-review",
-      "unit-test-gen",
-      "summarize",
-      "extract",
-      "classify",
-      "data-transform",
-      "regex",
-      "sql",
-      "reason-math",
-      "reason-hard",
-      "rewrite",
-      "translate",
-      "plan-decompose",
-      "qa-factual",
-      "triage",
-      "memory-decision",
-      "research-plan",
-      "source-distill",
-      "claim-verify",
-      "gap-check",
-      "synthesis",
-      "conversation",
-      "other",
-    ]);
-    expect(schemaPath(submitSchema, ["properties", "alias_requested", "enum"])).toEqual(["m5"]);
-    expect(schemaPath(submitSchema, ["properties", "acceptance", "oneOf", 0, "properties", "mode", "const"])).toBe("l1_review");
-    expect(schemaPath(submitSchema, ["properties", "acceptance", "oneOf", 1, "properties", "mode", "const"])).toBe("verifier");
-
-    expect(schemaPath(rateSchema, ["properties", "rating", "enum"])).toEqual([
-      "pass",
-      "partial",
-      "redo",
-      "wrong",
-    ]);
-    expect(schemaPath(rateSchema, ["properties", "verification_outcome", "enum"])).toEqual([
-      "accepted_unchanged",
-      "minor_edit",
-      "major_rewrite",
-      "discarded",
-      "escalated_to_claude",
-    ]);
-    expect(schemaPath(rateSchema, ["properties", "reviewer_role", "enum"])).toEqual([
-      "independent",
-      "self",
-    ]);
-
-    expect(schemaPath(listSchema, ["properties", "outcome", "enum"])).toEqual([
-      "completed",
-      "failed",
-      "running",
-      "any",
-    ]);
+  it("keeps the combined discovery payload below the issue-318 parent baseline", async () => {
+    const harness = await connectWireClient();
+    try {
+      const discovery = await readWireDiscovery(harness.client);
+      expect(discovery.combinedBytes).toBeLessThan(ISSUE_318_PARENT_DISCOVERY_BYTES);
+    } finally {
+      await harness.close();
+    }
   });
 
-  it("surfaces experiment vocabularies in the discovery schema", () => {
-    const createSchema = schemaForInputShape(tools.experimentCreate.inputShape);
-    const observeSchema = schemaForInputShape(tools.experimentObserve.inputShape);
-    const rateSchema = schemaForInputShape(tools.experimentRate.inputShape);
+  it("preserves the M5/Hugin boundary exactly once and keeps await statuses discoverable", async () => {
+    const harness = await connectWireClient();
+    try {
+      const discovery = await readWireDiscovery(harness.client);
+      const awaitDescription = findToolDefinition(
+        discovery.listToolsResult,
+        "hugin_await",
+      ).description;
+      const toolDescriptions = discovery.listToolsResult.tools
+        .map((tool) => tool.description)
+        .filter((description): description is string => typeof description === "string");
 
-    expect(schemaPath(createSchema, ["properties", "change_axis", "enum"])).toEqual([
-      "logging",
-      "test-harness",
-      "agent-prompt",
-      "agent-harness",
-      "model",
-      "model-config",
-      "routing",
-    ]);
-    expect(schemaPath(createSchema, ["properties", "gates", "properties", "primaryMetric", "enum"])).toEqual([
-      "quality-rate",
-      "useful-rate",
-      "rescue-rate",
-      "latency-ms",
-      "cost-usd",
-      "human-review-seconds",
-      "edit-start-ms",
-      "observability-coverage",
-      "verifier-score",
-    ]);
-    expect(schemaPath(createSchema, ["properties", "champion", "properties", "model", "properties", "config", "properties", "reasoning", "enum"])).toEqual([
-      "off",
-      "low",
-      "medium",
-      "high",
-    ]);
-
-    expect(schemaPath(observeSchema, ["properties", "arm", "enum"])).toEqual([
-      "champion",
-      "challenger",
-    ]);
-    expect(schemaPath(observeSchema, ["properties", "quality_outcome", "enum"])).toEqual([
-      "pass",
-      "fail",
-      "unverified",
-      "infra-error",
-    ]);
-    expect(schemaPath(observeSchema, ["properties", "product_outcome", "enum"])).toEqual([
-      "accepted-unchanged",
-      "minor-edit",
-      "major-rewrite",
-      "discarded",
-      "unrated",
-    ]);
-    expect(schemaPath(observeSchema, ["properties", "verifier", "properties", "kind", "enum"])).toEqual([
-      "mechanical",
-      "human",
-      "judge",
-      "none",
-    ]);
-    expect(schemaPath(observeSchema, ["properties", "agent_checks", "properties", "state", "enum"])).toEqual([
-      "none",
-      "attempted",
-      "unobservable",
-      "partial",
-    ]);
-    expect(schemaPath(observeSchema, ["properties", "agent_checks", "properties", "attempts", "items", "properties", "kind", "enum"])).toEqual([
-      "typescript",
-      "test",
-      "lint",
-      "build",
-      "validation",
-    ]);
-    expect(schemaPath(observeSchema, ["properties", "agent_checks", "properties", "attempts", "items", "properties", "status", "enum"])).toEqual([
-      "passed",
-      "failed",
-      "execution-error",
-    ]);
-
-    expect(schemaPath(rateSchema, ["properties", "product_outcome", "enum"])).toEqual([
-      "accepted-unchanged",
-      "minor-edit",
-      "major-rewrite",
-      "discarded",
-    ]);
+      expect(discovery.instructions).toContain(M5_BOUNDED_LEAF_PHRASE);
+      expect(discovery.instructions).toContain(M5_BOUNDARY_PHRASE);
+      expect(countOccurrences(discovery.instructions, M5_BOUNDED_LEAF_PHRASE)).toBe(1);
+      expect(countOccurrences(discovery.instructions, M5_BOUNDARY_PHRASE)).toBe(1);
+      expect(toolDescriptions.filter((description) => description.includes(M5_BOUNDED_LEAF_PHRASE))).toEqual([]);
+      expect(toolDescriptions.filter((description) => description.includes(M5_BOUNDARY_PHRASE))).toEqual([]);
+      expect(awaitDescription).toContain("`running`");
+      expect(awaitDescription).toContain("`completed`");
+      expect(awaitDescription).toContain("`failed`");
+    } finally {
+      await harness.close();
+    }
   });
 
-  it("moves the shared Hugin preamble to server instructions without duplicating it per tool", () => {
-    expect(HUGIN_MCP_SERVER_INSTRUCTIONS).toContain(HUGIN_MCP_SHARED_PREAMBLE);
-    for (const tool of Object.values(tools)) {
-      expect(tool.description).not.toContain(HUGIN_MCP_SHARED_PREAMBLE);
+  it("supports a naive schema-only caller submit and await sequence", async () => {
+    const submit = vi.fn(async () => ({ task_id: "t-wire", state: "pending" }));
+    const await_ = vi.fn(async () => ({
+      status: "completed",
+      result: {
+        outcome: "completed",
+        exitCode: 0,
+        bodyText: "done",
+      },
+    }));
+    const harness = await connectWireClient({ submit, await_ });
+    try {
+      const discovery = await readWireDiscovery(harness.client);
+      const aliasRequested = schemaPath(
+        findToolDefinition(discovery.listToolsResult, "hugin_submit"),
+        ["inputSchema", "properties", "alias_requested", "enum", 0],
+      );
+
+      const submitResult = await harness.client.callTool({
+        name: "hugin_submit",
+        arguments: {
+          task_type: "summarize",
+          prompt: "Summarize this.",
+          alias_requested: aliasRequested,
+        },
+      });
+      const submitPayload = parseResult(submitResult);
+      expect(submitPayload).toMatchObject({
+        task_id: "t-wire",
+      });
+
+      const awaitResult = await harness.client.callTool({
+        name: "hugin_await",
+        arguments: {
+          task_id: "t-wire",
+          verbosity: "summary",
+        },
+      });
+      expect(parseResult(awaitResult)).toEqual({
+        task_id: "t-wire",
+        status: "completed",
+        outcome: "completed",
+        exitCode: 0,
+        bodyText: "done",
+        refs: {
+          status: { namespace: "tasks/t-wire", key: "status" },
+          fullResult: { namespace: "tasks/t-wire", key: "result-structured" },
+        },
+      });
+    } finally {
+      await harness.close();
     }
   });
 });


### PR DESCRIPTION
Closes #318.

## Summary
- move stable ownership guidance into MCP initialization instructions and trim repeated tool prose
- exercise discovery through the production server factory with live Broker alias metadata
- pin closed schema vocabularies, await polling semantics, and a byte-level payload ratchet
- prove a naive schema-only submit/await client remains compatible

## Verification
- full npm test: 163 files passed; 2,561 tests passed, 3 skipped
- focused tests/mcp/tools.test.ts: 34 tests passed
- npm run build: passed
- independent Claude Opus high review: ACCEPT
