### PR TITLE
Fix Pi deploy path resolution

### DIFF
--- a/scripts/deploy-pi.sh
+++ b/scripts/deploy-pi.sh
@@ -112,10 +112,16 @@ echo "==> Installing pinned research Pi harness ($RESEARCH_PI_PACKAGE@$RESEARCH_
 ssh "$REMOTE" "
   set -e
   npm install --global --ignore-scripts '$RESEARCH_PI_PACKAGE@$RESEARCH_PI_VERSION'
-  command -v pi >/dev/null
-  test \"\$(pi --version 2>/dev/null)\" = \"$RESEARCH_PI_VERSION\" || {
+  NPM_GLOBAL_PREFIX=\"\$(npm prefix --global)\"
+  case \"\$NPM_GLOBAL_PREFIX\" in
+    /*) ;;
+    *) echo 'npm global prefix is not absolute' >&2; exit 1 ;;
+  esac
+  PI_BIN=\"\$NPM_GLOBAL_PREFIX/bin/pi\"
+  test -x \"\$PI_BIN\" || { echo 'research Pi executable missing from npm global prefix' >&2; exit 1; }
+  test \"\$(\"\$PI_BIN\" --version 2>/dev/null)\" = \"$RESEARCH_PI_VERSION\" || {
     echo 'research Pi version mismatch' >&2
-    pi --version >&2 || true
+    \"\$PI_BIN\" --version >&2 || true
     exit 1
   }
   command -v bwrap >/dev/null || { echo 'bubblewrap (bwrap) is required for Runtime: research' >&2; exit 1; }

--- a/scripts/deploy-pi.test.sh
+++ b/scripts/deploy-pi.test.sh
@@ -255,6 +255,8 @@ assert_not_contains "$full_calls" "git fetch origin" "deployment never depends o
 assert_not_contains "$full_calls" "git reset" "deployment never depends on a remote Git checkout"
 assert_contains "$full_calls" "npm ci --omit=dev" "deployment installs the shipped lockfile deterministically"
 assert_not_contains "$full_calls" "npm install --omit=dev" "deployment never rewrites the shipped lockfile with npm install"
+assert_contains "$full_calls" "npm prefix --global" "deployment resolves Pi from npm's user-global prefix"
+assert_contains "$full_calls" 'PI_BIN="$NPM_GLOBAL_PREFIX/bin/pi"' "deployment verifies Pi by absolute installed path"
 assert_contains "$full_calls" "curl -fsS http://127.0.0.1:3032/health" "deployment retains the health acceptance gate"
 assert_contains "$full_calls" "health.codex_sandbox?.available !== true" "deployment health gate requires the live service-context Codex probe"
 assert_contains "$full_calls" "in-service Codex sandbox self-test unavailable after 15 attempts" "deployment waits for a definitive in-service probe result"


### PR DESCRIPTION
Follow-up to #367.

The first fail-closed production deployment installed Pi successfully under the configured user-global npm prefix, but the non-interactive SSH shell could not find it through `command -v`. Resolve and validate `npm prefix --global`, then execute Pi by its absolute installed path.

Verification:
- `bash scripts/deploy-pi.test.sh`
- `shellcheck -S warning scripts/deploy-pi.sh scripts/deploy-pi.test.sh`