### PR TITLE
Require trusted research grounding evidence

### DIFF
--- a/scripts/research-pi-extension.mjs
+++ b/scripts/research-pi-extension.mjs
@@ -4,6 +4,8 @@
 import { spawn } from "node:child_process";
 import { writeFile } from "node:fs/promises";
 import { promises as dns } from "node:dns";
+import { createHash } from "node:crypto";
+import net from "node:net";
 
 const schema = (properties, required) => ({ type: "object", properties, required, additionalProperties: false });
 const string = { type: "string", minLength: 1 };
@@ -17,21 +19,42 @@ function allowedUrl(raw) {
     (octets[0] === 0 || octets[0] === 10 || octets[0] === 127 || (octets[0] === 169 && octets[1] === 254) ||
       (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) || (octets[0] === 192 && octets[1] === 168) ||
       (octets[0] === 100 && octets[1] >= 64 && octets[1] <= 127));
-  if (!["http:", "https:"].includes(url.protocol) || url.username || url.password || privateV4 || host === "localhost" || host === "::1" || host.startsWith("fc") || host.startsWith("fd") || host.startsWith("fe80:") || host.endsWith(".local") || host.endsWith(".ts.net")) throw new Error("URL targets a forbidden host");
+  const literalForbidden = net.isIP(host) !== 0 && !isPublicAddress(host);
+  if (!["http:", "https:"].includes(url.protocol) || url.username || url.password || privateV4 || literalForbidden || host === "localhost" || host === "::1" || host.startsWith("fc") || host.startsWith("fd") || host.startsWith("fe80:") || host.endsWith(".local") || host.endsWith(".ts.net")) throw new Error("URL targets a forbidden host");
   const allow = (process.env.HUGIN_RESEARCH_ALLOWED_SEARCH_HOSTS || "*").split(",").map((h) => h.trim().toLowerCase()).filter(Boolean);
   if (!allow.includes("*") && !allow.some((h) => host === h || (h.startsWith("*.") && host.endsWith(h.slice(1))))) throw new Error(`URL host ${host} is not allowlisted`);
   return url.toString();
+}
+
+function isPublicAddress(address) {
+  const normalized = address.toLowerCase().replace(/^::ffff:/, "");
+  const mapped = address.toLowerCase().split("::");
+  if (mapped.length === 2) {
+    const right = mapped[1].split(":");
+    const groups = [...mapped[0].split(":").filter(Boolean), ...Array.from({ length: 8 - mapped[0].split(":").filter(Boolean).length - right.length }, () => "0"), ...right];
+    if (groups.length === 8 && groups.slice(0, 5).every((group) => group === "0") && groups[5] === "ffff") {
+      const first = Number.parseInt(groups[6], 16); const second = Number.parseInt(groups[7], 16);
+      return isPublicAddress(`${first >> 8}.${first & 255}.${second >> 8}.${second & 255}`);
+    }
+  }
+  if (net.isIPv4(normalized)) {
+    const [a, b] = normalized.split(".").map(Number);
+    return !(a === 0 || a === 10 || a === 127 || a >= 224 ||
+      (a === 100 && b >= 64 && b <= 127) || (a === 169 && b === 254) ||
+      (a === 172 && b >= 16 && b <= 31) || (a === 192 && (b === 0 || b === 168)) ||
+      (a === 198 && (b === 18 || b === 19)));
+  }
+  if (!net.isIPv6(normalized)) return true;
+  return normalized !== "::" && normalized !== "::1" &&
+    !normalized.startsWith("fc") && !normalized.startsWith("fd") &&
+    !/^fe[89ab]/.test(normalized) && !normalized.startsWith("ff");
 }
 
 async function resolvePublicUrl(raw) {
   const checked = allowedUrl(raw);
   const host = new URL(checked).hostname;
   const addresses = await dns.lookup(host, { all: true, verbatim: true });
-  if (addresses.length === 0 || addresses.some(({ address }) => {
-    const octets = address.split(".").map(Number);
-    return address === "::1" || address.startsWith("fc") || address.startsWith("fd") || address.startsWith("fe80:") ||
-      (octets.length === 4 && (octets[0] === 0 || octets[0] === 10 || octets[0] === 127 || (octets[0] === 169 && octets[1] === 254) || (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) || (octets[0] === 192 && octets[1] === 168) || (octets[0] === 100 && octets[1] >= 64 && octets[1] <= 127)));
-  })) throw new Error("URL DNS resolution returned a forbidden private address");
+  if (addresses.length === 0 || addresses.some(({ address }) => !isPublicAddress(address))) throw new Error("URL DNS resolution returned a forbidden private address");
   return checked;
 }
 
@@ -50,16 +73,46 @@ function helper(command, payload) {
 
 const result = (text) => ({ content: [{ type: "text", text }], details: {} });
 
+async function recordEvidence(record) {
+  const file = process.env.HUGIN_RESEARCH_EVIDENCE_FILE;
+  if (!file) return;
+  await writeFile(file, `${JSON.stringify(record)}\n`, { encoding: "utf8", flag: "a", mode: 0o600 });
+}
+
+function parseHelperJson(raw, label) {
+  let parsed;
+  try { parsed = JSON.parse(raw); } catch { throw new Error(`${label} helper returned invalid JSON`); }
+  if (!parsed || typeof parsed !== "object") throw new Error(`${label} helper returned invalid JSON`);
+  return parsed;
+}
+
 export default function registerResearchTools(pi) {
   pi.registerTool({
     name: "web_search", label: "web_search", description: "Search the public web through the configured Hugin helper.",
     parameters: schema({ query: string }, ["query"]),
-    execute: async (_id, params) => result(String(await helper(process.env.HUGIN_RESEARCH_SEARCH_HELPER, { query: params.query }))),
+    execute: async (_id, params) => {
+      const raw = await helper(process.env.HUGIN_RESEARCH_SEARCH_HELPER, { query: params.query });
+      const parsed = parseHelperJson(raw, "search");
+      if (!Array.isArray(parsed.results) || parsed.results.length === 0) throw new Error("search helper returned no results");
+      await recordEvidence({ kind: "search" });
+      return result(raw);
+    },
   });
   pi.registerTool({
     name: "fetch_content", label: "fetch_content", description: "Fetch one public web page through the configured Hugin helper.",
     parameters: schema({ url: string }, ["url"]),
-    execute: async (_id, params) => result(String(await helper(process.env.HUGIN_RESEARCH_FETCH_HELPER, { url: await resolvePublicUrl(params.url) }))),
+    execute: async (_id, params) => {
+      const raw = await helper(process.env.HUGIN_RESEARCH_FETCH_HELPER, { url: await resolvePublicUrl(params.url) });
+      const parsed = parseHelperJson(raw, "fetch");
+      if (typeof parsed.url !== "string" || typeof parsed.content !== "string" || parsed.content.trim().length === 0) throw new Error("fetch helper returned empty content");
+      const fetchedUrl = await resolvePublicUrl(parsed.url);
+      await recordEvidence({
+        kind: "fetch",
+        url: fetchedUrl,
+        sha256: createHash("sha256").update(parsed.content, "utf8").digest("hex"),
+      });
+      return result(raw);
+    },
   });
   pi.registerTool({
     name: "write_artifact", label: "write_artifact", description: "Write a completed research artifact by declared ID.",

--- a/src/index.ts
+++ b/src/index.ts
@@ -315,6 +315,11 @@ import {
   researchRuntimePreflight,
 } from "./research-spike-executor.js";
 import {
+  parseResearchGroundingAttestation,
+  validateResearchGroundingAttestation,
+  type ResearchGroundingAttestation,
+} from "./research-grounding.js";
+import {
   extractSignatureField,
   buildTaskSubmissionProvenance,
   loadKeyStoreFromEnv,
@@ -328,6 +333,8 @@ import {
   type TaskSignatureAssessment,
   type TaskSubmissionProvenance,
 } from "./task-signing.js";
+
+const RESEARCH_GROUNDING_KEY = "research-grounding";
 import { consultSkillLane } from "./skill/skill-lane-dispatch.js";
 import { readBrokerEnv, type RunningBroker } from "./broker/server.js";
 import {
@@ -3204,6 +3211,7 @@ async function reconcileDeliveryPending(
   let recoveryResearchIndexTag: string | undefined;
   let recoveryFailureKind: string | undefined;
   let recoveryFailureReason: string | undefined;
+  let recoveryGrounding: StructuredTaskResult["researchGrounding"];
   if (ok && delivery.ok && isResearchSpike(entry.tags)) {
     if (!task?.researchSpikeIndex || !hasResearchSpikeArtifactContract(task.artifactManifest)) {
       ok = false;
@@ -3213,6 +3221,23 @@ async function reconcileDeliveryPending(
       baseDoc += `\n\n### Research indexing\n\n- **Indexing:** failed — ${recoveryFailureReason}\n`;
     } else {
       try {
+        // Recovery may occur after the live worker has already delivered the
+        // files but before indexing. The sidecar is intentionally ephemeral;
+        // the bounded Hugin-owned attestation is the durable proof.
+        const groundingResultEntry = await client.read(taskNs, RESEARCH_GROUNDING_KEY);
+        let groundingAccepted = false;
+        if (groundingResultEntry?.content) {
+          try {
+            const parsed = parseResearchGroundingAttestation(groundingResultEntry.content);
+            const requiredArtifactIds = task.artifactManifest.artifacts.filter((artifact) => artifact.required).map((artifact) => artifact.id);
+            const validated = parsed ? validateResearchGroundingAttestation(parsed, requiredArtifactIds) : null;
+            if (validated?.accepted === true) {
+              groundingAccepted = true;
+              recoveryGrounding = validated;
+            }
+          } catch { groundingAccepted = false; }
+        }
+        if (!groundingAccepted) throw new Error("durable accepted research grounding attestation is missing or invalid");
         await writeResearchSpikeIndexes(
           client,
           task.researchSpikeIndex,
@@ -3297,6 +3322,7 @@ async function reconcileDeliveryPending(
           error: r.error,
         })),
       },
+      researchGrounding: recoveryGrounding,
     }),
     classification,
     client,
@@ -5599,6 +5625,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     let homeserverResult: HomeserverExecutorResult | null = null;
     let effectiveExecutor = executorLabel;
     let researchEffectiveModel: string | undefined;
+    let researchGrounding: ResearchGroundingAttestation | undefined;
     // Trusted failure-kind discriminator from a pre-flight short-circuit
     // (issue #123 Codex review) — set only when executeClaudeSdkWithPreflightChecks
     // refused the task itself, so the classification below never has to
@@ -5804,6 +5831,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     currentResearchAbort = null;
     exitCode = researchResult.exitCode;
     researchEffectiveModel = researchResult.model;
+    researchGrounding = researchResult.grounding;
     output = researchResult.output;
     resultText = researchResult.resultText;
     logFile = researchResult.logFile;
@@ -6741,6 +6769,35 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
     // checkpoint (single-owner model, Codex review #1) cannot be clobbered by
     // this worker's late finalize.
     let deliveryCheckpointUpdatedAt: string | undefined;
+    // Persist the accepted, content-blind grounding attestation before any
+    // delivery checkpoint. Deferred delivery recovery relies on this exact
+    // Hugin-owned key after the ephemeral sidecar has been removed.
+    let researchGroundingFailureReason: string | undefined;
+    if (isResearch && !isCancelled && !isTimeout && exitCode === 0) {
+      const requiredArtifactIds = task.artifactManifest?.artifacts.filter((artifact) => artifact.required).map((artifact) => artifact.id) ?? [];
+      const validatedGrounding = researchGrounding ? validateResearchGroundingAttestation(researchGrounding, requiredArtifactIds) : null;
+      if (!validatedGrounding?.accepted) {
+        ok = false;
+        exitCode = 1;
+        researchGroundingFailureReason = "Hugin-owned research grounding evidence is missing or rejected";
+      } else {
+        try {
+          await munin.write(
+            taskNs,
+            RESEARCH_GROUNDING_KEY,
+            JSON.stringify(validatedGrounding),
+            ["type:research-grounding", "writer:hugin"],
+            undefined,
+            taskClassification,
+          );
+        } catch (error) {
+          ok = false;
+          exitCode = 1;
+          researchGroundingFailureReason = "Hugin-owned research grounding attestation could not be persisted";
+          await munin.log(taskNs, `Research grounding attestation failed: ${error instanceof Error ? error.message : String(error)}`).catch(() => undefined);
+        }
+      }
+    }
     const deliveryEligible =
       config.deliveryPolicy !== "off" &&
       !!task.artifactManifest &&
@@ -7344,6 +7401,8 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
                   ? undefined
                   : failureClassification
                     ? failureClassification.reason
+                    : researchGroundingFailureReason
+                      ? researchGroundingFailureReason
                     : deliveryFailureKind === "RESEARCH_INDEX_FAILED"
                       ? "Hugin-owned research indexing failed after verified delivery"
                     : deliveryResult && !deliveryResult.ok
@@ -7367,6 +7426,7 @@ async function pollOnce(): Promise<{ hadTask: boolean; queueDepth: number }> {
                       })),
                     }
                   : undefined,
+                researchGrounding,
                 orchestratorOutcomes,
                 savings: savingsResult,
               }),

--- a/src/research-grounding.ts
+++ b/src/research-grounding.ts
@@ -1,0 +1,232 @@
+import { z } from "zod";
+import { createHash } from "node:crypto";
+import { isIP } from "node:net";
+
+/** The deterministic minimum for every research contract. */
+export const RESEARCH_REQUIRED_SEARCHES = 1;
+export const RESEARCH_REQUIRED_FETCHES = 3;
+
+export const researchGroundingFailureCodeSchema = z.enum([
+  "process-failed",
+  "evidence-missing",
+  "evidence-invalid",
+  "insufficient-searches",
+  "insufficient-fetches",
+  "artifact-missing",
+  "artifact-no-links",
+  "artifact-unsafe-url",
+  "artifact-unfetched-url",
+  "artifact-not-enough-links",
+  "artifact-duplicate-url",
+]);
+export type ResearchGroundingFailureCode = z.infer<typeof researchGroundingFailureCodeSchema>;
+
+function publicIpv4(octets: number[]): boolean {
+  if (octets.length !== 4 || octets.some((value) => !Number.isInteger(value) || value < 0 || value > 255)) return false;
+  const [a, b] = octets;
+  return !(a === 0 || a === 10 || a === 127 || a >= 224
+    || (a === 100 && b >= 64 && b <= 127)
+    || (a === 169 && b === 254)
+    || (a === 172 && b >= 16 && b <= 31)
+    || (a === 192 && (b === 0 || b === 168))
+    || (a === 198 && (b === 18 || b === 19)));
+}
+
+function parseIpv6(raw: string): number[] | null {
+  const value = raw.toLowerCase();
+  const pieces = value.split("::");
+  if (pieces.length > 2) return null;
+  const parseSide = (side: string): number[] | null => {
+    if (!side) return [];
+    const parts = side.split(":");
+    const output: number[] = [];
+    for (let index = 0; index < parts.length; index += 1) {
+      const part = parts[index]!;
+      if (part.includes(".")) {
+        if (index !== parts.length - 1 || !publicIpv4(part.split(".").map(Number))) return null;
+        const octets = part.split(".").map(Number);
+        output.push((octets[0]! << 8) | octets[1]!, (octets[2]! << 8) | octets[3]!);
+      } else if (/^[0-9a-f]{1,4}$/.test(part)) output.push(Number.parseInt(part, 16));
+      else return null;
+    }
+    return output;
+  };
+  const left = parseSide(pieces[0]!);
+  const right = parseSide(pieces[1] ?? "");
+  if (!left || !right) return null;
+  if (pieces.length === 1 && left.length !== 8) return null;
+  if (pieces.length === 2 && left.length + right.length >= 8) return null;
+  return [...left, ...(pieces.length === 2 ? Array.from({ length: 8 - left.length - right.length }, () => 0) : []), ...right];
+}
+
+function publicIpLiteral(host: string): boolean {
+  const normalized = host.replace(/^\[|\]$/g, "").toLowerCase();
+  if (isIP(normalized) === 4) return publicIpv4(normalized.split(".").map(Number));
+  if (isIP(normalized) !== 6) return true;
+  const groups = parseIpv6(normalized);
+  if (!groups) return false;
+  const bytes = groups.flatMap((group) => [group >> 8, group & 0xff]);
+  const mapped = bytes.slice(0, 10).every((value) => value === 0)
+    && bytes[10] === 0xff && bytes[11] === 0xff;
+  if (mapped) return publicIpv4(bytes.slice(12));
+  const unspecified = bytes.every((value) => value === 0);
+  const loopback = unspecified ? false : bytes.slice(0, 15).every((value) => value === 0) && bytes[15] === 1;
+  const uniqueLocal = (bytes[0]! & 0xfe) === 0xfc;
+  const linkLocal = bytes[0] === 0xfe && (bytes[1]! & 0xc0) === 0x80;
+  const multicast = bytes[0] === 0xff;
+  return !unspecified && !loopback && !uniqueLocal && !linkLocal && !multicast;
+}
+
+function safePublicUrl(raw: string): boolean {
+  try {
+    const parsed = new URL(raw);
+    const hostname = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, "").replace(/\.$/, "");
+    return (parsed.protocol === "http:" || parsed.protocol === "https:")
+      && !parsed.username && !parsed.password
+      && publicIpLiteral(hostname)
+      && hostname !== "localhost"
+      && !hostname.endsWith(".local")
+      && !hostname.endsWith(".ts.net");
+  } catch {
+    return false;
+  }
+}
+
+const digestSchema = z.string().regex(/^[a-f0-9]{64}$/);
+
+/** Safe persisted metadata. Raw URLs remain in the ephemeral validator only. */
+export const researchGroundingFetchSchema = z.object({
+  urlSha256: digestSchema,
+  contentSha256: digestSchema,
+});
+
+export const researchGroundingSchema = z.object({
+  version: z.literal(1),
+  accepted: z.boolean(),
+  requiredSearches: z.literal(RESEARCH_REQUIRED_SEARCHES),
+  requiredFetches: z.literal(RESEARCH_REQUIRED_FETCHES),
+  successfulSearches: z.number().int().nonnegative(),
+  uniqueSuccessfulFetches: z.array(researchGroundingFetchSchema),
+  artifactUrlSha256: z.record(z.string().min(1), z.array(digestSchema)),
+  failureCode: researchGroundingFailureCodeSchema.optional(),
+}).superRefine((value, ctx) => {
+  if (value.accepted && value.failureCode) {
+    ctx.addIssue({ code: "custom", path: ["failureCode"], message: "accepted grounding cannot carry a failure code" });
+  }
+  if (!value.accepted && !value.failureCode) {
+    ctx.addIssue({ code: "custom", path: ["failureCode"], message: "rejected grounding requires a failure code" });
+  }
+  if (value.accepted) {
+    if (value.successfulSearches < RESEARCH_REQUIRED_SEARCHES) {
+      ctx.addIssue({ code: "custom", path: ["successfulSearches"], message: "accepted grounding requires a successful search" });
+    }
+    if (value.uniqueSuccessfulFetches.length < RESEARCH_REQUIRED_FETCHES) {
+      ctx.addIssue({ code: "custom", path: ["uniqueSuccessfulFetches"], message: "accepted grounding requires three unique fetches" });
+    }
+    if (new Set(value.uniqueSuccessfulFetches.map((fetch) => fetch.urlSha256)).size !== value.uniqueSuccessfulFetches.length) {
+      ctx.addIssue({ code: "custom", path: ["uniqueSuccessfulFetches"], message: "accepted grounding requires unique fetched URL digests" });
+    }
+    if (Object.keys(value.artifactUrlSha256).length === 0) {
+      ctx.addIssue({ code: "custom", path: ["artifactUrlSha256"], message: "accepted grounding requires artifact citations" });
+    }
+    for (const [artifactId, urls] of Object.entries(value.artifactUrlSha256)) {
+      if (urls.length < RESEARCH_REQUIRED_FETCHES) {
+        ctx.addIssue({ code: "custom", path: ["artifactUrlSha256", artifactId], message: "accepted artifact requires three linked sources" });
+      }
+      if (new Set(urls).size !== urls.length) {
+        ctx.addIssue({ code: "custom", path: ["artifactUrlSha256", artifactId], message: "accepted artifact requires unique citation digests" });
+      }
+      const fetched = new Set(value.uniqueSuccessfulFetches.map((fetch) => fetch.urlSha256));
+      if (urls.some((url) => !fetched.has(url))) {
+        ctx.addIssue({ code: "custom", path: ["artifactUrlSha256", artifactId], message: "artifact citation digest was not fetched" });
+      }
+    }
+  }
+});
+export type ResearchGroundingAttestation = z.infer<typeof researchGroundingSchema>;
+
+export interface ResearchGroundingEvidence {
+  version: 1;
+  accepted: boolean;
+  requiredSearches: typeof RESEARCH_REQUIRED_SEARCHES;
+  requiredFetches: typeof RESEARCH_REQUIRED_FETCHES;
+  successfulSearches: number;
+  uniqueSuccessfulFetches: Array<{ url: string; contentSha256: string }>;
+  artifactUrls: Record<string, string[]>;
+  failureCode?: ResearchGroundingFailureCode;
+}
+
+export interface ResearchGroundingRecord {
+  kind: "search" | "fetch";
+  url?: string;
+  sha256?: string;
+}
+
+export function canonicalResearchUrl(raw: string): string {
+  try {
+    const parsed = new URL(raw);
+    parsed.hash = "";
+    return parsed.toString();
+  } catch {
+    return raw;
+  }
+}
+
+export function isSafePublicResearchUrl(raw: string): boolean {
+  return safePublicUrl(raw);
+}
+
+export function buildResearchGroundingAttestation(evidence: ResearchGroundingEvidence): ResearchGroundingAttestation {
+  const digestUrl = (url: string) => createHash("sha256").update(canonicalResearchUrl(url), "utf8").digest("hex");
+  return researchGroundingSchema.parse({
+    version: 1,
+    accepted: evidence.accepted,
+    requiredSearches: RESEARCH_REQUIRED_SEARCHES,
+    requiredFetches: RESEARCH_REQUIRED_FETCHES,
+    successfulSearches: evidence.successfulSearches,
+    uniqueSuccessfulFetches: evidence.uniqueSuccessfulFetches.map((fetch) => ({
+      urlSha256: digestUrl(fetch.url),
+      contentSha256: fetch.contentSha256,
+    })),
+    artifactUrlSha256: Object.fromEntries(Object.entries(evidence.artifactUrls).map(([id, urls]) => [id, urls.map(digestUrl)])),
+    ...(evidence.failureCode ? { failureCode: evidence.failureCode } : {}),
+  });
+}
+
+export function parseResearchGroundingAttestation(raw: string): ResearchGroundingAttestation | null {
+  try {
+    const parsed = researchGroundingSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Validate the durable attestation against the exact required task artifacts. */
+export function validateResearchGroundingAttestation(
+  value: unknown,
+  requiredArtifactIds: readonly string[],
+): ResearchGroundingAttestation | null {
+  const parsed = researchGroundingSchema.safeParse(value);
+  if (!parsed.success || !parsed.data.accepted) return null;
+  const actual = Object.keys(parsed.data.artifactUrlSha256).sort();
+  const required = [...new Set(requiredArtifactIds)].sort();
+  if (actual.length !== required.length || actual.some((id, index) => id !== required[index])) return null;
+  return parsed.data;
+}
+
+export const isPublicResearchIpLiteral = publicIpLiteral;
+
+export function extractMarkdownLinks(content: string): string[] {
+  const links: string[] = [];
+  const pattern = /\[[^\]]+\]\(\s*(https?:\/\/[^\s)]+)(?:\s+["'][^)]*)?\)/gi;
+  for (const match of content.matchAll(pattern)) {
+    if (match[1]) links.push(match[1]);
+  }
+  return links;
+}
+
+export function extractUrls(content: string): string[] {
+  return [...content.matchAll(/https?:\/\/[^\s<>"')\]]+/gi)]
+    .map((match) => match[0]!.replace(/[.,;:!?]+$/, ""));
+}

--- a/src/research-spike-executor.ts
+++ b/src/research-spike-executor.ts
@@ -7,6 +7,18 @@ import { fileURLToPath } from "node:url";
 import { randomUUID } from "node:crypto";
 import type { ArtifactManifest } from "./artifact-delivery.js";
 import { isSovereignGatewayHost, resolveGatewayRootUrl } from "./orchestrator/provider-config.js";
+import {
+  canonicalResearchUrl,
+  buildResearchGroundingAttestation,
+  extractMarkdownLinks,
+  extractUrls,
+  isSafePublicResearchUrl,
+  RESEARCH_REQUIRED_FETCHES,
+  RESEARCH_REQUIRED_SEARCHES,
+  type ResearchGroundingAttestation,
+  type ResearchGroundingEvidence,
+  type ResearchGroundingRecord,
+} from "./research-grounding.js";
 
 export const RESEARCH_PI_FLAGS = [
   "--no-session",
@@ -50,6 +62,7 @@ export interface ResearchSpikeRunResult {
   resultText: string | null;
   model: string;
   error?: string;
+  grounding?: ResearchGroundingAttestation;
 }
 
 const DEFAULT_MODEL = "qwen3-coder-next-80b";
@@ -260,6 +273,7 @@ export function buildResearchLaunch(
   const env: NodeJS.ProcessEnv = {
     PATH: "/home/magnus/.npm-global/bin:/usr/local/bin:/usr/bin:/bin", HOME: "/tmp/hugin-research-home", PI_CODING_AGENT_DIR: SANDBOX_PI_CONFIG_DIR,
     HUGIN_RESEARCH_SEARCH_HELPER: config.searchHelper, HUGIN_RESEARCH_FETCH_HELPER: config.fetchHelper,
+    HUGIN_RESEARCH_EVIDENCE_FILE: `${SANDBOX_PI_CONFIG_DIR}/grounding.jsonl`,
     HUGIN_RESEARCH_ALLOWED_SEARCH_HOSTS: config.allowedSearchHosts.join(","),
     HUGIN_RESEARCH_ARTIFACTS: JSON.stringify(Object.fromEntries(request.artifactManifest.artifacts.filter((a) => a.required).map((a) => [a.id, a.local]))),
     HUGIN_RESEARCH_M5_API_KEY: config.gatewayApiKey, HUGIN_RESEARCH_M5_URL: config.gatewayBaseUrl,
@@ -412,6 +426,56 @@ function parsePiOutput(raw: string, maxOutputChars = Number.MAX_SAFE_INTEGER): {
   return parser.result();
 }
 
+async function readGroundingEvidence(file: string, artifactManifest: ArtifactManifest): Promise<ResearchGroundingEvidence> {
+  const raw = await fs.readFile(file, "utf8").catch(() => "");
+  const records: ResearchGroundingRecord[] = [];
+  for (const line of raw.split(/\r?\n/).filter(Boolean)) {
+    try {
+      const value = JSON.parse(line) as ResearchGroundingRecord;
+      if (value.kind === "search" || value.kind === "fetch") records.push(value);
+    } catch { return {
+      version: 1, accepted: false, requiredSearches: RESEARCH_REQUIRED_SEARCHES,
+      requiredFetches: RESEARCH_REQUIRED_FETCHES, successfulSearches: 0,
+      uniqueSuccessfulFetches: [], artifactUrls: {}, failureCode: "evidence-invalid",
+    }; }
+  }
+  const searches = records.filter((record) => record.kind === "search").length;
+  const fetched = new Map<string, { url: string; contentSha256: string }>();
+  for (const record of records.filter((value) => value.kind === "fetch")) {
+    if (!record.url || !record.sha256 || !isSafePublicResearchUrl(record.url) || !/^[a-f0-9]{64}$/.test(record.sha256)) continue;
+    const url = canonicalResearchUrl(record.url);
+    if (!fetched.has(url)) fetched.set(url, { url, contentSha256: record.sha256 });
+  }
+  const artifactUrls: Record<string, string[]> = {};
+  let failureCode: ResearchGroundingEvidence["failureCode"];
+  if (searches < RESEARCH_REQUIRED_SEARCHES) failureCode = "insufficient-searches";
+  if (fetched.size < RESEARCH_REQUIRED_FETCHES) failureCode = failureCode ?? "insufficient-fetches";
+  for (const artifact of artifactManifest.artifacts.filter((value) => value.required)) {
+    const content = await fs.readFile(artifact.local, "utf8").catch(() => "");
+    if (!content) { failureCode = "artifact-missing"; continue; }
+    const linked = extractMarkdownLinks(content);
+    const allUrls = extractUrls(content);
+    if (linked.length === 0) { failureCode = failureCode ?? "artifact-no-links"; continue; }
+    const urls = [...new Set(linked.map((url) => canonicalResearchUrl(url)))];
+    artifactUrls[artifact.id] = urls.filter((url) => isSafePublicResearchUrl(url) && fetched.has(url));
+    if (urls.length !== linked.length) failureCode = failureCode ?? "artifact-duplicate-url";
+    if (allUrls.some((url) => !isSafePublicResearchUrl(url))) failureCode = failureCode ?? "artifact-unsafe-url";
+    if (allUrls.some((url) => !fetched.has(canonicalResearchUrl(url)))) failureCode = failureCode ?? "artifact-unfetched-url";
+    if (urls.length < RESEARCH_REQUIRED_FETCHES) failureCode = failureCode ?? "artifact-not-enough-links";
+  }
+  const grounding: ResearchGroundingEvidence = {
+    version: 1,
+    accepted: !failureCode,
+    requiredSearches: RESEARCH_REQUIRED_SEARCHES,
+    requiredFetches: RESEARCH_REQUIRED_FETCHES,
+    successfulSearches: searches,
+    uniqueSuccessfulFetches: [...fetched.values()],
+    artifactUrls,
+    ...(failureCode ? { failureCode } : {}),
+  };
+  return grounding;
+}
+
 export async function executeResearchSpike(request: ResearchSpikeRunRequest): Promise<ResearchSpikeRunResult> {
   const maxResultChars = effectiveResearchResultChars(request.maxOutputChars);
   const loaded = loadResearchRuntimeConfig(request.env);
@@ -435,6 +499,8 @@ export async function executeResearchSpike(request: ResearchSpikeRunRequest): Pr
     return { exitCode: 1, output: reason, resultText: null, ...base, error: reason };
   }
   const configDir = await fs.mkdtemp(path.join(os.tmpdir(), "hugin-research-pi-"));
+  const evidencePath = path.join(configDir, "grounding.jsonl");
+  await fs.writeFile(evidencePath, "", { mode: 0o600 });
   const modelsPath = path.join(configDir, "models.json");
   await fs.writeFile(modelsPath, providerModelsJson(loaded.config), { mode: 0o600 });
   const extension = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../scripts/research-pi-extension.mjs");
@@ -474,17 +540,35 @@ export async function executeResearchSpike(request: ResearchSpikeRunRequest): Pr
     });
     child.on("close", async (code) => {
       clearTimeout(timer); request.signal?.removeEventListener("abort", abort);
-      await fs.rm(configDir, { recursive: true, force: true }).catch(() => undefined);
       parser.finish();
       const parsed = parser.result();
       const semanticError = parsed.error;
-      const exitCode = timedOut ? "TIMEOUT" : killReason ? 1 : code === 0 && !semanticError ? 0 : 1;
-      const resultText = semanticError ? composeResearchResult(semanticError, parsed.text, maxResultChars) : parsed.text || null;
+      let grounding: ResearchGroundingAttestation | undefined;
+      if (code === 0 && !semanticError && !timedOut && !killReason) {
+        const evidence = await readGroundingEvidence(evidencePath, request.artifactManifest);
+        grounding = buildResearchGroundingAttestation(evidence);
+      }
+      await fs.rm(configDir, { recursive: true, force: true }).catch(() => undefined);
+      const groundingError = grounding && !grounding.accepted ? `Research grounding rejected: ${grounding.failureCode}` : undefined;
+      const exitCode = timedOut ? "TIMEOUT" : killReason ? 1 : code === 0 && !semanticError && !groundingError ? 0 : 1;
+      const partialOutput = parsed.text || stderrFallback.toString();
+      const visibleError = semanticError ?? groundingError;
+      const resultText = visibleError
+        ? composeResearchResult(visibleError, partialOutput, maxResultChars)
+        : parsed.text || null;
       const output = resultText || stderrFallback.toString();
       await fs.writeFile(base.logFile, diagnostic.toString(), { mode: 0o600 }).catch(() => undefined);
-      resolve({ exitCode, output: output.slice(0, maxResultChars), resultText, model: loaded.config.model, logFile: base.logFile, ...(semanticError ? { error: semanticError } : {}) });
+      resolve({
+        exitCode,
+        output: output.slice(0, maxResultChars),
+        resultText,
+        model: loaded.config.model,
+        logFile: base.logFile,
+        ...(visibleError ? { error: visibleError } : {}),
+        grounding,
+      });
     });
   });
 }
 
-export const __test__ = { privateAddress, parsePiOutput, providerModelsJson, buildPiPrompt, precreateArtifacts };
+export const __test__ = { privateAddress, parsePiOutput, providerModelsJson, buildPiPrompt, precreateArtifacts, readGroundingEvidence, composeResearchResult };

--- a/src/task-result-schema.ts
+++ b/src/task-result-schema.ts
@@ -17,6 +17,7 @@ import {
 } from "./task-signing.js";
 import { huginTaskIdentitySchema } from "./task-identity.js";
 import { learningTaskExecutionEvidenceSchema } from "./learning-task-handshake.js";
+import { researchGroundingSchema } from "./research-grounding.js";
 
 export const taskExecutionOutcomeSchema = z.enum([
   "completed",
@@ -491,6 +492,8 @@ export const structuredTaskResultSchema = z.object({
   approval: taskExecutionApprovalMetadataSchema.optional(),
   sensitivity: taskExecutionSensitivitySchema.optional(),
   artifactDelivery: artifactDeliverySchema.optional(),
+  /** Hugin-owned, content-blind web-grounding acceptance evidence. */
+  researchGrounding: researchGroundingSchema.optional(),
   orchestratorOutcomes: z.array(orchestratorOutcomeSchema).optional(),
   savings: savingsSummarySchema.optional(),
   provenance: taskSubmissionProvenanceSchema.optional(),

--- a/tests/delivery-sensitivity-recovery.test.ts
+++ b/tests/delivery-sensitivity-recovery.test.ts
@@ -19,7 +19,7 @@ function sliceBetween(startMarker: string, endMarker: string): string {
   return SRC.slice(start, end);
 }
 
-describe("delivery recovery preserves sensitivity evidence (#280)", () => {
+describe("delivery recovery preserves sensitivity and grounding evidence", () => {
   it("checkpoints the exact sensitivity snapshot before delivery can crash", () => {
     const liveDelivery = sliceBetween(
       "if (deliveryEligible && task.artifactManifest)",
@@ -32,6 +32,18 @@ describe("delivery recovery preserves sensitivity evidence (#280)", () => {
     );
   });
 
+  it("persists accepted research grounding before the delivery checkpoint", () => {
+    const grounding = sliceBetween(
+      "let researchGroundingFailureReason",
+      "const deliveryEligible",
+    );
+    expect(grounding).toContain('RESEARCH_GROUNDING_KEY');
+    expect(grounding).toContain('JSON.stringify(validatedGrounding)');
+    expect(SRC.indexOf('JSON.stringify(validatedGrounding)')).toBeLessThan(
+      SRC.indexOf('if (deliveryEligible && task.artifactManifest)'),
+    );
+  });
+
   it("reuses the checkpoint in delivery reconciliation's terminal result", () => {
     const recovery = sliceBetween(
       "async function reconcileDeliveryPending(",
@@ -39,5 +51,10 @@ describe("delivery recovery preserves sensitivity evidence (#280)", () => {
     );
     expect(recovery).toContain("readSensitivityCheckpoint(");
     expect(recovery).toContain("sensitivity: recoverySensitivity");
+    expect(recovery).toContain("RESEARCH_GROUNDING_KEY");
+    expect(recovery).toContain("parseResearchGroundingAttestation");
+    expect(recovery).toContain("validateResearchGroundingAttestation");
+    expect(recovery).toContain("requiredArtifactIds");
+    expect(recovery).toContain("durable accepted research grounding attestation is missing or invalid");
   });
 });

--- a/tests/research-grounding.test.ts
+++ b/tests/research-grounding.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildStructuredTaskResult,
+} from "../src/task-result-schema.js";
+import {
+  canonicalResearchUrl,
+  buildResearchGroundingAttestation,
+  parseResearchGroundingAttestation,
+  validateResearchGroundingAttestation,
+  extractMarkdownLinks,
+  isSafePublicResearchUrl,
+} from "../src/research-grounding.js";
+
+describe("research grounding evidence (#377)", () => {
+  it("is additive structured metadata and never carries fetched bodies", () => {
+    const result = buildStructuredTaskResult({
+      schemaVersion: 1,
+      taskId: "grounded",
+      taskNamespace: "tasks/grounded",
+      lifecycle: "completed",
+      outcome: "completed",
+      runtime: "research",
+      executor: "research-pi-m5",
+      resultSource: "research-pi-m5",
+      exitCode: 0,
+      completedAt: "2026-08-13T07:00:00Z",
+      bodyKind: "response",
+      bodyText: "answer",
+      researchGrounding: {
+        version: 1,
+        accepted: true,
+        requiredSearches: 1,
+        requiredFetches: 3,
+        successfulSearches: 1,
+        uniqueSuccessfulFetches: [
+          { urlSha256: "a".repeat(64), contentSha256: "1".repeat(64) },
+          { urlSha256: "b".repeat(64), contentSha256: "2".repeat(64) },
+          { urlSha256: "c".repeat(64), contentSha256: "3".repeat(64) },
+        ],
+        artifactUrlSha256: { report: ["a".repeat(64), "b".repeat(64), "c".repeat(64)] },
+      },
+    });
+    expect(result.researchGrounding?.uniqueSuccessfulFetches).toHaveLength(3);
+    expect(JSON.stringify(result.researchGrounding)).not.toContain("body");
+    expect(JSON.stringify(result.researchGrounding)).not.toContain("example.com");
+  });
+
+  it("projects ephemeral exact URLs into digest-only durable metadata", () => {
+    const attestation = buildResearchGroundingAttestation({
+      version: 1,
+      accepted: true,
+      requiredSearches: 1,
+      requiredFetches: 3,
+      successfulSearches: 1,
+      uniqueSuccessfulFetches: [
+        { url: "https://example.com/a?secret=query-value", contentSha256: "a".repeat(64) },
+        { url: "https://example.com/b", contentSha256: "b".repeat(64) },
+        { url: "https://example.com/c", contentSha256: "c".repeat(64) },
+      ],
+      artifactUrls: { report: ["https://example.com/a?secret=query-value", "https://example.com/b", "https://example.com/c"] },
+    });
+    expect(JSON.stringify(attestation)).not.toContain("secret");
+    expect(JSON.stringify(attestation)).not.toContain("example.com");
+  });
+
+  it("accepts only valid accepted durable attestations for recovery", () => {
+    const valid = JSON.stringify({
+      version: 1,
+      accepted: true,
+      requiredSearches: 1,
+      requiredFetches: 3,
+      successfulSearches: 1,
+      uniqueSuccessfulFetches: [
+        { urlSha256: "a".repeat(64), contentSha256: "b".repeat(64) },
+        { urlSha256: "c".repeat(64), contentSha256: "d".repeat(64) },
+        { urlSha256: "e".repeat(64), contentSha256: "f".repeat(64) },
+      ],
+      artifactUrlSha256: { report: ["a".repeat(64), "c".repeat(64), "e".repeat(64)] },
+    });
+    expect(parseResearchGroundingAttestation(valid)?.accepted).toBe(true);
+    expect(validateResearchGroundingAttestation(JSON.parse(valid), ["report"])?.accepted).toBe(true);
+    expect(validateResearchGroundingAttestation(JSON.parse(valid), ["reading"])).toBeNull();
+    expect(parseResearchGroundingAttestation("not-json")).toBeNull();
+    expect(parseResearchGroundingAttestation(valid.replace('"accepted":true', '"accepted":false'))).toBeNull();
+  });
+
+  it.each([
+    ["duplicate fetched URL digest", {
+      uniqueSuccessfulFetches: [
+        { urlSha256: "a".repeat(64), contentSha256: "b".repeat(64) },
+        { urlSha256: "a".repeat(64), contentSha256: "c".repeat(64) },
+        { urlSha256: "e".repeat(64), contentSha256: "f".repeat(64) },
+      ], artifactUrlSha256: { report: ["a".repeat(64), "a".repeat(64), "e".repeat(64)] },
+    }],
+    ["empty artifact map", {
+      uniqueSuccessfulFetches: [
+        { urlSha256: "a".repeat(64), contentSha256: "b".repeat(64) },
+        { urlSha256: "c".repeat(64), contentSha256: "d".repeat(64) },
+        { urlSha256: "e".repeat(64), contentSha256: "f".repeat(64) },
+      ], artifactUrlSha256: {},
+    }],
+    ["non-fetched citation digest", {
+      uniqueSuccessfulFetches: [
+        { urlSha256: "a".repeat(64), contentSha256: "b".repeat(64) },
+        { urlSha256: "c".repeat(64), contentSha256: "d".repeat(64) },
+        { urlSha256: "e".repeat(64), contentSha256: "f".repeat(64) },
+      ], artifactUrlSha256: { report: ["a".repeat(64), "c".repeat(64), "9".repeat(64)] },
+    }],
+  ])("rejects %s in accepted durable metadata", (_label, overrides) => {
+    const base = {
+      version: 1, accepted: true, requiredSearches: 1, requiredFetches: 3, successfulSearches: 1,
+      uniqueSuccessfulFetches: [], artifactUrlSha256: {},
+    };
+    expect(parseResearchGroundingAttestation(JSON.stringify({ ...base, ...overrides }))).toBeNull();
+  });
+
+  it("normalizes fragments but rejects private and credential-bearing URLs", () => {
+    expect(canonicalResearchUrl("https://example.com/a#section")).toBe("https://example.com/a");
+    expect(isSafePublicResearchUrl("https://example.com/a")).toBe(true);
+    expect(isSafePublicResearchUrl("http://127.0.0.1/a")).toBe(false);
+    expect(isSafePublicResearchUrl("https://user:pass@example.com/a")).toBe(false);
+    for (const address of [
+      "[::ffff:127.0.0.1]",
+      "[::ffff:10.0.0.1]",
+      "[::]",
+      "[::1]",
+      "[fe80::1]",
+      "[fd00::1]",
+      "[ff02::1]",
+    ]) expect(isSafePublicResearchUrl(`http://${address}/a`)).toBe(false);
+    expect(isSafePublicResearchUrl("https://[2001:4860:4860::8888]/a")).toBe(true);
+  });
+
+  it("extracts markdown links rather than accepting source names as evidence", () => {
+    expect(extractMarkdownLinks("[Example](https://example.com/a) source-name")).toEqual(["https://example.com/a"]);
+    expect(extractMarkdownLinks("Example source-name only")).toEqual([]);
+  });
+});

--- a/tests/research-spike-executor.test.ts
+++ b/tests/research-spike-executor.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
-import { mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, readFile, realpath, rm, writeFile } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 const spawnMock = vi.hoisted(() => vi.fn());
@@ -24,10 +24,12 @@ const env = {
 function mockPi(stdout: string, stderr = "", code = 0): void {
   spawnMock.mockImplementationOnce(() => {
     const child = new EventEmitter() as EventEmitter & {
+      stdin: { end: ReturnType<typeof vi.fn> };
       stdout: EventEmitter;
       stderr: EventEmitter;
       kill: ReturnType<typeof vi.fn>;
     };
+    child.stdin = { end: vi.fn() };
     child.stdout = new EventEmitter();
     child.stderr = new EventEmitter();
     child.kill = vi.fn();
@@ -218,6 +220,74 @@ describe("dedicated research Pi/M5 runtime", () => {
     }
   });
 
+  it("puts grounding rejection code and reason first in visible result text", () => {
+    const result = __test__.composeResearchResult("Research grounding rejected: insufficient-fetches", "partial model answer", 1000);
+    expect(result).toMatch(/^Research grounding rejected: insufficient-fetches/);
+    expect(result).toContain("partial model answer");
+  });
+
+  it("accepts only Hugin-recorded searches, three unique public fetches, and linked fetched sources", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "hugin-research-grounding-"));
+    const evidence = path.join(root, "grounding.jsonl");
+    const detailed = path.join(root, "detailed.md");
+    const popular = path.join(root, "popular.md");
+    const urls = ["https://example.com/one", "https://example.com/two", "https://example.com/three"];
+    try {
+      await writeFile(evidence, [
+        JSON.stringify({ kind: "search" }),
+        ...urls.map((url, index) => JSON.stringify({ kind: "fetch", url, sha256: String(index + 1).repeat(64) })),
+      ].join("\n"));
+      const links = urls.map((url) => `[source](${url})`).join(" ");
+      await writeFile(detailed, links);
+      await writeFile(popular, links);
+      const result = await __test__.readGroundingEvidence(evidence, { artifacts: [
+        { id: "detailed", local: detailed, remote: "magnus@nas:/detailed", required: true },
+        { id: "popular", local: popular, remote: "magnus@nas:/popular", required: true },
+      ] });
+      expect(result.accepted).toBe(true);
+      expect(result.successfulSearches).toBe(1);
+      expect(result.uniqueSuccessfulFetches).toHaveLength(3);
+      expect(JSON.stringify(result)).not.toContain("body");
+    } finally { await rm(root, { recursive: true, force: true }); }
+  });
+
+  it.each([
+    ["missing search", [{ kind: "fetch", url: "https://example.com/one", sha256: "1".repeat(64) }], "insufficient-searches"],
+    ["duplicate fetches", [
+      { kind: "search" },
+      ...["one", "one", "two"].map((part) => ({ kind: "fetch", url: `https://example.com/${part}`, sha256: "1".repeat(64) })),
+    ], "insufficient-fetches"],
+  ])("rejects %s before delivery/indexing", async (_label, records, failureCode) => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "hugin-research-grounding-reject-"));
+    const evidence = path.join(root, "grounding.jsonl");
+    const artifacts = ["detailed", "popular"].map((id) => ({ id, local: path.join(root, `${id}.md`), remote: `magnus@nas:/${id}`, required: true }));
+    try {
+      await writeFile(evidence, (records as Array<Record<string, string>>).map((record) => JSON.stringify(record)).join("\n"));
+      for (const artifact of artifacts) await writeFile(artifact.local, "[source](https://example.com/one) [source](https://example.com/two) [source](https://example.com/three)");
+      const result = await __test__.readGroundingEvidence(evidence, { artifacts });
+      expect(result.accepted).toBe(false);
+      if (failureCode === "insufficient-fetches") {
+        expect(["insufficient-fetches", "artifact-unfetched-url", "artifact-not-enough-links"]).toContain(result.failureCode);
+      } else {
+        expect(result.failureCode).toBe(failureCode);
+      }
+    } finally { await rm(root, { recursive: true, force: true }); }
+  });
+
+  it("rejects invented, private, and duplicate artifact links", async () => {
+    const root = await mkdtemp(path.join(os.tmpdir(), "hugin-research-grounding-links-"));
+    const evidence = path.join(root, "grounding.jsonl");
+    const artifact = path.join(root, "report.md");
+    const fetched = ["https://example.com/one", "https://example.com/two", "https://example.com/three"];
+    try {
+      await writeFile(evidence, [JSON.stringify({ kind: "search" }), ...fetched.map((url) => JSON.stringify({ kind: "fetch", url, sha256: "a".repeat(64) }))].join("\n"));
+      await writeFile(artifact, `[one](${fetched[0]}) [duplicate](${fetched[0]}) [private](http://127.0.0.1/x)`);
+      const result = await __test__.readGroundingEvidence(evidence, { artifacts: [{ id: "report", local: artifact, remote: "magnus@nas:/report", required: true }] });
+      expect(result.accepted).toBe(false);
+      expect(["artifact-duplicate-url", "artifact-unsafe-url"]).toContain(result.failureCode);
+    } finally { await rm(root, { recursive: true, force: true }); }
+  });
+
   it("exposes only the three Hugin tool result shapes and refuses unknown artifact IDs", async () => {
     const registered: Record<string, { execute: (id: string, params: Record<string, string>) => Promise<unknown> }> = {};
     const module = await import("../scripts/research-pi-extension.mjs");
@@ -230,8 +300,77 @@ describe("dedicated research Pi/M5 runtime", () => {
       const written = await registered.write_artifact!.execute("id", { id: "report", content: "hello" });
       expect(written).toEqual({ content: [{ type: "text", text: "artifact report written" }], details: {} });
       await expect(registered.write_artifact!.execute("id", { id: "../escape", content: "no" })).rejects.toThrow(/Unknown artifact ID/);
+      await expect(registered.fetch_content!.execute("id", { url: "http://[::ffff:127.0.0.1]/" })).rejects.toThrow(/forbidden/);
       expect(await readFile(artifact, "utf8")).toBe("hello");
       expect(Object.keys(registered).sort()).toEqual(["fetch_content", "web_search", "write_artifact"]);
+    } finally {
+      for (const key of Object.keys(process.env)) if (!(key in previous)) delete process.env[key];
+      Object.assign(process.env, previous);
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("records successful extension calls in the Hugin sidecar, outside model text", async () => {
+    const registered: Record<string, { execute: (id: string, params: Record<string, string>) => Promise<unknown> }> = {};
+    const module = await import("../scripts/research-pi-extension.mjs");
+    const root = await mkdtemp(path.join(os.tmpdir(), "hugin-research-evidence-test-"));
+    const helper = path.join(root, "helper.mjs");
+    const evidence = path.join(root, "grounding.jsonl");
+    await writeFile(helper, "#!/usr/bin/env node\nprocess.stdin.resume(); process.stdin.on('end', () => process.stdout.write(JSON.stringify(process.argv[1] === 'fetch' ? {url:'https://example.com/a', content:'body'} : {results:[{url:'https://example.com/a'}]})));\n");
+    await chmod(helper, 0o700);
+    const previous = { ...process.env };
+    process.env.HUGIN_RESEARCH_EVIDENCE_FILE = evidence;
+    try {
+      // The production setting is an absolute command; use a tiny shell-free
+      // node wrapper per helper so this test exercises the real child boundary.
+      const searchHelper = path.join(root, "search.mjs");
+      const fetchHelper = path.join(root, "fetch.mjs");
+      await writeFile(searchHelper, "#!/usr/bin/env node\nprocess.stdin.resume(); process.stdin.on('end', () => process.stdout.write(JSON.stringify({results:[{url:'https://93.184.216.34/a'}]})));\n");
+      await writeFile(fetchHelper, "#!/usr/bin/env node\nprocess.stdin.resume(); process.stdin.on('end', () => process.stdout.write(JSON.stringify({url:'https://93.184.216.34/a', content:'body'})));\n");
+      await chmod(searchHelper, 0o700); await chmod(fetchHelper, 0o700);
+      process.env.HUGIN_RESEARCH_SEARCH_HELPER = searchHelper;
+      process.env.HUGIN_RESEARCH_FETCH_HELPER = fetchHelper;
+      module.default({ registerTool(tool: { name: string; execute: (id: string, params: Record<string, string>) => Promise<unknown> }) { registered[tool.name] = tool; } });
+      mockPi(JSON.stringify({ results: [{ url: "https://93.184.216.34/a" }] }));
+      await registered.web_search!.execute("id", { query: "test" });
+      mockPi(JSON.stringify({ url: "https://93.184.216.34/a", content: "body" }));
+      await registered.fetch_content!.execute("id", { url: "https://93.184.216.34/a" });
+      const records = (await readFile(evidence, "utf8")).trim().split("\n").map((line) => JSON.parse(line));
+      expect(records).toEqual([
+        { kind: "search" },
+        { kind: "fetch", url: "https://93.184.216.34/a", sha256: expect.any(String) },
+      ]);
+      expect(JSON.stringify(records)).not.toContain("body");
+    } finally {
+      for (const key of Object.keys(process.env)) if (!(key in previous)) delete process.env[key];
+      Object.assign(process.env, previous);
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not record empty search or fetch helper results as successful evidence", async () => {
+    const registered: Record<string, { execute: (id: string, params: Record<string, string>) => Promise<unknown> }> = {};
+    const module = await import("../scripts/research-pi-extension.mjs");
+    const root = await mkdtemp(path.join(os.tmpdir(), "hugin-research-empty-evidence-test-"));
+    const searchHelper = path.join(root, "search.mjs");
+    const fetchHelper = path.join(root, "fetch.mjs");
+    const evidence = path.join(root, "grounding.jsonl");
+    await writeFile(searchHelper, "#!/usr/bin/env node\nprocess.stdin.resume(); process.stdin.on('end', () => process.stdout.write(JSON.stringify({results:[]})));\n");
+    await writeFile(fetchHelper, "#!/usr/bin/env node\nprocess.stdin.resume(); process.stdin.on('end', () => process.stdout.write(JSON.stringify({url:'https://93.184.216.34/a', content:''})));\n");
+    await chmod(searchHelper, 0o700); await chmod(fetchHelper, 0o700);
+    const previous = { ...process.env };
+    Object.assign(process.env, {
+      HUGIN_RESEARCH_EVIDENCE_FILE: evidence,
+      HUGIN_RESEARCH_SEARCH_HELPER: searchHelper,
+      HUGIN_RESEARCH_FETCH_HELPER: fetchHelper,
+    });
+    try {
+      module.default({ registerTool(tool: { name: string; execute: (id: string, params: Record<string, string>) => Promise<unknown> }) { registered[tool.name] = tool; } });
+      mockPi(JSON.stringify({ results: [] }));
+      await expect(registered.web_search!.execute("id", { query: "empty" })).rejects.toThrow(/no results/);
+      mockPi(JSON.stringify({ url: "https://93.184.216.34/a", content: "" }));
+      await expect(registered.fetch_content!.execute("id", { url: "https://93.184.216.34/a" })).rejects.toThrow(/empty content/);
+      await expect(readFile(evidence, "utf8")).rejects.toThrow();
     } finally {
       for (const key of Object.keys(process.env)) if (!(key in previous)) delete process.env[key];
       Object.assign(process.env, previous);

--- a/tests/research-web-helpers.test.ts
+++ b/tests/research-web-helpers.test.ts
@@ -4,7 +4,7 @@ import { parseDuckDuckGoResults } from "../scripts/research-web-search.mjs";
 
 describe("research web helpers", () => {
   it("rejects private, loopback, link-local, CGNAT, and mapped addresses", () => {
-    for (const address of ["127.0.0.1", "10.2.3.4", "172.16.0.1", "192.168.1.1", "169.254.169.254", "100.64.0.1", "::1", "fd00::1", "fe80::1", "::ffff:127.0.0.1"]) {
+    for (const address of ["127.0.0.1", "10.2.3.4", "172.16.0.1", "192.168.1.1", "169.254.169.254", "100.64.0.1", "::", "::1", "fd00::1", "fe80::1", "ff02::1", "::ffff:127.0.0.1", "::ffff:10.0.0.1"]) {
       expect(isPublicAddress(address), address).toBe(false);
     }
     expect(isPublicAddress("1.1.1.1")).toBe(true);


### PR DESCRIPTION
## Summary

- record Hugin-controlled search/fetch evidence outside model-authored text
- require one successful search, three unique public fetches, and linked fetched citations in both required artifacts
- persist digest-only grounding attestations before delivery for safe recovery
- reject private/mapped addresses, empty helper results, invented or duplicate citations, and missing artifact evidence
- expose body-free grounding metadata in structured results

Fixes #377.

## Verification

- focused grounding/research tests: 27 passed
- full suite: 2734 passed, 3 skipped; known parallel-load dispatcher timeout passed isolated 3/3
- `npm run build` passed
- `git diff --check` passed

## M5 dogfood

`qwen3-coder-next-80b` provided partial useful design review; findings were independently checked and the final implementation was deterministically verified.
