### PR TITLE
Fix research Bubblewrap mount destinations

### DIFF
--- a/src/research-spike-executor.ts
+++ b/src/research-spike-executor.ts
@@ -18,6 +18,9 @@ export const RESEARCH_PI_FLAGS = [
   "web_search,fetch_content,write_artifact",
 ] as const;
 
+const SANDBOX_PI_CONFIG_DIR = "/tmp/hugin-research-pi";
+const SANDBOX_PI_EXTENSION = "/tmp/hugin-research-pi-extension.mjs";
+
 export interface ResearchSpikeRuntimeConfig {
   piCommand: string;
   bwrapCommand: string;
@@ -244,13 +247,15 @@ export function buildResearchLaunch(
 ): { args: string[]; env: NodeJS.ProcessEnv } {
   const args = [
     "--die-with-parent", "--ro-bind", "/", "/", "--tmpfs", "/tmp", "--dir", "/tmp/hugin-research-home", "--proc", "/proc", "--dev", "/dev",
-    "--chdir", request.workingDir, "--ro-bind", configDir, "/opt/hugin-research-pi",
-    "--ro-bind", extension, "/opt/hugin-research-pi-extension.mjs",
+    // `/` is already read-only. Mount ephemeral runtime inputs under the
+    // private `/tmp` tmpfs, whose destination parent Bubblewrap can create.
+    "--chdir", request.workingDir, "--ro-bind", configDir, SANDBOX_PI_CONFIG_DIR,
+    "--ro-bind", extension, SANDBOX_PI_EXTENSION,
     ...artifactPaths.flatMap((file) => ["--bind", file, file]),
-    "--", config.piCommand, ...RESEARCH_PI_FLAGS, "--extension", "/opt/hugin-research-pi-extension.mjs", "--provider", "m5-local", "--model", config.model, "--mode", "json", "-p", buildPiPrompt(request),
+    "--", config.piCommand, ...RESEARCH_PI_FLAGS, "--extension", SANDBOX_PI_EXTENSION, "--provider", "m5-local", "--model", config.model, "--mode", "json", "-p", buildPiPrompt(request),
   ];
   const env: NodeJS.ProcessEnv = {
-    PATH: "/home/magnus/.npm-global/bin:/usr/local/bin:/usr/bin:/bin", HOME: "/tmp/hugin-research-home", PI_CODING_AGENT_DIR: "/opt/hugin-research-pi",
+    PATH: "/home/magnus/.npm-global/bin:/usr/local/bin:/usr/bin:/bin", HOME: "/tmp/hugin-research-home", PI_CODING_AGENT_DIR: SANDBOX_PI_CONFIG_DIR,
     HUGIN_RESEARCH_SEARCH_HELPER: config.searchHelper, HUGIN_RESEARCH_FETCH_HELPER: config.fetchHelper,
     HUGIN_RESEARCH_ALLOWED_SEARCH_HOSTS: config.allowedSearchHosts.join(","),
     HUGIN_RESEARCH_ARTIFACTS: JSON.stringify(Object.fromEntries(request.artifactManifest.artifacts.filter((a) => a.required).map((a) => [a.id, a.local]))),

--- a/tests/research-spike-executor.test.ts
+++ b/tests/research-spike-executor.test.ts
@@ -65,6 +65,10 @@ describe("dedicated research Pi/M5 runtime", () => {
     expect(launch.args).toContain("--no-builtin-tools");
     expect(launch.args).toContain("web_search,fetch_content,write_artifact");
     expect(launch.args).toContain("--bind");
+    expect(launch.args).toContain("/tmp/hugin-research-pi");
+    expect(launch.args).toContain("/tmp/hugin-research-pi-extension.mjs");
+    expect(launch.args).not.toContain("/opt/hugin-research-pi");
+    expect(launch.env.PI_CODING_AGENT_DIR).toBe("/tmp/hugin-research-pi");
     expect(launch.env).toEqual(expect.objectContaining({ PATH: "/home/magnus/.npm-global/bin:/usr/local/bin:/usr/bin:/bin", HOME: "/tmp/hugin-research-home" }));
     expect(launch.env).not.toHaveProperty("MUNIN_API_KEY");
   });


### PR DESCRIPTION
Closes #369

Moves the Pi config and extension bind destinations from read-only `/opt` to the private `/tmp` tmpfs already created by the research sandbox. This fixes the first live canary failure while preserving the read-only root and exact writable artifact bindings.

Verification:
- focused research executor tests: 9 passed
- `npm run build`
- `git diff --check`