### PR TITLE
fix: bound broker list history reads

### DIFF
--- a/src/broker/handlers.ts
+++ b/src/broker/handlers.ts
@@ -78,6 +78,48 @@ export interface BrokerHandlerDependencies {
   now?: () => Date;
 }
 
+// Canonical task state is the authority for the active broker. The journal is
+// retained solely to surface legacy orch-v1 rows, so it must not turn a status
+// request into an unbounded read while a worker is busy or a journal is slow.
+const LIST_HISTORY_READ_BUDGET_MS = 1_000;
+
+type HistoricalListResult =
+  | { complete: true; rows: Array<Record<string, any>> }
+  | { complete: false; rows: [] };
+
+async function readHistoricalListRows(
+  journal: DelegationJournal,
+  principal: string,
+): Promise<HistoricalListResult> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const controller = new AbortController();
+  try {
+    const result = await Promise.race([
+      journal.readAll(controller.signal).then(
+        (events) => ({ kind: "events" as const, events }),
+        () => ({ kind: "unavailable" as const }),
+      ),
+      new Promise<{ kind: "timeout" }>((resolve) => {
+        timer = setTimeout(() => {
+          controller.abort();
+          resolve({ kind: "timeout" });
+        }, LIST_HISTORY_READ_BUDGET_MS);
+      }),
+    ]);
+    if (result.kind !== "events") return { complete: false, rows: [] };
+    return {
+      complete: true,
+      rows: Array.from(projectDelegations(result.events).values())
+        .filter((row) => row.envelope?.broker_principal === principal),
+    };
+  } catch (err) {
+    console.warn(`[broker] historical list projection unavailable: ${err instanceof Error ? err.message : String(err)}`);
+    return { complete: false, rows: [] };
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
 function nowFn(deps: BrokerHandlerDependencies): () => Date {
   return deps.now ?? (() => new Date());
 }
@@ -827,12 +869,11 @@ export function createListHandler(deps: BrokerHandlerDependencies) {
       return;
     }
     const canonical = await deps.taskStore.listCanonical(principal, parsed.since_ts);
-    const historical = Array.from(projectDelegations(await deps.journal.readAll()).values())
-      .filter((row) => row.envelope?.broker_principal === principal);
+    const historical = await readHistoricalListRows(deps.journal, principal);
     const canonicalIds = new Set(canonical.rows.map((row) => row.task_id));
     const combined: Array<Record<string, any>> = [
       ...canonical.rows,
-      ...historical.filter((row) => !canonicalIds.has(row.task_id)),
+      ...historical.rows.filter((row) => !canonicalIds.has(row.task_id)),
     ];
     const rows = combined.filter((row) => {
       if (parsed.outcome === "completed" && row.outcome !== "completed") return false;
@@ -852,7 +893,8 @@ export function createListHandler(deps: BrokerHandlerDependencies) {
     res.status(200).json({
       rows: rows.slice(0, parsed.limit ?? 50),
       total: rows.length,
-      truncated: canonical.truncated,
+      truncated: canonical.truncated || !historical.complete,
+      historical_complete: historical.complete,
     });
   };
 }

--- a/src/broker/journal.ts
+++ b/src/broker/journal.ts
@@ -100,30 +100,55 @@ export class DelegationJournal {
    * forward-compat rule. For v1 there is no streaming consumer; callers are
    * expected to read in full and project.
    */
-  async readAll(): Promise<DelegationEvent[]> {
+  async readAll(signal?: AbortSignal): Promise<DelegationEvent[]> {
     if (!existsSync(this.filePath)) return [];
+    if (signal?.aborted) throw new Error("delegation journal read aborted");
 
     const events: DelegationEvent[] = [];
     const stream = createReadStream(this.filePath, { encoding: "utf-8" });
     const rl = readline.createInterface({ input: stream, crlfDelay: Infinity });
+    let aborted = false;
+    // readline's async iterator normally observes stream errors. It may close
+    // first on cancellation, though, so retain an error listener until the
+    // underlying stream closes rather than leaving an asynchronous open/read
+    // failure unhandled.
+    const retainStreamErrorListener = () => {};
+    stream.on("error", retainStreamErrorListener);
+    const abort = () => {
+      aborted = true;
+      // Do not destroy with an Error after closing readline: that can emit an
+      // unhandled stream error after the iterator has detached its listener.
+      stream.destroy();
+      rl.close();
+    };
+    signal?.addEventListener("abort", abort, { once: true });
     let lineNumber = 0;
-    for await (const line of rl) {
-      lineNumber++;
-      if (line.trim() === "") continue;
-      try {
-        const parsed = JSON.parse(line) as { event_schema_version?: unknown };
-        if (parsed.event_schema_version !== 1) {
+    try {
+      for await (const line of rl) {
+        lineNumber++;
+        if (line.trim() === "") continue;
+        try {
+          const parsed = JSON.parse(line) as { event_schema_version?: unknown };
+          if (parsed.event_schema_version !== 1) {
+            console.warn(
+              `[delegation-journal] skipping event with unsupported event_schema_version on line ${lineNumber}: ${String(parsed.event_schema_version)}`,
+            );
+            continue;
+          }
+          events.push(parsed as DelegationEvent);
+        } catch (err) {
           console.warn(
-            `[delegation-journal] skipping event with unsupported event_schema_version on line ${lineNumber}: ${String(parsed.event_schema_version)}`,
+            `[delegation-journal] failed to parse line ${lineNumber}: ${err instanceof Error ? err.message : String(err)}`,
           );
-          continue;
         }
-        events.push(parsed as DelegationEvent);
-      } catch (err) {
-        console.warn(
-          `[delegation-journal] failed to parse line ${lineNumber}: ${err instanceof Error ? err.message : String(err)}`,
-        );
       }
+      if (aborted) throw new Error("delegation journal read aborted");
+    } finally {
+      signal?.removeEventListener("abort", abort);
+      if (!stream.closed) {
+        await new Promise<void>((resolve) => stream.once("close", resolve));
+      }
+      stream.removeListener("error", retainStreamErrorListener);
     }
     return events;
   }

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -435,7 +435,7 @@ export function buildTools(deps: ToolDeps): {
     name: "hugin_list",
     title: "List recent delegated tasks",
     description:
-      "List recent tasks for this authenticated principal. If `truncated` is true, the query hit its cap and `total` is only a lower bound.",
+      "List recent tasks for this authenticated principal. `truncated` means a cap or unavailable legacy history; `historical_complete` says whether that history was read.",
     inputShape: listInputShape,
     handler: async (rawInput) => {
       try {

--- a/tests/broker/handlers.test.ts
+++ b/tests/broker/handlers.test.ts
@@ -2050,6 +2050,40 @@ describe("GET /v1/delegate/list", () => {
     expect(body.rows[0].envelope.alias_requested).toBe("large-reasoning");
   });
 
+  it("returns canonical running state when historical journal projection exceeds its budget", async () => {
+    await fetch(`${harness.url}/v1/delegate/submit`, {
+      method: "POST",
+      headers: authHeader(),
+      body: JSON.stringify(validRequest()),
+    });
+    const submitted = harness.munin.writes.find((write) => write.key === "status")!;
+    harness.munin.queryReturn = {
+      results: [{ namespace: submitted.namespace, key: "status", tags: submitted.tags }],
+      total: 1,
+    };
+    let aborted = false;
+    harness.journal.readAll = async (signal?: AbortSignal) => new Promise((_, reject) => {
+      signal?.addEventListener("abort", () => {
+        aborted = true;
+        reject(new Error("aborted"));
+      }, { once: true });
+    });
+
+    const startedAt = Date.now();
+    const res = await fetch(`${harness.url}/v1/delegate/list`, {
+      headers: { authorization: `Bearer ${SECRET}` },
+    });
+    const body = await res.json();
+
+    expect(Date.now() - startedAt).toBeLessThan(2_000);
+    expect(res.status).toBe(200);
+    expect(body.rows).toHaveLength(1);
+    expect(body.rows[0].task_id).toBe(submitted.namespace.split("/")[1]);
+    expect(body.historical_complete).toBe(false);
+    expect(body.truncated).toBe(true);
+    expect(aborted).toBe(true);
+  });
+
   // #181: a task that is visible right after submission must stay visible
   // after a rating event (hugin_rate) is appended, including under an
   // explicit since_ts filter — the acceptance criterion from the issue.

--- a/tests/broker/journal.test.ts
+++ b/tests/broker/journal.test.ts
@@ -104,6 +104,16 @@ describe("DelegationJournal", () => {
     expect(await j.readAll()).toEqual([]);
   });
 
+  it("aborts a real journal stream without an unhandled stream error", async () => {
+    const file = path.join(tmpDir, "events.jsonl");
+    writeFileSync(file, `${JSON.stringify(submitted("t1"))}\n`.repeat(20_000));
+    const j = new DelegationJournal({ path: file });
+    const controller = new AbortController();
+    const pending = j.readAll(controller.signal);
+    controller.abort();
+    await expect(pending).rejects.toThrow("delegation journal read aborted");
+  });
+
   it("skips events with unsupported event_schema_version (forward-compat)", async () => {
     const file = path.join(tmpDir, "events.jsonl");
     const future = JSON.stringify({

--- a/tests/mcp/tools.test.ts
+++ b/tests/mcp/tools.test.ts
@@ -40,10 +40,10 @@ const ISSUE_318_WIRE_MODELS_RESPONSE = {
 // `byteLength(client.getInstructions()) + byteLength(JSON.stringify(await client.listTools()))`
 // measured through the production `discoverBrokerContract()` + `createHuginMcpServer()` path.
 // Parent `20f2cef` measured 30_361 bytes through its equivalent inline server construction.
-// This source tree measures 28_632 bytes,
-// so the ratchet allows only a 96-byte slack to 28_728 bytes.
+// This source tree measures 28_664 bytes,
+// so the ratchet allows only a 96-byte slack to 28_760 bytes.
 const ISSUE_318_PARENT_DISCOVERY_BYTES = 30_361;
-const ISSUE_318_CURRENT_DISCOVERY_BYTES = 28_632;
+const ISSUE_318_CURRENT_DISCOVERY_BYTES = 28_664;
 const ISSUE_318_DISCOVERY_SLACK_BYTES = 96;
 const ISSUE_318_DISCOVERY_CEILING_BYTES =
   ISSUE_318_CURRENT_DISCOVERY_BYTES + ISSUE_318_DISCOVERY_SLACK_BYTES;


### PR DESCRIPTION
## Summary

Bound the legacy journal read used by `/v1/delegate/list` so canonical task rows return promptly while a historical read is unavailable. The response now explicitly records incomplete historical coverage.

Closes #359.

## Validation

- full `npm test`: 2,700 passed, 3 skipped
- `npm run build`
- focused broker, journal, and MCP suites: 126 passed
- independent Sol review: no findings
