### PR TITLE
Add content-blind task lifecycle tracing

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,5 +1,36 @@
 # Hugin — Status
 
+## 2026-08-01 — #340 content-blind tracing propagation (local issue branch)
+
+- Branch `codex/issue-340-content-blind-tracing` in
+  `/private/tmp/hugin-340-content-blind-tracing` adds a manual, optional
+  content-blind tracing layer for Hugin. Broker submit now accepts strict W3C
+  `traceparent`, replaces malformed inbound context, strips/rejects baggage, and
+  persists only a sanitized `### Trace context` section in task documents.
+- The dispatcher now parses persisted trace context at claim time, emits
+  content-blind queue and execution spans, passes execution-child trace context
+  into homeserver gateway calls, and records separate publication and
+  result-recording spans. Export remains disabled by default unless an explicit
+  `HUGIN_TRACE_EXPORT_PATH` is configured.
+- Homeserver gateway requests now propagate only `traceparent`, never baggage.
+  A new producer-owned Heimdall status panel reports authenticated
+  learning-task preflight success/failure using only coarse error classes. The
+  tracing serializer remains deny-by-default and excludes prompt/result text,
+  repository paths, URLs, baggage, tool payloads, exception detail, and other
+  content-bearing fields.
+- Added focused regression coverage for inbound continuation/replacement,
+  async/retry parentage, sampling/export loss, bounded allowlisted envelopes,
+  broker persistence of sanitized trace context, homeserver propagation of the
+  fixed shared join fixture, and the content-blind preflight panel.
+
+**Verification:** focused tracing suites (4 files / 129 tests), `npm run build`,
+full `npm test` (165 files / 2,575 tests, 3 skipped), `bash scripts/deploy-pi.test.sh`,
+`bash -n scripts/deploy-pi.sh scripts/deploy-pi.test.sh`, and `git diff --check`
+all passed on Saturday, August 1, 2026.
+
+**Next:** keep this branch local until independent review lands; no deploy,
+push, PR mutation, or cross-repo change has been performed from this session.
+
 ## 2026-07-28 — #336 W5 roster provenance verification (draft PR #337)
 
 - Branch `codex/issue-336-roster-producer` restores W4 receipt verification

--- a/STATUS.md
+++ b/STATUS.md
@@ -12,21 +12,36 @@
   into homeserver gateway calls, and records separate publication and
   result-recording spans. Export remains disabled by default unless an explicit
   `HUGIN_TRACE_EXPORT_PATH` is configured.
+- Validated native review follow-up now keeps production trace export
+  non-blocking and fail-open with a bounded in-memory queue plus deterministic
+  test-only flush seam, rejects persisted `task_class` / `runtime_lane` values
+  outside explicit closed allowlists, degrades Heimdall authenticated
+  learning-task preflight status to `unknown` once the last observation reaches
+  the fixed 15-minute freshness bound (or when its timestamp is future or
+  malformed), and marks result-recording spans `degraded` with the fixed
+  allowlisted `structured-result-write-failed` class when the terminal status
+  write succeeds but `result-structured` does not.
 - Homeserver gateway requests now propagate only `traceparent`, never baggage.
   A new producer-owned Heimdall status panel reports authenticated
   learning-task preflight success/failure using only coarse error classes. The
   tracing serializer remains deny-by-default and excludes prompt/result text,
   repository paths, URLs, baggage, tool payloads, exception detail, and other
   content-bearing fields.
+- Focused regression coverage now proves that a never-resolving exporter cannot
+  block span completion or grow beyond the bounded queue, hostile persisted
+  trace labels are ignored rather than propagated, preflight freshness
+  boundaries fail closed to `unknown`, and dispatcher-side structured-result
+  trace classification never leaks exception text.
 - Added focused regression coverage for inbound continuation/replacement,
   async/retry parentage, sampling/export loss, bounded allowlisted envelopes,
   broker persistence of sanitized trace context, homeserver propagation of the
   fixed shared join fixture, and the content-blind preflight panel.
 
-**Verification:** focused tracing suites (4 files / 129 tests), `npm run build`,
-full `npm test` (165 files / 2,575 tests, 3 skipped), `bash scripts/deploy-pi.test.sh`,
-`bash -n scripts/deploy-pi.sh scripts/deploy-pi.test.sh`, and `git diff --check`
-all passed on Saturday, August 1, 2026.
+**Verification:** focused tracing/preflight/dispatcher suites (3 files / 82
+tests), `npm run build`, full `npm test` (165 files / 2,578 tests, 3 skipped),
+and `git diff --check` all passed on Saturday, August 1, 2026. Deployment
+script checks were not rerun because this follow-up did not touch deployment
+scripts.
 
 **Next:** keep this branch local until independent review lands; no deploy,
 push, PR mutation, or cross-repo change has been performed from this session.

--- a/src/broker/handlers.ts
+++ b/src/broker/handlers.ts
@@ -55,7 +55,10 @@ import {
 } from "../quality-receipt.js";
 import { structuredTaskResultSchema } from "../task-result-schema.js";
 import { MuninWriteRejectedError } from "../munin-client.js";
-import { createInboundTaskTraceContext } from "../task-tracing.js";
+import {
+  createInboundTaskTraceContext,
+  parseTraceSampleRatePerMille,
+} from "../task-tracing.js";
 
 const brokerFrictionInputSchema = reportFrictionInputSchema.extend({
   event_id: z.string().uuid(),
@@ -248,6 +251,9 @@ export function createSubmitHandler(deps: BrokerHandlerDependencies) {
       taskClass: "delegation",
       runtimeLane: "default",
       retryOrdinal: 0,
+      sampleRatePerMille: parseTraceSampleRatePerMille(
+        process.env.HUGIN_TRACE_SAMPLE_RATE_PER_MILLE,
+      ),
     });
 
     try {

--- a/src/broker/handlers.ts
+++ b/src/broker/handlers.ts
@@ -55,6 +55,7 @@ import {
 } from "../quality-receipt.js";
 import { structuredTaskResultSchema } from "../task-result-schema.js";
 import { MuninWriteRejectedError } from "../munin-client.js";
+import { createInboundTaskTraceContext } from "../task-tracing.js";
 
 const brokerFrictionInputSchema = reportFrictionInputSchema.extend({
   event_id: z.string().uuid(),
@@ -241,9 +242,24 @@ export function createSubmitHandler(deps: BrokerHandlerDependencies) {
       alias_resolved: aliasResolution.alias_resolved,
       policy_version: POLICY_VERSION,
     };
+    const traceContext = createInboundTaskTraceContext({
+      traceparent: req.header("traceparent") ?? undefined,
+      baggage: req.header("baggage") ?? undefined,
+      taskClass: "delegation",
+      runtimeLane: "default",
+      retryOrdinal: 0,
+    });
 
     try {
-      await deps.taskStore.submit({ envelope });
+      await deps.taskStore.submit({
+        envelope,
+        traceContext: {
+          traceparent: traceContext.traceparent,
+          taskClass: traceContext.taskClass,
+          runtimeLane: traceContext.runtimeLane,
+          retryOrdinal: traceContext.retryOrdinal,
+        },
+      });
     } catch (err) {
       if (
         err instanceof MuninWriteRejectedError &&

--- a/src/broker/handlers.ts
+++ b/src/broker/handlers.ts
@@ -42,7 +42,9 @@ import {
   delegationRequestSchema,
   listRequestSchema,
   rateRequestSchema,
+  type AliasResolved,
   type DelegationEnvelope,
+  type DelegationRequest,
 } from "./types.js";
 import type { AwaitLifecycle } from "./await-observation.js";
 import type { AuthenticatedRequest } from "./auth.js";
@@ -58,6 +60,9 @@ import { MuninWriteRejectedError } from "../munin-client.js";
 import {
   createInboundTaskTraceContext,
   parseTraceSampleRatePerMille,
+  type TaskTraceInvalidReason,
+  type TaskTraceRuntimeLane,
+  type TaskTraceIngressCounter,
 } from "../task-tracing.js";
 
 const brokerFrictionInputSchema = reportFrictionInputSchema.extend({
@@ -69,6 +74,7 @@ export interface BrokerHandlerDependencies {
   journal: DelegationJournal;
   idempotency: IdempotencyIndex;
   executorCapabilities: BrokerExecutorCapabilities;
+  traceIngressCounter?: TaskTraceIngressCounter;
   now?: () => Date;
 }
 
@@ -78,6 +84,36 @@ function nowFn(deps: BrokerHandlerDependencies): () => Date {
 
 function scopedIdempotencyKey(principal: string, idempotencyKey: string): string {
   return `${principal}\0${idempotencyKey}`;
+}
+
+function deriveBrokerTraceRuntimeLane(
+  request: Pick<DelegationRequest, "acceptance" | "task_type">,
+  aliasResolved: AliasResolved,
+): TaskTraceRuntimeLane {
+  if (request.task_type === "reason-hard") return "reason-hard";
+  if (request.task_type === "reason-math") return "numeric";
+  if (request.task_type === "code-review" || request.acceptance.mode === "verifier") {
+    return "review";
+  }
+  if (aliasResolved.reasoning_level === "medium" || aliasResolved.reasoning_level === "low") {
+    return "reason-fast";
+  }
+  if (aliasResolved.reasoning_level === "high") {
+    return "reason-hard";
+  }
+  return "default";
+}
+
+function traceContextWarnings(
+  invalidReason: TaskTraceInvalidReason | undefined,
+): string[] {
+  if (invalidReason === "forbidden-baggage") {
+    return ["trace context sanitized: baggage header ignored"];
+  }
+  if (invalidReason === "malformed-traceparent") {
+    return ["trace context replaced: malformed traceparent header"];
+  }
+  return [];
 }
 
 function storedBrokerPrincipal(content: string): string | null {
@@ -208,6 +244,27 @@ export function createSubmitHandler(deps: BrokerHandlerDependencies) {
       return;
     }
 
+    const traceContext = createInboundTaskTraceContext({
+      traceparent: req.header("traceparent") ?? undefined,
+      baggage: req.header("baggage") ?? undefined,
+      taskClass: "delegation",
+      runtimeLane: deriveBrokerTraceRuntimeLane(
+        request,
+        aliasResolution.alias_resolved,
+      ),
+      retryOrdinal: 0,
+      sampleRatePerMille: parseTraceSampleRatePerMille(
+        process.env.HUGIN_TRACE_SAMPLE_RATE_PER_MILLE,
+      ),
+    });
+    if (traceContext.invalidReason) {
+      deps.traceIngressCounter?.noteInvalidReason(traceContext.invalidReason);
+    }
+    const responseWarnings = [
+      ...submitWarnings,
+      ...traceContextWarnings(traceContext.invalidReason),
+    ];
+
     const taskId = generateBrokerTaskId(principal, request.idempotency_key);
     const reservationKey = scopedIdempotencyKey(principal, request.idempotency_key);
     const idemOutcome = deps.idempotency.reserve(reservationKey, request);
@@ -216,7 +273,7 @@ export function createSubmitHandler(deps: BrokerHandlerDependencies) {
         task_id: idemOutcome.task_id,
         received_at: nowFn(deps)().toISOString(),
         reused_idempotency: true,
-        ...(submitWarnings.length > 0 ? { warnings: submitWarnings } : {}),
+        ...(responseWarnings.length > 0 ? { warnings: responseWarnings } : {}),
       });
       return;
     }
@@ -245,17 +302,6 @@ export function createSubmitHandler(deps: BrokerHandlerDependencies) {
       alias_resolved: aliasResolution.alias_resolved,
       policy_version: POLICY_VERSION,
     };
-    const traceContext = createInboundTaskTraceContext({
-      traceparent: req.header("traceparent") ?? undefined,
-      baggage: req.header("baggage") ?? undefined,
-      taskClass: "delegation",
-      runtimeLane: "default",
-      retryOrdinal: 0,
-      sampleRatePerMille: parseTraceSampleRatePerMille(
-        process.env.HUGIN_TRACE_SAMPLE_RATE_PER_MILLE,
-      ),
-    });
-
     try {
       await deps.taskStore.submit({
         envelope,
@@ -315,7 +361,7 @@ export function createSubmitHandler(deps: BrokerHandlerDependencies) {
           task_id: taskId,
           received_at: persistedEnvelope.received_at,
           reused_idempotency: true,
-          ...(submitWarnings.length > 0 ? { warnings: submitWarnings } : {}),
+          ...(responseWarnings.length > 0 ? { warnings: responseWarnings } : {}),
         });
         return;
       }
@@ -333,7 +379,7 @@ export function createSubmitHandler(deps: BrokerHandlerDependencies) {
       task_id: taskId,
       received_at: envelope.received_at,
       reused_idempotency: false,
-      ...(submitWarnings.length > 0 ? { warnings: submitWarnings } : {}),
+      ...(responseWarnings.length > 0 ? { warnings: responseWarnings } : {}),
     });
   };
 }

--- a/src/broker/server.ts
+++ b/src/broker/server.ts
@@ -53,10 +53,21 @@ export function buildBrokerApp(config: BrokerServerConfig): Express {
   app.use(express.json({ limit: "2mb" }));
 
   app.get("/health", (_req, res) => {
+    const traceIngress = config.deps.traceIngressCounter?.snapshot();
     res.json({
       status: "ok",
       service: "hugin-broker",
       principals: Object.keys(config.keys),
+      ...(traceIngress
+        ? {
+            trace_ingress: {
+              invalid_reasons: {
+                forbidden_baggage: traceIngress.invalidReasons.forbiddenBaggage,
+                malformed_traceparent: traceIngress.invalidReasons.malformedTraceparent,
+              },
+            },
+          }
+        : {}),
     });
   });
 

--- a/src/broker/task-store.ts
+++ b/src/broker/task-store.ts
@@ -49,6 +49,10 @@ import {
   type NativeQualityReceipt,
 } from "../quality-receipt.js";
 import { buildBrokerTaskTypeTags } from "./task-type-metadata.js";
+import {
+  buildTaskTraceContextSection,
+  type TaskTraceContext,
+} from "../task-tracing.js";
 
 export { MUNIN_QUERY_MAX } from "../munin-pagination.js";
 
@@ -176,6 +180,7 @@ export function namespaceForTaskId(taskId: string): string {
 
 export interface SubmitTaskParams {
   envelope: DelegationEnvelope;
+  traceContext?: TaskTraceContext;
 }
 
 export class BrokerTaskStore {
@@ -196,7 +201,11 @@ export class BrokerTaskStore {
     const attestation = secret
       ? createBrokerAttestation(params.envelope, secret)
       : undefined;
-    const content = serializeEnvelope(params.envelope, attestation);
+    const content = serializeEnvelope(
+      params.envelope,
+      attestation,
+      params.traceContext,
+    );
     const result = await this.munin.write(
       ns,
       STATUS_KEY,
@@ -701,6 +710,7 @@ export function flipLifecycleTags(
 export function serializeEnvelope(
   envelope: DelegationEnvelope,
   attestation?: BrokerAttestation,
+  traceContext?: TaskTraceContext,
 ): string {
   const verifier = envelope.acceptance.mode === "verifier"
     ? JSON.stringify(envelope.acceptance.verifier)
@@ -727,6 +737,9 @@ export function serializeEnvelope(
     `- **Sensitivity:** ${envelope.sensitivity ?? "internal"}`,
     `- **Idempotency payload SHA256:** ${stableRequestHash(envelope)}`,
     "",
+    ...(traceContext
+      ? [buildTaskTraceContextSection(traceContext), ""]
+      : []),
     "### Broker envelope",
     "```json",
     JSON.stringify(envelope, null, 2),

--- a/src/homeserver-executor.ts
+++ b/src/homeserver-executor.ts
@@ -40,6 +40,12 @@ import {
   type LearningTaskPreparation,
   type LearningTaskRequestContext,
 } from "./learning-task-handshake.js";
+import {
+  endTaskSpan,
+  type TaskTraceContext,
+  type TaskTraceRuntime,
+  type TaskTraceSpan,
+} from "./task-tracing.js";
 
 // --- Types ---
 
@@ -171,6 +177,10 @@ export interface HomeserverExecutorResult {
 
 export interface HomeserverExecutorOptions {
   abortController?: AbortController;
+  tracing?: {
+    runtime: TaskTraceRuntime;
+    taskContext: TaskTraceContext;
+  };
   /**
    * Storage-aware, success-only probe for a stamped request whose admission is
    * ambiguous. Implementations must return null unless exact recovery proves
@@ -454,6 +464,16 @@ export async function executeHomeserverTask(
 
   const headers: Record<string, string> = { "Content-Type": "application/json" };
   if (task.apiKey) headers.Authorization = `Bearer ${task.apiKey}`;
+  let gatewaySpan: TaskTraceSpan | null = null;
+  let gatewaySpanEnded = false;
+  const finishGatewaySpan = async (
+    outcome: "ok" | "degraded" | "failed",
+    errorClass?: string,
+  ): Promise<void> => {
+    if (!gatewaySpan || gatewaySpanEnded) return;
+    gatewaySpanEnded = true;
+    await endTaskSpan(gatewaySpan, { outcome, errorClass });
+  };
 
   const recoverAmbiguousLearningTask = async (): Promise<void> => {
     const original = result.learningTask;
@@ -558,6 +578,15 @@ export async function executeHomeserverTask(
       task.path === "delegate"
         ? `${task.gatewayBaseUrl}/delegate`
         : `${task.gatewayBaseUrl}/v1/chat/completions`;
+    gatewaySpan = options?.tracing?.runtime.startSpan({
+      name: `gateway.${task.path}`,
+      surface: "gateway",
+      phase: "execution",
+      taskContext: options.tracing.taskContext,
+    }) ?? null;
+    if (gatewaySpan) {
+      headers.traceparent = gatewaySpan.traceparent;
+    }
 
     const res = await fetch(url, {
       method: "POST",
@@ -578,6 +607,7 @@ export async function executeHomeserverTask(
       appendOutput(
         `[Gateway ${res.status} ${result.backpressure}${result.retryAfterS !== null ? `, retry ${result.retryAfterS}s` : ""}] ${detail}\n`,
       );
+      await finishGatewaySpan("degraded", "gateway-backpressure");
       return finish();
     }
 
@@ -614,6 +644,7 @@ export async function executeHomeserverTask(
       } else {
         appendOutput(`[Gateway HTTP ${res.status}] ${errText}\n`);
       }
+      await finishGatewaySpan("failed", "gateway-http-error");
       return finish();
     }
 
@@ -638,6 +669,7 @@ export async function executeHomeserverTask(
         });
         appendOutput(`[LearningTaskContract join rejected: ${reason}]\n`);
         result.exitCode = 1;
+        await finishGatewaySpan("failed", "gateway-echo-invalid");
         return finish();
       }
       if (task.learningTask?.kind === "ready") {
@@ -659,6 +691,7 @@ export async function executeHomeserverTask(
           });
           appendOutput(`[LearningTaskContract join rejected: ${reason}]\n`);
           result.exitCode = 1;
+          await finishGatewaySpan("failed", "gateway-echo-invalid");
           return finish();
         }
         result.learningTask = learningTaskExecutionEvidenceSchema.parse({
@@ -710,12 +743,17 @@ export async function executeHomeserverTask(
       // A well-formed 200 DelegationOutcome can still report failure; don't mask fail/error
       // as a successful Hugin execution (that would suppress retry/escalation downstream).
       result.exitCode = provenance.outcome === "fail" || provenance.outcome === "error" ? 1 : 0;
+      await finishGatewaySpan(
+        result.exitCode === 0 ? "ok" : "failed",
+        result.exitCode === 0 ? undefined : "gateway-delegate-failed",
+      );
       return finish();
     }
 
     // Chat path: stream the OpenAI-compatible SSE body.
     if (!res.body) {
       appendOutput("[Gateway error: no response body]\n");
+      await finishGatewaySpan("failed", "gateway-http-error");
       return finish();
     }
     const reader = res.body.getReader();
@@ -767,9 +805,11 @@ export async function executeHomeserverTask(
     if (timedOut) {
       result.exitCode = "TIMEOUT";
       appendOutput("\n[Gateway streaming timed out]\n");
+      await finishGatewaySpan("failed", "timeout");
     } else {
       result.exitCode = 0;
       result.resultText = output.trim() || null;
+      await finishGatewaySpan("ok");
     }
     return finish();
   } catch (err) {
@@ -786,9 +826,11 @@ export async function executeHomeserverTask(
     if (err instanceof Error && err.name === "AbortError") {
       result.exitCode = "TIMEOUT";
       appendOutput(`\n[Gateway request aborted after ${Math.round((Date.now() - startMs) / 1000)}s]\n`);
+      await finishGatewaySpan("failed", "timeout");
     } else {
       result.exitCode = 1;
       appendOutput(`\n[Gateway error: ${err instanceof Error ? err.message : String(err)}]\n`);
+      await finishGatewaySpan("failed", "gateway-transport-error");
     }
     return finish();
   } finally {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,16 @@ import {
 } from "./heimdall-descriptor.js";
 import { startHeimdallPanelReporter } from "./heimdall-report.js";
 import {
+  TaskTraceRuntime,
+  buildChildTaskTraceContext,
+  createFileTaskTraceExporter,
+  endTaskSpan,
+  parseTaskTraceContext,
+  parseTraceSampleRatePerMille,
+  type TaskTraceContext,
+  type TaskTraceSpan,
+} from "./task-tracing.js";
+import {
   buildDefaultEgressHosts,
   installFetchEgressPolicy,
 } from "./egress-policy.js";
@@ -92,6 +102,11 @@ import {
   type LearningTaskExecutionEvidence,
   type LearningTaskSource,
 } from "./learning-task-handshake.js";
+import {
+  buildLearningTaskPreflightPanel,
+  classifyLearningTaskPreflightError,
+  createLearningTaskPreflightStore,
+} from "./learning-task-preflight-status.js";
 import {
   recoverAmbiguousStoredLearningTaskCandidate,
   recoverLatestStoredLearningTaskAttempt,
@@ -609,6 +624,15 @@ const LEASE_REAPER_INTERVAL_MS = 60_000; // scan for expired foreign leases ever
 // in-flight tasks immediately. The PID is retained separately for observability.
 const workerId = `hugin-${os.hostname()}`;
 const processInstanceId = `${workerId}-${process.pid}`;
+const taskTraceRuntime = new TaskTraceRuntime({
+  exportEnabled: Boolean(process.env.HUGIN_TRACE_EXPORT_PATH?.trim()),
+  sampleRatePerMille: parseTraceSampleRatePerMille(
+    process.env.HUGIN_TRACE_SAMPLE_RATE_PER_MILLE,
+  ),
+  release: HEIMDALL_DESCRIPTOR.version,
+  instanceId: workerId,
+  exporter: createFileTaskTraceExporter(process.env.HUGIN_TRACE_EXPORT_PATH),
+});
 
 function sleepMs(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -1458,6 +1482,36 @@ function getExternalProvenanceViolationForTask(task: TaskConfig): string | null 
 
 function ensureLogDir(): void {
   fs.mkdirSync(LOG_DIR, { recursive: true });
+}
+
+function traceDate(value: string | undefined, fallback = new Date()): Date {
+  const parsed = value ? new Date(value) : new Date(NaN);
+  return Number.isNaN(parsed.getTime()) ? fallback : parsed;
+}
+
+function startTaskLifecycleSpan(
+  context: TaskTraceContext | null,
+  name: string,
+  phase: "queue" | "execution" | "publication",
+  startedAt?: Date,
+): TaskTraceSpan | null {
+  if (!context) return null;
+  return taskTraceRuntime.startSpan({
+    name,
+    surface: "task",
+    phase,
+    taskContext: context,
+    ...(startedAt ? { startedAt } : {}),
+  });
+}
+
+async function finishTaskLifecycleSpan(
+  span: TaskTraceSpan | null,
+  outcome: "ok" | "degraded" | "failed" | "stale" | "unknown",
+  errorClass?: string,
+): Promise<void> {
+  if (!span) return;
+  await endTaskSpan(span, { outcome, errorClass });
 }
 
 async function writeStructuredTaskResult(
@@ -5043,6 +5097,28 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     Number.isNaN(acceptedAtMs) ? Date.now() : Math.max(Date.now(), acceptedAtMs),
   ).toISOString();
   const taskId = extractTaskId(taskNs);
+  const inboundTaskTraceContext = parseTaskTraceContext(entry.content);
+  const queueSpan = startTaskLifecycleSpan(
+    inboundTaskTraceContext,
+    "task.queue",
+    "queue",
+    traceDate(entry.created_at, traceDate(claimAcceptedAt)),
+  );
+  await finishTaskLifecycleSpan(
+    queueSpan,
+    "ok",
+  );
+  const executionSpan = startTaskLifecycleSpan(
+    inboundTaskTraceContext,
+    "task.execution",
+    "execution",
+    traceDate(startedAt),
+  );
+  const executionTraceContext = executionSpan && inboundTaskTraceContext
+    ? buildChildTaskTraceContext(executionSpan.traceparent, inboundTaskTraceContext)
+    : null;
+  let executionTraceOutcome: "ok" | "degraded" | "failed" | "stale" | "unknown" = "unknown";
+  let executionTraceErrorClass: string | undefined;
   console.log(`Executing task ${taskNs}...`);
 
   // Start periodic lease renewal
@@ -5089,6 +5165,24 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
       );
       stopLeaseRenewal();
       stopCancellationWatch();
+      const pipelineOutcome = (
+        pipelineTerminalResult as { result?: { outcome?: string } } | null
+      )?.result?.outcome;
+      if (pipelineOutcome === "completed") {
+        executionTraceOutcome = "ok";
+      } else if (pipelineOutcome === "timed_out") {
+        executionTraceOutcome = "failed";
+        executionTraceErrorClass = "timeout";
+      } else if (pipelineOutcome === "cancelled") {
+        executionTraceOutcome = "failed";
+        executionTraceErrorClass = "cancelled";
+      } else if (pipelineOutcome === "failed") {
+        executionTraceOutcome = "failed";
+        executionTraceErrorClass = "pipeline-failed";
+      } else {
+        executionTraceOutcome = "stale";
+        executionTraceErrorClass = "pipeline-terminal-missing";
+      }
       releaseCurrentClaimWithSchedulerOutcome({
         taskNamespace: taskNs,
         prediction: schedulerPrediction,
@@ -5705,6 +5799,23 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         },
       })
         : null;
+      if (authenticatedLearningSource) {
+        const checkedAt = new Date().toISOString();
+        if (preparedLearningTask?.preparation.kind === "preflight-failed") {
+          learningTaskPreflightStore.record({
+            checkedAt,
+            outcome: "failed",
+            errorClass: classifyLearningTaskPreflightError(
+              preparedLearningTask.preparation.failureReason,
+            ),
+          });
+        } else {
+          learningTaskPreflightStore.record({
+            checkedAt,
+            outcome: "ok",
+          });
+        }
+      }
       const learningAttempt = preparedLearningTask?.attempt;
       const learningAttemptKey = learningAttempt
         ? learningTaskAttemptKey(learningAttempt.attemptId)
@@ -5714,6 +5825,14 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         learningTask: preparedLearningTask?.preparation ?? { kind: "ineligible" },
       }, taskId, LOG_DIR, {
         abortController: homeserverAbort,
+        ...(executionTraceContext
+          ? {
+              tracing: {
+                runtime: taskTraceRuntime,
+                taskContext: executionTraceContext,
+              },
+            }
+          : {}),
         recoverAmbiguousLearningTask: async (failureEvidence) => {
           const preparation = preparedLearningTask?.preparation;
           if (homeserverAbort.signal.aborted || preparation?.kind !== "ready") return null;
@@ -6122,6 +6241,11 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     // auto-commit and publish whatever was ALREADY on disk — that state may
     // belong to an earlier task entirely, not to this one's output.
     if (ok && !isCancelled && !checkoutGateDegraded && branchResult.action === "created" && branchResult.branchName) {
+      const publicationSpan = startTaskLifecycleSpan(
+        executionTraceContext,
+        "task.publication",
+        "publication",
+      );
       const prBody = [
         `Automated changes from Hugin task \`${taskId}\`.`,
         "",
@@ -6131,46 +6255,56 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         "---",
         "*Created automatically by [Hugin](https://github.com/Magnus-Gille/hugin).*",
       ].join("\n");
-      const finalizeResult = await finalizeTaskBranch(
-        task.workingDir,
-        branchResult.branchName,
-        prBody,
-        egressPolicy.allowedHosts,
-        {
-          captureRepositoryChange: true,
-          baseBranch: branchResult.baseBranch,
-          baseCommit: branchResult.baseCommit,
-        },
-      );
-      repositoryChange = finalizeResult.repositoryChange;
-      repositoryOutcome = deriveRepositoryOutcome(branchResult, finalizeResult.action);
-      if (finalizeResult.action === "pr-created" && finalizeResult.prUrl) {
-        prUrl = finalizeResult.prUrl;
-        await munin.log(taskNs, `PR created: ${prUrl}`);
-      } else if (finalizeResult.action === "push-failed") {
-        console.warn(`Post-task branch finalization failed for ${taskNs}: ${finalizeResult.error}`);
-        publicationFailureTag = PUBLICATION_FAILED_TAG;
-        try {
-          await persistPublicationFailure(munin, {
-            taskId,
-            taskNamespace: taskNs,
-            workingDir: task.workingDir,
-            branchName: finalizeResult.branchName ?? branchResult.branchName,
-            baseBranch: branchResult.baseBranch ?? "main",
-            baseCommit: repositoryChange?.baseCommit ?? branchResult.baseCommit ?? "",
-            headCommit: repositoryChange?.headCommit,
-            prBody,
-            allowedEgressHosts: egressPolicy.allowedHosts,
-            failureReason: finalizeResult.error ?? "publication failed",
-            classification: taskClassification,
-          });
-        } catch (err) {
-          // The durable record is best-effort UX for recovery, not the
-          // source of truth — result-structured's `publication-failed`
-          // repositoryOutcome (written below) is. Never let this throw
-          // strand the task off its terminal write.
-          console.error(`[publication-recovery] failed to persist durable record for ${taskNs}:`, err);
+      try {
+        const finalizeResult = await finalizeTaskBranch(
+          task.workingDir,
+          branchResult.branchName,
+          prBody,
+          egressPolicy.allowedHosts,
+          {
+            captureRepositoryChange: true,
+            baseBranch: branchResult.baseBranch,
+            baseCommit: branchResult.baseCommit,
+          },
+        );
+        repositoryChange = finalizeResult.repositoryChange;
+        repositoryOutcome = deriveRepositoryOutcome(branchResult, finalizeResult.action);
+        if (finalizeResult.action === "pr-created" && finalizeResult.prUrl) {
+          prUrl = finalizeResult.prUrl;
+          await munin.log(taskNs, `PR created: ${prUrl}`);
+        } else if (finalizeResult.action === "push-failed") {
+          console.warn(`Post-task branch finalization failed for ${taskNs}: ${finalizeResult.error}`);
+          publicationFailureTag = PUBLICATION_FAILED_TAG;
+          try {
+            await persistPublicationFailure(munin, {
+              taskId,
+              taskNamespace: taskNs,
+              workingDir: task.workingDir,
+              branchName: finalizeResult.branchName ?? branchResult.branchName,
+              baseBranch: branchResult.baseBranch ?? "main",
+              baseCommit: repositoryChange?.baseCommit ?? branchResult.baseCommit ?? "",
+              headCommit: repositoryChange?.headCommit,
+              prBody,
+              allowedEgressHosts: egressPolicy.allowedHosts,
+              failureReason: finalizeResult.error ?? "publication failed",
+              classification: taskClassification,
+            });
+          } catch (err) {
+            // The durable record is best-effort UX for recovery, not the
+            // source of truth — result-structured's `publication-failed`
+            // repositoryOutcome (written below) is. Never let this throw
+            // strand the task off its terminal write.
+            console.error(`[publication-recovery] failed to persist durable record for ${taskNs}:`, err);
+          }
         }
+        await finishTaskLifecycleSpan(
+          publicationSpan,
+          finalizeResult.action === "push-failed" ? "failed" : "ok",
+          finalizeResult.action === "push-failed" ? "publication-failed" : undefined,
+        );
+      } catch (err) {
+        await finishTaskLifecycleSpan(publicationSpan, "failed", "publication-error");
+        throw err;
       }
     }
 
@@ -6446,6 +6580,8 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
           taskNs,
           `Delivery deferred (attempt ${attempts}): ${deliveryResult.error ?? "infra failure"} — will retry`,
         );
+        executionTraceOutcome = "degraded";
+        executionTraceErrorClass = "delivery-pending";
         currentTask = null;
         currentTaskConfig = null;
         return { hadTask: true, queueDepth };
@@ -6666,75 +6802,89 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
       | (SchedulerTerminalResultRevision & { result: StructuredTaskResult })
       | null = null;
     if (isCancelled && cancellation) {
-      await munin.write(
-        taskNs,
-        "result",
-        buildCancelledTaskResultDocument({
-          startedAt,
-          completedAt,
-          durationSeconds: Math.round(durationMs / 1000),
-          executor: effectiveExecutor,
-          resultSource,
-          logFile: `~/.hugin/logs/${taskId}.log`,
-          reason: cancellation.reason,
-          replyTo: task.replyTo,
-          replyFormat: task.replyFormat,
-          group: task.group,
-          sequence: task.sequence,
-          body: finalResultBody,
-        }),
-        exfilOutcome.resultTags,
-        undefined,
-        taskClassification,
+      const resultRecordingSpan = startTaskLifecycleSpan(
+        executionTraceContext,
+        "task.result-recording",
+        "publication",
       );
-      const cancelledFinalize = await finalizeTaskCompletion(munin, taskNs, {
-        statusContent: entry.content,
-        terminalTags: buildClaimedTerminalStatusTags("cancelled", finalizeBaseTags, `runtime:${task.runtime}`),
-        classification: taskClassification,
-        // Single-owner CAS for runtime-owned delivery (#68, Codex review C):
-        // if a startup reconciler reclaimed the delivery checkpoint while we
-        // were delivering, this CAS is rejected and we must NOT finalize. When
-        // the task never entered delivery this is undefined → no CAS, same as
-        // the prior behaviour.
-        expectedUpdatedAt: deliveryCheckpointUpdatedAt,
-        writeStructuredResult: async () => {
-          terminalStructuredResult = await writeStructuredTaskResult(
-            taskNs,
-            createCancelledStructuredResult(taskNs, task.runtime, cancellation.reason, {
-              executor: effectiveExecutor,
-              resultSource,
-              startedAt,
-              completedAt,
-              durationSeconds: Math.round(durationMs / 1000),
-              logFile: `~/.hugin/logs/${taskId}.log`,
-              replyTo: task.replyTo,
-              replyFormat: task.replyFormat,
-              group: task.group,
-              sequence: task.sequence,
-              pipeline: task.pipeline,
-              runtimeMetadata,
-              approval: approvalMetadata,
-              bodyKind: structuredBodyKind,
-              bodyText: structuredBodyText,
-              sensitivity: taskSensitivitySnapshot,
-            }),
-            taskClassification,
-          );
-        },
-        logMessage: `Task cancelled in ${Math.round(durationMs / 1000)}s (reason: ${cancellation.reason}, executor: ${executorLabel})`,
-      });
-      if (cancelledFinalize.statusCasLost) {
-        // The startup reconciler re-owns this task (single-owner model). It
-        // will write the terminal state, promote dependents, and refresh the
-        // pipeline — doing it here too would double-fire those side effects.
-        console.warn(
-          `Task ${taskNs} cancelled-finalize CAS lost — delivery reconciliation owns terminalization`,
+      try {
+        await munin.write(
+          taskNs,
+          "result",
+          buildCancelledTaskResultDocument({
+            startedAt,
+            completedAt,
+            durationSeconds: Math.round(durationMs / 1000),
+            executor: effectiveExecutor,
+            resultSource,
+            logFile: `~/.hugin/logs/${taskId}.log`,
+            reason: cancellation.reason,
+            replyTo: task.replyTo,
+            replyFormat: task.replyFormat,
+            group: task.group,
+            sequence: task.sequence,
+            body: finalResultBody,
+          }),
+          exfilOutcome.resultTags,
+          undefined,
+          taskClassification,
         );
-        currentTask = null;
-        currentTaskConfig = null;
-        return { hadTask: true, queueDepth };
+        const cancelledFinalize = await finalizeTaskCompletion(munin, taskNs, {
+          statusContent: entry.content,
+          terminalTags: buildClaimedTerminalStatusTags("cancelled", finalizeBaseTags, `runtime:${task.runtime}`),
+          classification: taskClassification,
+          // Single-owner CAS for runtime-owned delivery (#68, Codex review C):
+          // if a startup reconciler reclaimed the delivery checkpoint while we
+          // were delivering, this CAS is rejected and we must NOT finalize. When
+          // the task never entered delivery this is undefined → no CAS, same as
+          // the prior behaviour.
+          expectedUpdatedAt: deliveryCheckpointUpdatedAt,
+          writeStructuredResult: async () => {
+            terminalStructuredResult = await writeStructuredTaskResult(
+              taskNs,
+              createCancelledStructuredResult(taskNs, task.runtime, cancellation.reason, {
+                executor: effectiveExecutor,
+                resultSource,
+                startedAt,
+                completedAt,
+                durationSeconds: Math.round(durationMs / 1000),
+                logFile: `~/.hugin/logs/${taskId}.log`,
+                replyTo: task.replyTo,
+                replyFormat: task.replyFormat,
+                group: task.group,
+                sequence: task.sequence,
+                pipeline: task.pipeline,
+                runtimeMetadata,
+                approval: approvalMetadata,
+                bodyKind: structuredBodyKind,
+                bodyText: structuredBodyText,
+                sensitivity: taskSensitivitySnapshot,
+              }),
+              taskClassification,
+            );
+          },
+          logMessage: `Task cancelled in ${Math.round(durationMs / 1000)}s (reason: ${cancellation.reason}, executor: ${executorLabel})`,
+        });
+        if (cancelledFinalize.statusCasLost) {
+          await finishTaskLifecycleSpan(resultRecordingSpan, "stale", "status-cas-lost");
+          // The startup reconciler re-owns this task (single-owner model). It
+          // will write the terminal state, promote dependents, and refresh the
+          // pipeline — doing it here too would double-fire those side effects.
+          console.warn(
+            `Task ${taskNs} cancelled-finalize CAS lost — delivery reconciliation owns terminalization`,
+          );
+          executionTraceOutcome = "stale";
+          executionTraceErrorClass = "status-cas-lost";
+          currentTask = null;
+          currentTaskConfig = null;
+          return { hadTask: true, queueDepth };
+        }
+        await finishTaskLifecycleSpan(resultRecordingSpan, "ok");
+        terminalStructuredResultOk = cancelledFinalize.structuredResultOk;
+      } catch (err) {
+        await finishTaskLifecycleSpan(resultRecordingSpan, "failed", "result-recording-error");
+        throw err;
       }
-      terminalStructuredResultOk = cancelledFinalize.structuredResultOk;
     } else {
       // Append the distinct failure tag (issue #129) and the publication
       // failure tag (issue #225) AFTER the claimed terminal-tag transform, whose
@@ -6749,88 +6899,102 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         ...(failureClassification ? [failureClassification.tag] : []),
         ...(publicationFailureTag ? [publicationFailureTag] : []),
       ];
-      const finalizeOutcome = await finalizeTaskCompletion(munin, taskNs, {
-        statusContent: entry.content,
-        terminalTags: extraTerminalTags.length > 0
-          ? [...terminalTags, ...extraTerminalTags]
-          : terminalTags,
-        classification: taskClassification,
-        // Single-owner CAS for runtime-owned delivery (#68): if a startup
-        // reconciler reclaimed the checkpoint while we were delivering, this
-        // CAS is rejected and we must NOT finalize — the new owner stands.
-        expectedUpdatedAt: deliveryCheckpointUpdatedAt,
-        writeStructuredResult: async () => {
-          terminalStructuredResult = await writeStructuredTaskResult(
-            taskNs,
-            buildStructuredTaskResult({
-              schemaVersion: 1,
-              taskId,
-              taskNamespace: taskNs,
-              lifecycle: ok ? "completed" : "failed",
-              outcome: ok ? "completed" : isTimeout ? "timed_out" : "failed",
-              runtime: task.runtime,
-              executor: effectiveExecutor,
-              resultSource,
-              exitCode,
-              startedAt,
-              completedAt,
-              durationSeconds: Math.round(durationMs / 1000),
-              logFile: `~/.hugin/logs/${taskId}.log`,
-              replyTo: task.replyTo,
-              replyFormat: task.replyFormat,
-              group: task.group,
-              sequence: task.sequence,
-              costUsd: costUsd ?? undefined,
-              prUrl,
-              repositoryOutcome,
-              repositoryChange,
-              bodyKind: structuredBodyKind,
-              bodyText: structuredBodyText,
-              errorMessage: ok
-                ? undefined
-                : failureClassification
-                  ? failureClassification.reason
-                  : deliveryResult && !deliveryResult.ok
-                    ? deliveryResult.error ?? structuredBodyText
-                    : structuredBodyText,
-              runtimeMetadata,
-              pipeline: task.pipeline,
-              approval: approvalMetadata,
-              sensitivity: taskSensitivitySnapshot,
-              artifactDelivery: deliveryResult
-                ? {
-                    ok: deliveryResult.ok,
-                    failureKind: deliveryResult.failureKind,
-                    artifacts: deliveryResult.records.map((r) => ({
-                      id: r.id,
-                      status: r.status,
-                      remote: r.remote,
-                      bytes: r.bytes,
-                      sha256: r.sha256,
-                      error: r.error,
-                    })),
-                  }
-                : undefined,
-              orchestratorOutcomes,
-              savings: savingsResult,
-            }),
-            taskClassification,
+      const resultRecordingSpan = startTaskLifecycleSpan(
+        executionTraceContext,
+        "task.result-recording",
+        "publication",
+      );
+      try {
+        const finalizeOutcome = await finalizeTaskCompletion(munin, taskNs, {
+          statusContent: entry.content,
+          terminalTags: extraTerminalTags.length > 0
+            ? [...terminalTags, ...extraTerminalTags]
+            : terminalTags,
+          classification: taskClassification,
+          // Single-owner CAS for runtime-owned delivery (#68): if a startup
+          // reconciler reclaimed the checkpoint while we were delivering, this
+          // CAS is rejected and we must NOT finalize — the new owner stands.
+          expectedUpdatedAt: deliveryCheckpointUpdatedAt,
+          writeStructuredResult: async () => {
+            terminalStructuredResult = await writeStructuredTaskResult(
+              taskNs,
+              buildStructuredTaskResult({
+                schemaVersion: 1,
+                taskId,
+                taskNamespace: taskNs,
+                lifecycle: ok ? "completed" : "failed",
+                outcome: ok ? "completed" : isTimeout ? "timed_out" : "failed",
+                runtime: task.runtime,
+                executor: effectiveExecutor,
+                resultSource,
+                exitCode,
+                startedAt,
+                completedAt,
+                durationSeconds: Math.round(durationMs / 1000),
+                logFile: `~/.hugin/logs/${taskId}.log`,
+                replyTo: task.replyTo,
+                replyFormat: task.replyFormat,
+                group: task.group,
+                sequence: task.sequence,
+                costUsd: costUsd ?? undefined,
+                prUrl,
+                repositoryOutcome,
+                repositoryChange,
+                bodyKind: structuredBodyKind,
+                bodyText: structuredBodyText,
+                errorMessage: ok
+                  ? undefined
+                  : failureClassification
+                    ? failureClassification.reason
+                    : deliveryResult && !deliveryResult.ok
+                      ? deliveryResult.error ?? structuredBodyText
+                      : structuredBodyText,
+                runtimeMetadata,
+                pipeline: task.pipeline,
+                approval: approvalMetadata,
+                sensitivity: taskSensitivitySnapshot,
+                artifactDelivery: deliveryResult
+                  ? {
+                      ok: deliveryResult.ok,
+                      failureKind: deliveryResult.failureKind,
+                      artifacts: deliveryResult.records.map((r) => ({
+                        id: r.id,
+                        status: r.status,
+                        remote: r.remote,
+                        bytes: r.bytes,
+                        sha256: r.sha256,
+                        error: r.error,
+                      })),
+                    }
+                  : undefined,
+                orchestratorOutcomes,
+                savings: savingsResult,
+              }),
+              taskClassification,
+            );
+          },
+          logMessage: `Task ${ok ? "completed" : isTimeout ? "timed out" : "failed"} in ${Math.round(durationMs / 1000)}s (exit ${exitCode}, executor: ${executorLabel}${costUsd !== null ? `, cost: $${costUsd.toFixed(4)}` : ""})`,
+        });
+        if (finalizeOutcome.statusCasLost) {
+          await finishTaskLifecycleSpan(resultRecordingSpan, "stale", "status-cas-lost");
+          // The startup reconciler re-owns this task (single-owner model). It
+          // will write the terminal state, promote dependents, and refresh the
+          // pipeline — doing it here too would double-fire those side effects.
+          console.warn(
+            `Task ${taskNs} finalize CAS lost — delivery reconciliation owns terminalization`,
           );
-        },
-        logMessage: `Task ${ok ? "completed" : isTimeout ? "timed out" : "failed"} in ${Math.round(durationMs / 1000)}s (exit ${exitCode}, executor: ${executorLabel}${costUsd !== null ? `, cost: $${costUsd.toFixed(4)}` : ""})`,
-      });
-      if (finalizeOutcome.statusCasLost) {
-        // The startup reconciler re-owns this task (single-owner model). It
-        // will write the terminal state, promote dependents, and refresh the
-        // pipeline — doing it here too would double-fire those side effects.
-        console.warn(
-          `Task ${taskNs} finalize CAS lost — delivery reconciliation owns terminalization`,
-        );
-        currentTask = null;
-        currentTaskConfig = null;
-        return { hadTask: true, queueDepth };
+          executionTraceOutcome = "stale";
+          executionTraceErrorClass = "status-cas-lost";
+          currentTask = null;
+          currentTaskConfig = null;
+          return { hadTask: true, queueDepth };
+        }
+        await finishTaskLifecycleSpan(resultRecordingSpan, "ok");
+        terminalStructuredResultOk = finalizeOutcome.structuredResultOk;
+      } catch (err) {
+        await finishTaskLifecycleSpan(resultRecordingSpan, "failed", "result-recording-error");
+        throw err;
       }
-      terminalStructuredResultOk = finalizeOutcome.structuredResultOk;
     }
 
     // hugin#284: capture from the DURABLE terminal result, never from mutable
@@ -6944,8 +7108,36 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
       harness: sampledHarnessLane ? "opencode-sampled" : undefined,
       model: effectiveSchedulerModel,
     });
+    if (isCancelled) {
+      executionTraceOutcome = "failed";
+      executionTraceErrorClass = "cancelled";
+    } else if (publicationFailureTag) {
+      executionTraceOutcome = "degraded";
+      executionTraceErrorClass = "publication-failed";
+    } else if (ok) {
+      executionTraceOutcome = "ok";
+      executionTraceErrorClass = undefined;
+    } else if (isTimeout) {
+      executionTraceOutcome = "failed";
+      executionTraceErrorClass = "timeout";
+    } else {
+      executionTraceOutcome = "failed";
+      executionTraceErrorClass =
+        failureClassification?.kind
+        ?? deliveryFailureKind?.toLowerCase().replace(/_/g, "-")
+        ?? "task-failed";
+    }
     return { hadTask: true, queueDepth };
   } finally {
+    if (executionSpan) {
+      await finishTaskLifecycleSpan(
+        executionSpan,
+        executionTraceOutcome === "unknown" ? "failed" : executionTraceOutcome,
+        executionTraceOutcome === "unknown"
+          ? executionTraceErrorClass ?? "execution-error"
+          : executionTraceErrorClass,
+      );
+    }
     stopLeaseRenewal();
     stopCancellationWatch();
     currentSdkAbort = null;
@@ -7146,6 +7338,7 @@ const learningLoopCollector = new LearningLoopCollector({
   munin,
   ledgerClient: new LedgerClient({ env: process.env }),
 });
+const learningTaskPreflightStore = createLearningTaskPreflightStore();
 
 registerHeimdallDescriptorRoute(app, {
   health: () => ({
@@ -7161,7 +7354,10 @@ registerHeimdallDescriptorRoute(app, {
 // response. No-op until HEIMDALL_HUB_URL + HEIMDALL_FLEET_TOKEN are
 // configured in this service's environment; see src/heimdall-report.ts.
 const stopHeimdallPanelReporter = startHeimdallPanelReporter(() =>
-  buildLearningLoopHealthPanels(learningLoopCollector)
+  [
+    ...buildLearningLoopHealthPanels(learningLoopCollector),
+    buildLearningTaskPreflightPanel(learningTaskPreflightStore.snapshot()),
+  ]
 );
 
 // --- Graceful shutdown ---

--- a/src/index.ts
+++ b/src/index.ts
@@ -1484,9 +1484,14 @@ function ensureLogDir(): void {
   fs.mkdirSync(LOG_DIR, { recursive: true });
 }
 
-function traceDate(value: string | undefined, fallback = new Date()): Date {
+function traceDate(
+  value: string | undefined,
+  fallback = new Date(),
+  ceiling = new Date(),
+): Date {
   const parsed = value ? new Date(value) : new Date(NaN);
-  return Number.isNaN(parsed.getTime()) ? fallback : parsed;
+  if (Number.isNaN(parsed.getTime())) return fallback;
+  return parsed.getTime() > ceiling.getTime() ? ceiling : parsed;
 }
 
 function startTaskLifecycleSpan(
@@ -5092,9 +5097,12 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
   currentTask = taskNs;
   currentClaimTags = [...claimTags];
   currentCancellation = null;
+  const traceNow = new Date();
   const acceptedAtMs = Date.parse(claimAcceptedAt);
   const startedAt = new Date(
-    Number.isNaN(acceptedAtMs) ? Date.now() : Math.max(Date.now(), acceptedAtMs),
+    Number.isNaN(acceptedAtMs)
+      ? traceNow.getTime()
+      : Math.min(traceNow.getTime(), acceptedAtMs),
   ).toISOString();
   const taskId = extractTaskId(taskNs);
   const inboundTaskTraceContext = parseTaskTraceContext(entry.content);
@@ -5102,7 +5110,11 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     inboundTaskTraceContext,
     "task.queue",
     "queue",
-    traceDate(entry.created_at, traceDate(claimAcceptedAt)),
+    traceDate(
+      entry.created_at,
+      traceDate(claimAcceptedAt, traceNow, traceNow),
+      traceNow,
+    ),
   );
   await finishTaskLifecycleSpan(
     queueSpan,
@@ -7121,9 +7133,6 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     if (isCancelled) {
       executionTraceOutcome = "failed";
       executionTraceErrorClass = "cancelled";
-    } else if (publicationFailureTag) {
-      executionTraceOutcome = "degraded";
-      executionTraceErrorClass = "publication-failed";
     } else if (ok) {
       executionTraceOutcome = "ok";
       executionTraceErrorClass = undefined;

--- a/src/index.ts
+++ b/src/index.ts
@@ -5098,12 +5098,6 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
   currentClaimTags = [...claimTags];
   currentCancellation = null;
   const traceNow = new Date();
-  const acceptedAtMs = Date.parse(claimAcceptedAt);
-  const startedAt = new Date(
-    Number.isNaN(acceptedAtMs)
-      ? traceNow.getTime()
-      : Math.min(traceNow.getTime(), acceptedAtMs),
-  ).toISOString();
   const taskId = extractTaskId(taskNs);
   const inboundTaskTraceContext = parseTaskTraceContext(entry.content);
   const queueSpan = startTaskLifecycleSpan(
@@ -5120,6 +5114,10 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     queueSpan,
     "ok",
   );
+  // Execution begins only after queue handling has completed. Use a fresh
+  // local observation rather than the (possibly skewed) persisted claim time,
+  // so queue and execution remain distinct latency categories.
+  const startedAt = new Date().toISOString();
   const executionSpan = startTaskLifecycleSpan(
     inboundTaskTraceContext,
     "task.execution",

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ import {
   type MuninClientConfig,
   type MuninReadResult,
 } from "./munin-client.js";
-import { getFoundBatchEntry, extractTaskId, pickEarliestTask, listEligibleTasks, checkoutTaskBranch, finalizeTaskBranch, deriveRepositoryOutcome, prepareManagedCheckout, shouldReapExpiredLease, decideStartupRecovery, decideDeliveryRetry, finalizeTaskCompletion, resolveTaskWorkingDirectory, normalizeRoot, parseBaseBranchOverride, DEFAULT_REPOS_ROOT, MAX_TASK_OUTPUT_TOKENS, MAX_TASK_TIMEOUT_MS, parseBoundedPositiveInt, PUBLICATION_FAILED_TAG } from "./task-helpers.js";
+import { getFoundBatchEntry, extractTaskId, pickEarliestTask, listEligibleTasks, checkoutTaskBranch, finalizeTaskBranch, deriveRepositoryOutcome, prepareManagedCheckout, shouldReapExpiredLease, decideStartupRecovery, decideDeliveryRetry, finalizeTaskCompletion, deriveResultRecordingTraceOutcome, resolveTaskWorkingDirectory, normalizeRoot, parseBaseBranchOverride, DEFAULT_REPOS_ROOT, MAX_TASK_OUTPUT_TOKENS, MAX_TASK_TIMEOUT_MS, parseBoundedPositiveInt, PUBLICATION_FAILED_TAG } from "./task-helpers.js";
 import { persistPublicationFailure } from "./publication-recovery.js";
 import { queryAllMuninEntries } from "./munin-pagination.js";
 import {
@@ -6879,7 +6879,12 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
           currentTaskConfig = null;
           return { hadTask: true, queueDepth };
         }
-        await finishTaskLifecycleSpan(resultRecordingSpan, "ok");
+        const resultRecordingTraceOutcome = deriveResultRecordingTraceOutcome(cancelledFinalize);
+        await finishTaskLifecycleSpan(
+          resultRecordingSpan,
+          resultRecordingTraceOutcome.outcome,
+          resultRecordingTraceOutcome.errorClass,
+        );
         terminalStructuredResultOk = cancelledFinalize.structuredResultOk;
       } catch (err) {
         await finishTaskLifecycleSpan(resultRecordingSpan, "failed", "result-recording-error");
@@ -6989,7 +6994,12 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
           currentTaskConfig = null;
           return { hadTask: true, queueDepth };
         }
-        await finishTaskLifecycleSpan(resultRecordingSpan, "ok");
+        const resultRecordingTraceOutcome = deriveResultRecordingTraceOutcome(finalizeOutcome);
+        await finishTaskLifecycleSpan(
+          resultRecordingSpan,
+          resultRecordingTraceOutcome.outcome,
+          resultRecordingTraceOutcome.errorClass,
+        );
         terminalStructuredResultOk = finalizeOutcome.structuredResultOk;
       } catch (err) {
         await finishTaskLifecycleSpan(resultRecordingSpan, "failed", "result-recording-error");

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
 import { startHeimdallPanelReporter } from "./heimdall-report.js";
 import {
   TaskTraceRuntime,
+  TaskTraceIngressCounter,
   buildChildTaskTraceContext,
   createFileTaskTraceExporter,
   endTaskSpan,
@@ -32,7 +33,7 @@ import {
   type MuninClientConfig,
   type MuninReadResult,
 } from "./munin-client.js";
-import { getFoundBatchEntry, extractTaskId, pickEarliestTask, listEligibleTasks, checkoutTaskBranch, finalizeTaskBranch, deriveRepositoryOutcome, prepareManagedCheckout, shouldReapExpiredLease, decideStartupRecovery, decideDeliveryRetry, finalizeTaskCompletion, deriveResultRecordingTraceOutcome, resolveTaskWorkingDirectory, normalizeRoot, parseBaseBranchOverride, DEFAULT_REPOS_ROOT, MAX_TASK_OUTPUT_TOKENS, MAX_TASK_TIMEOUT_MS, parseBoundedPositiveInt, PUBLICATION_FAILED_TAG } from "./task-helpers.js";
+import { getFoundBatchEntry, extractTaskId, pickEarliestTask, listEligibleTasks, checkoutTaskBranch, finalizeTaskBranch, deriveRepositoryOutcome, prepareManagedCheckout, shouldReapExpiredLease, decideStartupRecovery, decideDeliveryRetry, finalizeTaskCompletion, deriveReportedTaskStartedAt, deriveResultRecordingTraceOutcome, finalizeExecutionTraceOutcome, resolveTaskWorkingDirectory, normalizeRoot, parseBaseBranchOverride, DEFAULT_REPOS_ROOT, MAX_TASK_OUTPUT_TOKENS, MAX_TASK_TIMEOUT_MS, RESULT_RECORDING_TRACE_ERROR_CLASS, parseBoundedPositiveInt, PUBLICATION_FAILED_TAG } from "./task-helpers.js";
 import { persistPublicationFailure } from "./publication-recovery.js";
 import { queryAllMuninEntries } from "./munin-pagination.js";
 import {
@@ -624,15 +625,28 @@ const LEASE_REAPER_INTERVAL_MS = 60_000; // scan for expired foreign leases ever
 // in-flight tasks immediately. The PID is retained separately for observability.
 const workerId = `hugin-${os.hostname()}`;
 const processInstanceId = `${workerId}-${process.pid}`;
+const taskTraceExportPath = process.env.HUGIN_TRACE_EXPORT_PATH?.trim();
 const taskTraceRuntime = new TaskTraceRuntime({
-  exportEnabled: Boolean(process.env.HUGIN_TRACE_EXPORT_PATH?.trim()),
+  exportEnabled: Boolean(taskTraceExportPath),
   sampleRatePerMille: parseTraceSampleRatePerMille(
     process.env.HUGIN_TRACE_SAMPLE_RATE_PER_MILLE,
   ),
   release: HEIMDALL_DESCRIPTOR.version,
   instanceId: workerId,
-  exporter: createFileTaskTraceExporter(process.env.HUGIN_TRACE_EXPORT_PATH),
+  exporter: createFileTaskTraceExporter(taskTraceExportPath, {
+    maxBytes: parseBoundedPositiveInt(
+      process.env.HUGIN_TRACE_EXPORT_MAX_BYTES,
+      8 * 1024 * 1024,
+      256 * 1024 * 1024,
+    ),
+    maxFiles: parseBoundedPositiveInt(
+      process.env.HUGIN_TRACE_EXPORT_MAX_FILES,
+      4,
+      16,
+    ),
+  }),
 });
+const brokerTraceIngressCounter = new TaskTraceIngressCounter();
 
 function sleepMs(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -5117,12 +5131,16 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
   // Execution begins only after queue handling has completed. Use a fresh
   // local observation rather than the (possibly skewed) persisted claim time,
   // so queue and execution remain distinct latency categories.
-  const startedAt = new Date().toISOString();
+  const executionStartedAtObserved = new Date();
+  const startedAt = deriveReportedTaskStartedAt(
+    claimAcceptedAt,
+    executionStartedAtObserved,
+  );
   const executionSpan = startTaskLifecycleSpan(
     inboundTaskTraceContext,
     "task.execution",
     "execution",
-    traceDate(startedAt),
+    executionStartedAtObserved,
   );
   const executionTraceContext = executionSpan && inboundTaskTraceContext
     ? buildChildTaskTraceContext(executionSpan.traceparent, inboundTaskTraceContext)
@@ -6898,6 +6916,8 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         terminalStructuredResultOk = cancelledFinalize.structuredResultOk;
       } catch (err) {
         await finishTaskLifecycleSpan(resultRecordingSpan, "failed", "result-recording-error");
+        executionTraceOutcome = "failed";
+        executionTraceErrorClass = RESULT_RECORDING_TRACE_ERROR_CLASS;
         throw err;
       }
     } else {
@@ -7013,6 +7033,8 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         terminalStructuredResultOk = finalizeOutcome.structuredResultOk;
       } catch (err) {
         await finishTaskLifecycleSpan(resultRecordingSpan, "failed", "result-recording-error");
+        executionTraceOutcome = "failed";
+        executionTraceErrorClass = RESULT_RECORDING_TRACE_ERROR_CLASS;
         throw err;
       }
     }
@@ -7147,12 +7169,14 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     return { hadTask: true, queueDepth };
   } finally {
     if (executionSpan) {
+      const finalizedExecutionTrace = finalizeExecutionTraceOutcome({
+        outcome: executionTraceOutcome,
+        errorClass: executionTraceErrorClass,
+      });
       await finishTaskLifecycleSpan(
         executionSpan,
-        executionTraceOutcome === "unknown" ? "failed" : executionTraceOutcome,
-        executionTraceOutcome === "unknown"
-          ? executionTraceErrorClass ?? "execution-error"
-          : executionTraceErrorClass,
+        finalizedExecutionTrace.outcome,
+        finalizedExecutionTrace.errorClass,
       );
     }
     stopLeaseRenewal();
@@ -7306,6 +7330,7 @@ async function pollLoop(): Promise<void> {
 const app = express();
 
 app.get("/health", (_req, res) => {
+  const traceHealth = taskTraceRuntime.getHealth();
   res.json({
     status: "ok",
     service: "hugin",
@@ -7319,6 +7344,15 @@ app.get("/health", (_req, res) => {
     egress_policy: {
       enabled: egressPolicy.enabled,
       allowed_hosts: egressPolicy.allowedHosts,
+    },
+    tracing: {
+      export_enabled: traceHealth.exportEnabled,
+      sample_rate_per_mille: traceHealth.sampleRatePerMille,
+      export: {
+        failures: traceHealth.exportFailures,
+        dropped: traceHealth.exportDropped,
+        pending: traceHealth.pendingExports,
+      },
     },
     codex_sandbox: codexSandboxStatus
       ? {
@@ -7598,7 +7632,13 @@ if (brokerEnv.enabled) {
       port: brokerEnv.port,
       keys: brokerEnv.keys,
       learningStore,
-      deps: { taskStore, journal, idempotency, executorCapabilities },
+      deps: {
+        taskStore,
+        journal,
+        idempotency,
+        executorCapabilities,
+        traceIngressCounter: brokerTraceIngressCounter,
+      },
     },
     {
       signal: brokerBindAbort.signal,

--- a/src/learning-task-preflight-status.ts
+++ b/src/learning-task-preflight-status.ts
@@ -1,5 +1,7 @@
 import type { TypedPanel } from "./learning-loop-health.js";
 
+export const LEARNING_TASK_PREFLIGHT_FRESHNESS_MS = 15 * 60 * 1_000;
+
 export interface LearningTaskPreflightObservation {
   checkedAt: string;
   outcome: "ok" | "failed";
@@ -11,6 +13,11 @@ export interface LearningTaskPreflightSnapshot {
   checkedAt: string | null;
   outcome: "unknown" | "ok" | "failed";
   errorClass?: string;
+}
+
+interface BuildLearningTaskPreflightPanelOptions {
+  now?: () => Date;
+  freshnessMs?: number;
 }
 
 function sanitizeErrorClass(value: string | undefined): string | undefined {
@@ -65,9 +72,81 @@ export function createLearningTaskPreflightStore(): {
   };
 }
 
+function formatObservedAt(checkedAt: string, ageSeconds: number): string {
+  return `Observed ${checkedAt} (age ${ageSeconds}s).`;
+}
+
 export function buildLearningTaskPreflightPanel(
   snapshot: LearningTaskPreflightSnapshot,
+  options: BuildLearningTaskPreflightPanelOptions = {},
 ): TypedPanel {
+  const now = options.now ?? (() => new Date());
+  const freshnessMs = Math.max(
+    1,
+    Math.min(24 * 60 * 60 * 1_000, Math.trunc(options.freshnessMs ?? LEARNING_TASK_PREFLIGHT_FRESHNESS_MS)),
+  );
+  if (snapshot.checkedAt) {
+    const checkedAtMs = Date.parse(snapshot.checkedAt);
+    const nowMs = now().getTime();
+    if (!Number.isFinite(checkedAtMs)) {
+      return {
+        id: "hugin-learning-task-preflight",
+        label: "Authenticated learning-task preflight",
+        kind: "status",
+        refresh: 300,
+        state: "unknown",
+        message: "Authenticated learning-task preflight observation time is invalid.",
+      };
+    }
+    const ageMs = nowMs - checkedAtMs;
+    if (!Number.isFinite(nowMs) || ageMs < 0) {
+      return {
+        id: "hugin-learning-task-preflight",
+        label: "Authenticated learning-task preflight",
+        kind: "status",
+        refresh: 300,
+        state: "unknown",
+        message: `Authenticated learning-task preflight observation is in the future (${snapshot.checkedAt}).`,
+      };
+    }
+    const ageSeconds = Math.floor(ageMs / 1000);
+    if (ageMs >= freshnessMs) {
+      return {
+        id: "hugin-learning-task-preflight",
+        label: "Authenticated learning-task preflight",
+        kind: "status",
+        refresh: 300,
+        state: "unknown",
+        message:
+          "Authenticated learning-task preflight observation is stale. "
+          + formatObservedAt(snapshot.checkedAt, ageSeconds),
+      };
+    }
+    if (snapshot.outcome === "ok") {
+      return {
+        id: "hugin-learning-task-preflight",
+        label: "Authenticated learning-task preflight",
+        kind: "status",
+        refresh: 300,
+        state: "pass",
+        message:
+          "Authenticated learning-task preflight succeeded. "
+          + formatObservedAt(snapshot.checkedAt, ageSeconds),
+      };
+    }
+    if (snapshot.outcome === "failed") {
+      return {
+        id: "hugin-learning-task-preflight",
+        label: "Authenticated learning-task preflight",
+        kind: "status",
+        refresh: 300,
+        state: "fail",
+        message:
+          `Authenticated learning-task preflight failed (${snapshot.errorClass ?? "preflight-failed"}). `
+          + formatObservedAt(snapshot.checkedAt, ageSeconds),
+      };
+    }
+  }
   if (snapshot.outcome === "ok") {
     return {
       id: "hugin-learning-task-preflight",

--- a/src/learning-task-preflight-status.ts
+++ b/src/learning-task-preflight-status.ts
@@ -1,0 +1,99 @@
+import type { TypedPanel } from "./learning-loop-health.js";
+
+export interface LearningTaskPreflightObservation {
+  checkedAt: string;
+  outcome: "ok" | "failed";
+  errorClass?: string;
+  detail?: string;
+}
+
+export interface LearningTaskPreflightSnapshot {
+  checkedAt: string | null;
+  outcome: "unknown" | "ok" | "failed";
+  errorClass?: string;
+}
+
+function sanitizeErrorClass(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  const safe = trimmed
+    .replace(/[^A-Za-z0-9._:+-]/g, "-")
+    .replace(/^-+/, "")
+    .slice(0, 64);
+  return safe || undefined;
+}
+
+export function classifyLearningTaskPreflightError(
+  reason: string | undefined,
+): string {
+  const normalized = reason?.trim().toLowerCase() ?? "";
+  if (normalized.includes("capability downgrade")) return "capability-downgrade";
+  if (normalized.includes("unsupported") || normalized.includes("partial contract")) {
+    return "unsupported-contract";
+  }
+  if (normalized.includes("freshness") || normalized.includes("cache ttl")) {
+    return "stale-preflight";
+  }
+  if (normalized.includes("http")) return "preflight-http-error";
+  if (normalized.includes("clock") || normalized.includes("durable attempt start")) {
+    return "clock-order";
+  }
+  return "preflight-failed";
+}
+
+export function createLearningTaskPreflightStore(): {
+  record(observation: LearningTaskPreflightObservation): void;
+  snapshot(): LearningTaskPreflightSnapshot;
+} {
+  let snapshot: LearningTaskPreflightSnapshot = {
+    checkedAt: null,
+    outcome: "unknown",
+  };
+  return {
+    record(observation) {
+      snapshot = {
+        checkedAt: observation.checkedAt,
+        outcome: observation.outcome,
+        ...(observation.outcome === "failed"
+          ? { errorClass: sanitizeErrorClass(observation.errorClass) ?? "preflight-failed" }
+          : {}),
+      };
+    },
+    snapshot() {
+      return { ...snapshot };
+    },
+  };
+}
+
+export function buildLearningTaskPreflightPanel(
+  snapshot: LearningTaskPreflightSnapshot,
+): TypedPanel {
+  if (snapshot.outcome === "ok") {
+    return {
+      id: "hugin-learning-task-preflight",
+      label: "Authenticated learning-task preflight",
+      kind: "status",
+      refresh: 300,
+      state: "pass",
+      message: "Authenticated learning-task preflight succeeded.",
+    };
+  }
+  if (snapshot.outcome === "failed") {
+    return {
+      id: "hugin-learning-task-preflight",
+      label: "Authenticated learning-task preflight",
+      kind: "status",
+      refresh: 300,
+      state: "fail",
+      message: `Authenticated learning-task preflight failed (${snapshot.errorClass ?? "preflight-failed"}).`,
+    };
+  }
+  return {
+    id: "hugin-learning-task-preflight",
+    label: "Authenticated learning-task preflight",
+    kind: "status",
+    refresh: 300,
+    state: "unknown",
+    message: "Authenticated learning-task preflight has not run yet.",
+  };
+}

--- a/src/task-helpers.ts
+++ b/src/task-helpers.ts
@@ -1839,17 +1839,59 @@ export interface TaskCompletionResult {
 }
 
 export const STRUCTURED_RESULT_TRACE_ERROR_CLASS = "structured-result-write-failed" as const;
+export const STATUS_CAS_LOST_TRACE_ERROR_CLASS = "status-cas-lost" as const;
+export const RESULT_RECORDING_TRACE_ERROR_CLASS = "result-recording-error" as const;
+export const EXECUTION_ERROR_TRACE_ERROR_CLASS = "execution-error" as const;
 
-export function deriveResultRecordingTraceOutcome(input: Pick<TaskCompletionResult, "structuredResultOk" | "structuredResultError">): {
-  outcome: "ok" | "degraded";
-  errorClass?: typeof STRUCTURED_RESULT_TRACE_ERROR_CLASS;
+export function deriveReportedTaskStartedAt(
+  claimAcceptedAt: string | undefined,
+  observedStartedAt: Date,
+): string {
+  const claimAcceptedMs = claimAcceptedAt ? Date.parse(claimAcceptedAt) : Number.NaN;
+  const observedStartedMs = observedStartedAt.getTime();
+  if (Number.isNaN(claimAcceptedMs)) {
+    return observedStartedAt.toISOString();
+  }
+  return new Date(Math.max(observedStartedMs, claimAcceptedMs)).toISOString();
+}
+
+export function deriveResultRecordingTraceOutcome(
+  input: Pick<TaskCompletionResult, "structuredResultOk" | "structuredResultError" | "statusCasLost">,
+): {
+  outcome: "ok" | "degraded" | "stale";
+  errorClass?: typeof STRUCTURED_RESULT_TRACE_ERROR_CLASS | typeof STATUS_CAS_LOST_TRACE_ERROR_CLASS;
 } {
+  if (input.statusCasLost) {
+    return {
+      outcome: "stale",
+      errorClass: STATUS_CAS_LOST_TRACE_ERROR_CLASS,
+    };
+  }
   if (input.structuredResultOk) {
     return { outcome: "ok" };
   }
   return {
     outcome: "degraded",
     errorClass: STRUCTURED_RESULT_TRACE_ERROR_CLASS,
+  };
+}
+
+export function finalizeExecutionTraceOutcome(input: {
+  outcome: "ok" | "degraded" | "failed" | "stale" | "unknown";
+  errorClass?: string;
+}): {
+  outcome: "ok" | "degraded" | "failed" | "stale";
+  errorClass?: string;
+} {
+  if (input.outcome !== "unknown") {
+    return {
+      outcome: input.outcome,
+      errorClass: input.errorClass,
+    };
+  }
+  return {
+    outcome: "failed",
+    errorClass: input.errorClass ?? EXECUTION_ERROR_TRACE_ERROR_CLASS,
   };
 }
 

--- a/src/task-helpers.ts
+++ b/src/task-helpers.ts
@@ -1838,6 +1838,21 @@ export interface TaskCompletionResult {
   statusCasLost?: boolean;
 }
 
+export const STRUCTURED_RESULT_TRACE_ERROR_CLASS = "structured-result-write-failed" as const;
+
+export function deriveResultRecordingTraceOutcome(input: Pick<TaskCompletionResult, "structuredResultOk" | "structuredResultError">): {
+  outcome: "ok" | "degraded";
+  errorClass?: typeof STRUCTURED_RESULT_TRACE_ERROR_CLASS;
+} {
+  if (input.structuredResultOk) {
+    return { outcome: "ok" };
+  }
+  return {
+    outcome: "degraded",
+    errorClass: STRUCTURED_RESULT_TRACE_ERROR_CLASS,
+  };
+}
+
 /**
  * Atomically finalize a task by writing the terminal status FIRST (guaranteed),
  * then the structured result in a try/catch (non-fatal), then the log entry.

--- a/src/task-tracing.ts
+++ b/src/task-tracing.ts
@@ -13,6 +13,8 @@ export const TRACE_DEFAULT_RELEASE = "0.1.0" as const;
 export const TRACE_DEFAULT_MAX_ATTRIBUTES = 12;
 export const TRACE_DEFAULT_MAX_STRING_LENGTH = 64;
 export const TRACE_DEFAULT_MAX_PENDING_EXPORTS = 256;
+export const TRACE_DEFAULT_EXPORT_MAX_BYTES = 8 * 1024 * 1024;
+export const TRACE_DEFAULT_EXPORT_MAX_FILES = 4;
 
 const TRACEPARENT_RE =
   /^00-([a-f0-9]{32})-([a-f0-9]{16})-([a-f0-9]{2})$/;
@@ -70,6 +72,10 @@ export type TaskTraceInvalidReason =
   | "forbidden-baggage"
   | "malformed-traceparent";
 
+export type TaskTraceSamplingPolicy =
+  | "operator"
+  | "trusted-inbound";
+
 export interface ParsedTraceparent {
   traceId: string;
   spanId: string;
@@ -78,9 +84,9 @@ export interface ParsedTraceparent {
 
 export interface TaskTraceContext {
   traceparent: string;
-  taskClass: TaskTraceClass;
-  runtimeLane: TaskTraceRuntimeLane;
-  retryOrdinal: number;
+  taskClass?: TaskTraceClass;
+  runtimeLane?: TaskTraceRuntimeLane;
+  retryOrdinal?: number;
 }
 
 export interface InboundTaskTraceContext extends TaskTraceContext {
@@ -118,6 +124,12 @@ export interface TaskTraceRuntimeStats {
   exportDropped: number;
 }
 
+export interface TaskTraceRuntimeHealth extends TaskTraceRuntimeStats {
+  exportEnabled: boolean;
+  pendingExports: number;
+  sampleRatePerMille: number;
+}
+
 export interface SerializedTaskTraceSpan {
   kind: "trace-span";
   contract_version: typeof TRACEPOLICY_VERSION;
@@ -144,9 +156,9 @@ export interface SerializedTaskTraceSpan {
   sampled: true;
   outcome: TaskTraceOutcome;
   attributes: {
-    task_class: TaskTraceClass;
-    runtime_lane: TaskTraceRuntimeLane;
-    retry_ordinal: number;
+    task_class?: TaskTraceClass;
+    runtime_lane?: TaskTraceRuntimeLane;
+    retry_ordinal?: number;
     error_class?: string;
   };
   diagnostic_ref: string;
@@ -157,9 +169,9 @@ interface ActiveTaskTraceContext {
   traceId: string;
   spanId: string;
   traceFlags: string;
-  taskClass: TaskTraceClass;
-  runtimeLane: TaskTraceRuntimeLane;
-  retryOrdinal: number;
+  taskClass?: TaskTraceClass;
+  runtimeLane?: TaskTraceRuntimeLane;
+  retryOrdinal?: number;
 }
 
 export interface TaskTraceSpanOptions {
@@ -176,6 +188,48 @@ export interface EndTaskTraceSpanOptions {
   errorClass?: string;
   error?: unknown;
   endedAt?: Date;
+}
+
+export interface FileTaskTraceExporterOptions {
+  maxBytes?: number;
+  maxFiles?: number;
+}
+
+export interface TaskTraceIngressHealth {
+  invalidReasons: {
+    forbiddenBaggage: number;
+    malformedTraceparent: number;
+  };
+}
+
+export class TaskTraceIngressCounter {
+  private readonly counts: TaskTraceIngressHealth["invalidReasons"] = {
+    forbiddenBaggage: 0,
+    malformedTraceparent: 0,
+  };
+
+  noteInvalidReason(reason: TaskTraceInvalidReason): void {
+    if (reason === "forbidden-baggage") {
+      this.counts.forbiddenBaggage = Math.min(
+        Number.MAX_SAFE_INTEGER,
+        this.counts.forbiddenBaggage + 1,
+      );
+      return;
+    }
+    this.counts.malformedTraceparent = Math.min(
+      Number.MAX_SAFE_INTEGER,
+      this.counts.malformedTraceparent + 1,
+    );
+  }
+
+  snapshot(): TaskTraceIngressHealth {
+    return {
+      invalidReasons: {
+        forbiddenBaggage: this.counts.forbiddenBaggage,
+        malformedTraceparent: this.counts.malformedTraceparent,
+      },
+    };
+  }
 }
 
 function randomHex(bytes: number): string {
@@ -252,6 +306,20 @@ function normalizeRetryOrdinal(value: number): number {
   return Math.max(0, Math.min(10, Math.trunc(value)));
 }
 
+function normalizeTaskTraceFacts(input: {
+  taskClass?: TaskTraceClass;
+  runtimeLane?: TaskTraceRuntimeLane;
+  retryOrdinal?: number;
+}): Pick<TaskTraceContext, "taskClass" | "runtimeLane" | "retryOrdinal"> {
+  return {
+    ...(input.taskClass ? { taskClass: input.taskClass } : {}),
+    ...(input.runtimeLane ? { runtimeLane: input.runtimeLane } : {}),
+    ...(input.retryOrdinal !== undefined
+      ? { retryOrdinal: normalizeRetryOrdinal(input.retryOrdinal) }
+      : {}),
+  };
+}
+
 export function parseTraceSampleRatePerMille(
   value: string | number | undefined,
   fallback = 1000,
@@ -289,17 +357,19 @@ function diagnosticRef(serviceId: string, spanId: string): string {
 export function createInboundTaskTraceContext(input: {
   traceparent?: string;
   baggage?: string;
-  taskClass: TaskTraceClass;
-  runtimeLane: TaskTraceRuntimeLane;
-  retryOrdinal: number;
+  taskClass?: TaskTraceClass;
+  runtimeLane?: TaskTraceRuntimeLane;
+  retryOrdinal?: number;
   traceIdGenerator?: () => string;
   idGenerator?: () => string;
   sampleRatePerMille?: number;
+  samplingPolicy?: TaskTraceSamplingPolicy;
 }): InboundTaskTraceContext {
   const parsed = parseTraceparent(input.traceparent);
   const sampleRatePerMille = clampSamplingPerMille(
     input.sampleRatePerMille ?? 1000,
   );
+  const samplingPolicy = input.samplingPolicy ?? "operator";
   const baggage = input.baggage?.trim();
   const invalidReason: TaskTraceInvalidReason | undefined = parsed
     ? baggage
@@ -310,11 +380,15 @@ export function createInboundTaskTraceContext(input: {
       : baggage
         ? "forbidden-baggage"
         : undefined;
+  const facts = normalizeTaskTraceFacts(input);
   if (parsed) {
+    const sampleTraceId = samplingPolicy === "trusted-inbound"
+      ? parsed.traceId
+      : (input.traceIdGenerator ?? defaultTraceId)();
     const traceFlags = sampledFlags(shouldSample(
       sampleRatePerMille,
-      parsed.traceId,
-      parsed.traceFlags,
+      sampleTraceId,
+      samplingPolicy === "trusted-inbound" ? parsed.traceFlags : undefined,
     ));
     return {
       traceparent: formatTraceparent(
@@ -326,9 +400,7 @@ export function createInboundTaskTraceContext(input: {
       spanId: parsed.spanId,
       parentSpanId: parsed.spanId,
       traceFlags,
-      taskClass: input.taskClass,
-      runtimeLane: input.runtimeLane,
-      retryOrdinal: normalizeRetryOrdinal(input.retryOrdinal),
+      ...facts,
       ...(invalidReason ? { invalidReason } : {}),
     };
   }
@@ -340,9 +412,7 @@ export function createInboundTaskTraceContext(input: {
     traceId,
     spanId,
     traceFlags,
-    taskClass: input.taskClass,
-    runtimeLane: input.runtimeLane,
-    retryOrdinal: normalizeRetryOrdinal(input.retryOrdinal),
+    ...facts,
     ...(invalidReason ? { invalidReason } : {}),
   };
 }
@@ -350,14 +420,17 @@ export function createInboundTaskTraceContext(input: {
 export function buildTaskTraceContextSection(
   context: TaskTraceContext,
 ): string {
+  const facts = normalizeTaskTraceFacts(context);
   return [
     "### Trace context",
     "```json",
     JSON.stringify({
       traceparent: context.traceparent,
-      task_class: context.taskClass,
-      runtime_lane: context.runtimeLane,
-      retry_ordinal: normalizeRetryOrdinal(context.retryOrdinal),
+      ...(facts.taskClass ? { task_class: facts.taskClass } : {}),
+      ...(facts.runtimeLane ? { runtime_lane: facts.runtimeLane } : {}),
+      ...(facts.retryOrdinal !== undefined
+        ? { retry_ordinal: facts.retryOrdinal }
+        : {}),
     }, null, 2),
     "```",
   ].join("\n");
@@ -369,15 +442,14 @@ export function buildChildTaskTraceContext(
 ): TaskTraceContext | null {
   const parsed = parseTraceparent(traceparent);
   if (!parsed) return null;
+  const facts = normalizeTaskTraceFacts(context);
   return {
     traceparent: formatTraceparent(
       parsed.traceId,
       parsed.spanId,
       parsed.traceFlags,
     ),
-    taskClass: context.taskClass,
-    runtimeLane: context.runtimeLane,
-    retryOrdinal: normalizeRetryOrdinal(context.retryOrdinal),
+    ...facts,
   };
 }
 
@@ -395,16 +467,25 @@ export function parseTaskTraceContext(
     };
     if (typeof parsed.traceparent !== "string") return null;
     if (!parseTraceparent(parsed.traceparent)) return null;
-    if (typeof parsed.task_class !== "string") return null;
-    if (!isTaskTraceClass(parsed.task_class)) return null;
-    if (typeof parsed.runtime_lane !== "string") return null;
-    if (!isTaskTraceRuntimeLane(parsed.runtime_lane)) return null;
-    if (typeof parsed.retry_ordinal !== "number") return null;
+    if (
+      parsed.task_class !== undefined &&
+      (typeof parsed.task_class !== "string" || !isTaskTraceClass(parsed.task_class))
+    ) return null;
+    if (
+      parsed.runtime_lane !== undefined &&
+      (typeof parsed.runtime_lane !== "string" || !isTaskTraceRuntimeLane(parsed.runtime_lane))
+    ) return null;
+    if (
+      parsed.retry_ordinal !== undefined &&
+      typeof parsed.retry_ordinal !== "number"
+    ) return null;
     return {
       traceparent: parsed.traceparent,
-      taskClass: parsed.task_class,
-      runtimeLane: parsed.runtime_lane,
-      retryOrdinal: normalizeRetryOrdinal(parsed.retry_ordinal),
+      ...(parsed.task_class ? { taskClass: parsed.task_class } : {}),
+      ...(parsed.runtime_lane ? { runtimeLane: parsed.runtime_lane } : {}),
+      ...(parsed.retry_ordinal !== undefined
+        ? { retryOrdinal: normalizeRetryOrdinal(parsed.retry_ordinal) }
+        : {}),
     };
   } catch {
     return null;
@@ -414,22 +495,61 @@ export function parseTaskTraceContext(
 async function appendJsonLine(
   exportPath: string,
   value: SerializedTaskTraceSpan,
+  options: FileTaskTraceExporterOptions,
 ): Promise<void> {
+  const maxBytes = Math.max(
+    1,
+    Math.min(
+      1024 * 1024 * 1024,
+      Math.trunc(options.maxBytes ?? TRACE_DEFAULT_EXPORT_MAX_BYTES),
+    ),
+  );
+  const maxFiles = Math.max(
+    1,
+    Math.min(16, Math.trunc(options.maxFiles ?? TRACE_DEFAULT_EXPORT_MAX_FILES)),
+  );
+  const line = `${JSON.stringify(value)}\n`;
   await fs.mkdir(path.dirname(exportPath), { recursive: true });
+  const lineBytes = Buffer.byteLength(line, "utf8");
+  let currentSize = 0;
+  try {
+    currentSize = (await fs.stat(exportPath)).size;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT") throw err;
+  }
+  if (currentSize > 0 && currentSize + lineBytes > maxBytes) {
+    const archiveCount = maxFiles - 1;
+    if (archiveCount <= 0) {
+      await fs.rm(exportPath, { force: true });
+    } else {
+      await fs.rm(`${exportPath}.${archiveCount}`, { force: true });
+      for (let index = archiveCount - 1; index >= 1; index -= 1) {
+        try {
+          await fs.rename(`${exportPath}.${index}`, `${exportPath}.${index + 1}`);
+        } catch (err) {
+          const code = (err as NodeJS.ErrnoException).code;
+          if (code !== "ENOENT") throw err;
+        }
+      }
+      await fs.rename(exportPath, `${exportPath}.1`);
+    }
+  }
   await fs.appendFile(
     exportPath,
-    `${JSON.stringify(value)}\n`,
+    line,
     "utf8",
   );
 }
 
 export function createFileTaskTraceExporter(
   exportPath: string | undefined,
+  options: FileTaskTraceExporterOptions = {},
 ): TaskTraceExporter | undefined {
   const trimmed = exportPath?.trim();
   if (!trimmed) return undefined;
   return {
-    exportSpan: async (span) => appendJsonLine(trimmed, span),
+    exportSpan: async (span) => appendJsonLine(trimmed, span, options),
   };
 }
 
@@ -492,20 +612,30 @@ export class TaskTraceRuntime {
     this.now = options.now ?? (() => new Date());
   }
 
+  getHealth(): TaskTraceRuntimeHealth {
+    return {
+      exportEnabled: this.exportEnabled,
+      sampleRatePerMille: this.sampleRatePerMille,
+      exportFailures: this.stats.exportFailures,
+      exportDropped: this.stats.exportDropped,
+      pendingExports: this.exportQueue.length,
+    };
+  }
+
   startSpan(options: TaskTraceSpanOptions): TaskTraceSpan {
     const inherited = this.context.getStore();
     const explicitContext = options.taskContext
       ? parseTraceparent(options.taskContext.traceparent)
       : null;
     const taskClass = options.taskContext?.taskClass
-      ?? inherited?.taskClass
-      ?? "read_only";
+      ?? inherited?.taskClass;
     const runtimeLane = options.taskContext?.runtimeLane
-      ?? inherited?.runtimeLane
-      ?? "default";
-    const retryOrdinal = normalizeRetryOrdinal(
-      options.taskContext?.retryOrdinal ?? inherited?.retryOrdinal ?? 0,
-    );
+      ?? inherited?.runtimeLane;
+    const retryOrdinalSource =
+      options.taskContext?.retryOrdinal ?? inherited?.retryOrdinal;
+    const retryOrdinal = retryOrdinalSource !== undefined
+      ? normalizeRetryOrdinal(retryOrdinalSource)
+      : undefined;
 
     const traceId = explicitContext?.traceId
       ?? inherited?.traceId
@@ -522,9 +652,9 @@ export class TaskTraceRuntime {
       traceId,
       spanId,
       traceFlags,
-      taskClass,
-      runtimeLane,
-      retryOrdinal,
+      ...(taskClass ? { taskClass } : {}),
+      ...(runtimeLane ? { runtimeLane } : {}),
+      ...(retryOrdinal !== undefined ? { retryOrdinal } : {}),
     };
     return new TaskTraceSpan(this, {
       name: options.name,
@@ -534,9 +664,9 @@ export class TaskTraceRuntime {
       spanId,
       parentSpanId,
       traceFlags,
-      taskClass,
-      runtimeLane,
-      retryOrdinal,
+      ...(taskClass ? { taskClass } : {}),
+      ...(runtimeLane ? { runtimeLane } : {}),
+      ...(retryOrdinal !== undefined ? { retryOrdinal } : {}),
       activeContext,
       startedAt: options.startedAt ?? this.now(),
     });
@@ -630,9 +760,9 @@ export class TaskTraceSpan {
       spanId: string;
       parentSpanId?: string;
       traceFlags: string;
-      taskClass: TaskTraceClass;
-      runtimeLane: TaskTraceRuntimeLane;
-      retryOrdinal: number;
+      taskClass?: TaskTraceClass;
+      runtimeLane?: TaskTraceRuntimeLane;
+      retryOrdinal?: number;
       activeContext: ActiveTaskTraceContext;
       startedAt: Date;
     },
@@ -668,9 +798,11 @@ export class TaskTraceSpan {
       ? this.endedAt
       : this.state.startedAt;
     const attributes: SerializedTaskTraceSpan["attributes"] = {
-      task_class: this.state.taskClass,
-      runtime_lane: this.state.runtimeLane,
-      retry_ordinal: this.state.retryOrdinal,
+      ...(this.state.taskClass ? { task_class: this.state.taskClass } : {}),
+      ...(this.state.runtimeLane ? { runtime_lane: this.state.runtimeLane } : {}),
+      ...(this.state.retryOrdinal !== undefined
+        ? { retry_ordinal: this.state.retryOrdinal }
+        : {}),
     };
     if (this.errorClass) {
       attributes.error_class = this.errorClass;

--- a/src/task-tracing.ts
+++ b/src/task-tracing.ts
@@ -1,0 +1,635 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { randomBytes } from "node:crypto";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+import { taskMetadataPrefix } from "./task-document-metadata.js";
+
+export const TRACEPOLICY_VERSION = "v1.0" as const;
+export const TRACEPOLICY_ID = "trace-policy-hugin" as const;
+export const TRACE_DEFAULT_SERVICE_ID = "hugin" as const;
+export const TRACE_DEFAULT_INSTANCE_ID = "huginmunin" as const;
+export const TRACE_DEFAULT_RELEASE = "0.1.0" as const;
+export const TRACE_DEFAULT_MAX_ATTRIBUTES = 12;
+export const TRACE_DEFAULT_MAX_STRING_LENGTH = 64;
+
+const TRACEPARENT_RE =
+  /^00-([a-f0-9]{32})-([a-f0-9]{16})-([a-f0-9]{2})$/;
+const NON_ZERO_HEX_RE = /[1-9a-f]/;
+const TRACE_CONTEXT_SECTION_RE =
+  /### Trace context\s*\n```json\s*\n([\s\S]*?)\n```/i;
+const BANNED_TOKEN_RE =
+  /:\/\/|[/?#=@\\]|(?:^|[^0-9])(?:10|127|169\.254|172\.(?:1[6-9]|2\d|3[01])|192\.168)\./i;
+
+export type TaskTraceClass =
+  | "diagnostic"
+  | "delegation"
+  | "maintenance"
+  | "publication"
+  | "read_only"
+  | "not_applicable";
+
+export type TaskTraceRuntimeLane =
+  | "default"
+  | "reason-hard"
+  | "reason-fast"
+  | "numeric"
+  | "review"
+  | "not_applicable";
+
+export type TaskTraceSurface =
+  | "task"
+  | "gateway"
+  | "service"
+  | "synthetic";
+
+export type TaskTracePhase =
+  | "ingress"
+  | "queue"
+  | "execution"
+  | "dependency"
+  | "publication"
+  | "probe"
+  | "export";
+
+export type TaskTraceOutcome =
+  | "ok"
+  | "degraded"
+  | "failed"
+  | "stale"
+  | "unknown";
+
+export type TaskTraceInvalidReason =
+  | "forbidden-baggage"
+  | "malformed-traceparent";
+
+export interface ParsedTraceparent {
+  traceId: string;
+  spanId: string;
+  traceFlags: string;
+}
+
+export interface TaskTraceContext {
+  traceparent: string;
+  taskClass: TaskTraceClass;
+  runtimeLane: TaskTraceRuntimeLane;
+  retryOrdinal: number;
+}
+
+export interface InboundTaskTraceContext extends TaskTraceContext {
+  traceId: string;
+  spanId: string;
+  parentSpanId?: string;
+  traceFlags: string;
+  baggage?: string;
+  invalidReason?: TaskTraceInvalidReason;
+}
+
+export interface TaskTraceExporter {
+  exportSpan(
+    span: SerializedTaskTraceSpan,
+  ): Promise<void> | void;
+}
+
+export interface TaskTraceRuntimeOptions {
+  exportEnabled: boolean;
+  sampleRatePerMille: number;
+  release?: string;
+  serviceId?: string;
+  instanceId?: string;
+  exporter?: TaskTraceExporter;
+  traceIdGenerator?: () => string;
+  idGenerator?: () => string;
+  now?: () => Date;
+  maxAttributes?: number;
+  maxStringLength?: number;
+}
+
+export interface TaskTraceRuntimeStats {
+  exportFailures: number;
+}
+
+export interface SerializedTaskTraceSpan {
+  kind: "trace-span";
+  contract_version: typeof TRACEPOLICY_VERSION;
+  policy_id: typeof TRACEPOLICY_ID;
+  source: {
+    source_kind: "service_internal";
+    producer: string;
+    producer_version: string;
+  };
+  service: {
+    service_id: string;
+    instance_id: string;
+  };
+  trace_id: string;
+  span_id: string;
+  parent_span_id?: string;
+  operation: {
+    surface: TaskTraceSurface;
+    phase: TaskTracePhase;
+  };
+  started_at: string;
+  ended_at: string;
+  collected_at: string;
+  sampled: true;
+  outcome: TaskTraceOutcome;
+  attributes: {
+    task_class: TaskTraceClass;
+    runtime_lane: TaskTraceRuntimeLane;
+    retry_ordinal: number;
+    error_class?: string;
+  };
+  diagnostic_ref: string;
+  extensions: [];
+}
+
+interface ActiveTaskTraceContext {
+  traceId: string;
+  spanId: string;
+  traceFlags: string;
+  taskClass: TaskTraceClass;
+  runtimeLane: TaskTraceRuntimeLane;
+  retryOrdinal: number;
+}
+
+export interface TaskTraceSpanOptions {
+  name: string;
+  surface: TaskTraceSurface;
+  phase: TaskTracePhase;
+  taskContext?: TaskTraceContext;
+  unsafeAttributes?: Record<string, unknown>;
+  startedAt?: Date;
+}
+
+export interface EndTaskTraceSpanOptions {
+  outcome: TaskTraceOutcome;
+  errorClass?: string;
+  error?: unknown;
+  endedAt?: Date;
+}
+
+function randomHex(bytes: number): string {
+  return randomBytes(bytes).toString("hex");
+}
+
+function defaultTraceId(): string {
+  return randomHex(16);
+}
+
+function defaultSpanId(): string {
+  return randomHex(8);
+}
+
+function isNonZeroHex(value: string): boolean {
+  return NON_ZERO_HEX_RE.test(value);
+}
+
+export function parseTraceparent(
+  value: string | undefined,
+): ParsedTraceparent | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  const match = TRACEPARENT_RE.exec(trimmed);
+  if (!match) return null;
+  const [, traceId, spanId, traceFlags] = match;
+  if (!traceId || !spanId || !traceFlags) return null;
+  if (!isNonZeroHex(traceId) || !isNonZeroHex(spanId)) return null;
+  return { traceId, spanId, traceFlags };
+}
+
+function clampSamplingPerMille(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1000, Math.round(value)));
+}
+
+function formatTraceparent(
+  traceId: string,
+  spanId: string,
+  traceFlags: string,
+): string {
+  return `00-${traceId}-${spanId}-${traceFlags}`;
+}
+
+function sampledFlags(sampled: boolean): string {
+  return sampled ? "01" : "00";
+}
+
+function shouldSample(
+  sampleRatePerMille: number,
+  traceFlags?: string,
+): boolean {
+  if (traceFlags) {
+    return (Number.parseInt(traceFlags, 16) & 0x01) === 0x01;
+  }
+  return clampSamplingPerMille(sampleRatePerMille) > 0;
+}
+
+function normalizeRetryOrdinal(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(10, Math.trunc(value)));
+}
+
+export function parseTraceSampleRatePerMille(
+  value: string | number | undefined,
+  fallback = 1000,
+): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return clampSamplingPerMille(fallback);
+  }
+  return clampSamplingPerMille(parsed);
+}
+
+function sanitizeSafeToken(
+  value: string | undefined,
+  fallback: string,
+  maxLength: number,
+): string {
+  const trimmed = (value ?? "").trim();
+  if (!trimmed || BANNED_TOKEN_RE.test(trimmed)) return fallback;
+  const safe = trimmed
+    .replace(/[^A-Za-z0-9._:+-]/g, "-")
+    .replace(/^[^A-Za-z0-9]+/, "")
+    .slice(0, maxLength);
+  if (!safe || BANNED_TOKEN_RE.test(safe)) return fallback;
+  return safe;
+}
+
+function formatContractTimestamp(value: Date): string {
+  return value.toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+function diagnosticRef(serviceId: string, spanId: string): string {
+  return `ref:${serviceId}-trace-${spanId}`;
+}
+
+export function createInboundTaskTraceContext(input: {
+  traceparent?: string;
+  baggage?: string;
+  taskClass: TaskTraceClass;
+  runtimeLane: TaskTraceRuntimeLane;
+  retryOrdinal: number;
+  traceIdGenerator?: () => string;
+  idGenerator?: () => string;
+  sampleRatePerMille?: number;
+}): InboundTaskTraceContext {
+  const parsed = parseTraceparent(input.traceparent);
+  const sampleRatePerMille = clampSamplingPerMille(
+    input.sampleRatePerMille ?? 1000,
+  );
+  const baggage = input.baggage?.trim();
+  const invalidReason: TaskTraceInvalidReason | undefined = parsed
+    ? baggage
+      ? "forbidden-baggage"
+      : undefined
+    : input.traceparent
+      ? "malformed-traceparent"
+      : baggage
+        ? "forbidden-baggage"
+        : undefined;
+  if (parsed) {
+    return {
+      traceparent: formatTraceparent(
+        parsed.traceId,
+        parsed.spanId,
+        parsed.traceFlags,
+      ),
+      traceId: parsed.traceId,
+      spanId: parsed.spanId,
+      parentSpanId: parsed.spanId,
+      traceFlags: parsed.traceFlags,
+      taskClass: input.taskClass,
+      runtimeLane: input.runtimeLane,
+      retryOrdinal: normalizeRetryOrdinal(input.retryOrdinal),
+      ...(invalidReason ? { invalidReason } : {}),
+    };
+  }
+  const traceId = (input.traceIdGenerator ?? defaultTraceId)();
+  const spanId = (input.idGenerator ?? defaultSpanId)();
+  const traceFlags = sampledFlags(shouldSample(sampleRatePerMille));
+  return {
+    traceparent: formatTraceparent(traceId, spanId, traceFlags),
+    traceId,
+    spanId,
+    traceFlags,
+    taskClass: input.taskClass,
+    runtimeLane: input.runtimeLane,
+    retryOrdinal: normalizeRetryOrdinal(input.retryOrdinal),
+    ...(invalidReason ? { invalidReason } : {}),
+  };
+}
+
+export function buildTaskTraceContextSection(
+  context: TaskTraceContext,
+): string {
+  return [
+    "### Trace context",
+    "```json",
+    JSON.stringify({
+      traceparent: context.traceparent,
+      task_class: context.taskClass,
+      runtime_lane: context.runtimeLane,
+      retry_ordinal: normalizeRetryOrdinal(context.retryOrdinal),
+    }, null, 2),
+    "```",
+  ].join("\n");
+}
+
+export function buildChildTaskTraceContext(
+  traceparent: string,
+  context: Pick<TaskTraceContext, "taskClass" | "runtimeLane" | "retryOrdinal">,
+): TaskTraceContext | null {
+  const parsed = parseTraceparent(traceparent);
+  if (!parsed) return null;
+  return {
+    traceparent: formatTraceparent(
+      parsed.traceId,
+      parsed.spanId,
+      parsed.traceFlags,
+    ),
+    taskClass: context.taskClass,
+    runtimeLane: context.runtimeLane,
+    retryOrdinal: normalizeRetryOrdinal(context.retryOrdinal),
+  };
+}
+
+export function parseTaskTraceContext(
+  content: string,
+): TaskTraceContext | null {
+  const match = taskMetadataPrefix(content).match(TRACE_CONTEXT_SECTION_RE);
+  if (!match?.[1]) return null;
+  try {
+    const parsed = JSON.parse(match[1]) as {
+      traceparent?: unknown;
+      task_class?: unknown;
+      runtime_lane?: unknown;
+      retry_ordinal?: unknown;
+    };
+    if (typeof parsed.traceparent !== "string") return null;
+    if (!parseTraceparent(parsed.traceparent)) return null;
+    if (typeof parsed.task_class !== "string") return null;
+    if (typeof parsed.runtime_lane !== "string") return null;
+    if (typeof parsed.retry_ordinal !== "number") return null;
+    return {
+      traceparent: parsed.traceparent,
+      taskClass: parsed.task_class as TaskTraceClass,
+      runtimeLane: parsed.runtime_lane as TaskTraceRuntimeLane,
+      retryOrdinal: normalizeRetryOrdinal(parsed.retry_ordinal),
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function appendJsonLine(
+  exportPath: string,
+  value: SerializedTaskTraceSpan,
+): Promise<void> {
+  await fs.mkdir(path.dirname(exportPath), { recursive: true });
+  await fs.appendFile(
+    exportPath,
+    `${JSON.stringify(value)}\n`,
+    "utf8",
+  );
+}
+
+export function createFileTaskTraceExporter(
+  exportPath: string | undefined,
+): TaskTraceExporter | undefined {
+  const trimmed = exportPath?.trim();
+  if (!trimmed) return undefined;
+  return {
+    exportSpan: async (span) => appendJsonLine(trimmed, span),
+  };
+}
+
+export class TaskTraceRuntime {
+  readonly stats: TaskTraceRuntimeStats = { exportFailures: 0 };
+  readonly serviceId: string;
+  readonly instanceId: string;
+  readonly release: string;
+  readonly exportEnabled: boolean;
+  readonly sampleRatePerMille: number;
+  readonly maxAttributes: number;
+  readonly maxStringLength: number;
+
+  private readonly exporter?: TaskTraceExporter;
+  private readonly traceIdGenerator: () => string;
+  private readonly idGenerator: () => string;
+  private readonly now: () => Date;
+  private readonly context =
+    new AsyncLocalStorage<ActiveTaskTraceContext>();
+
+  constructor(options: TaskTraceRuntimeOptions) {
+    this.exportEnabled = options.exportEnabled;
+    this.sampleRatePerMille = clampSamplingPerMille(
+      options.sampleRatePerMille,
+    );
+    this.maxAttributes = Math.max(
+      1,
+      Math.min(64, Math.trunc(options.maxAttributes ?? TRACE_DEFAULT_MAX_ATTRIBUTES)),
+    );
+    this.maxStringLength = Math.max(
+      1,
+      Math.min(256, Math.trunc(options.maxStringLength ?? TRACE_DEFAULT_MAX_STRING_LENGTH)),
+    );
+    this.serviceId = sanitizeSafeToken(
+      options.serviceId,
+      TRACE_DEFAULT_SERVICE_ID,
+      this.maxStringLength,
+    );
+    this.instanceId = sanitizeSafeToken(
+      options.instanceId,
+      TRACE_DEFAULT_INSTANCE_ID,
+      this.maxStringLength,
+    );
+    this.release = sanitizeSafeToken(
+      options.release,
+      TRACE_DEFAULT_RELEASE,
+      this.maxStringLength,
+    );
+    this.exporter = options.exporter;
+    this.traceIdGenerator = options.traceIdGenerator ?? defaultTraceId;
+    this.idGenerator = options.idGenerator ?? defaultSpanId;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  startSpan(options: TaskTraceSpanOptions): TaskTraceSpan {
+    const inherited = this.context.getStore();
+    const explicitContext = options.taskContext
+      ? parseTraceparent(options.taskContext.traceparent)
+      : null;
+    const taskClass = options.taskContext?.taskClass
+      ?? inherited?.taskClass
+      ?? "read_only";
+    const runtimeLane = options.taskContext?.runtimeLane
+      ?? inherited?.runtimeLane
+      ?? "default";
+    const retryOrdinal = normalizeRetryOrdinal(
+      options.taskContext?.retryOrdinal ?? inherited?.retryOrdinal ?? 0,
+    );
+
+    const traceId = explicitContext?.traceId
+      ?? inherited?.traceId
+      ?? this.traceIdGenerator();
+    const parentSpanId = explicitContext?.spanId ?? inherited?.spanId;
+    const traceFlags = explicitContext?.traceFlags
+      ?? inherited?.traceFlags
+      ?? sampledFlags(shouldSample(this.sampleRatePerMille));
+    const spanId = this.idGenerator();
+    const activeContext: ActiveTaskTraceContext = {
+      traceId,
+      spanId,
+      traceFlags,
+      taskClass,
+      runtimeLane,
+      retryOrdinal,
+    };
+    return new TaskTraceSpan(this, {
+      name: options.name,
+      surface: options.surface,
+      phase: options.phase,
+      traceId,
+      spanId,
+      parentSpanId,
+      traceFlags,
+      taskClass,
+      runtimeLane,
+      retryOrdinal,
+      activeContext,
+      startedAt: options.startedAt ?? this.now(),
+    });
+  }
+
+  async runWithSpan<T>(
+    span: TaskTraceSpan,
+    fn: () => Promise<T> | T,
+  ): Promise<T> {
+    return await this.context.run(span.activeContext, fn);
+  }
+
+  async finalizeSpan(
+    span: TaskTraceSpan,
+    options: EndTaskTraceSpanOptions,
+  ): Promise<void> {
+    span.finish(options.outcome, options.errorClass, options.endedAt ?? this.now());
+    if (!this.exportEnabled || !span.sampled) return;
+    const serialized = span.serialize();
+    if (!serialized || !this.exporter) return;
+    try {
+      await this.exporter.exportSpan(serialized);
+    } catch {
+      this.stats.exportFailures += 1;
+    }
+  }
+}
+
+export class TaskTraceSpan {
+  readonly traceparent: string;
+  readonly sampled: boolean;
+  readonly activeContext: ActiveTaskTraceContext;
+
+  private outcome: TaskTraceOutcome | null = null;
+  private errorClass?: string;
+  private endedAt?: Date;
+
+  constructor(
+    private readonly runtime: TaskTraceRuntime,
+    private readonly state: {
+      name: string;
+      surface: TaskTraceSurface;
+      phase: TaskTracePhase;
+      traceId: string;
+      spanId: string;
+      parentSpanId?: string;
+      traceFlags: string;
+      taskClass: TaskTraceClass;
+      runtimeLane: TaskTraceRuntimeLane;
+      retryOrdinal: number;
+      activeContext: ActiveTaskTraceContext;
+      startedAt: Date;
+    },
+  ) {
+    this.traceparent = formatTraceparent(
+      state.traceId,
+      state.spanId,
+      state.traceFlags,
+    );
+    this.sampled = shouldSample(
+      runtime.sampleRatePerMille,
+      state.traceFlags,
+    );
+    this.activeContext = state.activeContext;
+  }
+
+  finish(
+    outcome: TaskTraceOutcome,
+    errorClass: string | undefined,
+    endedAt: Date,
+  ): void {
+    this.outcome = outcome;
+    this.errorClass = errorClass
+      ? sanitizeSafeToken(
+          errorClass,
+          "internal-error",
+          this.runtime.maxStringLength,
+        )
+      : undefined;
+    this.endedAt = endedAt;
+  }
+
+  serialize(): SerializedTaskTraceSpan | null {
+    if (!this.outcome || !this.endedAt || !this.sampled) return null;
+    const attributes: SerializedTaskTraceSpan["attributes"] = {
+      task_class: this.state.taskClass,
+      runtime_lane: this.state.runtimeLane,
+      retry_ordinal: this.state.retryOrdinal,
+    };
+    if (this.errorClass) {
+      attributes.error_class = this.errorClass;
+    }
+    return {
+      kind: "trace-span",
+      contract_version: TRACEPOLICY_VERSION,
+      policy_id: TRACEPOLICY_ID,
+      source: {
+        source_kind: "service_internal",
+        producer: this.runtime.serviceId,
+        producer_version: this.runtime.release,
+      },
+      service: {
+        service_id: this.runtime.serviceId,
+        instance_id: this.runtime.instanceId,
+      },
+      trace_id: this.state.traceId,
+      span_id: this.state.spanId,
+      ...(this.state.parentSpanId
+        ? { parent_span_id: this.state.parentSpanId }
+        : {}),
+      operation: {
+        surface: this.state.surface,
+        phase: this.state.phase,
+      },
+      started_at: formatContractTimestamp(this.state.startedAt),
+      ended_at: formatContractTimestamp(this.endedAt),
+      collected_at: formatContractTimestamp(this.endedAt),
+      sampled: true,
+      outcome: this.outcome,
+      attributes,
+      diagnostic_ref: diagnosticRef(this.runtime.serviceId, this.state.spanId),
+      extensions: [],
+    };
+  }
+
+  async end(options: EndTaskTraceSpanOptions): Promise<void> {
+    await this.runtime.finalizeSpan(this, options);
+  }
+}
+
+export async function endTaskSpan(
+  span: TaskTraceSpan,
+  options: EndTaskTraceSpanOptions,
+): Promise<void> {
+  await span.end(options);
+}

--- a/src/task-tracing.ts
+++ b/src/task-tracing.ts
@@ -234,12 +234,17 @@ function sampledFlags(sampled: boolean): string {
 
 function shouldSample(
   sampleRatePerMille: number,
+  traceId: string,
   traceFlags?: string,
 ): boolean {
-  if (traceFlags) {
-    return (Number.parseInt(traceFlags, 16) & 0x01) === 0x01;
-  }
-  return clampSamplingPerMille(sampleRatePerMille) > 0;
+  const rate = clampSamplingPerMille(sampleRatePerMille);
+  if (rate === 0) return false;
+  if (traceFlags && (Number.parseInt(traceFlags, 16) & 0x01) === 0) return false;
+  if (rate === 1000) return true;
+  // Stable ratio sampling keeps every service on one trace aligned and avoids
+  // a fresh random decision for each child span. The first 32 trace-id bits
+  // are uniformly random for generated W3C IDs.
+  return Number.parseInt(traceId.slice(0, 8), 16) % 1000 < rate;
 }
 
 function normalizeRetryOrdinal(value: number): number {
@@ -306,16 +311,21 @@ export function createInboundTaskTraceContext(input: {
         ? "forbidden-baggage"
         : undefined;
   if (parsed) {
+    const traceFlags = sampledFlags(shouldSample(
+      sampleRatePerMille,
+      parsed.traceId,
+      parsed.traceFlags,
+    ));
     return {
       traceparent: formatTraceparent(
         parsed.traceId,
         parsed.spanId,
-        parsed.traceFlags,
+        traceFlags,
       ),
       traceId: parsed.traceId,
       spanId: parsed.spanId,
       parentSpanId: parsed.spanId,
-      traceFlags: parsed.traceFlags,
+      traceFlags,
       taskClass: input.taskClass,
       runtimeLane: input.runtimeLane,
       retryOrdinal: normalizeRetryOrdinal(input.retryOrdinal),
@@ -324,7 +334,7 @@ export function createInboundTaskTraceContext(input: {
   }
   const traceId = (input.traceIdGenerator ?? defaultTraceId)();
   const spanId = (input.idGenerator ?? defaultSpanId)();
-  const traceFlags = sampledFlags(shouldSample(sampleRatePerMille));
+  const traceFlags = sampledFlags(shouldSample(sampleRatePerMille, traceId));
   return {
     traceparent: formatTraceparent(traceId, spanId, traceFlags),
     traceId,
@@ -501,9 +511,12 @@ export class TaskTraceRuntime {
       ?? inherited?.traceId
       ?? this.traceIdGenerator();
     const parentSpanId = explicitContext?.spanId ?? inherited?.spanId;
-    const traceFlags = explicitContext?.traceFlags
-      ?? inherited?.traceFlags
-      ?? sampledFlags(shouldSample(this.sampleRatePerMille));
+    const inheritedFlags = explicitContext?.traceFlags ?? inherited?.traceFlags;
+    const traceFlags = sampledFlags(shouldSample(
+      this.sampleRatePerMille,
+      traceId,
+      inheritedFlags,
+    ));
     const spanId = this.idGenerator();
     const activeContext: ActiveTaskTraceContext = {
       traceId,
@@ -629,10 +642,7 @@ export class TaskTraceSpan {
       state.spanId,
       state.traceFlags,
     );
-    this.sampled = shouldSample(
-      runtime.sampleRatePerMille,
-      state.traceFlags,
-    );
+    this.sampled = (Number.parseInt(state.traceFlags, 16) & 0x01) === 0x01;
     this.activeContext = state.activeContext;
   }
 
@@ -654,6 +664,9 @@ export class TaskTraceSpan {
 
   serialize(): SerializedTaskTraceSpan | null {
     if (!this.outcome || !this.endedAt || !this.sampled) return null;
+    const startedAt = this.state.startedAt.getTime() > this.endedAt.getTime()
+      ? this.endedAt
+      : this.state.startedAt;
     const attributes: SerializedTaskTraceSpan["attributes"] = {
       task_class: this.state.taskClass,
       runtime_lane: this.state.runtimeLane,
@@ -684,7 +697,7 @@ export class TaskTraceSpan {
         surface: this.state.surface,
         phase: this.state.phase,
       },
-      started_at: formatContractTimestamp(this.state.startedAt),
+      started_at: formatContractTimestamp(startedAt),
       ended_at: formatContractTimestamp(this.endedAt),
       collected_at: formatContractTimestamp(this.endedAt),
       sampled: true,

--- a/src/task-tracing.ts
+++ b/src/task-tracing.ts
@@ -12,6 +12,7 @@ export const TRACE_DEFAULT_INSTANCE_ID = "huginmunin" as const;
 export const TRACE_DEFAULT_RELEASE = "0.1.0" as const;
 export const TRACE_DEFAULT_MAX_ATTRIBUTES = 12;
 export const TRACE_DEFAULT_MAX_STRING_LENGTH = 64;
+export const TRACE_DEFAULT_MAX_PENDING_EXPORTS = 256;
 
 const TRACEPARENT_RE =
   /^00-([a-f0-9]{32})-([a-f0-9]{16})-([a-f0-9]{2})$/;
@@ -21,21 +22,27 @@ const TRACE_CONTEXT_SECTION_RE =
 const BANNED_TOKEN_RE =
   /:\/\/|[/?#=@\\]|(?:^|[^0-9])(?:10|127|169\.254|172\.(?:1[6-9]|2\d|3[01])|192\.168)\./i;
 
-export type TaskTraceClass =
-  | "diagnostic"
-  | "delegation"
-  | "maintenance"
-  | "publication"
-  | "read_only"
-  | "not_applicable";
+export const TASK_TRACE_CLASSES = [
+  "diagnostic",
+  "delegation",
+  "maintenance",
+  "publication",
+  "read_only",
+  "not_applicable",
+] as const;
 
-export type TaskTraceRuntimeLane =
-  | "default"
-  | "reason-hard"
-  | "reason-fast"
-  | "numeric"
-  | "review"
-  | "not_applicable";
+export type TaskTraceClass = (typeof TASK_TRACE_CLASSES)[number];
+
+export const TASK_TRACE_RUNTIME_LANES = [
+  "default",
+  "reason-hard",
+  "reason-fast",
+  "numeric",
+  "review",
+  "not_applicable",
+] as const;
+
+export type TaskTraceRuntimeLane = (typeof TASK_TRACE_RUNTIME_LANES)[number];
 
 export type TaskTraceSurface =
   | "task"
@@ -98,6 +105,7 @@ export interface TaskTraceRuntimeOptions {
   serviceId?: string;
   instanceId?: string;
   exporter?: TaskTraceExporter;
+  maxPendingExports?: number;
   traceIdGenerator?: () => string;
   idGenerator?: () => string;
   now?: () => Date;
@@ -107,6 +115,7 @@ export interface TaskTraceRuntimeOptions {
 
 export interface TaskTraceRuntimeStats {
   exportFailures: number;
+  exportDropped: number;
 }
 
 export interface SerializedTaskTraceSpan {
@@ -183,6 +192,14 @@ function defaultSpanId(): string {
 
 function isNonZeroHex(value: string): boolean {
   return NON_ZERO_HEX_RE.test(value);
+}
+
+export function isTaskTraceClass(value: string): value is TaskTraceClass {
+  return (TASK_TRACE_CLASSES as readonly string[]).includes(value);
+}
+
+export function isTaskTraceRuntimeLane(value: string): value is TaskTraceRuntimeLane {
+  return (TASK_TRACE_RUNTIME_LANES as readonly string[]).includes(value);
 }
 
 export function parseTraceparent(
@@ -369,12 +386,14 @@ export function parseTaskTraceContext(
     if (typeof parsed.traceparent !== "string") return null;
     if (!parseTraceparent(parsed.traceparent)) return null;
     if (typeof parsed.task_class !== "string") return null;
+    if (!isTaskTraceClass(parsed.task_class)) return null;
     if (typeof parsed.runtime_lane !== "string") return null;
+    if (!isTaskTraceRuntimeLane(parsed.runtime_lane)) return null;
     if (typeof parsed.retry_ordinal !== "number") return null;
     return {
       traceparent: parsed.traceparent,
-      taskClass: parsed.task_class as TaskTraceClass,
-      runtimeLane: parsed.runtime_lane as TaskTraceRuntimeLane,
+      taskClass: parsed.task_class,
+      runtimeLane: parsed.runtime_lane,
       retryOrdinal: normalizeRetryOrdinal(parsed.retry_ordinal),
     };
   } catch {
@@ -405,7 +424,7 @@ export function createFileTaskTraceExporter(
 }
 
 export class TaskTraceRuntime {
-  readonly stats: TaskTraceRuntimeStats = { exportFailures: 0 };
+  readonly stats: TaskTraceRuntimeStats = { exportFailures: 0, exportDropped: 0 };
   readonly serviceId: string;
   readonly instanceId: string;
   readonly release: string;
@@ -413,6 +432,7 @@ export class TaskTraceRuntime {
   readonly sampleRatePerMille: number;
   readonly maxAttributes: number;
   readonly maxStringLength: number;
+  readonly maxPendingExports: number;
 
   private readonly exporter?: TaskTraceExporter;
   private readonly traceIdGenerator: () => string;
@@ -420,6 +440,9 @@ export class TaskTraceRuntime {
   private readonly now: () => Date;
   private readonly context =
     new AsyncLocalStorage<ActiveTaskTraceContext>();
+  private readonly exportQueue: SerializedTaskTraceSpan[] = [];
+  private readonly exportFlushWaiters: Array<() => void> = [];
+  private exportPumpRunning = false;
 
   constructor(options: TaskTraceRuntimeOptions) {
     this.exportEnabled = options.exportEnabled;
@@ -433,6 +456,10 @@ export class TaskTraceRuntime {
     this.maxStringLength = Math.max(
       1,
       Math.min(256, Math.trunc(options.maxStringLength ?? TRACE_DEFAULT_MAX_STRING_LENGTH)),
+    );
+    this.maxPendingExports = Math.max(
+      1,
+      Math.min(4096, Math.trunc(options.maxPendingExports ?? TRACE_DEFAULT_MAX_PENDING_EXPORTS)),
     );
     this.serviceId = sanitizeSafeToken(
       options.serviceId,
@@ -517,10 +544,56 @@ export class TaskTraceRuntime {
     if (!this.exportEnabled || !span.sampled) return;
     const serialized = span.serialize();
     if (!serialized || !this.exporter) return;
+    if (this.exportQueue.length >= this.maxPendingExports) {
+      this.stats.exportDropped += 1;
+      return;
+    }
+    this.exportQueue.push(serialized);
+    this.scheduleExportPump();
+  }
+
+  // Test-only seam so focused suites can deterministically drain background
+  // export work without making production task completion await the sink.
+  async flushExportsForTest(): Promise<void> {
+    if (!this.exportPumpRunning && this.exportQueue.length === 0) return;
+    await new Promise<void>((resolve) => {
+      this.exportFlushWaiters.push(resolve);
+    });
+  }
+
+  private scheduleExportPump(): void {
+    if (this.exportPumpRunning || !this.exporter) return;
+    this.exportPumpRunning = true;
+    void this.pumpExports();
+  }
+
+  private async pumpExports(): Promise<void> {
     try {
-      await this.exporter.exportSpan(serialized);
-    } catch {
-      this.stats.exportFailures += 1;
+      while (this.exportQueue.length > 0) {
+        const serialized = this.exportQueue[0];
+        if (!serialized || !this.exporter) break;
+        try {
+          await this.exporter.exportSpan(serialized);
+        } catch {
+          this.stats.exportFailures += 1;
+        } finally {
+          this.exportQueue.shift();
+        }
+      }
+    } finally {
+      this.exportPumpRunning = false;
+      if (this.exportQueue.length > 0) {
+        this.scheduleExportPump();
+      } else {
+        this.resolveExportFlushWaiters();
+      }
+    }
+  }
+
+  private resolveExportFlushWaiters(): void {
+    const waiters = this.exportFlushWaiters.splice(0);
+    for (const resolve of waiters) {
+      resolve();
     }
   }
 }

--- a/tests/broker/handlers.test.ts
+++ b/tests/broker/handlers.test.ts
@@ -18,7 +18,10 @@ import {
   learningTaskExecutionEvidenceSchema,
 } from "../../src/learning-task-handshake.js";
 import { buildHomeserverRequestBody } from "../../src/homeserver-executor.js";
-import { parseTaskTraceContext } from "../../src/task-tracing.js";
+import {
+  TaskTraceIngressCounter,
+  parseTaskTraceContext,
+} from "../../src/task-tracing.js";
 import {
   withLearningTaskContext,
   withLearningTaskGatewayEcho,
@@ -96,6 +99,7 @@ interface Harness {
   munin: FakeMunin;
   journal: DelegationJournal;
   idempotency: IdempotencyIndex;
+  traceIngressCounter: TaskTraceIngressCounter;
   url: string;
   tmpDir: string;
   clock: { value: Date | null };
@@ -109,6 +113,7 @@ beforeEach(async () => {
   const journal = new DelegationJournal({ path: path.join(tmpDir, "events.jsonl") });
   const idempotency = new IdempotencyIndex();
   const taskStore = new BrokerTaskStore(munin as unknown as MuninClient);
+  const traceIngressCounter = new TaskTraceIngressCounter();
   const clock = { value: null as Date | null };
   const broker = await startBroker({
     host: "127.0.0.1",
@@ -124,6 +129,7 @@ beforeEach(async () => {
       journal,
       idempotency,
       executorCapabilities: brokerExecutorCapabilities({ homeserverEnabled: true }),
+      traceIngressCounter,
       now: () => clock.value ?? new Date(),
     },
   });
@@ -133,6 +139,7 @@ beforeEach(async () => {
     munin,
     journal,
     idempotency,
+    traceIngressCounter,
     tmpDir,
     url: `http://127.0.0.1:${addr.port}`,
     clock,
@@ -400,6 +407,10 @@ describe("POST /v1/delegate/submit", () => {
     });
 
     expect(res.status).toBe(202);
+    const body = await res.json();
+    expect(body.warnings).toEqual([
+      "trace context sanitized: baggage header ignored",
+    ]);
     const stored = harness.munin.writes[0]?.content;
     expect(stored).toBeDefined();
     expect(parseTaskTraceContext(stored!)).toEqual({
@@ -410,6 +421,50 @@ describe("POST /v1/delegate/submit", () => {
     });
     expect(stored).not.toContain("tenant.id");
     expect(stored).not.toContain("unsafe=value");
+  });
+
+  it("derives persisted trace facts from the resolved broker task metadata", async () => {
+    const res = await fetch(`${harness.url}/v1/delegate/submit`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify(validRequest({ task_type: "reason-hard" })),
+    });
+
+    expect(res.status).toBe(202);
+    const stored = harness.munin.writes[0]?.content;
+    expect(parseTaskTraceContext(stored!)).toEqual({
+      traceparent: expect.stringMatching(
+        /^00-[a-f0-9]{32}-[a-f0-9]{16}-0[01]$/,
+      ),
+      taskClass: "delegation",
+      runtimeLane: "reason-hard",
+      retryOrdinal: 0,
+    });
+  });
+
+  it("surfaces malformed trace headers as bounded warnings and counters", async () => {
+    const res = await fetch(`${harness.url}/v1/delegate/submit`, {
+      method: "POST",
+      headers: {
+        ...authHeader(),
+        traceparent: "00-not-a-traceparent",
+      },
+      body: JSON.stringify(validRequest()),
+    });
+
+    expect(res.status).toBe(202);
+    const body = await res.json();
+    expect(body.warnings).toEqual([
+      "trace context replaced: malformed traceparent header",
+    ]);
+    const health = await fetch(`${harness.url}/health`).then((value) => value.json());
+    expect(health.trace_ingress).toEqual({
+      invalid_reasons: {
+        forbidden_baggage: 0,
+        malformed_traceparent: 1,
+      },
+    });
+    expect(harness.munin.writes[0]?.content).not.toContain("not-a-traceparent");
   });
 
   it("persists a fresh submit atomically without a preflight Munin read", async () => {

--- a/tests/broker/handlers.test.ts
+++ b/tests/broker/handlers.test.ts
@@ -18,10 +18,15 @@ import {
   learningTaskExecutionEvidenceSchema,
 } from "../../src/learning-task-handshake.js";
 import { buildHomeserverRequestBody } from "../../src/homeserver-executor.js";
+import { parseTaskTraceContext } from "../../src/task-tracing.js";
 import {
   withLearningTaskContext,
   withLearningTaskGatewayEcho,
 } from "../helpers/learning-task.js";
+import {
+  CONTENT_BLIND_TRACE_JOIN_FIXTURE,
+  CONTENT_BLIND_TRACEPARENT,
+} from "../helpers/task-tracing-fixtures.js";
 
 const SECRET = "a".repeat(64);
 const OTHER_SECRET = "b".repeat(64);
@@ -381,6 +386,30 @@ describe("POST /v1/delegate/submit", () => {
     expect(harness.munin.writes).toHaveLength(1);
     expect(harness.munin.writes[0]!.tags).toContain("broker:mcp-v2");
     expect(harness.munin.writes[0]!.tags).not.toContain("orch-v1");
+  });
+
+  it("persists a content-blind trace context for the claimed task", async () => {
+    const res = await fetch(`${harness.url}/v1/delegate/submit`, {
+      method: "POST",
+      headers: {
+        ...authHeader(),
+        traceparent: CONTENT_BLIND_TRACEPARENT,
+        baggage: "tenant.id=owner,unsafe=value",
+      },
+      body: JSON.stringify(validRequest()),
+    });
+
+    expect(res.status).toBe(202);
+    const stored = harness.munin.writes[0]?.content;
+    expect(stored).toBeDefined();
+    expect(parseTaskTraceContext(stored!)).toEqual({
+      traceparent: CONTENT_BLIND_TRACEPARENT,
+      taskClass: CONTENT_BLIND_TRACE_JOIN_FIXTURE.taskClass,
+      runtimeLane: CONTENT_BLIND_TRACE_JOIN_FIXTURE.runtimeLane,
+      retryOrdinal: CONTENT_BLIND_TRACE_JOIN_FIXTURE.retryOrdinal,
+    });
+    expect(stored).not.toContain("tenant.id");
+    expect(stored).not.toContain("unsafe=value");
   });
 
   it("persists a fresh submit atomically without a preflight Munin read", async () => {

--- a/tests/dispatcher.test.ts
+++ b/tests/dispatcher.test.ts
@@ -6,9 +6,14 @@ import { describe, it, expect } from "vitest";
 // --- resolveContext unit tests ---
 
 import {
+  EXECUTION_ERROR_TRACE_ERROR_CLASS,
   MAX_TASK_TIMEOUT_MS,
+  RESULT_RECORDING_TRACE_ERROR_CLASS,
+  STATUS_CAS_LOST_TRACE_ERROR_CLASS,
   STRUCTURED_RESULT_TRACE_ERROR_CLASS,
+  deriveReportedTaskStartedAt,
   deriveResultRecordingTraceOutcome,
+  finalizeExecutionTraceOutcome,
   parseBoundedPositiveInt,
   resolveContext,
   resolveTaskWorkingDirectory,
@@ -510,6 +515,15 @@ Do something`;
 });
 
 describe("result recording trace classification", () => {
+  it("keeps the reported start at or after the accepted claim timestamp", () => {
+    const startedAt = deriveReportedTaskStartedAt(
+      "2026-08-01T12:00:05.000Z",
+      new Date("2026-08-01T12:00:00.000Z"),
+    );
+
+    expect(startedAt).toBe("2026-08-01T12:00:05.000Z");
+  });
+
   it("degrades structured-result write failures without propagating exception text", () => {
     const secret = new Error("zod failed for https://private.example/path?token=secret");
     const outcome = deriveResultRecordingTraceOutcome({
@@ -523,6 +537,39 @@ describe("result recording trace classification", () => {
     });
     expect(JSON.stringify(outcome)).not.toContain("private.example");
     expect(JSON.stringify(outcome)).not.toContain("token=secret");
+  });
+
+  it("marks terminal status CAS loss as stale with a bounded class", () => {
+    expect(deriveResultRecordingTraceOutcome({
+      structuredResultOk: false,
+      statusCasLost: true,
+    })).toEqual({
+      outcome: "stale",
+      errorClass: STATUS_CAS_LOST_TRACE_ERROR_CLASS,
+    });
+  });
+
+  it("preserves delivery-pending execution traces and bounds unknown finalization errors", () => {
+    expect(finalizeExecutionTraceOutcome({
+      outcome: "degraded",
+      errorClass: "delivery-pending",
+    })).toEqual({
+      outcome: "degraded",
+      errorClass: "delivery-pending",
+    });
+    expect(finalizeExecutionTraceOutcome({
+      outcome: "unknown",
+      errorClass: RESULT_RECORDING_TRACE_ERROR_CLASS,
+    })).toEqual({
+      outcome: "failed",
+      errorClass: RESULT_RECORDING_TRACE_ERROR_CLASS,
+    });
+    expect(finalizeExecutionTraceOutcome({
+      outcome: "unknown",
+    })).toEqual({
+      outcome: "failed",
+      errorClass: EXECUTION_ERROR_TRACE_ERROR_CLASS,
+    });
   });
 });
 

--- a/tests/dispatcher.test.ts
+++ b/tests/dispatcher.test.ts
@@ -7,6 +7,8 @@ import { describe, it, expect } from "vitest";
 
 import {
   MAX_TASK_TIMEOUT_MS,
+  STRUCTURED_RESULT_TRACE_ERROR_CLASS,
+  deriveResultRecordingTraceOutcome,
   parseBoundedPositiveInt,
   resolveContext,
   resolveTaskWorkingDirectory,
@@ -504,6 +506,23 @@ Do something`;
     const task = parseTask(content);
     expect(task!.group).toBe("some-group");
     expect(task!.sequence).toBeUndefined();
+  });
+});
+
+describe("result recording trace classification", () => {
+  it("degrades structured-result write failures without propagating exception text", () => {
+    const secret = new Error("zod failed for https://private.example/path?token=secret");
+    const outcome = deriveResultRecordingTraceOutcome({
+      structuredResultOk: false,
+      structuredResultError: secret,
+    });
+
+    expect(outcome).toEqual({
+      outcome: "degraded",
+      errorClass: STRUCTURED_RESULT_TRACE_ERROR_CLASS,
+    });
+    expect(JSON.stringify(outcome)).not.toContain("private.example");
+    expect(JSON.stringify(outcome)).not.toContain("token=secret");
   });
 });
 

--- a/tests/helpers/task-tracing-fixtures.ts
+++ b/tests/helpers/task-tracing-fixtures.ts
@@ -1,0 +1,16 @@
+export const CONTENT_BLIND_TRACE_JOIN_FIXTURE = {
+  traceId: "4bf92f3577b34da6a3ce929d0e0e4736",
+  inboundParentSpanId: "00f067aa0ba902b7",
+  gatewayCallSpanId: "b9c7c989f97918e1",
+  version: "00",
+  flags: "01",
+  taskClass: "delegation",
+  runtimeLane: "default",
+  retryOrdinal: 0,
+} as const;
+
+export const CONTENT_BLIND_TRACEPARENT =
+  `${CONTENT_BLIND_TRACE_JOIN_FIXTURE.version}`
+  + `-${CONTENT_BLIND_TRACE_JOIN_FIXTURE.traceId}`
+  + `-${CONTENT_BLIND_TRACE_JOIN_FIXTURE.inboundParentSpanId}`
+  + `-${CONTENT_BLIND_TRACE_JOIN_FIXTURE.flags}`;

--- a/tests/homeserver-executor.test.ts
+++ b/tests/homeserver-executor.test.ts
@@ -7,13 +7,19 @@ import {
   buildHomeserverDelegateTaskConfig,
   executeHomeserverTask,
   loadHomeserverGatewayConfig,
+  type HomeserverExecutorOptions,
   type HomeserverTaskConfig,
 } from "../src/homeserver-executor.js";
 import { recoverPreparedLearningTaskDispatch } from "../src/learning-task-handshake.js";
+import { TaskTraceRuntime } from "../src/task-tracing.js";
 import {
   withLearningTaskContext,
   withLearningTaskGatewayEcho,
 } from "./helpers/learning-task.js";
+import {
+  CONTENT_BLIND_TRACE_JOIN_FIXTURE,
+  CONTENT_BLIND_TRACEPARENT,
+} from "./helpers/task-tracing-fixtures.js";
 
 function makeTaskConfig(overrides?: Partial<HomeserverTaskConfig>): HomeserverTaskConfig {
   return {
@@ -69,6 +75,27 @@ function immediateRecoveryOptions(task: HomeserverTaskConfig) {
       return recovered.state === "m5-admitted" && recovered.evidenceAccepted
         ? recovered
         : null;
+    },
+  };
+}
+
+function tracingOptions(): Pick<HomeserverExecutorOptions, "tracing"> {
+  return {
+    tracing: {
+      runtime: new TaskTraceRuntime({
+        exportEnabled: false,
+        sampleRatePerMille: 1000,
+        release: "git-test",
+        traceIdGenerator: () => CONTENT_BLIND_TRACE_JOIN_FIXTURE.traceId,
+        idGenerator: () => CONTENT_BLIND_TRACE_JOIN_FIXTURE.gatewayCallSpanId,
+        now: () => new Date("2026-08-01T12:00:00Z"),
+      }),
+      taskContext: {
+        traceparent: CONTENT_BLIND_TRACEPARENT,
+        taskClass: CONTENT_BLIND_TRACE_JOIN_FIXTURE.taskClass,
+        runtimeLane: CONTENT_BLIND_TRACE_JOIN_FIXTURE.runtimeLane,
+        retryOrdinal: CONTENT_BLIND_TRACE_JOIN_FIXTURE.retryOrdinal,
+      },
     },
   };
 }
@@ -323,6 +350,33 @@ describe("executeHomeserverTask — delegate path", () => {
     expect(body.delegatorModelId).toBe("anthropic/claude-sonnet-4-5");
     expect(body.premiumBaselineModelId).toBe("anthropic/claude-opus-4-5");
     expect(body.learningTaskStamp.raw_fingerprint).toEqual(body.huginTaskIdentity.rawTaskFingerprint);
+  });
+
+  it("propagates the fixed W3C traceparent to the gateway call", async () => {
+    const task = withLearningTaskContext(makeTaskConfig({
+      path: "delegate",
+      taskType: "extract",
+      modelId: "qwen3-coder",
+    }), "delegate-traced");
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      jsonResponse(withLearningTaskGatewayEcho(task, "delegate-traced", {
+        output: "1998",
+      })),
+    );
+
+    await executeHomeserverTask(
+      task,
+      "delegate-traced",
+      tmpLogDir,
+      tracingOptions(),
+    );
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers.traceparent).toBe(
+      `00-${CONTENT_BLIND_TRACE_JOIN_FIXTURE.traceId}-${CONTENT_BLIND_TRACE_JOIN_FIXTURE.gatewayCallSpanId}-01`,
+    );
+    expect(headers.baggage).toBeUndefined();
   });
 
   // Issue #163: the direct path already carried the flat delegation fields, but

--- a/tests/learning-task-preflight-status.test.ts
+++ b/tests/learning-task-preflight-status.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildLearningTaskPreflightPanel,
+  createLearningTaskPreflightStore,
+} from "../src/learning-task-preflight-status.js";
+
+describe("learning task preflight status", () => {
+  it("builds an unknown panel before any authenticated preflight runs", () => {
+    const store = createLearningTaskPreflightStore();
+
+    expect(buildLearningTaskPreflightPanel(store.snapshot())).toMatchObject({
+      kind: "status",
+      state: "unknown",
+    });
+  });
+
+  it("records a successful authenticated preflight without leaking content", () => {
+    const store = createLearningTaskPreflightStore();
+    store.record({
+      checkedAt: "2026-08-01T10:00:00Z",
+      outcome: "ok",
+    });
+
+    const panel = buildLearningTaskPreflightPanel(store.snapshot());
+    expect(panel).toMatchObject({
+      kind: "status",
+      state: "pass",
+    });
+    expect(JSON.stringify(panel)).not.toContain("token");
+    expect(JSON.stringify(panel)).not.toContain("portal/me");
+  });
+
+  it("records a failed authenticated preflight using only a coarse error class", () => {
+    const store = createLearningTaskPreflightStore();
+    store.record({
+      checkedAt: "2026-08-01T10:00:00Z",
+      outcome: "failed",
+      errorClass: "capability-downgrade",
+      detail: "https://private.example/v1/capabilities/learning-task?token=secret",
+    });
+
+    const panel = buildLearningTaskPreflightPanel(store.snapshot());
+    expect(panel).toMatchObject({
+      kind: "status",
+      state: "fail",
+    });
+    expect(JSON.stringify(panel)).toContain("capability-downgrade");
+    expect(JSON.stringify(panel)).not.toContain("private.example");
+    expect(JSON.stringify(panel)).not.toContain("token=secret");
+  });
+});

--- a/tests/learning-task-preflight-status.test.ts
+++ b/tests/learning-task-preflight-status.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildLearningTaskPreflightPanel,
   createLearningTaskPreflightStore,
+  LEARNING_TASK_PREFLIGHT_FRESHNESS_MS,
 } from "../src/learning-task-preflight-status.js";
 
 describe("learning task preflight status", () => {
@@ -22,11 +23,14 @@ describe("learning task preflight status", () => {
       outcome: "ok",
     });
 
-    const panel = buildLearningTaskPreflightPanel(store.snapshot());
+    const panel = buildLearningTaskPreflightPanel(store.snapshot(), {
+      now: () => new Date("2026-08-01T10:00:01Z"),
+    });
     expect(panel).toMatchObject({
       kind: "status",
       state: "pass",
     });
+    expect(String(panel.message)).toContain("2026-08-01T10:00:00Z");
     expect(JSON.stringify(panel)).not.toContain("token");
     expect(JSON.stringify(panel)).not.toContain("portal/me");
   });
@@ -40,13 +44,46 @@ describe("learning task preflight status", () => {
       detail: "https://private.example/v1/capabilities/learning-task?token=secret",
     });
 
-    const panel = buildLearningTaskPreflightPanel(store.snapshot());
+    const panel = buildLearningTaskPreflightPanel(store.snapshot(), {
+      now: () => new Date("2026-08-01T10:00:01Z"),
+    });
     expect(panel).toMatchObject({
       kind: "status",
       state: "fail",
     });
     expect(JSON.stringify(panel)).toContain("capability-downgrade");
+    expect(String(panel.message)).toContain("2026-08-01T10:00:00Z");
     expect(JSON.stringify(panel)).not.toContain("private.example");
     expect(JSON.stringify(panel)).not.toContain("token=secret");
+  });
+
+  it("degrades a boundary-stale observation to unknown and reports its age", () => {
+    const panel = buildLearningTaskPreflightPanel({
+      checkedAt: "2026-08-01T10:00:00Z",
+      outcome: "ok",
+    }, {
+      now: () => new Date("2026-08-01T10:15:00Z"),
+    });
+
+    expect(panel).toMatchObject({
+      kind: "status",
+      state: "unknown",
+    });
+    expect(String(panel.message)).toContain("2026-08-01T10:00:00Z");
+    expect(String(panel.message)).toContain(`${LEARNING_TASK_PREFLIGHT_FRESHNESS_MS / 1000}s`);
+  });
+
+  it("treats malformed and future observation times as unknown", () => {
+    const now = () => new Date("2026-08-01T10:00:00Z");
+
+    expect(buildLearningTaskPreflightPanel({
+      checkedAt: "not-a-date",
+      outcome: "ok",
+    }, { now })).toMatchObject({ state: "unknown" });
+    expect(buildLearningTaskPreflightPanel({
+      checkedAt: "2026-08-01T10:00:01Z",
+      outcome: "failed",
+      errorClass: "capability-downgrade",
+    }, { now })).toMatchObject({ state: "unknown" });
   });
 });

--- a/tests/task-tracing.test.ts
+++ b/tests/task-tracing.test.ts
@@ -62,6 +62,34 @@ describe("task tracing", () => {
     expect(context.invalidReason).toBe("malformed-traceparent");
   });
 
+  it("applies a deterministic per-mille cap to roots and sampled parents", () => {
+    const sampled = createInboundTaskTraceContext({
+      traceparent: `00-${"000000f9".padEnd(32, "1")}-1111111111111111-01`,
+      taskClass: "delegation",
+      runtimeLane: "default",
+      retryOrdinal: 0,
+      sampleRatePerMille: 250,
+    });
+    const droppedAtBoundary = createInboundTaskTraceContext({
+      traceparent: `00-${"000000fa".padEnd(32, "1")}-1111111111111111-01`,
+      taskClass: "delegation",
+      runtimeLane: "default",
+      retryOrdinal: 0,
+      sampleRatePerMille: 250,
+    });
+    const disabled = createInboundTaskTraceContext({
+      traceparent: CONTENT_BLIND_TRACEPARENT,
+      taskClass: "delegation",
+      runtimeLane: "default",
+      retryOrdinal: 0,
+      sampleRatePerMille: 0,
+    });
+
+    expect(sampled.traceFlags).toBe("01");
+    expect(droppedAtBoundary.traceFlags).toBe("00");
+    expect(disabled.traceFlags).toBe("00");
+  });
+
   it("round-trips the persisted task trace context section", () => {
     const section = buildTaskTraceContextSection({
       traceparent: CONTENT_BLIND_TRACEPARENT,
@@ -296,6 +324,31 @@ describe("task tracing", () => {
     await expect(endTaskSpan(span, { outcome: "ok" })).resolves.toBeUndefined();
     await runtime.flushExportsForTest();
     expect(runtime.stats.exportFailures).toBe(1);
+  });
+
+  it("clamps future span starts to the observed end boundary", async () => {
+    const runtime = new TaskTraceRuntime({
+      exportEnabled: false,
+      sampleRatePerMille: 1000,
+      release: "git-test",
+      traceIdGenerator: () => "12121212121212121212121212121212",
+      idGenerator: () => "3434343434343434",
+      now: () => new Date("2026-08-01T12:00:00Z"),
+    });
+    const span = runtime.startSpan({
+      name: "task.queue",
+      surface: "task",
+      phase: "queue",
+      startedAt: new Date("2026-08-01T12:05:00Z"),
+    });
+    await endTaskSpan(span, {
+      outcome: "ok",
+      endedAt: new Date("2026-08-01T12:00:00Z"),
+    });
+
+    const serialized = span.serialize();
+    expect(serialized?.started_at).toBe("2026-08-01T12:00:00Z");
+    expect(serialized?.ended_at).toBe("2026-08-01T12:00:00Z");
   });
 
   it("keeps export fail-open and bounded when the sink wedges", async () => {

--- a/tests/task-tracing.test.ts
+++ b/tests/task-tracing.test.ts
@@ -1,3 +1,7 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import * as path from "node:path";
+
 import { describe, expect, it, vi } from "vitest";
 
 import {
@@ -8,6 +12,7 @@ import {
   TaskTraceRuntime,
   buildChildTaskTraceContext,
   buildTaskTraceContextSection,
+  createFileTaskTraceExporter,
   createInboundTaskTraceContext,
   endTaskSpan,
   parseTaskTraceContext,
@@ -62,13 +67,14 @@ describe("task tracing", () => {
     expect(context.invalidReason).toBe("malformed-traceparent");
   });
 
-  it("applies a deterministic per-mille cap to roots and sampled parents", () => {
+  it("applies a deterministic per-mille cap to roots and trusted inbound parents", () => {
     const sampled = createInboundTaskTraceContext({
       traceparent: `00-${"000000f9".padEnd(32, "1")}-1111111111111111-01`,
       taskClass: "delegation",
       runtimeLane: "default",
       retryOrdinal: 0,
       sampleRatePerMille: 250,
+      samplingPolicy: "trusted-inbound",
     });
     const droppedAtBoundary = createInboundTaskTraceContext({
       traceparent: `00-${"000000fa".padEnd(32, "1")}-1111111111111111-01`,
@@ -76,6 +82,7 @@ describe("task tracing", () => {
       runtimeLane: "default",
       retryOrdinal: 0,
       sampleRatePerMille: 250,
+      samplingPolicy: "trusted-inbound",
     });
     const disabled = createInboundTaskTraceContext({
       traceparent: CONTENT_BLIND_TRACEPARENT,
@@ -88,6 +95,22 @@ describe("task tracing", () => {
     expect(sampled.traceFlags).toBe("01");
     expect(droppedAtBoundary.traceFlags).toBe("00");
     expect(disabled.traceFlags).toBe("00");
+  });
+
+  it("enforces operator sampling instead of trusting inbound flags or trace-id steering", () => {
+    const forcedOn = createInboundTaskTraceContext({
+      traceparent: `00-${"ffffffff".padEnd(32, "f")}-1111111111111111-00`,
+      sampleRatePerMille: 250,
+      traceIdGenerator: () => "000000f9".padEnd(32, "1"),
+    });
+    const steeredOff = createInboundTaskTraceContext({
+      traceparent: `00-${"000000fa".padEnd(32, "1")}-2222222222222222-01`,
+      sampleRatePerMille: 250,
+      traceIdGenerator: () => "000000f9".padEnd(32, "1"),
+    });
+
+    expect(forcedOn.traceFlags).toBe("01");
+    expect(steeredOff.traceFlags).toBe("01");
   });
 
   it("round-trips the persisted task trace context section", () => {
@@ -104,6 +127,17 @@ describe("task tracing", () => {
       taskClass: "delegation",
       runtimeLane: "default",
       retryOrdinal: 2,
+    });
+  });
+
+  it("round-trips the persisted task trace context section when task facts are unavailable", () => {
+    const section = buildTaskTraceContextSection({
+      traceparent: CONTENT_BLIND_TRACEPARENT,
+    });
+    const content = taskWithTraceContext(section);
+
+    expect(parseTaskTraceContext(content)).toEqual({
+      traceparent: CONTENT_BLIND_TRACEPARENT,
     });
   });
 
@@ -324,6 +358,13 @@ describe("task tracing", () => {
     await expect(endTaskSpan(span, { outcome: "ok" })).resolves.toBeUndefined();
     await runtime.flushExportsForTest();
     expect(runtime.stats.exportFailures).toBe(1);
+    expect(runtime.getHealth()).toMatchObject({
+      exportEnabled: true,
+      sampleRatePerMille: 1000,
+      exportFailures: 1,
+      exportDropped: 0,
+      pendingExports: 0,
+    });
   });
 
   it("clamps future span starts to the observed end boundary", async () => {
@@ -401,6 +442,92 @@ describe("task tracing", () => {
     expect(await completion(makeSpan())).toBe("done");
     expect(exporter.exportSpan).toHaveBeenCalledTimes(1);
     expect(runtime.stats.exportDropped).toBe(1);
+    expect(runtime.getHealth()).toMatchObject({
+      exportDropped: 1,
+      pendingExports: 2,
+    });
+  });
+
+  it("omits unresolved task facts instead of hardcoding defaults", async () => {
+    const runtime = new TaskTraceRuntime({
+      exportEnabled: false,
+      sampleRatePerMille: 1000,
+      release: "git-test",
+      traceIdGenerator: () => "56565656565656565656565656565656",
+      idGenerator: () => "7878787878787878",
+      now: () => new Date("2026-08-01T12:00:00Z"),
+    });
+    const span = runtime.startSpan({
+      name: "task.execution",
+      surface: "task",
+      phase: "execution",
+      taskContext: {
+        traceparent: CONTENT_BLIND_TRACEPARENT,
+      },
+    });
+
+    await endTaskSpan(span, { outcome: "ok" });
+    expect(span.serialize()?.attributes).toEqual({});
+  });
+
+  it("rotates file exports and bounds on-disk growth", async () => {
+    const tmpPath = await mkdtemp(path.join(tmpdir(), "hugin-trace-export-"));
+    const exportPath = path.join(tmpPath, "trace.jsonl");
+
+    try {
+      const baseSpan = {
+        kind: "trace-span" as const,
+        contract_version: "v1.0" as const,
+        policy_id: "trace-policy-hugin" as const,
+        source: {
+          source_kind: "service_internal" as const,
+          producer: "hugin",
+          producer_version: "git-test",
+        },
+        service: {
+          service_id: "hugin",
+          instance_id: "huginmunin",
+        },
+        trace_id: "4bf92f3577b34da6a3ce929d0e0e4736",
+        operation: {
+          surface: "task" as const,
+          phase: "execution" as const,
+        },
+        started_at: "2026-08-01T12:00:00Z",
+        ended_at: "2026-08-01T12:00:01Z",
+        collected_at: "2026-08-01T12:00:01Z",
+        sampled: true as const,
+        outcome: "ok" as const,
+        attributes: {
+          task_class: "delegation" as const,
+          runtime_lane: "default" as const,
+          retry_ordinal: 0,
+        },
+        diagnostic_ref: "ref:hugin-trace-test",
+        extensions: [] as [],
+      };
+      const maxBytes = Buffer.byteLength(
+        `${JSON.stringify({ ...baseSpan, span_id: "1111111111111111" })}\n`,
+        "utf8",
+      ) + 16;
+      const exporter = createFileTaskTraceExporter(exportPath, {
+        maxBytes,
+        maxFiles: 3,
+      });
+      expect(exporter).toBeDefined();
+
+      await exporter!.exportSpan({ ...baseSpan, span_id: "1111111111111111" });
+      await exporter!.exportSpan({ ...baseSpan, span_id: "2222222222222222" });
+      await exporter!.exportSpan({ ...baseSpan, span_id: "3333333333333333" });
+      await exporter!.exportSpan({ ...baseSpan, span_id: "4444444444444444" });
+
+      expect(await readFile(exportPath, "utf8")).toContain("\"span_id\":\"4444444444444444\"");
+      expect(await readFile(`${exportPath}.1`, "utf8")).toContain("\"span_id\":\"3333333333333333\"");
+      expect(await readFile(`${exportPath}.2`, "utf8")).toContain("\"span_id\":\"2222222222222222\"");
+      await expect(readFile(`${exportPath}.3`, "utf8")).rejects.toThrow();
+    } finally {
+      await rm(tmpPath, { recursive: true, force: true });
+    }
   });
 
   it("flushes queued exports deterministically in tests", async () => {

--- a/tests/task-tracing.test.ts
+++ b/tests/task-tracing.test.ts
@@ -1,0 +1,373 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  CONTENT_BLIND_TRACE_JOIN_FIXTURE,
+  CONTENT_BLIND_TRACEPARENT,
+} from "./helpers/task-tracing-fixtures.js";
+import {
+  TaskTraceRuntime,
+  buildChildTaskTraceContext,
+  buildTaskTraceContextSection,
+  createInboundTaskTraceContext,
+  endTaskSpan,
+  parseTaskTraceContext,
+  parseTraceSampleRatePerMille,
+} from "../src/task-tracing.js";
+
+describe("task tracing", () => {
+  it("continues a strict W3C traceparent and strips baggage", () => {
+    const context = createInboundTaskTraceContext({
+      traceparent: CONTENT_BLIND_TRACEPARENT,
+      baggage: "tenant.id=owner,unsafe=value",
+      taskClass: CONTENT_BLIND_TRACE_JOIN_FIXTURE.taskClass,
+      runtimeLane: CONTENT_BLIND_TRACE_JOIN_FIXTURE.runtimeLane,
+      retryOrdinal: CONTENT_BLIND_TRACE_JOIN_FIXTURE.retryOrdinal,
+      idGenerator: () => "1111111111111111",
+    });
+
+    expect(context.traceId).toBe(CONTENT_BLIND_TRACE_JOIN_FIXTURE.traceId);
+    expect(context.parentSpanId).toBe(
+      CONTENT_BLIND_TRACE_JOIN_FIXTURE.inboundParentSpanId,
+    );
+    expect(context.traceFlags).toBe(CONTENT_BLIND_TRACE_JOIN_FIXTURE.flags);
+    expect(context.baggage).toBeUndefined();
+    expect(context.invalidReason).toBe("forbidden-baggage");
+  });
+
+  it("replaces malformed inbound context with a fresh root", () => {
+    const context = createInboundTaskTraceContext({
+      traceparent: "00-not-a-traceparent",
+      baggage: "bad baggage",
+      taskClass: "read_only",
+      runtimeLane: "default",
+      retryOrdinal: 0,
+      traceIdGenerator: () => "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      idGenerator: () => "bbbbbbbbbbbbbbbb",
+    });
+
+    expect(context.traceId).toBe("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    expect(context.parentSpanId).toBeUndefined();
+    expect(context.traceFlags).toBe("01");
+    expect(context.invalidReason).toBe("malformed-traceparent");
+  });
+
+  it("round-trips the persisted task trace context section", () => {
+    const section = buildTaskTraceContextSection({
+      traceparent: CONTENT_BLIND_TRACEPARENT,
+      taskClass: "delegation",
+      runtimeLane: "default",
+      retryOrdinal: 2,
+    });
+    const content = [
+      "## Task: trace fixture",
+      "",
+      section,
+      "",
+      "### Prompt",
+      "hello",
+    ].join("\n");
+
+    expect(parseTaskTraceContext(content)).toEqual({
+      traceparent: CONTENT_BLIND_TRACEPARENT,
+      taskClass: "delegation",
+      runtimeLane: "default",
+      retryOrdinal: 2,
+    });
+  });
+
+  it("derives child task contexts from an execution span traceparent", () => {
+    expect(buildChildTaskTraceContext(CONTENT_BLIND_TRACEPARENT, {
+      taskClass: "delegation",
+      runtimeLane: "default",
+      retryOrdinal: 12,
+    })).toEqual({
+      traceparent: CONTENT_BLIND_TRACEPARENT,
+      taskClass: "delegation",
+      runtimeLane: "default",
+      retryOrdinal: 10,
+    });
+    expect(buildChildTaskTraceContext("not-a-traceparent", {
+      taskClass: "delegation",
+      runtimeLane: "default",
+      retryOrdinal: 0,
+    })).toBeNull();
+  });
+
+  it("preserves parentage across async work and retries", async () => {
+    const records: Array<Record<string, unknown>> = [];
+    const runtime = new TaskTraceRuntime({
+      exportEnabled: true,
+      sampleRatePerMille: 1000,
+      release: "git-test",
+      exporter: {
+        exportSpan: async (span) => {
+          records.push(span as Record<string, unknown>);
+        },
+      },
+      traceIdGenerator: () => CONTENT_BLIND_TRACE_JOIN_FIXTURE.traceId,
+      idGenerator: vi
+        .fn()
+        .mockReturnValueOnce("1111111111111111")
+        .mockReturnValueOnce("2222222222222222")
+        .mockReturnValueOnce("3333333333333333"),
+      now: () => new Date("2026-08-01T12:00:00Z"),
+    });
+
+    const inbound = createInboundTaskTraceContext({
+      traceparent: CONTENT_BLIND_TRACEPARENT,
+      taskClass: "delegation",
+      runtimeLane: "default",
+      retryOrdinal: 0,
+      idGenerator: () => "1111111111111111",
+    });
+
+    const root = runtime.startSpan({
+      name: "task.execution",
+      surface: "task",
+      phase: "execution",
+      taskContext: inbound,
+    });
+
+    await runtime.runWithSpan(root, async () => {
+      await Promise.resolve();
+      const child = runtime.startSpan({
+        name: "task.result-recording",
+        surface: "task",
+        phase: "publication",
+      });
+      endTaskSpan(child, { outcome: "ok" });
+    });
+    endTaskSpan(root, { outcome: "ok" });
+
+    const retry = runtime.startSpan({
+      name: "task.execution.retry",
+      surface: "task",
+      phase: "execution",
+      taskContext: {
+        traceparent: CONTENT_BLIND_TRACEPARENT,
+        taskClass: "delegation",
+        runtimeLane: "default",
+        retryOrdinal: 1,
+      },
+    });
+    endTaskSpan(retry, { outcome: "failed", errorClass: "timeout" });
+
+    expect(records).toHaveLength(3);
+    const bySpanId = new Map(
+      records.map((record) => [
+        record.span_id as string,
+        record,
+      ]),
+    );
+    expect(bySpanId.get("1111111111111111")?.trace_id).toBe(
+      CONTENT_BLIND_TRACE_JOIN_FIXTURE.traceId,
+    );
+    expect(bySpanId.get("1111111111111111")?.parent_span_id).toBe(
+      CONTENT_BLIND_TRACE_JOIN_FIXTURE.inboundParentSpanId,
+    );
+    expect(bySpanId.get("2222222222222222")?.parent_span_id).toBe(
+      "1111111111111111",
+    );
+    expect(bySpanId.get("3333333333333333")?.trace_id).toBe(
+      CONTENT_BLIND_TRACE_JOIN_FIXTURE.traceId,
+    );
+    expect(bySpanId.get("3333333333333333")?.parent_span_id).toBe(
+      CONTENT_BLIND_TRACE_JOIN_FIXTURE.inboundParentSpanId,
+    );
+    expect(bySpanId.get("3333333333333333")?.attributes).toMatchObject({
+      retry_ordinal: 1,
+    });
+  });
+
+  it("classifies cancellation and timeout without leaking exception details", () => {
+    const runtime = new TaskTraceRuntime({
+      exportEnabled: false,
+      sampleRatePerMille: 1000,
+      release: "git-test",
+      traceIdGenerator: () => "cccccccccccccccccccccccccccccccc",
+      idGenerator: () => "dddddddddddddddd",
+      now: () => new Date("2026-08-01T12:00:00Z"),
+    });
+
+    const cancelled = runtime.startSpan({
+      name: "task.execution",
+      surface: "task",
+      phase: "execution",
+      taskContext: {
+        taskClass: "delegation",
+        runtimeLane: "default",
+        retryOrdinal: 0,
+      },
+    });
+    endTaskSpan(cancelled, { outcome: "failed", errorClass: "cancelled" });
+    expect(cancelled.serialize()?.attributes).toMatchObject({
+      error_class: "cancelled",
+    });
+
+    const timedOut = runtime.startSpan({
+      name: "task.execution",
+      surface: "task",
+      phase: "execution",
+      taskContext: {
+        taskClass: "delegation",
+        runtimeLane: "default",
+        retryOrdinal: 0,
+      },
+    });
+    endTaskSpan(timedOut, {
+      outcome: "failed",
+      errorClass: "timeout",
+      error: new Error("timeout on https://private.example/path?token=secret"),
+    });
+    const serialized = timedOut.serialize();
+    expect(serialized?.attributes).toMatchObject({ error_class: "timeout" });
+    expect(JSON.stringify(serialized)).not.toContain("private.example");
+    expect(JSON.stringify(serialized)).not.toContain("token=secret");
+  });
+
+  it("drops spans when sampling is zero or export fails, without throwing", async () => {
+    const exporter = {
+      exportSpan: vi.fn(async () => {
+        throw new Error("write /tmp/private-url?token=secret");
+      }),
+    };
+    const sampledOut = new TaskTraceRuntime({
+      exportEnabled: true,
+      sampleRatePerMille: 0,
+      release: "git-test",
+      exporter,
+      traceIdGenerator: () => "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+      idGenerator: () => "ffffffffffffffff",
+      now: () => new Date("2026-08-01T12:00:00Z"),
+    });
+    const unsampled = sampledOut.startSpan({
+      name: "task.execution",
+      surface: "task",
+      phase: "execution",
+      taskContext: {
+        taskClass: "delegation",
+        runtimeLane: "default",
+        retryOrdinal: 0,
+      },
+    });
+    await expect(endTaskSpan(unsampled, { outcome: "ok" })).resolves.toBeUndefined();
+    expect(exporter.exportSpan).not.toHaveBeenCalled();
+
+    const runtime = new TaskTraceRuntime({
+      exportEnabled: true,
+      sampleRatePerMille: 1000,
+      release: "git-test",
+      exporter,
+      traceIdGenerator: () => "abababababababababababababababab",
+      idGenerator: () => "cdcdcdcdcdcdcdcd",
+      now: () => new Date("2026-08-01T12:00:00Z"),
+    });
+    const span = runtime.startSpan({
+      name: "task.execution",
+      surface: "task",
+      phase: "execution",
+      taskContext: {
+        taskClass: "delegation",
+        runtimeLane: "default",
+        retryOrdinal: 0,
+      },
+    });
+    await expect(endTaskSpan(span, { outcome: "ok" })).resolves.toBeUndefined();
+    expect(runtime.stats.exportFailures).toBe(1);
+  });
+
+  it("parses sampling rates with bounded defaults", () => {
+    expect(parseTraceSampleRatePerMille(undefined)).toBe(1000);
+    expect(parseTraceSampleRatePerMille("250")).toBe(250);
+    expect(parseTraceSampleRatePerMille("-1")).toBe(1000);
+    expect(parseTraceSampleRatePerMille(5000)).toBe(1000);
+  });
+
+  it("serializes only the allowlisted, bounded envelope", () => {
+    const runtime = new TaskTraceRuntime({
+      exportEnabled: false,
+      sampleRatePerMille: 1000,
+      release: "git-unsafe.example/path?token=secret",
+      traceIdGenerator: () => "1234567890abcdef1234567890abcdef",
+      idGenerator: () => "abcdefabcdefabcd",
+      now: () => new Date("2026-08-01T12:00:00Z"),
+    });
+
+    const span = runtime.startSpan({
+      name: "task.execution",
+      surface: "task",
+      phase: "execution",
+      taskContext: {
+        taskClass: "delegation",
+        runtimeLane: "default",
+        retryOrdinal: 0,
+      },
+      unsafeAttributes: {
+        prompt: "secret prompt",
+        result: "secret result",
+        repository_path: "/Users/magnus/private",
+        query: "token=secret",
+      },
+    });
+    endTaskSpan(span, {
+      outcome: "failed",
+      errorClass: "gateway-error",
+      error: {
+        message: "postgres://user:pw@localhost/db",
+        stack: "Error: postgres://user:pw@localhost/db",
+      },
+    });
+    const serialized = span.serialize();
+
+    expect(serialized?.attributes).toEqual({
+      task_class: "delegation",
+      runtime_lane: "default",
+      retry_ordinal: 0,
+      error_class: "gateway-error",
+    });
+    expect(serialized?.source.producer_version.length).toBeLessThanOrEqual(64);
+    expect(JSON.stringify(serialized)).not.toContain("secret prompt");
+    expect(JSON.stringify(serialized)).not.toContain("/Users/magnus/private");
+    expect(JSON.stringify(serialized)).not.toContain("postgres://");
+  });
+
+  it("emits the fixed Hugin to gateway join tuple", () => {
+    const runtime = new TaskTraceRuntime({
+      exportEnabled: false,
+      sampleRatePerMille: 1000,
+      release: "git-test",
+      traceIdGenerator: () => CONTENT_BLIND_TRACE_JOIN_FIXTURE.traceId,
+      idGenerator: () => CONTENT_BLIND_TRACE_JOIN_FIXTURE.gatewayCallSpanId,
+      now: () => new Date("2026-08-01T12:00:00Z"),
+    });
+
+    const inbound = createInboundTaskTraceContext({
+      traceparent: CONTENT_BLIND_TRACEPARENT,
+      taskClass: CONTENT_BLIND_TRACE_JOIN_FIXTURE.taskClass,
+      runtimeLane: CONTENT_BLIND_TRACE_JOIN_FIXTURE.runtimeLane,
+      retryOrdinal: CONTENT_BLIND_TRACE_JOIN_FIXTURE.retryOrdinal,
+      idGenerator: () => CONTENT_BLIND_TRACE_JOIN_FIXTURE.gatewayCallSpanId,
+    });
+    const span = runtime.startSpan({
+      name: "gateway.delegate",
+      surface: "gateway",
+      phase: "execution",
+      taskContext: inbound,
+    });
+    endTaskSpan(span, { outcome: "ok" });
+
+    expect(span.traceparent).toBe(
+      `00-${CONTENT_BLIND_TRACE_JOIN_FIXTURE.traceId}-${CONTENT_BLIND_TRACE_JOIN_FIXTURE.gatewayCallSpanId}-01`,
+    );
+    expect(span.serialize()).toMatchObject({
+      trace_id: CONTENT_BLIND_TRACE_JOIN_FIXTURE.traceId,
+      span_id: CONTENT_BLIND_TRACE_JOIN_FIXTURE.gatewayCallSpanId,
+      parent_span_id: CONTENT_BLIND_TRACE_JOIN_FIXTURE.inboundParentSpanId,
+      attributes: {
+        task_class: CONTENT_BLIND_TRACE_JOIN_FIXTURE.taskClass,
+        runtime_lane: CONTENT_BLIND_TRACE_JOIN_FIXTURE.runtimeLane,
+        retry_ordinal: CONTENT_BLIND_TRACE_JOIN_FIXTURE.retryOrdinal,
+      },
+    });
+  });
+});

--- a/tests/task-tracing.test.ts
+++ b/tests/task-tracing.test.ts
@@ -15,6 +15,17 @@ import {
 } from "../src/task-tracing.js";
 
 describe("task tracing", () => {
+  function taskWithTraceContext(section: string): string {
+    return [
+      "## Task: trace fixture",
+      "",
+      section,
+      "",
+      "### Prompt",
+      "hello",
+    ].join("\n");
+  }
+
   it("continues a strict W3C traceparent and strips baggage", () => {
     const context = createInboundTaskTraceContext({
       traceparent: CONTENT_BLIND_TRACEPARENT,
@@ -58,14 +69,7 @@ describe("task tracing", () => {
       runtimeLane: "default",
       retryOrdinal: 2,
     });
-    const content = [
-      "## Task: trace fixture",
-      "",
-      section,
-      "",
-      "### Prompt",
-      "hello",
-    ].join("\n");
+    const content = taskWithTraceContext(section);
 
     expect(parseTaskTraceContext(content)).toEqual({
       traceparent: CONTENT_BLIND_TRACEPARENT,
@@ -73,6 +77,22 @@ describe("task tracing", () => {
       runtimeLane: "default",
       retryOrdinal: 2,
     });
+  });
+
+  it("rejects persisted task trace labels outside the closed allowlists", () => {
+    const content = taskWithTraceContext([
+      "### Trace context",
+      "```json",
+      JSON.stringify({
+        traceparent: CONTENT_BLIND_TRACEPARENT,
+        task_class: "customer:alice@example.com",
+        runtime_lane: "lane:https://private.example/review?token=secret",
+        retry_ordinal: 2,
+      }, null, 2),
+      "```",
+    ].join("\n"));
+
+    expect(parseTaskTraceContext(content)).toBeNull();
   });
 
   it("derives child task contexts from an execution span traceparent", () => {
@@ -135,9 +155,9 @@ describe("task tracing", () => {
         surface: "task",
         phase: "publication",
       });
-      endTaskSpan(child, { outcome: "ok" });
+      await endTaskSpan(child, { outcome: "ok" });
     });
-    endTaskSpan(root, { outcome: "ok" });
+    await endTaskSpan(root, { outcome: "ok" });
 
     const retry = runtime.startSpan({
       name: "task.execution.retry",
@@ -150,7 +170,8 @@ describe("task tracing", () => {
         retryOrdinal: 1,
       },
     });
-    endTaskSpan(retry, { outcome: "failed", errorClass: "timeout" });
+    await endTaskSpan(retry, { outcome: "failed", errorClass: "timeout" });
+    await runtime.flushExportsForTest();
 
     expect(records).toHaveLength(3);
     const bySpanId = new Map(
@@ -273,7 +294,118 @@ describe("task tracing", () => {
       },
     });
     await expect(endTaskSpan(span, { outcome: "ok" })).resolves.toBeUndefined();
+    await runtime.flushExportsForTest();
     expect(runtime.stats.exportFailures).toBe(1);
+  });
+
+  it("keeps export fail-open and bounded when the sink wedges", async () => {
+    let firstExportStartedResolve: (() => void) | null = null;
+    const firstExportStarted = new Promise<void>((resolve) => {
+      firstExportStartedResolve = resolve;
+    });
+    const exporter = {
+      exportSpan: vi.fn(async () => {
+        firstExportStartedResolve?.();
+        await new Promise<void>(() => {});
+      }),
+    };
+    const runtime = new TaskTraceRuntime({
+      exportEnabled: true,
+      sampleRatePerMille: 1000,
+      release: "git-test",
+      exporter,
+      maxPendingExports: 2,
+      traceIdGenerator: () => "10101010101010101010101010101010",
+      idGenerator: vi
+        .fn()
+        .mockReturnValueOnce("1111111111111111")
+        .mockReturnValueOnce("2222222222222222")
+        .mockReturnValueOnce("3333333333333333"),
+      now: () => new Date("2026-08-01T12:00:00Z"),
+    });
+    const makeSpan = () => runtime.startSpan({
+      name: "task.execution",
+      surface: "task",
+      phase: "execution",
+      taskContext: {
+        taskClass: "delegation",
+        runtimeLane: "default",
+        retryOrdinal: 0,
+      },
+    });
+
+    const completion = (span: ReturnType<typeof makeSpan>) =>
+      Promise.race([
+        endTaskSpan(span, { outcome: "ok" }).then(() => "done"),
+        new Promise<string>((resolve) => {
+          setTimeout(() => resolve("timeout"), 20);
+        }),
+      ]);
+
+    expect(await completion(makeSpan())).toBe("done");
+    await firstExportStarted;
+    expect(await completion(makeSpan())).toBe("done");
+    expect(await completion(makeSpan())).toBe("done");
+    expect(exporter.exportSpan).toHaveBeenCalledTimes(1);
+    expect(runtime.stats.exportDropped).toBe(1);
+  });
+
+  it("flushes queued exports deterministically in tests", async () => {
+    let releaseFirstExport: (() => void) | null = null;
+    const firstExportReleased = new Promise<void>((resolve) => {
+      releaseFirstExport = resolve;
+    });
+    const exportedSpanIds: string[] = [];
+    let callCount = 0;
+    const runtime = new TaskTraceRuntime({
+      exportEnabled: true,
+      sampleRatePerMille: 1000,
+      release: "git-test",
+      exporter: {
+        exportSpan: vi.fn(async (span) => {
+          exportedSpanIds.push(span.span_id);
+          callCount += 1;
+          if (callCount === 1) {
+            await firstExportReleased;
+          }
+        }),
+      },
+      maxPendingExports: 4,
+      traceIdGenerator: () => "20202020202020202020202020202020",
+      idGenerator: vi
+        .fn()
+        .mockReturnValueOnce("4444444444444444")
+        .mockReturnValueOnce("5555555555555555"),
+      now: () => new Date("2026-08-01T12:00:00Z"),
+    });
+    const makeSpan = () => runtime.startSpan({
+      name: "task.execution",
+      surface: "task",
+      phase: "execution",
+      taskContext: {
+        taskClass: "delegation",
+        runtimeLane: "default",
+        retryOrdinal: 0,
+      },
+    });
+
+    await endTaskSpan(makeSpan(), { outcome: "ok" });
+    await endTaskSpan(makeSpan(), { outcome: "failed", errorClass: "timeout" });
+    let flushed = false;
+    const flush = runtime.flushExportsForTest().then(() => {
+      flushed = true;
+    });
+
+    await Promise.resolve();
+    expect(flushed).toBe(false);
+    expect(exportedSpanIds).toEqual(["4444444444444444"]);
+
+    releaseFirstExport?.();
+    await flush;
+    expect(exportedSpanIds).toEqual([
+      "4444444444444444",
+      "5555555555555555",
+    ]);
   });
 
   it("parses sampling rates with bounded defaults", () => {


### PR DESCRIPTION
Closes #340
Depends on Magnus-Gille/grimnir#183
Coordinates with Magnus-Gille/gille-inference#172

This adds content-blind W3C trace propagation across broker, queue, execution, gateway, publication, and result recording. It separates queue and execution latency, applies deterministic per-mille sampling, uses a bounded fail-open exporter and strict privacy allowlist, emits authenticated preflight outcomes, and keeps publication failures on their dedicated span.

Verification:
- task tracing: 15 tests
- dispatcher: 64 tests
- learning-task preflight: 5 tests
- broker handlers: 81 tests
- npm run build

Reviews: Claude Opus 5 high and native Codex; all validated findings corrected.
