### PR TITLE
Make experiment cadence wait for Munin readiness

### DIFF
--- a/src/experiment-cadence-cli.ts
+++ b/src/experiment-cadence-cli.ts
@@ -32,6 +32,7 @@ import { createGilleOutcomeExportClient } from "./learning/experiment-outcome-ex
 import { createCandidatePoolAssembler } from "./learning/candidate-pool-assembler.js";
 import { createGilleOutcomeEvidenceResolver } from "./learning/gille-outcome-evidence-resolver.js";
 import { runExperimentCadenceTick, type CadenceTickResult } from "./learning/experiment-cadence.js";
+import { waitForMuninReadiness } from "./experiment-cadence-readiness.js";
 
 export const DEFAULT_CADENCE_PRINCIPAL = "service:hugin-experiment-cadence";
 
@@ -115,6 +116,11 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     baseUrl: process.env.MUNIN_URL?.trim() || "http://localhost:3030",
     apiKey,
   });
+
+  // systemd can start this timer while Munin is still completing boot. Keep
+  // the bounded startup retry on the experiment cadence path only; the daily
+  // exam factory has a separate service and lifecycle.
+  await waitForMuninReadiness(munin);
 
   const registry = new LearningRegistryStore(munin);
   const experimentStore = new LearningExperimentStore(munin);

--- a/src/experiment-cadence-readiness.ts
+++ b/src/experiment-cadence-readiness.ts
@@ -1,0 +1,99 @@
+/**
+ * Bounded Munin startup readiness for the experiment cadence oneshot.
+ *
+ * The cadence timer may run while Munin is still completing boot. Keep this
+ * retry policy local to the cadence conductor; the daily exam factory has its
+ * own independent lifecycle and must not inherit cadence behavior.
+ */
+
+export interface MuninReadinessProbe {
+  health(options?: { requestTimeoutMs?: number }): Promise<boolean>;
+}
+
+export interface MuninReadinessOptions {
+  /** Maximum number of health probes, including the first attempt. */
+  maxAttempts?: number;
+  /** Delay between failed probes. */
+  retryDelayMs?: number;
+  /** Timeout supplied to each health probe. */
+  probeTimeoutMs?: number;
+  /** Injectable delay for deterministic tests. */
+  sleep?: (delayMs: number) => Promise<void>;
+}
+
+export const DEFAULT_MUNIN_READINESS: Required<Pick<
+  MuninReadinessOptions,
+  "maxAttempts" | "retryDelayMs" | "probeTimeoutMs"
+>> = {
+  // 5 x 5s probes plus 4 x 2s delays = 33s worst case, well inside the
+  // cadence service's 120s startup timeout.
+  maxAttempts: 5,
+  retryDelayMs: 2_000,
+  probeTimeoutMs: 5_000,
+};
+
+function validateNonNegativeInteger(value: number, name: string): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+}
+
+function validatePositiveInteger(value: number, name: string): void {
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+}
+
+function defaultSleep(delayMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+async function probeWithDeadline(
+  munin: MuninReadinessProbe,
+  probeTimeoutMs: number,
+): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<boolean>((resolve) => {
+    timer = setTimeout(() => resolve(false), probeTimeoutMs);
+  });
+  try {
+    return await Promise.race([
+      munin.health({ requestTimeoutMs: probeTimeoutMs }),
+      timeout,
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
+/**
+ * Wait until Munin reports ready, or fail after a fixed probe/delay budget.
+ * The probe implementation is expected to enforce `requestTimeoutMs`; the
+ * explicit option keeps that bound visible at this orchestration boundary.
+ */
+export async function waitForMuninReadiness(
+  munin: MuninReadinessProbe,
+  options: MuninReadinessOptions = {},
+): Promise<void> {
+  const maxAttempts = options.maxAttempts ?? DEFAULT_MUNIN_READINESS.maxAttempts;
+  const retryDelayMs = options.retryDelayMs ?? DEFAULT_MUNIN_READINESS.retryDelayMs;
+  const probeTimeoutMs = options.probeTimeoutMs ?? DEFAULT_MUNIN_READINESS.probeTimeoutMs;
+  const sleep = options.sleep ?? defaultSleep;
+
+  validatePositiveInteger(maxAttempts, "maxAttempts");
+  validateNonNegativeInteger(retryDelayMs, "retryDelayMs");
+  validatePositiveInteger(probeTimeoutMs, "probeTimeoutMs");
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      if (await probeWithDeadline(munin, probeTimeoutMs)) return;
+    } catch (error) {
+      lastError = error;
+    }
+    if (attempt < maxAttempts) await sleep(retryDelayMs);
+  }
+
+  const detail = lastError instanceof Error ? `: ${lastError.message}` : "";
+  throw new Error(`Munin readiness failed after ${maxAttempts} probe(s)${detail}`);
+}

--- a/src/munin-client.ts
+++ b/src/munin-client.ts
@@ -47,6 +47,10 @@ export interface MuninRequestOptions {
   maxRetries?: number;
 }
 
+export interface MuninHealthOptions {
+  requestTimeoutMs?: number;
+}
+
 export type MuninReadResult =
   | (MuninEntry & { found: true })
   | { namespace: string; key: string; found: false };
@@ -504,9 +508,12 @@ export class MuninClient {
     await this.callTool("memory_log", args);
   }
 
-  async health(): Promise<boolean> {
+  async health(options: MuninHealthOptions = {}): Promise<boolean> {
+    const timeoutMs = options.requestTimeoutMs ?? this.requestTimeoutMs;
     try {
-      const res = await fetch(`${this.baseUrl}/health`);
+      const res = await fetch(`${this.baseUrl}/health`, {
+        signal: AbortSignal.timeout(timeoutMs),
+      });
       return res.ok;
     } catch {
       return false;

--- a/tests/experiment-cadence-readiness.test.ts
+++ b/tests/experiment-cadence-readiness.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import { waitForMuninReadiness } from "../src/experiment-cadence-readiness.js";
+
+describe("experiment cadence Munin readiness", () => {
+  it("retries boot-time unavailability before allowing the cadence tick to run", async () => {
+    const health = vi.fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await waitForMuninReadiness({ health }, {
+      maxAttempts: 4,
+      probeTimeoutMs: 10,
+      retryDelayMs: 25,
+      sleep,
+    });
+
+    expect(health).toHaveBeenCalledTimes(3);
+    expect(health).toHaveBeenNthCalledWith(1, { requestTimeoutMs: 10 });
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenNthCalledWith(1, 25);
+  });
+
+  it("fails after the bounded probe budget is exhausted", async () => {
+    const health = vi.fn().mockResolvedValue(false);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await expect(waitForMuninReadiness({ health }, {
+      maxAttempts: 3,
+      probeTimeoutMs: 10,
+      retryDelayMs: 25,
+      sleep,
+    })).rejects.toThrow("Munin readiness failed after 3 probe(s)");
+
+    expect(health).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it("bounds a health probe that never resolves", async () => {
+    const health = vi.fn()
+      .mockImplementationOnce(() => new Promise<boolean>(() => {}))
+      .mockResolvedValueOnce(true);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await waitForMuninReadiness({ health }, {
+      maxAttempts: 2,
+      probeTimeoutMs: 1,
+      retryDelayMs: 0,
+      sleep,
+    });
+
+    expect(health).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(0);
+  });
+});

--- a/tests/munin-client.test.ts
+++ b/tests/munin-client.test.ts
@@ -603,4 +603,24 @@ describe("MuninClient", () => {
     await first;
     await second;
   });
+
+  it("bounds unauthenticated health probes with the requested timeout", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+      const signal = (init as RequestInit).signal!;
+      await new Promise<void>((resolve) => {
+        if (signal.aborted) resolve();
+        else signal.addEventListener("abort", () => resolve(), { once: true });
+      });
+      throw signal.reason;
+    });
+    const client = new MuninClient({
+      baseUrl: "http://munin.test",
+      apiKey: "test-key",
+      minRequestSpacingMs: 0,
+    });
+
+    await expect(client.health({ requestTimeoutMs: 1 })).resolves.toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect((fetchMock.mock.calls[0]?.[1] as RequestInit).signal).toBeInstanceOf(AbortSignal);
+  });
 });


### PR DESCRIPTION
## What changed

- Add a cadence-only Munin readiness probe with bounded retries, per-probe deadlines, and deterministic exhaustion.
- Apply the readiness gate before the experiment cadence tick starts; the daily exam factory remains separate.
- Add regression coverage for boot-time retries, exhaustion, hanging probes, and health-probe timeouts.

## Why

A boot-time Munin timeout could make the experiment cadence oneshot fail before Munin was ready. The bounded startup gate lets the cadence recover transient boot ordering without changing daily exam behavior.

## Checks

- `npm test -- --run tests/experiment-cadence-readiness.test.ts tests/munin-client.test.ts`
- `npm run build`
- `npm test` (171 files, 2,686 passed, 3 skipped)
- `git diff --check`

Fixes #351