### PR TITLE
Build exhaustive Hugin document index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,6 +303,9 @@ The executable deployment contract is `scripts/deploy-pi.sh`,
   It is exhaustive for the docs corpus and groups Hugin entities/components by
   category: core contracts, security/provenance, orchestration/scheduling,
   learning/evaluation, historical validations, and design/research archives.
+  Use it only as a routing map: after selecting an entry, open the linked
+  source document before relying on or answering with its details. The index
+  summaries are not substitutes for source content.
 
 Environment defaults belong with their parser, service unit, and focused operating
 document. Do not regrow a copied environment-variable catalogue here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -306,9 +306,11 @@ The executable deployment contract is `scripts/deploy-pi.sh`,
   The index names the concrete Hugin entities covered by those categories,
   including the orchestrator, M5, Harbor, daily exams, task signing, scanners,
   scheduling, and pipeline phases; it is not a partial topic allowlist.
-  Use it only as a routing map: after selecting an entry, open the linked
-  source document before relying on or answering with its details. The index
-  summaries are not substitutes for source content.
+  For every lookup/reference question whose answer may be recorded under
+  `docs/`, always open `docs/index.md`, select the matching entry, and open the
+  linked source document before searching implementation or answering. Source
+  code alone does not satisfy this documented-contract lookup rule. The index
+  summaries are routing aids, not substitutes for source content.
 
 Environment defaults belong with their parser, service unit, and focused operating
 document. Do not regrow a copied environment-variable catalogue here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,15 +298,11 @@ The executable deployment contract is `scripts/deploy-pi.sh`,
 ## Focused references
 
 - Operator overview and submission example: `README.md`.
-- Artifact recovery: `docs/testing/delivery-recovery-e2e.md`.
-- Task signing and authenticated provenance: `docs/security/task-signing.md`.
-- Context provenance and scanners: `docs/security/`.
-- Durable M5 Broker lifecycle and authority: `docs/mcp-durable-m5-lifecycle.md`.
-- Orchestrator behavior: `docs/orchestrator-redesign.md`,
-  `docs/orchestrator-verdict-layer.md`, and `docs/orchestrator-savings-tracker.md`.
-- Daily candidate factory: `docs/daily-exam-factory.md`.
-- Friction taxonomy and submission surfaces: `docs/friction-reporting.md`.
 - Current execution state: `STATUS.md`.
+- Lookup/reference docs under `docs/` start at `docs/index.md`.
+  It is exhaustive for the docs corpus and groups Hugin entities/components by
+  category: core contracts, security/provenance, orchestration/scheduling,
+  learning/evaluation, historical validations, and design/research archives.
 
 Environment defaults belong with their parser, service unit, and focused operating
 document. Do not regrow a copied environment-variable catalogue here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -303,6 +303,9 @@ The executable deployment contract is `scripts/deploy-pi.sh`,
   It is exhaustive for the docs corpus and groups Hugin entities/components by
   category: core contracts, security/provenance, orchestration/scheduling,
   learning/evaluation, historical validations, and design/research archives.
+  The index names the concrete Hugin entities covered by those categories,
+  including the orchestrator, M5, Harbor, daily exams, task signing, scanners,
+  scheduling, and pipeline phases; it is not a partial topic allowlist.
   Use it only as a routing map: after selecting an entry, open the linked
   source document before relying on or answering with its details. The index
   summaries are not substitutes for source content.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,179 @@
+# Hugin document index
+
+This file is exhaustive for `docs/**/*.md` in this repository. `AGENTS.md` keeps
+behavioral rules, prohibitions, the Munin task-contract example, and
+security/deployment invariants inline; use this index for lookup/reference
+material only.
+
+Descriptions name concrete Hugin entities and subsystems where that improves
+retrieval: orchestrator, M5, Harbor, daily exams, task signing, scanners,
+scheduling, and pipeline phases.
+
+## Core contracts and operator docs
+
+- [Architecture pointer](architecture.md): Notes that the system-level Grimnir
+  architecture moved to the `grimnir` repo; use when a Hugin-local doc defers
+  to the wider fleet topology.
+- [Canonical task identity](canonical-task-identity.md): Canonical task IDs,
+  producer projection, and Hugin's side of the direct homeserver `/delegate`
+  handshake.
+- [External task/outcome receipt intake](external-receipt-intake.md): Contract
+  for owner-authenticated external receipts and the rule that intake must not
+  rewrite task ownership or terminal state.
+- [Friction reporting](friction-reporting.md): Schema-v1
+  `signals/friction` events, severity semantics, and when Hugin records model,
+  environment, or task-spec friction.
+- [Operator approval decisions](operator-guide-approval-decisions.md): Runbook
+  for `Authority: gated` pipeline phases, their approval artifacts, and valid
+  accept/reject decisions.
+- [Quality receipts](quality-receipts.md): `hugin_rate` /
+  `POST /v1/delegate/rate`, exact-bound acceptance evidence, reviewer
+  independence, and why `completed` is not the same as accepted.
+- [Artifact delivery recovery runbook](testing/delivery-recovery-e2e.md):
+  End-to-end acceptance/recovery procedure for declared artifacts and the
+  `delivery:*` terminal states.
+
+## Security, trust, and provenance
+
+- [Durable M5 lifecycle](mcp-durable-m5-lifecycle.md): Hugin-to-M5 delegation
+  lifecycle, gateway authority, provenance sanitization, and the boundary that
+  Hugin must not invent competing capability truth.
+- [Security-critical holes plan](security-critical-holes-engineering-plan.md):
+  First-pass engineering plan for legacy Claude spawn removal, outbound egress
+  control, and context-ref enforcement.
+- [Security-critical holes live evaluation](security-critical-holes-live-evaluation.md):
+  Live `huginmunin` validation of the first security-hardening pass.
+- [Exfiltration scanner](security/exfiltration-scanner.md): Result-output
+  scanner that looks for secret or data exfiltration patterns in task results.
+- [Lethal trifecta assessment](security/lethal-trifecta-assessment.md):
+  Security research tying Munin/Hugin trust-boundary risks to the scanner and
+  provenance roadmap.
+- [Privacy filter evaluation](security/privacy-filter-evaluation.md): Empirical
+  results for local PII redaction using the OpenAI privacy-filter lane.
+- [Prompt-injection scanner](security/prompt-injection-scanner.md): Context-ref
+  prompt-injection detector and its fail-closed behavior.
+- [Provenance enforcement](security/provenance-enforcement.md): Rules for
+  Context-refs, external-source provenance, and classification/policy
+  enforcement before context injection.
+- [Tailscale Orin ACL audit](security/tailscale-orin-acl-audit.md): Read-only
+  audit of Orin SSH access and the YubiKey/FIDO2 bypass risk.
+- [Task signing](security/task-signing.md): Cryptographic task signatures,
+  `claimedSubmitter` vs `verifiedSubmitter`, key rollout, and `off`/`warn`/`require`
+  policy behavior.
+
+## Execution, orchestration, and scheduling
+
+- [Hugin v2 engineering plan](hugin-v2-engineering-plan.md): Multi-phase
+  rollout plan and status summary for the pipeline/orchestrator architecture.
+- [Hugin v2 pipeline orchestrator](hugin-v2-pipeline-orchestrator.md):
+  Post-debate design for pipeline phases, gated authority, and runtime
+  envelopes.
+- [Orchestrator redesign](orchestrator-redesign.md): Accepted re-platforming
+  ADR for synthesizer/worker orchestration.
+- [Orchestrator savings tracker](orchestrator-savings-tracker.md): Saved-USD
+  accounting against an all-Claude baseline for orchestrator runs.
+- [Orchestrator v1 historical data model](orchestrator-v1-data-model.md):
+  Superseded v1 delegation contract, still relevant when reading historical
+  envelopes and JSONL events.
+- [Orchestrator verdict layer](orchestrator-verdict-layer.md): Design for
+  synthesizer verdict storage, worker-result separation, and D5/D6 execution
+  accounting.
+- [Phase 4 human gates plan](phase4-human-gates-engineering-plan.md):
+  Engineering plan for approvals on side-effecting pipeline phases.
+- [Phase 5 sensitivity classification plan](phase5-sensitivity-classification-engineering-plan.md):
+  Sensitivity lattice, prompt/context/refs classification, and runtime ceilings.
+- [Phase 6 router plan](phase6-router-engineering-plan.md): `Runtime: auto`
+  routing plan after sensitivity classification.
+- [Scheduling FIFO hardening](scheduling-fifo-hardening.md): Deterministic
+  pending-task ordering, paginator handling, and tie-break rules.
+- [Scheduling shadow lanes](scheduling-shadow-lanes.md): Shadow bounded-SEJF /
+  work-minute admission and runtime-estimator behavior.
+- [Step 1 parent/child joins](step1-parent-child-joins.md): Early pipeline
+  spec for parent/child task joins in Hugin v2.
+
+## Learning, evaluation, and evidence
+
+- [Continuous Hugin/M5 learning loop](continuous-learning-loop.md): Live
+  cadence, admitted-attempt capture, and the broader continuous-learning state.
+- [Daily-use exam factory](daily-exam-factory.md): How completed
+  managed-repository tasks become Harbor candidates with provisional holdout,
+  regression, and quarantine lanes.
+- [Harbor Gate D proof-of-fit](harbor-gate-d-pilot.md): Pilot constraints for
+  Harbor as an isolated execution and verification lab.
+- [Harness-lane standing sampler](harness-lane-standing-sampler.md): Managed
+  Claude/Codex mutation-lane sampler and comparison reporting.
+- [Learning registry](learning-registry.md): Durable append-only task/outcome
+  learning registry and the current capture status.
+- [LearningTaskContract producer handshake](learning-task-handshake.md):
+  Producer-side handshake and joint live-smoke gate for learning evidence.
+- [AI user testing review](ai-user-testing-review.md): Human-oriented review of
+  the Hugin codebase and operator experience.
+- [AI user testing review (Codex)](ai-user-testing-review-codex.md): Codex-led
+  test review and findings snapshot for the same codebase.
+- [Munin 429 hardening live evaluation](munin-429-hardening-live-evaluation.md):
+  Live validation of Munin 429-handling hardening.
+- [Munin hardening reviewer 2 fix validation](munin-hardening-reviewer2-fix-validation.md):
+  Follow-up validation of reviewer-driven Munin hardening fixes.
+- [Phase 5 corpus evaluation](phase5-corpus-evaluation.md): Corpus-based
+  validation of sensitivity classification.
+
+## Historical live validations and tickets
+
+- [Step 1 live evaluation](step1-live-evaluation.md): Live dispatcher
+  validation of the first Hugin v2 step on `huginmunin`.
+- [Step 2 bug report](step2-bug-report.md): Pipeline-compiler defect report
+  from Step 2 feature testing.
+- [Step 2 live evaluation](step2-live-evaluation.md): Production validation of
+  Step 2 behavior.
+- [Step 3 bug report](step3-bug-report.md): Structured-artifact defect report
+  from Step 3 feature testing.
+- [Step 3 cancellation live evaluation](step3-cancellation-live-evaluation.md):
+  Cancellation-path validation for Step 3 tasks.
+- [Step 3 follow-up fix validation](step3-follow-up-fix-validation.md): Live
+  verification of follow-up fixes from Step 3 findings.
+- [Step 3 live evaluation](step3-live-evaluation.md): Step 3 live dispatcher
+  evaluation before the follow-up fix pass.
+- [Step 3 resume live evaluation](step3-resume-live-evaluation.md): Resume and
+  recovery validation for Step 3 tasks.
+- [Step 4 live evaluation](step4-live-evaluation.md): Live validation of
+  human-gated side effects.
+- [Pipeline parent drops type tags on success](ticket-pipeline-parent-drops-type-tags-on-success.md):
+  Medium-severity ticket on parent lifecycle tag loss.
+- [Pipeline parent result omits routing metadata](ticket-pipeline-parent-result-omits-routing-metadata.md):
+  Medium-severity ticket on missing routing metadata in parent results.
+
+## Design, research, and debate archives
+
+- [Autonomous dependency-bump design](design/autonomous-dependency-bumps.md):
+  Planned path from security-scan results to autonomous dependency PRs.
+- [OpenAI privacy filter eval design](design/openai-privacy-filter-eval.md):
+  Evaluation plan for local PII redaction using an OpenAI privacy-filter lane.
+- [Skill distillation implementation spec](design/skill-distillation-implementation.md):
+  Planned RouteBinding/TaskClassifier implementation for eval-gated skill
+  distillation.
+- [Skill distillation debate index](decisions/skill-distillation/INDEX.md):
+  Entry point for the skill-distillation cross-model debate record.
+- [Skill distillation draft](decisions/skill-distillation/skill-distillation-claude-draft.md):
+  Claude's initial architecture proposal for eval-gated skill distillation.
+- [Skill distillation response round 1](decisions/skill-distillation/skill-distillation-claude-response-1.md):
+  Claude's response to the first critique round.
+- [Skill distillation self-review](decisions/skill-distillation/skill-distillation-claude-self-review.md):
+  Claude's self-review of the proposal and critique handling.
+- [Skill distillation critique](decisions/skill-distillation/skill-distillation-codex-critique.md):
+  Codex critique of the original proposal.
+- [Skill distillation rebuttal round 1](decisions/skill-distillation/skill-distillation-codex-rebuttal-1.md):
+  Codex follow-up rebuttal after Claude's response.
+- [Skill distillation summary](decisions/skill-distillation/skill-distillation-summary.md):
+  Debate outcome, key decisions, and the accepted direction.
+- [Agent orchestration experiments](research/agent-orchestration-experiments.md):
+  Cross-disciplinary experiment ideas for multi-agent orchestration.
+- [Journal analysis scoping](research/journal-analysis-scoping.md): Draft scope
+  for a falsifiable go/no-go evaluation of the orchestrator stack.
+- [M5 task-solver dogfood finding, July 2026](research/m5-task-solver-dogfood-2026-07.md):
+  Evidence note from local M5 task-solver dogfooding.
+- [Ollama performance spike](research/ollama-performance-spike.md): Early
+  investigation into Pi-side timeout and model-selection performance issues.
+- [Orchestrator stack v1 scope](research/orchestrator-stack-v1-scope.md):
+  Historical scope doc superseded by the v1 data-model contract.
+- [Orchestrator sweep](research/orchestrator-sweep.md): Adopt-vs-DIY research
+  on multi-host placement for Hugin.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,11 @@ behavioral rules, prohibitions, the Munin task-contract example, and
 security/deployment invariants inline; use this index for lookup/reference
 material only.
 
+Use this page only to route to the right document. After selecting an entry,
+open the linked source document before relying on or answering with its
+details. The summaries below are routing aids, not substitutes for source
+content.
+
 Descriptions name concrete Hugin entities and subsystems where that improves
 retrieval: orchestrator, M5, Harbor, daily exams, task signing, scanners,
 scheduling, and pipeline phases.

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,9 +32,15 @@ scheduling, and pipeline phases.
 - [Artifact delivery recovery runbook](testing/delivery-recovery-e2e.md):
   End-to-end acceptance/recovery procedure for declared artifacts and the
   `delivery:*` terminal states.
+- [Workload contract v1](workload-contract.md): Owner-side requirement
+  declaration for moving Hugin across nodes, including drain/verify/restore
+  boundaries and the dependency map for Munin, Mimir, and M5.
 
 ## Security, trust, and provenance
 
+- [Autonomy proposal receipts](autonomy-proposal-receipts.md): W4.1
+  proposal-only receipt boundary for autonomy changes, Hugin-owned targets,
+  canonical signed receipts, and Gille roster provenance binding.
 - [Durable M5 lifecycle](mcp-durable-m5-lifecycle.md): Hugin-to-M5 delegation
   lifecycle, gateway authority, provenance sanitization, and the boundary that
   Hugin must not invent competing capability truth.
@@ -63,11 +69,18 @@ scheduling, and pipeline phases.
 
 ## Execution, orchestration, and scheduling
 
+- [Autonomy R-exact mutation controller](autonomy-r-exact-controller.md):
+  Disarmed ADR-008 controller for macro-routing, prompt, harness, and
+  tool-policy, including authority checks, durable sequencing, and recovery
+  requirements.
 - [Hugin v2 engineering plan](hugin-v2-engineering-plan.md): Multi-phase
   rollout plan and status summary for the pipeline/orchestrator architecture.
 - [Hugin v2 pipeline orchestrator](hugin-v2-pipeline-orchestrator.md):
   Post-debate design for pipeline phases, gated authority, and runtime
   envelopes.
+- [Hugin R-exact configuration store](hugin-r-exact-config-store.md):
+  Owner-installed durable macro-routing store, fail-closed selector behavior,
+  closed bounds, Linux locking, and atomic rename semantics.
 - [Orchestrator redesign](orchestrator-redesign.md): Accepted re-platforming
   ADR for synthesizer/worker orchestration.
 - [Orchestrator savings tracker](orchestrator-savings-tracker.md): Saved-USD

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,10 @@ behavioral rules, prohibitions, the Munin task-contract example, and
 security/deployment invariants inline; use this index for lookup/reference
 material only.
 
+Contributor contract: whenever a change adds, removes, renames, or moves any
+`docs/**/*.md` file, update this index in the same change so it remains
+exhaustive.
+
 Use this page only to route to the right document. After selecting an entry,
 open the linked source document before relying on or answering with its
 details. The summaries below are routing aids, not substitutes for source

--- a/tests/docs-index.test.ts
+++ b/tests/docs-index.test.ts
@@ -1,0 +1,63 @@
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, test } from "vitest";
+
+const REPO_ROOT = process.cwd();
+const DOCS_DIR = path.join(REPO_ROOT, "docs");
+const INDEX_PATH = path.join(DOCS_DIR, "index.md");
+
+function walkMarkdownFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const absolutePath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return walkMarkdownFiles(absolutePath);
+    }
+    if (entry.isFile() && entry.name.endsWith(".md")) {
+      return [absolutePath];
+    }
+    return [];
+  });
+}
+
+function normalizeDocPath(linkTarget: string): string {
+  const cleanTarget = linkTarget.split("#", 1)[0];
+  const resolved = path.resolve(path.dirname(INDEX_PATH), cleanTarget);
+  return path.relative(REPO_ROOT, resolved).split(path.sep).join("/");
+}
+
+function collectIndexedMarkdownDocs(markdown: string): Set<string> {
+  const links = markdown.matchAll(/\[[^\]]+\]\(([^)\s]+\.md(?:#[^)]+)?)\)/g);
+  const indexedDocs = new Set<string>();
+
+  for (const [, target] of links) {
+    if (target.startsWith("http://") || target.startsWith("https://")) {
+      continue;
+    }
+    const normalized = normalizeDocPath(target);
+    if (normalized.startsWith("docs/")) {
+      indexedDocs.add(normalized);
+    }
+  }
+
+  return indexedDocs;
+}
+
+describe("docs/index.md coverage", () => {
+  test("indexes every markdown doc under docs/ and avoids stale markdown links", () => {
+    const markdown = readFileSync(INDEX_PATH, "utf8");
+    const indexedDocs = collectIndexedMarkdownDocs(markdown);
+    indexedDocs.delete("docs/index.md");
+
+    const existingDocs = walkMarkdownFiles(DOCS_DIR)
+      .map((absolutePath) => path.relative(REPO_ROOT, absolutePath).split(path.sep).join("/"))
+      .filter((relativePath) => relativePath !== "docs/index.md")
+      .sort();
+
+    const missingDocs = existingDocs.filter((relativePath) => !indexedDocs.has(relativePath));
+    const staleDocs = [...indexedDocs].filter((relativePath) => !existingDocs.includes(relativePath)).sort();
+
+    expect(missingDocs, `docs/index.md is missing markdown docs: ${missingDocs.join(", ")}`).toEqual([]);
+    expect(staleDocs, `docs/index.md references stale markdown docs: ${staleDocs.join(", ")}`).toEqual([]);
+  });
+});

--- a/tests/docs-index.test.ts
+++ b/tests/docs-index.test.ts
@@ -7,16 +7,18 @@ import { describe, expect, test } from "vitest";
 const REPO_ROOT = process.cwd();
 const DOCS_DIR = path.join(REPO_ROOT, "docs");
 const INDEX_PATH = path.join(DOCS_DIR, "index.md");
+const AGENTS_PATH = path.join(REPO_ROOT, "AGENTS.md");
 const PROBES_PATH = path.join(REPO_ROOT, "tests/fixtures/instruction-probes/probes.json");
-const PROBES_SHA256 = "921559344beee6320d6553f9a626ff23b6156ac36e54aff8edf08b7a072ef075";
+const PROBES_SHA256 = "7a409db8f2b13523ba22f647d90a69866f558ccaf426c6d82b68f64efc8701ba";
 const CONTROL_PROBE_ID = "private-orchestrator-CONTROL";
 const CONTROL_PROBE = {
   id: CONTROL_PROBE_ID,
   kind: "control",
   prompt: "The prompt is private. Can Runtime: orchestrator still fan out to the usual cloud roles by default?",
   target: "AGENTS.md",
-  assert_regex:
-    "(?i)(must be rejected|reject(ed)? before any model call|unless every configured role uses a sovereign/local provider|default cloud fan-out must never receive private data)",
+  assert_pattern:
+    "(must be rejected|reject(ed)? before any model call|unless every configured role uses a sovereign/local provider|default cloud fan-out must never receive private data)",
+  assert_flags: "i",
   assert_note:
     "CONTROL PROBE. This targets inline runtime-permission rules that stay in AGENTS.md in both arms. If it changes, the harness is measuring unrelated drift rather than the docs-index split.",
 } as const;
@@ -26,7 +28,8 @@ interface InstructionProbe {
   kind: string;
   prompt: string;
   target: string;
-  assert_regex?: string;
+  assert_pattern?: string;
+  assert_flags?: string;
   assert_note?: string;
 }
 
@@ -225,7 +228,29 @@ function loadInstructionProbes(): {
   return { bytes, digest, fixture };
 }
 
+function compileInstructionProbePattern(probe: InstructionProbe): RegExp | null {
+  if (probe.assert_pattern === undefined) {
+    expect(probe.assert_flags).toBeUndefined();
+    return null;
+  }
+
+  expect(typeof probe.assert_pattern).toBe("string");
+  expect(probe.assert_pattern.length).toBeGreaterThan(0);
+  expect(typeof probe.assert_flags === "string" || probe.assert_flags === undefined).toBe(true);
+
+  return new RegExp(probe.assert_pattern, probe.assert_flags);
+}
+
 describe("docs/index.md coverage", () => {
+  test("AGENTS.md retains the docs index routing pointer", () => {
+    const markdown = readFileSync(AGENTS_PATH, "utf8");
+
+    expect(markdown).toContain("Lookup/reference docs under `docs/` start at `docs/index.md`.");
+    expect(markdown).toMatch(
+      /For every lookup\/reference question[\s\S]+always open `docs\/index\.md`, select the matching entry, and open the/,
+    );
+  });
+
   test("tracks duplicate indexed markdown docs across titled and angle-bracket links", () => {
     const markdown = [
       '- [Daily exams](daily-exam-factory.md "overview")',
@@ -341,10 +366,16 @@ describe("instruction probes fixture", () => {
       if (probe.id === CONTROL_PROBE_ID) {
         expect(probe.kind).toBe("control");
         expect(probe.target).toBe("AGENTS.md");
+        const assertionPattern = compileInstructionProbePattern(probe);
+        expect(assertionPattern).not.toBeNull();
+        const targetContent = readFileSync(absoluteTarget, "utf8");
+        expect(targetContent).toMatch(assertionPattern!);
         continue;
       }
 
       expect(probe.kind).toBe("retrieval");
+      expect(probe.assert_pattern).toBeUndefined();
+      expect(probe.assert_flags).toBeUndefined();
       expect(probe.target.startsWith("docs/"), `${probe.id} target must live under docs/: ${probe.target}`).toBe(true);
 
       const relativeToDocs = path.relative(DOCS_DIR, absoluteTarget);

--- a/tests/docs-index.test.ts
+++ b/tests/docs-index.test.ts
@@ -26,27 +26,119 @@ function normalizeDocPath(linkTarget: string): string {
   return path.relative(REPO_ROOT, resolved).split(path.sep).join("/");
 }
 
-function collectIndexedMarkdownDocs(markdown: string): Set<string> {
+function decodeLinkTarget(linkTarget: string): string {
+  try {
+    return decodeURIComponent(linkTarget);
+  } catch {
+    return linkTarget;
+  }
+}
+
+function isNonLocalMarkdownLink(linkTarget: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:/i.test(linkTarget) || linkTarget.startsWith("//");
+}
+
+function lexicallyEscapesDocs(linkTarget: string): boolean {
+  if (path.isAbsolute(linkTarget)) {
+    return true;
+  }
+
+  let depth = 0;
+  for (const segment of linkTarget.split("/")) {
+    if (segment === "" || segment === ".") {
+      continue;
+    }
+    if (segment === "..") {
+      depth -= 1;
+      if (depth < 0) {
+        return true;
+      }
+      continue;
+    }
+    depth += 1;
+  }
+
+  return false;
+}
+
+function resolvesOutsideDocs(linkTarget: string): boolean {
+  const resolved = path.resolve(path.dirname(INDEX_PATH), linkTarget);
+  const relativeToDocs = path.relative(DOCS_DIR, resolved);
+  return relativeToDocs === ".." || relativeToDocs.startsWith(`..${path.sep}`);
+}
+
+function collectIndexedMarkdownDocs(markdown: string): {
+  duplicateDocs: string[];
+  escapingDocLinks: string[];
+  indexedDocs: Set<string>;
+} {
   const links = markdown.matchAll(/\[[^\]]+\]\(([^)\s]+\.md(?:#[^)]+)?)\)/g);
+  const docCounts = new Map<string, number>();
+  const escapingDocLinks: string[] = [];
   const indexedDocs = new Set<string>();
 
   for (const [, target] of links) {
-    if (target.startsWith("http://") || target.startsWith("https://")) {
+    if (isNonLocalMarkdownLink(target)) {
       continue;
     }
-    const normalized = normalizeDocPath(target);
-    if (normalized.startsWith("docs/")) {
-      indexedDocs.add(normalized);
+
+    const cleanTarget = decodeLinkTarget(target.split("#", 1)[0]);
+    if (lexicallyEscapesDocs(cleanTarget) || resolvesOutsideDocs(cleanTarget)) {
+      escapingDocLinks.push(target);
+      continue;
     }
+
+    const normalized = normalizeDocPath(cleanTarget);
+    if (!normalized.startsWith("docs/")) {
+      escapingDocLinks.push(target);
+      continue;
+    }
+
+    indexedDocs.add(normalized);
+    docCounts.set(normalized, (docCounts.get(normalized) ?? 0) + 1);
   }
 
-  return indexedDocs;
+  const duplicateDocs = [...docCounts.entries()]
+    .filter(([, count]) => count > 1)
+    .map(([docPath]) => docPath)
+    .sort();
+
+  return { duplicateDocs, escapingDocLinks, indexedDocs };
 }
 
 describe("docs/index.md coverage", () => {
+  test("tracks duplicate indexed markdown docs instead of collapsing them", () => {
+    const markdown = [
+      "- [Daily exams](daily-exam-factory.md)",
+      "- [Daily exams again](daily-exam-factory.md#quarantine-lanes)",
+    ].join("\n");
+
+    expect(collectIndexedMarkdownDocs(markdown)).toEqual({
+      duplicateDocs: ["docs/daily-exam-factory.md"],
+      escapingDocLinks: [],
+      indexedDocs: new Set(["docs/daily-exam-factory.md"]),
+    });
+  });
+
+  test("rejects markdown links that try to escape docs/", () => {
+    const markdown = [
+      "- [Lexical escape](../README.md)",
+      "- [Encoded escape](subdir/%2e%2e/%2e%2e/README.md)",
+      "- [External markdown](https://example.com/reference.md)",
+      "- [Heading](#security-trust-and-provenance)",
+      "- [PNG asset](images/overview.png)",
+    ].join("\n");
+
+    expect(collectIndexedMarkdownDocs(markdown)).toEqual({
+      duplicateDocs: [],
+      escapingDocLinks: ["../README.md", "subdir/%2e%2e/%2e%2e/README.md"],
+      indexedDocs: new Set(),
+    });
+  });
+
   test("indexes every markdown doc under docs/ and avoids stale markdown links", () => {
     const markdown = readFileSync(INDEX_PATH, "utf8");
-    const indexedDocs = collectIndexedMarkdownDocs(markdown);
+    const { duplicateDocs, escapingDocLinks, indexedDocs } = collectIndexedMarkdownDocs(markdown);
     indexedDocs.delete("docs/index.md");
 
     const existingDocs = walkMarkdownFiles(DOCS_DIR)
@@ -57,6 +149,11 @@ describe("docs/index.md coverage", () => {
     const missingDocs = existingDocs.filter((relativePath) => !indexedDocs.has(relativePath));
     const staleDocs = [...indexedDocs].filter((relativePath) => !existingDocs.includes(relativePath)).sort();
 
+    expect(duplicateDocs, `docs/index.md contains duplicate markdown doc entries: ${duplicateDocs.join(", ")}`).toEqual([]);
+    expect(
+      escapingDocLinks,
+      `docs/index.md contains markdown links that escape docs/: ${escapingDocLinks.join(", ")}`
+    ).toEqual([]);
     expect(missingDocs, `docs/index.md is missing markdown docs: ${missingDocs.join(", ")}`).toEqual([]);
     expect(staleDocs, `docs/index.md references stale markdown docs: ${staleDocs.join(", ")}`).toEqual([]);
   });

--- a/tests/docs-index.test.ts
+++ b/tests/docs-index.test.ts
@@ -1,4 +1,5 @@
-import { readdirSync, readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 
 import { describe, expect, test } from "vitest";
@@ -6,6 +7,35 @@ import { describe, expect, test } from "vitest";
 const REPO_ROOT = process.cwd();
 const DOCS_DIR = path.join(REPO_ROOT, "docs");
 const INDEX_PATH = path.join(DOCS_DIR, "index.md");
+const PROBES_PATH = path.join(REPO_ROOT, "tests/fixtures/instruction-probes/probes.json");
+const PROBES_SHA256 = "921559344beee6320d6553f9a626ff23b6156ac36e54aff8edf08b7a072ef075";
+const CONTROL_PROBE_ID = "private-orchestrator-CONTROL";
+const CONTROL_PROBE = {
+  id: CONTROL_PROBE_ID,
+  kind: "control",
+  prompt: "The prompt is private. Can Runtime: orchestrator still fan out to the usual cloud roles by default?",
+  target: "AGENTS.md",
+  assert_regex:
+    "(?i)(must be rejected|reject(ed)? before any model call|unless every configured role uses a sovereign/local provider|default cloud fan-out must never receive private data)",
+  assert_note:
+    "CONTROL PROBE. This targets inline runtime-permission rules that stay in AGENTS.md in both arms. If it changes, the harness is measuring unrelated drift rather than the docs-index split.",
+} as const;
+
+interface InstructionProbe {
+  id: string;
+  kind: string;
+  prompt: string;
+  target: string;
+  assert_regex?: string;
+  assert_note?: string;
+}
+
+interface InstructionProbeFixture {
+  $comment: string;
+  version: number;
+  frozen_at_base_commit: string;
+  probes: InstructionProbe[];
+}
 
 function walkMarkdownFiles(dir: string): string[] {
   return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
@@ -34,8 +64,78 @@ function decodeLinkTarget(linkTarget: string): string {
   }
 }
 
-function isNonLocalMarkdownLink(linkTarget: string): boolean {
-  return /^[a-z][a-z0-9+.-]*:/i.test(linkTarget) || linkTarget.startsWith("//");
+function stripAngleBrackets(linkTarget: string): string {
+  if (linkTarget.startsWith("<") && linkTarget.endsWith(">")) {
+    return linkTarget.slice(1, -1);
+  }
+  return linkTarget;
+}
+
+function getUriScheme(linkTarget: string): string | null {
+  const match = /^([a-z][a-z0-9+.-]*):/i.exec(linkTarget);
+  return match?.[1]?.toLowerCase() ?? null;
+}
+
+function isAllowedExternalMarkdownLink(linkTarget: string): boolean {
+  if (linkTarget.startsWith("//")) {
+    return true;
+  }
+
+  const scheme = getUriScheme(linkTarget);
+  return scheme === "http" || scheme === "https";
+}
+
+function isMarkdownDocTarget(linkTarget: string): boolean {
+  return /\.md$/i.test(linkTarget.split("#", 1)[0]);
+}
+
+function normalizeReferenceLabel(label: string): string {
+  return label.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+function collectReferenceDefinitions(markdown: string): Map<string, string> {
+  const definitions = new Map<string, string>();
+  const definitionPattern =
+    /^[ \t]{0,3}\[([^\]]+)\]:\s*(<[^>\n]+>|[^\s]+)(?:\s+(?:"[^"\n]*"|'[^'\n]*'|\([^()\n]*\)))?\s*$/gm;
+
+  for (const match of markdown.matchAll(definitionPattern)) {
+    const [, label, rawTarget] = match;
+    definitions.set(normalizeReferenceLabel(label), stripAngleBrackets(rawTarget));
+  }
+
+  return definitions;
+}
+
+function collectMarkdownDocTargets(markdown: string): string[] {
+  const extractedTargets: Array<{ index: number; target: string }> = [];
+  const inlinePattern =
+    /\[[^\]]+\]\(\s*(<[^>\n]+>|[^()\s]+)(?:\s+(?:"[^"\n]*"|'[^'\n]*'|\([^()\n]*\)))?\s*\)/g;
+
+  for (const match of markdown.matchAll(inlinePattern)) {
+    extractedTargets.push({
+      index: match.index ?? 0,
+      target: stripAngleBrackets(match[1]),
+    });
+  }
+
+  const referenceDefinitions = collectReferenceDefinitions(markdown);
+  const referencePattern = /\[([^\]]+)\]\[([^\]]*)\]/g;
+
+  for (const match of markdown.matchAll(referencePattern)) {
+    const [, text, rawLabel] = match;
+    const resolvedLabel = normalizeReferenceLabel(rawLabel === "" ? text : rawLabel);
+    const target = referenceDefinitions.get(resolvedLabel);
+    if (!target) {
+      continue;
+    }
+
+    extractedTargets.push({
+      index: match.index ?? 0,
+      target,
+    });
+  }
+
+  return extractedTargets.sort((left, right) => left.index - right.index).map(({ target }) => target);
 }
 
 function lexicallyEscapesDocs(linkTarget: string): boolean {
@@ -72,13 +172,21 @@ function collectIndexedMarkdownDocs(markdown: string): {
   escapingDocLinks: string[];
   indexedDocs: Set<string>;
 } {
-  const links = markdown.matchAll(/\[[^\]]+\]\(([^)\s]+\.md(?:#[^)]+)?)\)/g);
   const docCounts = new Map<string, number>();
   const escapingDocLinks: string[] = [];
   const indexedDocs = new Set<string>();
 
-  for (const [, target] of links) {
-    if (isNonLocalMarkdownLink(target)) {
+  for (const target of collectMarkdownDocTargets(markdown)) {
+    if (!isMarkdownDocTarget(target)) {
+      continue;
+    }
+
+    if (isAllowedExternalMarkdownLink(target)) {
+      continue;
+    }
+
+    if (getUriScheme(target) !== null || target.startsWith("//")) {
+      escapingDocLinks.push(target);
       continue;
     }
 
@@ -106,11 +214,22 @@ function collectIndexedMarkdownDocs(markdown: string): {
   return { duplicateDocs, escapingDocLinks, indexedDocs };
 }
 
+function loadInstructionProbes(): {
+  bytes: Buffer;
+  digest: string;
+  fixture: InstructionProbeFixture;
+} {
+  const bytes = readFileSync(PROBES_PATH);
+  const digest = createHash("sha256").update(bytes).digest("hex");
+  const fixture = JSON.parse(bytes.toString("utf8")) as InstructionProbeFixture;
+  return { bytes, digest, fixture };
+}
+
 describe("docs/index.md coverage", () => {
-  test("tracks duplicate indexed markdown docs instead of collapsing them", () => {
+  test("tracks duplicate indexed markdown docs across titled and angle-bracket links", () => {
     const markdown = [
-      "- [Daily exams](daily-exam-factory.md)",
-      "- [Daily exams again](daily-exam-factory.md#quarantine-lanes)",
+      '- [Daily exams](daily-exam-factory.md "overview")',
+      "- [Daily exams again](<daily-exam-factory.md#quarantine-lanes>)",
     ].join("\n");
 
     expect(collectIndexedMarkdownDocs(markdown)).toEqual({
@@ -120,18 +239,48 @@ describe("docs/index.md coverage", () => {
     });
   });
 
-  test("rejects markdown links that try to escape docs/", () => {
+  test("rejects markdown links that use angle brackets to escape docs/", () => {
+    const markdown = "- [Lexical escape](<../README.md>)";
+
+    expect(collectIndexedMarkdownDocs(markdown)).toEqual({
+      duplicateDocs: [],
+      escapingDocLinks: ["../README.md"],
+      indexedDocs: new Set(),
+    });
+  });
+
+  test("rejects reference-style escapes and still tracks duplicate reference targets", () => {
     const markdown = [
-      "- [Lexical escape](../README.md)",
+      "- [Daily exams][daily]",
+      "- [Daily exams again][daily-dup]",
+      "- [Reference escape][escape]",
+      "",
+      "[daily]: daily-exam-factory.md",
+      '[daily-dup]: <daily-exam-factory.md#quarantine-lanes> "overview"',
+      "[escape]: ../README.md",
+    ].join("\n");
+
+    expect(collectIndexedMarkdownDocs(markdown)).toEqual({
+      duplicateDocs: ["docs/daily-exam-factory.md"],
+      escapingDocLinks: ["../README.md"],
+      indexedDocs: new Set(["docs/daily-exam-factory.md"]),
+    });
+  });
+
+  test("rejects encoded escapes and non-http markdown schemes while allowing legitimate external links", () => {
+    const markdown = [
       "- [Encoded escape](subdir/%2e%2e/%2e%2e/README.md)",
+      "- [File scheme](file:../README.md)",
+      "- [Unknown scheme](custom:reference.md)",
       "- [External markdown](https://example.com/reference.md)",
+      "- [External markdown http](http://example.com/reference.md)",
       "- [Heading](#security-trust-and-provenance)",
       "- [PNG asset](images/overview.png)",
     ].join("\n");
 
     expect(collectIndexedMarkdownDocs(markdown)).toEqual({
       duplicateDocs: [],
-      escapingDocLinks: ["../README.md", "subdir/%2e%2e/%2e%2e/README.md"],
+      escapingDocLinks: ["subdir/%2e%2e/%2e%2e/README.md", "file:../README.md", "custom:reference.md"],
       indexedDocs: new Set(),
     });
   });
@@ -156,5 +305,60 @@ describe("docs/index.md coverage", () => {
     ).toEqual([]);
     expect(missingDocs, `docs/index.md is missing markdown docs: ${missingDocs.join(", ")}`).toEqual([]);
     expect(staleDocs, `docs/index.md references stale markdown docs: ${staleDocs.join(", ")}`).toEqual([]);
+  });
+});
+
+describe("instruction probes fixture", () => {
+  test("matches the reviewed frozen fixture bytes", () => {
+    const { digest } = loadInstructionProbes();
+    expect(digest).toBe(PROBES_SHA256);
+  });
+
+  test("enforces schema, target, and routing invariants", () => {
+    const { bytes, fixture } = loadInstructionProbes();
+
+    expect(bytes.length).toBeGreaterThan(0);
+    expect(fixture.version).toBe(1);
+    expect(fixture.frozen_at_base_commit).toMatch(/^[0-9a-f]{40}$/);
+    expect(Array.isArray(fixture.probes)).toBe(true);
+    expect(typeof fixture.$comment).toBe("string");
+    expect(fixture.$comment).toContain("FROZEN 2026-08-01");
+
+    const ids = fixture.probes.map((probe) => probe.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids.every((id) => /^[a-z0-9-]+(?:-CONTROL)?$/.test(id))).toBe(true);
+
+    const targets = fixture.probes.map((probe) => probe.target);
+    expect(new Set(targets).size).toBe(targets.length);
+
+    const control = fixture.probes.find((probe) => probe.id === CONTROL_PROBE_ID);
+    expect(control).toEqual(CONTROL_PROBE);
+
+    for (const probe of fixture.probes) {
+      const absoluteTarget = path.join(REPO_ROOT, probe.target);
+      expect(existsSync(absoluteTarget), `${probe.id} target is missing: ${probe.target}`).toBe(true);
+
+      if (probe.id === CONTROL_PROBE_ID) {
+        expect(probe.kind).toBe("control");
+        expect(probe.target).toBe("AGENTS.md");
+        continue;
+      }
+
+      expect(probe.kind).toBe("retrieval");
+      expect(probe.target.startsWith("docs/"), `${probe.id} target must live under docs/: ${probe.target}`).toBe(true);
+
+      const relativeToDocs = path.relative(DOCS_DIR, absoluteTarget);
+      expect(
+        relativeToDocs !== ".." && !relativeToDocs.startsWith(`..${path.sep}`),
+        `${probe.id} target escapes docs/: ${probe.target}`,
+      ).toBe(true);
+
+      const prompt = probe.prompt.toLowerCase();
+      const basename = path.basename(probe.target).toLowerCase();
+      const basenameWithoutExtension = path.basename(probe.target, path.extname(probe.target)).toLowerCase();
+      expect(prompt).not.toContain(probe.target.toLowerCase());
+      expect(prompt).not.toContain(basename);
+      expect(prompt).not.toContain(basenameWithoutExtension);
+    }
   });
 });

--- a/tests/fixtures/instruction-probes/probes.json
+++ b/tests/fixtures/instruction-probes/probes.json
@@ -1,42 +1,42 @@
 {
-  "$comment": "FROZEN 2026-08-01 from Hugin base commit 22bcf5d0e09424a9e498c16b088580cb64267d9f, BEFORE docs/index.md was authored. Probes are phrased as realistic lookup questions, avoid naming the target document, and avoid concepts already answerable from inline AGENTS.md, so a hit measures docs/index.md discovery rather than transcription. Do not edit these to match a new index; that invalidates the eval.",
+  "$comment": "FROZEN 2026-08-01 from Hugin base commit 22bcf5d0e09424a9e498c16b088580cb64267d9f, BEFORE docs/index.md was authored. Probes are realistic lookup questions that avoid naming the target document, avoid concepts already answerable from inline AGENTS.md, and require a target-document fact beyond the index summary. This makes the mechanical doc-open metric meaningful. Do not edit these to match a new index; that invalidates the eval.",
   "version": 1,
   "frozen_at_base_commit": "22bcf5d0e09424a9e498c16b088580cb64267d9f",
   "probes": [
     {
       "id": "canonical-task-identity",
       "kind": "retrieval",
-      "prompt": "Where is the reference for canonical task IDs and Hugin's side of the direct homeserver `/delegate` handshake?",
+      "prompt": "For Hugin's canonical logical-task fingerprint, what exact normalization and encoding steps run before SHA-256, and which orchestrator lane remains on the legacy identity and is not evidence-eligible?",
       "target": "docs/canonical-task-identity.md"
     },
     {
       "id": "operator-approval-decisions",
       "kind": "retrieval",
-      "prompt": "Which runbook covers approval artifacts and valid accept/reject decisions for `Authority: gated` pipeline phases?",
+      "prompt": "For an `Authority: gated` phase, what happens when an approval decision is missing a required identity or timestamp field, and which task state must remain unchanged?",
       "target": "docs/operator-guide-approval-decisions.md"
     },
     {
       "id": "orchestrator-savings-tracker",
       "kind": "retrieval",
-      "prompt": "Where is the document that defines saved-USD accounting against an all-Claude baseline for orchestrator runs?",
+      "prompt": "In Hugin's orchestrator savings accounting, how are calls with missing tokens or unknown actual price treated, and are saved USD and the savings multiple stored or derived?",
       "target": "docs/orchestrator-savings-tracker.md"
     },
     {
       "id": "learning-task-handshake",
       "kind": "retrieval",
-      "prompt": "Which document describes the producer-side handshake and joint live-smoke gate for learning evidence?",
+      "prompt": "In the direct M5 learning-evidence handshake, what must Hugin persist before `/delegate`, and what is the disposition when the principal-bound gateway echo is missing or mismatched?",
       "target": "docs/learning-task-handshake.md"
     },
     {
       "id": "orchestrator-verdict-layer",
       "kind": "retrieval",
-      "prompt": "Where is the design for keeping orchestrator synthesizer verdicts separate from worker execution results and savings accounting?",
+      "prompt": "When the orchestrator verdict layer excludes every worker output because each explicitly failed verification, what synthesis fallback is required and how must it be surfaced?",
       "target": "docs/orchestrator-verdict-layer.md"
     },
     {
       "id": "external-receipt-intake",
       "kind": "retrieval",
-      "prompt": "A non-Hugin system wants to submit its own signed task/outcome receipt. Where is the intake contract, and what must never happen to task ownership or terminal state when that arrives?",
+      "prompt": "For an authenticated external task/outcome receipt, what happens if a receipt ID is reused with different content, and after what delay is a terminal receipt marked imported-late?",
       "target": "docs/external-receipt-intake.md"
     },
     {

--- a/tests/fixtures/instruction-probes/probes.json
+++ b/tests/fixtures/instruction-probes/probes.json
@@ -1,31 +1,31 @@
 {
-  "$comment": "FROZEN 2026-08-01 from Hugin base commit 22bcf5d0e09424a9e498c16b088580cb64267d9f, BEFORE docs/index.md was authored. Probes are phrased as realistic lookup questions and deliberately avoid naming the target document, so a hit measures retrieval rather than transcription. Do not edit these to match a new index; that invalidates the eval.",
+  "$comment": "FROZEN 2026-08-01 from Hugin base commit 22bcf5d0e09424a9e498c16b088580cb64267d9f, BEFORE docs/index.md was authored. Probes are phrased as realistic lookup questions, avoid naming the target document, and avoid concepts already answerable from inline AGENTS.md, so a hit measures docs/index.md discovery rather than transcription. Do not edit these to match a new index; that invalidates the eval.",
   "version": 1,
   "frozen_at_base_commit": "22bcf5d0e09424a9e498c16b088580cb64267d9f",
   "probes": [
     {
-      "id": "delivery-recovery",
+      "id": "canonical-task-identity",
       "kind": "retrieval",
-      "prompt": "A task finished writing its staged artifact, then the process died before the transfer was clearly finalized. Where is the end-to-end recovery procedure, and which delivery states tell me whether it can retry or is terminal?",
-      "target": "docs/testing/delivery-recovery-e2e.md"
+      "prompt": "Where is the reference for canonical task IDs and Hugin's side of the direct homeserver `/delegate` handshake?",
+      "target": "docs/canonical-task-identity.md"
     },
     {
-      "id": "task-signing",
+      "id": "operator-approval-decisions",
       "kind": "retrieval",
-      "prompt": "How does Hugin distinguish a claimed task submitter from a verified one, and what is supposed to happen when signature policy is set to require?",
-      "target": "docs/security/task-signing.md"
+      "prompt": "Which runbook covers approval artifacts and valid accept/reject decisions for `Authority: gated` pipeline phases?",
+      "target": "docs/operator-guide-approval-decisions.md"
     },
     {
-      "id": "daily-exam-factory",
+      "id": "orchestrator-savings-tracker",
       "kind": "retrieval",
-      "prompt": "If a managed-repository task becomes a daily exam candidate, where are provisional holdout, regression, and quarantine defined and separated?",
-      "target": "docs/daily-exam-factory.md"
+      "prompt": "Where is the document that defines saved-USD accounting against an all-Claude baseline for orchestrator runs?",
+      "target": "docs/orchestrator-savings-tracker.md"
     },
     {
-      "id": "m5-lifecycle",
+      "id": "learning-task-handshake",
       "kind": "retrieval",
-      "prompt": "Which document says Hugin preserves durable M5 delegation provenance but must not invent its own model-capability truth?",
-      "target": "docs/mcp-durable-m5-lifecycle.md"
+      "prompt": "Which document describes the producer-side handshake and joint live-smoke gate for learning evidence?",
+      "target": "docs/learning-task-handshake.md"
     },
     {
       "id": "orchestrator-verdict-layer",

--- a/tests/fixtures/instruction-probes/probes.json
+++ b/tests/fixtures/instruction-probes/probes.json
@@ -1,0 +1,51 @@
+{
+  "$comment": "FROZEN 2026-08-01 from Hugin base commit 22bcf5d0e09424a9e498c16b088580cb64267d9f, BEFORE docs/index.md was authored. Probes are phrased as realistic lookup questions and deliberately avoid naming the target document, so a hit measures retrieval rather than transcription. Do not edit these to match a new index; that invalidates the eval.",
+  "version": 1,
+  "frozen_at_base_commit": "22bcf5d0e09424a9e498c16b088580cb64267d9f",
+  "probes": [
+    {
+      "id": "delivery-recovery",
+      "kind": "retrieval",
+      "prompt": "A task finished writing its staged artifact, then the process died before the transfer was clearly finalized. Where is the end-to-end recovery procedure, and which delivery states tell me whether it can retry or is terminal?",
+      "target": "docs/testing/delivery-recovery-e2e.md"
+    },
+    {
+      "id": "task-signing",
+      "kind": "retrieval",
+      "prompt": "How does Hugin distinguish a claimed task submitter from a verified one, and what is supposed to happen when signature policy is set to require?",
+      "target": "docs/security/task-signing.md"
+    },
+    {
+      "id": "daily-exam-factory",
+      "kind": "retrieval",
+      "prompt": "If a managed-repository task becomes a daily exam candidate, where are provisional holdout, regression, and quarantine defined and separated?",
+      "target": "docs/daily-exam-factory.md"
+    },
+    {
+      "id": "m5-lifecycle",
+      "kind": "retrieval",
+      "prompt": "Which document says Hugin preserves durable M5 delegation provenance but must not invent its own model-capability truth?",
+      "target": "docs/mcp-durable-m5-lifecycle.md"
+    },
+    {
+      "id": "orchestrator-verdict-layer",
+      "kind": "retrieval",
+      "prompt": "Where is the design for keeping orchestrator synthesizer verdicts separate from worker execution results and savings accounting?",
+      "target": "docs/orchestrator-verdict-layer.md"
+    },
+    {
+      "id": "external-receipt-intake",
+      "kind": "retrieval",
+      "prompt": "A non-Hugin system wants to submit its own signed task/outcome receipt. Where is the intake contract, and what must never happen to task ownership or terminal state when that arrives?",
+      "target": "docs/external-receipt-intake.md"
+    },
+    {
+      "id": "private-orchestrator-CONTROL",
+      "kind": "control",
+      "prompt": "The prompt is private. Can Runtime: orchestrator still fan out to the usual cloud roles by default?",
+      "target": "AGENTS.md",
+      "assert_regex": "(?i)(must be rejected|reject(ed)? before any model call|unless every configured role uses a sovereign/local provider|default cloud fan-out must never receive private data)",
+      "assert_note": "CONTROL PROBE. This targets inline runtime-permission rules that stay in AGENTS.md in both arms. If it changes, the harness is measuring unrelated drift rather than the docs-index split."
+    }
+  ]
+}

--- a/tests/fixtures/instruction-probes/probes.json
+++ b/tests/fixtures/instruction-probes/probes.json
@@ -44,7 +44,8 @@
       "kind": "control",
       "prompt": "The prompt is private. Can Runtime: orchestrator still fan out to the usual cloud roles by default?",
       "target": "AGENTS.md",
-      "assert_regex": "(?i)(must be rejected|reject(ed)? before any model call|unless every configured role uses a sovereign/local provider|default cloud fan-out must never receive private data)",
+      "assert_pattern": "(must be rejected|reject(ed)? before any model call|unless every configured role uses a sovereign/local provider|default cloud fan-out must never receive private data)",
+      "assert_flags": "i",
       "assert_note": "CONTROL PROBE. This targets inline runtime-permission rules that stay in AGENTS.md in both arms. If it changes, the harness is measuring unrelated drift rather than the docs-index split."
     }
   ]


### PR DESCRIPTION
Closes #320

Builds an exhaustive docs/index.md for the complete Hugin Markdown corpus and replaces only the Focused references list with a categorical routing rule.

Behavioral rules kept inline: runtime and permission sensitivity gating, security boundaries, artifact-delivery grammar and validation, deployment invariants, repository and context rules, and the Munin task-contract example. No behavioral rule moved into the index.

Frozen A/B evidence, three repeats per arm:
- doc-hit rate: 80% before, 85% after
- mean tool calls: 3.9 before, 2 after
- mean prompt tokens: 31,586 before, 31,596 after, a measured 10-token overhead rather than a saving
- errors: 0 before and after
- individual probe regressions: none

Verification:
- docs index guard: 7 tests
- full suite: 164 files, 2,564 passed, 3 skipped
- npm run build
- git diff --check

Review: native Codex ACCEPT. Claude Opus high was attempted but returned an execution error.