### PR TITLE
Allow ephemeral Pi research trust lock

### DIFF
--- a/src/research-spike-executor.ts
+++ b/src/research-spike-executor.ts
@@ -249,7 +249,10 @@ export function buildResearchLaunch(
     "--die-with-parent", "--ro-bind", "/", "/", "--tmpfs", "/tmp", "--dir", "/tmp/hugin-research-home", "--proc", "/proc", "--dev", "/dev",
     // `/` is already read-only. Mount ephemeral runtime inputs under the
     // private `/tmp` tmpfs, whose destination parent Bubblewrap can create.
-    "--chdir", request.workingDir, "--ro-bind", configDir, SANDBOX_PI_CONFIG_DIR,
+    // Pi creates an ephemeral trust.json.lock even in one-shot mode. The host
+    // source is Hugin's fresh auto-deleted temp directory, so bind only that
+    // directory writable; models.json contains an env reference, not the key.
+    "--chdir", request.workingDir, "--bind", configDir, SANDBOX_PI_CONFIG_DIR,
     "--ro-bind", extension, SANDBOX_PI_EXTENSION,
     ...artifactPaths.flatMap((file) => ["--bind", file, file]),
     "--", config.piCommand, ...RESEARCH_PI_FLAGS, "--extension", SANDBOX_PI_EXTENSION, "--provider", "m5-local", "--model", config.model, "--mode", "json", "-p", buildPiPrompt(request),

--- a/tests/research-spike-executor.test.ts
+++ b/tests/research-spike-executor.test.ts
@@ -69,6 +69,10 @@ describe("dedicated research Pi/M5 runtime", () => {
     expect(launch.args).toContain("/tmp/hugin-research-pi-extension.mjs");
     expect(launch.args).not.toContain("/opt/hugin-research-pi");
     expect(launch.env.PI_CODING_AGENT_DIR).toBe("/tmp/hugin-research-pi");
+    const configDestination = launch.args.indexOf("/tmp/hugin-research-pi");
+    const extensionDestination = launch.args.indexOf("/tmp/hugin-research-pi-extension.mjs");
+    expect(launch.args[configDestination - 2]).toBe("--bind");
+    expect(launch.args[extensionDestination - 2]).toBe("--ro-bind");
     expect(launch.env).toEqual(expect.objectContaining({ PATH: "/home/magnus/.npm-global/bin:/usr/local/bin:/usr/bin:/bin", HOME: "/tmp/hugin-research-home" }));
     expect(launch.env).not.toHaveProperty("MUNIN_API_KEY");
   });


### PR DESCRIPTION
Closes #371

Pi 0.84.1 creates `trust.json.lock` in `PI_CODING_AGENT_DIR` even for one-shot runs. Bind only Hugin's fresh auto-deleted config directory writable, while retaining the read-only root, extension, helpers, and exact artifact-file bindings.

Verification:
- focused research executor tests: 9 passed
- `npm run build`
- Pi-native Bubblewrap smoke confirmed trust-lock creation in the temporary config bind while the extension stays read-only