### PR TITLE
Retry daily exam harvest while Munin starts

### DIFF
--- a/src/daily-exam-harvest-cli.ts
+++ b/src/daily-exam-harvest-cli.ts
@@ -32,6 +32,50 @@ interface CliOptions {
   output?: string;
 }
 
+export interface MuninStartupReadinessOptions {
+  /** Total number of full harvest attempts, including the first call. */
+  maxAttempts?: number;
+  /** Fixed delay between attempts; kept deterministic and bounded for oneshot use. */
+  retryDelayMs?: number;
+  sleep?: (delayMs: number) => Promise<void>;
+}
+
+const DAILY_EXAM_MUNIN_STARTUP_MAX_ATTEMPTS = 3;
+const DAILY_EXAM_MUNIN_STARTUP_RETRY_DELAY_MS = 1_000;
+
+/**
+ * Munin's service unit can be started before its HTTP endpoint accepts work.
+ * Retry the complete read-only harvest a small, explicit number of times so a
+ * boot-time race does not leave the daily manifest stale, while still letting
+ * persistent failures reach systemd's oneshot failure handling.
+ */
+export async function runWithMuninStartupReadiness<T>(
+  operation: () => Promise<T>,
+  options: MuninStartupReadinessOptions = {},
+): Promise<T> {
+  const maxAttempts = options.maxAttempts ?? DAILY_EXAM_MUNIN_STARTUP_MAX_ATTEMPTS;
+  const retryDelayMs = options.retryDelayMs ?? DAILY_EXAM_MUNIN_STARTUP_RETRY_DELAY_MS;
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+    throw new Error("Munin startup readiness maxAttempts must be a positive integer");
+  }
+  if (!Number.isInteger(retryDelayMs) || retryDelayMs < 0) {
+    throw new Error("Munin startup readiness retryDelayMs must be a non-negative integer");
+  }
+  const sleep = options.sleep ?? ((delayMs: number) => new Promise<void>((resolve) => {
+    setTimeout(resolve, delayMs);
+  }));
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (attempt === maxAttempts) throw error;
+      await sleep(retryDelayMs);
+    }
+  }
+  throw new Error("Munin startup readiness exhausted without an attempt");
+}
+
 function usage(): string {
   return [
     "Usage: npm run harvest:daily-exams -- [options]",
@@ -185,7 +229,7 @@ export async function main(argv = process.argv.slice(2)): Promise<void> {
     baseUrl: process.env.MUNIN_URL?.trim() || "http://localhost:3030",
     apiKey,
   });
-  const loaded = await loadSources(munin, options);
+  const loaded = await runWithMuninStartupReadiness(() => loadSources(munin, options));
   const generatedAt = new Date().toISOString();
   const provisionalManifest = buildDailyExamManifest({
     generatedAt,

--- a/tests/daily-exam-cli.test.ts
+++ b/tests/daily-exam-cli.test.ts
@@ -12,6 +12,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   parseArgs,
+  runWithMuninStartupReadiness,
   taskExposureFingerprintsForLookup,
   writeManifestFile,
 } from "../src/daily-exam-harvest-cli.js";
@@ -47,6 +48,31 @@ describe("daily exam factory CLI", () => {
   it("rejects unbounded or unknown options", () => {
     expect(() => parseArgs(["--limit", "10001"])).toThrow("--limit");
     expect(() => parseArgs(["--publish", "yes"])).toThrow("unknown option");
+  });
+
+  it("retries a boot-time Munin timeout within a bounded readiness budget", async () => {
+    let attempts = 0;
+    let failuresRemaining = 2;
+    const delays: number[] = [];
+
+    await expect(runWithMuninStartupReadiness(
+      async () => {
+        attempts += 1;
+        if (failuresRemaining > 0) {
+          failuresRemaining -= 1;
+          throw new Error("Munin request timed out after 10000ms");
+        }
+        return "ready";
+      },
+      {
+        maxAttempts: 3,
+        retryDelayMs: 25,
+        sleep: async (delayMs) => { delays.push(delayMs); },
+      },
+    )).resolves.toBe("ready");
+
+    expect(attempts).toBe(3);
+    expect(delays).toEqual([25, 25]);
   });
 
   it("queries only unique provisional fingerprints and smokes an empty eligible day", () => {


### PR DESCRIPTION
## What changed

- Add a bounded three-attempt startup readiness wrapper around the daily exam factory's read-only Munin harvest.
- Retry with a fixed one-second delay, then preserve the final failure for systemd's oneshot handling.
- Add a deterministic regression test covering two boot-time timeout failures followed by recovery.

## Why

The daily exam factory can start while Munin's HTTP endpoint is still coming up, leaving the scheduled manifest generation failed on a transient boot-time timeout. Retrying the complete read-only harvest gives Munin a short readiness window without allowing an unbounded loop.

## Validation

- Focused daily exam CLI, factory, and broker harvest tests: 36 passed.
- TypeScript check: passed.
- `git diff --check`: passed.
- Full Vitest run: 151 files / 2,301 tests passed; unrelated sandbox loopback and pre-existing external-receipt failures remain in this environment.

Closes #350