### PR TITLE
Fix Node 22 DNS lookup shape in research helpers

### DIFF
--- a/scripts/research-web-common.mjs
+++ b/scripts/research-web-common.mjs
@@ -58,7 +58,9 @@ export async function requestPublicText(rawUrl, options = {}) {
         "accept-encoding": "identity",
         "user-agent": "HuginResearch/1.0 (+https://github.com/Magnus-Gille/hugin)",
       },
-      lookup: (_host, _opts, callback) => callback(null, resolved.address, resolved.family),
+      lookup: (_host, opts, callback) => opts.all
+        ? callback(null, [{ address: resolved.address, family: resolved.family }])
+        : callback(null, resolved.address, resolved.family),
     }, resolve);
     req.setTimeout(timeoutMs, () => req.destroy(new Error("Research fetch timed out")));
     req.on("error", reject);

--- a/tests/research-web-helpers.test.ts
+++ b/tests/research-web-helpers.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isPublicAddress, resolvePublicHost } from "../scripts/research-web-common.mjs";
+import { isPublicAddress, requestPublicText, resolvePublicHost } from "../scripts/research-web-common.mjs";
 import { parseDuckDuckGoResults } from "../scripts/research-web-search.mjs";
 
 describe("research web helpers", () => {
@@ -16,6 +16,47 @@ describe("research web helpers", () => {
       { address: "1.1.1.1", family: 4 },
       { address: "127.0.0.1", family: 4 },
     ])).rejects.toThrow(/non-public/);
+  });
+
+  it("returns Node 22 lookup arrays only when the transport requests all addresses", async () => {
+    const lookupOptions: boolean[] = [];
+    const lookupResults: Array<{ all: boolean; address: unknown; family: unknown }> = [];
+    let dnsCalls = 0;
+    const requestImpl = (_url: URL, options: { lookup: (host: string, options: { all: boolean }, callback: (...args: unknown[]) => void) => void }, onResponse: (response: AsyncIterable<Buffer> & { statusCode: number; headers: Record<string, string> }) => void) => {
+      for (const all of [true, false]) {
+        options.lookup("example.com", { all }, (error, address, family) => {
+          if (error) throw error;
+          lookupOptions.push(all);
+          lookupResults.push({ all, address, family });
+        });
+      }
+      const response = {
+        statusCode: 200,
+        headers: { "content-type": "text/plain" },
+        async *[Symbol.asyncIterator]() { yield Buffer.from("ok"); },
+      } as AsyncIterable<Buffer> & { statusCode: number; headers: Record<string, string> };
+      queueMicrotask(() => onResponse(response));
+      return { setTimeout() {}, on() {}, end() {} };
+    };
+
+    const result = await requestPublicText("https://example.com", {
+      lookup: async () => {
+        dnsCalls += 1;
+        return [
+          { address: "1.1.1.1", family: 4 },
+          { address: "2606:4700:4700::1111", family: 6 },
+        ];
+      },
+      requestImpl,
+    });
+
+    expect(result.body).toBe("ok");
+    expect(dnsCalls).toBe(1);
+    expect(lookupOptions).toEqual([true, false]);
+    expect(lookupResults).toEqual([
+      { all: true, address: [{ address: "1.1.1.1", family: 4 }], family: undefined },
+      { all: false, address: "1.1.1.1", family: 4 },
+    ]);
   });
 
   it("extracts bounded DuckDuckGo result links and unwraps uddg redirects", () => {


### PR DESCRIPTION
## Summary

- honor Node 22's `lookup` callback contract when HTTP(S) requests set `all: true`
- retain the scalar callback form for ordinary lookups
- keep resolve-once DNS pinning and public-address validation intact
- add regression coverage for both callback shapes

Fixes #373.

## Verification

- focused research web-helper tests passed
- `npm run build` passed
- full suite passed: 174 files, 2718 passed, 3 skipped
- `git diff --check` passed

## M5 dogfood

`qwen3-coder-next-80b` provided partial useful guidance; output was independently verified by deterministic tests.
