### PR TITLE
Fix research spikes falsely completing without artifacts

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,9 @@ scheduling, and pipeline phases.
 - [Quality receipts](quality-receipts.md): `hugin_rate` /
   `POST /v1/delegate/rate`, exact-bound acceptance evidence, reviewer
   independence, and why `completed` is not the same as accepted.
+- [Research-spike execution contract](research-spike-contract.md): Fail-closed
+  two-artifact delivery and Hugin-owned three-record Munin indexing contract
+  for `type:research` tasks.
 - [Artifact delivery recovery runbook](testing/delivery-recovery-e2e.md):
   End-to-end acceptance/recovery procedure for declared artifacts and the
   `delivery:*` terminal states.

--- a/docs/research-spike-contract.md
+++ b/docs/research-spike-contract.md
@@ -1,0 +1,36 @@
+# Research-spike execution contract
+
+Research work is fail-closed. A task tagged `type:research` is not a normal
+text response: `completed` requires Hugin to have verified delivery of two
+declared required artefacts and to have committed its three discovery records
+to Munin.
+
+The task envelope must declare, before `### Prompt`:
+
+````markdown
+- **Project:** grimnir
+- **Research slug:** two-to-four-words
+- **Sensitivity:** internal
+
+### Artifacts
+
+```json
+[
+  {"id":"detailed","local":"/home/magnus/scratch/two-to-four-words-detailed.md","remote":"magnus@100.99.119.52:/home/magnus/mimir-inbox/research/grimnir/2026-08-12-two-to-four-words.md","required":true},
+  {"id":"popular","local":"/home/magnus/scratch/two-to-four-words-popular.md","remote":"magnus@100.99.119.52:/home/magnus/mimir-inbox/reading/2026-08-12-two-to-four-words.md","required":true}
+]
+```
+````
+
+The agent may write only the declared local staging files. It must not use
+SSH/rsync or write Munin discovery records. After delivery succeeds, Hugin
+writes `documents/<slug>/index`, `reading/<slug>/entry`, and
+`projects/<project>/research-<slug>`. A rejected write fails the task.
+
+The current Claude Agent SDK lane is explicitly read-only and does not provide
+the required web/fetch/staging capability set. Hugin rejects research tasks on
+that lane before execution. A future verified research executor is tracked in
+issue #363; it must not bypass this contract.
+
+Use Hugin's canonical `public`, `internal`, or `private` sensitivity values.
+`restricted` is accepted only as a legacy alias and is normalized to `private`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -304,6 +304,13 @@ import {
   type RuntimeCapability,
 } from "./runtime-registry.js";
 import {
+  hasResearchSpikeArtifactContract,
+  isResearchSpike,
+  parseResearchSpikeIndex,
+  researchSpikePreflightFailure,
+  type ResearchSpikeIndex,
+} from "./research-spike-contract.js";
+import {
   extractSignatureField,
   buildTaskSubmissionProvenance,
   loadKeyStoreFromEnv,
@@ -898,6 +905,7 @@ interface TaskConfig {
   // HUGIN_DELIVERY_POLICY=off (the manifest would otherwise leak into the
   // agent prompt; Codex review #5).
   artifactManifestGrammarViolation?: boolean;
+  researchSpikeIndex?: ResearchSpikeIndex;
   homeserverTaskType?: string;
   homeserverVerifier?: HomeserverVerifierSpec;
   maxOutputTokens?: number;
@@ -959,6 +967,56 @@ function parsePipelineSideEffectsField(content: string): PipelineSideEffectId[] 
     .map((parsed) => parsed.data);
 }
 
+/**
+ * Publish the three durable research discovery records only after Hugin has
+ * verified delivery.  The executor never receives these write capabilities:
+ * it can produce declared staging files, while Hugin owns the cross-service
+ * commit.  Each awaited write is a postcondition; callers fail the task if
+ * any one is rejected.
+ */
+async function writeResearchSpikeIndexes(
+  client: Pick<MuninClient, "write">,
+  index: ResearchSpikeIndex,
+  manifest: ArtifactManifest,
+  taskId: string,
+  classification: string | undefined,
+): Promise<void> {
+  const remotes = manifest.artifacts
+    .filter((artifact) => artifact.required)
+    .map((artifact) => artifact.remote);
+  const commonTags = [
+    "type:research",
+    `project:${index.project}`,
+    `sensitivity:${index.sensitivity}`,
+    `research-slug:${index.slug}`,
+    "writer:hugin",
+  ];
+  await client.write(
+    `documents/${index.slug}`,
+    "index",
+    `Research spike ${index.slug}. Verified artefacts: ${remotes.join(", ")}`,
+    commonTags,
+    undefined,
+    classification,
+  );
+  await client.write(
+    `reading/${index.slug}`,
+    "entry",
+    `Research reading entry for ${index.slug}. Verified artefacts: ${remotes.join(", ")}`,
+    [...commonTags, "type:summary"],
+    undefined,
+    classification,
+  );
+  await client.write(
+    `projects/${index.project}`,
+    `research-${index.slug}`,
+    `Research spike ${index.slug} completed by Hugin task ${taskId}. Verified artefacts: ${remotes.join(", ")}`,
+    [...commonTags, "type:project-event"],
+    undefined,
+    classification,
+  );
+}
+
 function parseTask(content: string): TaskConfig | null {
   const metadataPrefix = taskMetadataPrefix(content);
   const declaredRuntimeRaw = parseDeclaredRuntime(content);
@@ -1014,7 +1072,7 @@ function parseTask(content: string): TaskConfig | null {
     /\*\*Context-budget:\*\*\s*(\d+)/i
   )?.[1];
   const declaredSensitivityRaw = metadataPrefix.match(
-    /\*\*Sensitivity:\*\*\s*(public|internal|private)/i
+    /\*\*Sensitivity:\*\*\s*(public|internal|private|restricted)/i
   )?.[1]?.trim()?.toLowerCase();
   const pipelineId = metadataPrefix.match(
     /\*\*Pipeline:\*\*\s*(.+)/i
@@ -1145,7 +1203,9 @@ function parseTask(content: string): TaskConfig | null {
     declaredSensitivity: canonicalBrokerEnvelope?.sensitivity
       ? sensitivitySchema.parse(canonicalBrokerEnvelope.sensitivity)
       : declaredSensitivityRaw
-      ? sensitivitySchema.parse(declaredSensitivityRaw)
+      ? sensitivitySchema.parse(
+          declaredSensitivityRaw === "restricted" ? "private" : declaredSensitivityRaw,
+        )
       : undefined,
     capabilities: effectiveCapabilities.length > 0 ? effectiveCapabilities : undefined,
     permissionProfile:
@@ -1157,6 +1217,7 @@ function parseTask(content: string): TaskConfig | null {
     artifactManifestError: artifactManifestResult.error ?? undefined,
     artifactManifestGrammarViolation:
       artifactManifestResult.grammarViolation || undefined,
+    researchSpikeIndex: parseResearchSpikeIndex(content),
     homeserverTaskType: canonicalBrokerEnvelope?.task_type ?? homeserverTaskType ?? undefined,
     homeserverVerifier: canonicalBrokerEnvelope?.acceptance.mode === "verifier"
       ? canonicalBrokerEnvelope.acceptance.verifier
@@ -3128,10 +3189,46 @@ async function reconcileDeliveryPending(
     await client.log(taskNs, `Delivery retry budget exhausted: ${decision.reason}`);
   }
 
+  // A recovered delivery still has to complete the research postconditions.
+  // Otherwise a restart between rsync and indexing could terminalize a
+  // research task as completed with no discovery records.
+  let recoveryResearchIndexTag: string | undefined;
+  let recoveryFailureKind: string | undefined;
+  let recoveryFailureReason: string | undefined;
+  if (ok && delivery.ok && isResearchSpike(entry.tags)) {
+    if (!task?.researchSpikeIndex || !hasResearchSpikeArtifactContract(task.artifactManifest)) {
+      ok = false;
+      recoveryResearchIndexTag = "research-index:failed";
+      recoveryFailureKind = "RESEARCH_CONTRACT_FAILED";
+      recoveryFailureReason = "required Hugin research index and two-artifact contract is missing";
+      baseDoc += `\n\n### Research indexing\n\n- **Indexing:** failed — ${recoveryFailureReason}\n`;
+    } else {
+      try {
+        await writeResearchSpikeIndexes(
+          client,
+          task.researchSpikeIndex,
+          task.artifactManifest,
+          extractTaskId(taskNs),
+          classification,
+        );
+        recoveryResearchIndexTag = "research-index:verified";
+        baseDoc += "\n\n### Research indexing\n\n- **Indexing:** verified (three Hugin-owned Munin writes)\n";
+      } catch (err) {
+        ok = false;
+        recoveryResearchIndexTag = "research-index:failed";
+        const reason = err instanceof Error ? err.message : String(err);
+        recoveryFailureKind = "RESEARCH_INDEX_FAILED";
+        recoveryFailureReason = reason;
+        baseDoc += `\n\n### Research indexing\n\n- **Indexing:** failed — ${reason}\n`;
+        await client.log(taskNs, `Recovered research indexing failed: ${reason}`);
+      }
+    }
+  }
+
   if (!ok) {
     baseDoc = baseDoc.replace(
       /- \*\*Exit code:\*\* 0\b/,
-      "- **Exit code:** 2\n- **Failure kind:** DELIVERY_FAILED",
+      `- **Exit code:** 2\n- **Failure kind:** ${recoveryFailureKind ?? "DELIVERY_FAILED"}`,
     );
   }
   await client.write(
@@ -3155,6 +3252,7 @@ async function reconcileDeliveryPending(
       [
         ...entry.tags.filter((t) => !t.startsWith("delivery:")),
         terminalDeliveryTag,
+        ...(recoveryResearchIndexTag ? [recoveryResearchIndexTag] : []),
       ],
       runtimeTag || `runtime:${runtime}`,
     ),
@@ -3176,7 +3274,7 @@ async function reconcileDeliveryPending(
       completedAt: new Date().toISOString(),
       bodyKind: "response",
       bodyText: "",
-      errorMessage: ok ? undefined : delivery.error ?? "delivery failed",
+      errorMessage: ok ? undefined : recoveryFailureReason ?? delivery.error ?? "delivery failed",
       sensitivity: recoverySensitivity,
       artifactDelivery: {
         ok: delivery.ok,
@@ -4936,6 +5034,28 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
       return pendingTaskDeparted();
     }
 
+    // Research spikes have durable, cross-service postconditions.  The
+    // current Agent SDK sandbox is read-only and cannot satisfy them; refuse
+    // before claiming/spending rather than letting tool denials become a false
+    // exit-0 completion (#362).  A future verified research lane is the only
+    // route that may pass this gate.
+    const researchPreflightFailure = researchSpikePreflightFailure({
+      tags: entry.tags,
+      runtime: parsedTask.runtime,
+      permissionProfile: parsedTask.permissionProfile,
+      artifactManifest: parsedTask.artifactManifest,
+      deliveryPolicy: config.deliveryPolicy,
+      index: parsedTask.researchSpikeIndex,
+    });
+    if (researchPreflightFailure) {
+      console.warn(`Rejecting research spike ${taskNs}: ${researchPreflightFailure}`);
+      await failTaskWithMessage(taskNs, entry, researchPreflightFailure);
+      await munin.log(taskNs, `Research spike rejected before execution: ${researchPreflightFailure}`);
+      await promoteDependents(extractTaskId(taskNs));
+      await refreshPipelineSummaryFromContent(entry.content);
+      return pendingTaskDeparted();
+    }
+
     const securityViolation =
       getSecurityViolationForTask(parsedTask, sensitivityAssessment) ||
       getInjectionViolationForTask(parsedTask) ||
@@ -6563,6 +6683,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     let deliveryResult: DeliveryResult | undefined;
     let deliveryFailureKind: string | undefined;
     let terminalDeliveryTag: string | undefined;
+    let researchIndexTag: string | undefined;
     // #72: set when a live infra delivery failure under `defer` should leave the
     // task delivery:pending for the retry reaper rather than terminalizing.
     let deferDeliveryPending = false;
@@ -6686,6 +6807,27 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
         terminalDeliveryTag = "delivery:failed";
       } else if (deliveryResult.ok) {
         terminalDeliveryTag = "delivery:verified";
+        if (isResearchSpike(entry.tags) && task.researchSpikeIndex) {
+          try {
+            await writeResearchSpikeIndexes(
+              munin,
+              task.researchSpikeIndex,
+              task.artifactManifest,
+              taskId,
+              taskClassification,
+            );
+            researchIndexTag = "research-index:verified";
+            bodyForResult += "\n\n### Research indexing\n\n- **Indexing:** verified (three Hugin-owned Munin writes)\n";
+          } catch (err) {
+            ok = false;
+            exitCode = 2;
+            deliveryFailureKind = "RESEARCH_INDEX_FAILED";
+            researchIndexTag = "research-index:failed";
+            const reason = err instanceof Error ? err.message : String(err);
+            bodyForResult += `\n\n### Research indexing\n\n- **Indexing:** failed — ${reason}\n`;
+            await munin.log(taskNs, `Research indexing failed: ${reason}`);
+          }
+        }
       } else {
         terminalDeliveryTag = "delivery:failed";
         // missing-local / unsafe-local (no trustworthy deliverable) are ALWAYS
@@ -6971,12 +7113,13 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     // set so downstream consumers + startup reconciliation see a consistent
     // terminal delivery state. Shared by the cancelled and normal branches —
     // a cancel mid-delivery still set terminalDeliveryTag = "delivery:failed".
-    const deliveryAwareFinalizeTags = terminalDeliveryTag
+    let deliveryAwareFinalizeTags = terminalDeliveryTag
       ? [
           ...entry.tags.filter((t) => !t.startsWith("delivery:")),
           terminalDeliveryTag,
         ]
       : entry.tags;
+    if (researchIndexTag) deliveryAwareFinalizeTags.push(researchIndexTag);
     const learningCapturePending = isHomeserver
       && repositoryOutcome.state === "not-managed"
       && isPotentialAdmittedHomeserverAttempt(
@@ -7146,6 +7289,8 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
                   ? undefined
                   : failureClassification
                     ? failureClassification.reason
+                    : deliveryFailureKind === "RESEARCH_INDEX_FAILED"
+                      ? "Hugin-owned research indexing failed after verified delivery"
                     : deliveryResult && !deliveryResult.ok
                       ? deliveryResult.error ?? structuredBodyText
                       : structuredBodyText,
@@ -7582,6 +7727,7 @@ export const __test__ = {
   parseSubmittedByField,
   isSubmitterAllowed,
   pollOnce,
+  writeResearchSpikeIndexes,
   inspectState: () => ({
     currentTask,
     currentTaskConfig,

--- a/src/research-spike-contract.ts
+++ b/src/research-spike-contract.ts
@@ -1,0 +1,101 @@
+import type { ArtifactManifest, DeliveryPolicy } from "./artifact-delivery.js";
+import type { TaskPermissionProfile } from "./sdk-executor.js";
+import type { DispatcherRuntime } from "./runtime-registry.js";
+import type { Sensitivity } from "./sensitivity.js";
+
+// A research spike is materially different from an ordinary read-only task:
+// its stated result is two durable documents, gathered from the web and
+// delivered by Hugin.  Do not infer that those capabilities exist from a
+// generic `Capabilities: tools` routing hint.  That was the false-success
+// seam in #362.
+const REQUIRED_RESEARCH_CAPABILITIES = [
+  "web search",
+  "web fetch",
+  "local staging write",
+  "Hugin-managed delivery",
+  "Hugin-managed Munin indexing",
+] as const;
+
+export function isResearchSpike(tags: readonly string[]): boolean {
+  return tags.includes("type:research");
+}
+
+export interface ResearchSpikePreflightInput {
+  tags: readonly string[];
+  runtime: DispatcherRuntime;
+  permissionProfile: TaskPermissionProfile | undefined;
+  artifactManifest: ArtifactManifest | undefined;
+  deliveryPolicy: DeliveryPolicy;
+  index: ResearchSpikeIndex | undefined;
+}
+
+export interface ResearchSpikeIndex {
+  project: string;
+  slug: string;
+  sensitivity: Sensitivity;
+}
+
+const IDENTIFIER = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+/** Extract the Hugin-owned index coordinates from trusted task metadata. */
+export function parseResearchSpikeIndex(content: string): ResearchSpikeIndex | undefined {
+  const prefix = content.split(/^###\s*Prompt\s*$/im, 1)[0] ?? content;
+  const project = prefix.match(/^\s*(?:-\s*)?\*\*Project:\*\*\s*(.+)$/im)?.[1]?.trim();
+  const slug = prefix.match(/^\s*(?:-\s*)?\*\*Research slug:\*\*\s*(.+)$/im)?.[1]?.trim();
+  const sensitivity = prefix.match(/^\s*(?:-\s*)?\*\*Sensitivity:\*\*\s*(public|internal|private|restricted)\s*$/im)?.[1];
+  if (!project || !slug || !sensitivity || !IDENTIFIER.test(project) || !IDENTIFIER.test(slug)) {
+    return undefined;
+  }
+  // `restricted` is an old research-skill spelling.  Normalize it at the
+  // contract boundary rather than accidentally treating a private task as
+  // internal (the dispatcher-wide vocabulary is public|internal|private).
+  return { project, slug, sensitivity: sensitivity === "restricted" ? "private" : sensitivity as Sensitivity };
+}
+
+/** At least two distinct required staging files and destinations are required. */
+export function hasResearchSpikeArtifactContract(
+  manifest: ArtifactManifest | undefined,
+): manifest is ArtifactManifest {
+  const required = manifest?.artifacts.filter((artifact) => artifact.required) ?? [];
+  return required.length >= 2
+    && new Set(required.map((artifact) => artifact.local)).size >= 2
+    && new Set(required.map((artifact) => artifact.remote)).size >= 2;
+}
+
+/**
+ * Return a deterministic, operator-readable refusal before an executor is
+ * claimed or invoked.  The only currently wired Agent SDK lane is deliberately
+ * read-only and has no WebSearch/WebFetch tools.  No current dispatcher lane
+ * advertises the complete research contract, so every research spike is
+ * rejected until #363 wires and verifies a dedicated research executor.
+ *
+ * Keeping the capability declaration here (rather than trusting task prose)
+ * prevents a task from spending a model turn and then reporting exit 0 after
+ * tool denials.  Hugin retains ownership of delivery and indexing when a
+ * compatible lane is introduced.
+ */
+export function researchSpikePreflightFailure(
+  input: ResearchSpikePreflightInput,
+): string | null {
+  if (!isResearchSpike(input.tags)) return null;
+
+  const required = REQUIRED_RESEARCH_CAPABILITIES.join(", ");
+  // Report the executor denial first.  This is the actionable P0 condition
+  // for existing Agent SDK research tasks, even when their old task envelope
+  // also predates the Hugin-owned artifact/index metadata.
+  if (input.runtime === "claude" && input.permissionProfile !== "trusted-code") {
+    return `Research spike cannot run on claude agent-sdk read-only: missing capabilities ${required}`;
+  }
+  if (!input.index) {
+    return "Research spike requires valid **Project:** and **Research slug:** metadata for Hugin-managed Munin indexing";
+  }
+  if (!hasResearchSpikeArtifactContract(input.artifactManifest)) {
+    return `Research spike requires two distinct declared required artefacts for Hugin-managed delivery; missing capability contract: ${required}`;
+  }
+  if (input.deliveryPolicy === "off") {
+    return "Research spike requires Hugin-managed artefact delivery; HUGIN_DELIVERY_POLICY=off is incompatible";
+  }
+  return `Research spike cannot run on ${input.runtime}: no dispatcher executor currently declares verified capabilities ${required}. Route it only after the dedicated research lane is verified.`;
+}
+
+export const __test__ = { REQUIRED_RESEARCH_CAPABILITIES };

--- a/tests/research-spike-contract.test.ts
+++ b/tests/research-spike-contract.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import type { ArtifactManifest } from "../src/artifact-delivery.js";
+import { hasResearchSpikeArtifactContract, parseResearchSpikeIndex, researchSpikePreflightFailure } from "../src/research-spike-contract.js";
+const { __test__: dispatcherTest } = await import("../src/index.js");
+
+const manifest: ArtifactManifest = {
+  artifacts: [
+    { id: "detailed", local: "/scratch/detailed.md", remote: "magnus@nas:/research/detailed.md", required: true },
+    { id: "popular", local: "/scratch/popular.md", remote: "magnus@nas:/reading/popular.md", required: true },
+  ],
+};
+
+describe("research spike preflight (#362)", () => {
+  const index = { project: "grimnir", slug: "research-contract", sensitivity: "internal" as const };
+
+  it("parses the Hugin-owned index coordinates before the agent prompt", () => {
+    expect(parseResearchSpikeIndex(`## Task\n- **Project:** grimnir\n- **Research slug:** research-contract\n- **Sensitivity:** internal\n\n### Prompt\nuntrusted **Project:** evil`)).toEqual(index);
+    expect(parseResearchSpikeIndex("- **Project:** grimnir\n- **Research slug:** legacy\n- **Sensitivity:** restricted")).toEqual({ project: "grimnir", slug: "legacy", sensitivity: "private" });
+    expect(parseResearchSpikeIndex("- **Project:** ../evil\n- **Research slug:** x\n- **Sensitivity:** internal")).toBeUndefined();
+    const task = dispatcherTest.parseTask(`## Task: legacy private research\n- **Runtime:** claude\n- **Project:** grimnir\n- **Research slug:** legacy\n- **Sensitivity:** restricted\n\n### Prompt\nRead only`);
+    expect(task?.declaredSensitivity).toBe("private");
+  });
+
+  it("does not change ordinary task admission", () => {
+    expect(researchSpikePreflightFailure({
+      tags: ["pending", "runtime:claude"], runtime: "claude", permissionProfile: "read-only",
+      artifactManifest: undefined, deliveryPolicy: "require", index: undefined,
+    })).toBeNull();
+  });
+
+  it("refuses the read-only agent-sdk before it can falsely succeed", () => {
+    const failure = researchSpikePreflightFailure({
+      tags: ["pending", "type:research", "runtime:claude"], runtime: "claude", permissionProfile: "read-only",
+      artifactManifest: manifest, deliveryPolicy: "require", index,
+    });
+    expect(failure).toMatch(/claude agent-sdk read-only/);
+    expect(failure).toMatch(/web search/);
+    expect(failure).toMatch(/Hugin-managed Munin indexing/);
+  });
+
+  it("requires two declared artefacts even if a future executor is selected", () => {
+    const failure = researchSpikePreflightFailure({
+      tags: ["pending", "type:research"], runtime: "codex", permissionProfile: "trusted-code",
+      artifactManifest: { artifacts: [manifest.artifacts[0]!] }, deliveryPolicy: "require", index,
+    });
+    expect(failure).toMatch(/two distinct declared required artefacts/);
+  });
+
+  it("rejects duplicate paths masquerading as two outputs", () => {
+    expect(hasResearchSpikeArtifactContract({ artifacts: [
+      manifest.artifacts[0]!,
+      { ...manifest.artifacts[0]!, id: "same-document" },
+    ] })).toBe(false);
+  });
+
+  it("does not permit delivery rollback for research work", () => {
+    expect(researchSpikePreflightFailure({
+      tags: ["type:research"], runtime: "claude", permissionProfile: "trusted-code",
+      artifactManifest: manifest, deliveryPolicy: "off", index,
+    })).toMatch(/HUGIN_DELIVERY_POLICY=off/);
+  });
+
+  it("requires index metadata rather than trusting the agent to write it", () => {
+    expect(researchSpikePreflightFailure({
+      tags: ["type:research"], runtime: "claude", permissionProfile: "trusted-code",
+      artifactManifest: manifest, deliveryPolicy: "require", index: undefined,
+    })).toMatch(/Research slug/);
+  });
+
+  it("makes exactly the three Hugin-owned discovery writes after delivery", async () => {
+    const writes: Array<{ namespace: string; key: string; tags?: string[] }> = [];
+    await dispatcherTest.writeResearchSpikeIndexes({
+      write: async (namespace: string, key: string, _content: string, tags?: string[]) => {
+        writes.push({ namespace, key, tags });
+        return {};
+      },
+    }, index, manifest, "task-123", "internal");
+    expect(writes.map(({ namespace, key }) => `${namespace}/${key}`)).toEqual([
+      "documents/research-contract/index",
+      "reading/research-contract/entry",
+      "projects/grimnir/research-research-contract",
+    ]);
+    expect(writes.every((write) => write.tags?.includes("writer:hugin"))).toBe(true);
+  });
+
+  it("does not hide a rejected Hugin index write", async () => {
+    await expect(dispatcherTest.writeResearchSpikeIndexes({
+      write: async () => { throw new Error("Munin unavailable"); },
+    }, index, manifest, "task-123", "internal")).rejects.toThrow("Munin unavailable");
+  });
+});


### PR DESCRIPTION
## Summary
- fail closed before model execution when a research-tagged task lacks a verified research-capable lane
- make Hugin own post-delivery discovery indexing and require two distinct artefacts
- keep recovery fail closed and retain accurate indexing-failure provenance

## Verification
- focused research-spike and dispatcher tests: 79 passed
- TypeScript build passed
- independent Sol high review: no residual P0/P1 findings

Closes #362.